### PR TITLE
use presto to drop tables for td tasks

### DIFF
--- a/digdag-docs/src/operators.rst
+++ b/digdag-docs/src/operators.rst
@@ -202,12 +202,12 @@ Parameters
 :command:`create_table: NAME`
   Name of a table to create from the results. This option deletes the table if it already exists.
 
-  This option adds CREATE TABLE AS (Presto) or INSERT OVERWRITE (Hive) command at the beginning of SELECT statement. If the query includes ``-- DIGDAG_INSERT_LINE`` line, the command is inserted to the line.
+  This option adds DROP TABLE IF EXISTS; CREATE TABLE AS (Presto) or INSERT OVERWRITE (Hive) commands before the SELECT statement. If the query includes a ``-- DIGDAG_INSERT_LINE`` line, the commands are inserted there.
 
   * :command:`create_table: my_table`
 
 :command:`insert_into: NAME`
-  Name of a table to append results into.
+  Name of a table to append results into. The table is created if it does not already exist.
 
   This option adds INSERT INTO (Presto) or INSERT INTO TABLE (Hive) command at the beginning of SELECT statement. If the query includes ``-- DIGDAG_INSERT_LINE`` line, the command is inserted to the line.
 

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdOperatorFactory.java
@@ -119,8 +119,11 @@ public class TdOperatorFactory
                         stmt = insertCommandStatement("INSERT INTO " + escapePrestoTableName(insertInto.get()), query);
                     }
                     else if (createTable.isPresent()) {
-                        ensureTableDeleted(op, createTable.get());  // TODO this is not atomic.
-                        stmt = insertCommandStatement("CREATE TABLE " + escapePrestoTableName(createTable.get()) + " AS", query);
+                        // TODO: this is not atomic
+                        String tableName = escapePrestoTableName(createTable.get());
+                        stmt = insertCommandStatement(
+                                "DROP TABLE IF EXISTS " + tableName + ";\n" +
+                                "CREATE TABLE " + tableName + " AS", query);
                     }
                     else {
                         stmt = query;


### PR DESCRIPTION
Using the rest api to drop tables for `td>` tasks with `create_table` causes spurious `table already exists` in the subsequent `CREATE TABLE ... AS` presto query as the existence of the old table is cached in the presto metadata cache.

Avoid this by using presto to drop the table if it exists instead.

Note: This is just a stop-gap fix. Atomicity for `td>` `create_table` and `insert_into` ddl operations for both presto and hive should be implemented moving forward.
