### PR TITLE
fix setRetryWaitingState sql statement + id bind

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
@@ -687,11 +687,15 @@ public class DatabaseSessionStoreManager
 
         public boolean setRetryWaitingState(long taskId, TaskStateCode beforeState, TaskStateCode afterState, int retryInterval, Config stateParams, Optional<Config> updateError)
         {
-            int n = handle.createStatement("update tasks " +
-                    " set updated_at = now(), state = :newState, retry_at = TIMESTAMPADD('SECOND', state_params = :stateParams, :retryInterval, now())" +  // TODO this doesn't work on PostgreSQL
+            int n = handle.createStatement("update tasks" +
+                    " set updated_at = now()," +
+                        " state = :newState," +
+                        " state_params = :stateParams," +
+                        " retry_at = TIMESTAMPADD('SECOND', :retryInterval, now())" +  // TODO this doesn't work on PostgreSQL
                     " where id = :id" +
                     " and state = :oldState"
                 )
+                .bind("id", taskId)
                 .bind("oldState", beforeState.get())
                 .bind("newState", afterState.get())
                 .bind("stateParams", stateParams.isEmpty() ? null : cfm.toText(stateParams))


### PR DESCRIPTION
The `state_params = :stateParams` assignment had ended up inside the `TIMESTAMPADD` function invocation.

Also add missing `id` parameter binding.

https://github.com/treasure-data/digdag/issues/23
