### PR TITLE
cli: do not load ~/.digdag/config if -c is set

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/Command.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Command.java
@@ -1,5 +1,7 @@
 package io.digdag.cli;
 
+import java.io.File;
+import java.nio.file.Path;
 import java.util.Properties;
 import java.util.Map;
 import java.util.HashMap;
@@ -11,11 +13,18 @@ import java.nio.file.Paths;
 import io.digdag.core.config.PropertyUtils;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.DynamicParameter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class Command
 {
+    private static final Logger log = LoggerFactory.getLogger(Command.class);
+
     @Parameter()
     protected List<String> args = new ArrayList<>();
+
+    @Parameter(names = {"-c", "--config"})
+    protected String configPath = null;
 
     @Parameter(names = {"-L", "--log"})
     protected String logPath = "-";
@@ -33,23 +42,29 @@ public abstract class Command
 
     public abstract SystemExitException usage(String error);
 
+    protected static Path defaultConfigPath() {
+        return Paths.get(System.getProperty("user.home")).resolve(".digdag").resolve("config");
+    }
+
     protected Properties loadSystemProperties()
         throws IOException
     {
         Properties props;
 
-        // load from ~/.digdag/config
-        try {
-            props = PropertyUtils.loadFile(
-                    Paths.get(System.getProperty("user.home")).resolve(".digdag").resolve("config").toFile()
-                    );
-        }
-        catch (FileNotFoundException ex) {
-            // ignore if file doesn't exist
-            props = new Properties();
+        // Load specific configuration file, if specified.
+        if (configPath != null) {
+            props = PropertyUtils.loadFile(new File(configPath));
+        } else {
+            // If no configuration file was specified, load the default configuration, if it exists.
+            try {
+                props = PropertyUtils.loadFile(defaultConfigPath().toFile());
+            }
+            catch (FileNotFoundException ex) {
+                log.trace("configuration file not found: {}", configPath, ex);
+                props = new Properties();
+            }
         }
 
-        // system properties (mostly given by cmdline arguments) overwrite
         props.putAll(System.getProperties());
 
         return props;

--- a/digdag-cli/src/main/java/io/digdag/cli/Main.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Main.java
@@ -32,6 +32,8 @@ import java.util.Set;
 
 import static io.digdag.cli.SystemExitException.systemExit;
 
+import static io.digdag.cli.Command.defaultConfigPath;
+
 public class Main
 {
     private static final String PROGRAM_NAME = "digdag";
@@ -264,6 +266,7 @@ public class Main
         System.err.println("    -L, --log PATH                   output log messages to a file (default: -)");
         System.err.println("    -l, --log-level LEVEL            log level (error, warn, info, debug or trace)");
         System.err.println("    -X KEY=VALUE                     add a performance system config");
+        System.err.println("    -c, --config PATH.properties     Configuration file (default: " + defaultConfigPath() + ")");
         System.err.println("");
     }
 }

--- a/digdag-cli/src/main/java/io/digdag/cli/Server.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Server.java
@@ -34,9 +34,6 @@ public class Server
     @Parameter(names = {"-A", "--access-log"})
     String accessLogPath = null;
 
-    @Parameter(names = {"-c", "--config"})
-    String configPath = null;
-
     @Override
     public void main()
             throws Exception
@@ -84,10 +81,6 @@ public class Server
     {
         // parameters for ServerBootstrap
         Properties props = loadSystemProperties();
-
-        if (configPath != null) {
-            props.putAll(PropertyUtils.loadFile(new File(configPath)));
-        }
 
         // overwrite by command-line parameters
         if (database != null) {

--- a/digdag-cli/src/main/java/io/digdag/cli/client/ClientCommand.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/ClientCommand.java
@@ -7,21 +7,18 @@ import io.digdag.cli.Main;
 import io.digdag.cli.SystemExitException;
 import io.digdag.cli.YamlMapper;
 import io.digdag.client.DigdagClient;
-import io.digdag.core.config.PropertyUtils;
 
 import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.core.Response;
 
-import java.io.File;
 import java.io.IOException;
 import java.time.DateTimeException;
 import java.time.Instant;
-import java.time.OffsetDateTime;
-import java.time.ZoneId;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.time.DateTimeException;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.time.temporal.ChronoUnit;
@@ -34,22 +31,19 @@ import static io.digdag.cli.SystemExitException.systemExit;
 import static java.util.Locale.ENGLISH;
 
 public abstract class ClientCommand
-    extends Command
+        extends Command
 {
     private static final String DEFAULT_ENDPOINT = "http://127.0.0.1:65432";
 
     @Parameter(names = {"-e", "--endpoint"})
     protected String endpoint = null;
 
-    @Parameter(names = {"-c", "--config"})
-    protected String configPath = null;
-
     @DynamicParameter(names = {"-H", "--header"})
     Map<String, String> httpHeaders = new HashMap<>();
 
     @Override
     public void main()
-        throws Exception
+            throws Exception
     {
         try {
             mainWithClientException();
@@ -64,23 +58,23 @@ public abstract class ClientCommand
                 body = ex.getMessage();
             }
             switch (res.getStatus()) {
-            case 404:  // NOT_FOUND
-                throw systemExit("Resource not found: " + body);
-            case 409:  // CONFLICT
-                throw systemExit("Request conflicted: " + body);
-            case 422:  // UNPROCESSABLE_ENTITY
-                throw systemExit("Invalid option: " + body);
-            default:
-                throw systemExit("Status code " + res.getStatus() + ": " + body);
+                case 404:  // NOT_FOUND
+                    throw systemExit("Resource not found: " + body);
+                case 409:  // CONFLICT
+                    throw systemExit("Request conflicted: " + body);
+                case 422:  // UNPROCESSABLE_ENTITY
+                    throw systemExit("Invalid option: " + body);
+                default:
+                    throw systemExit("Status code " + res.getStatus() + ": " + body);
             }
         }
     }
 
     public abstract void mainWithClientException()
-        throws Exception;
+            throws Exception;
 
     protected DigdagClient buildClient()
-        throws IOException, SystemExitException
+            throws IOException, SystemExitException
     {
         // load config file
         Properties props = loadSystemProperties();
@@ -95,14 +89,14 @@ public abstract class ClientCommand
         if (fragments.length == 2 && fragments[1].startsWith("//")) {
             // http:// or https://
             switch (fragments[0]) {
-            case "http":
-                useSsl = false;
-                break;
-            case "https":
-                useSsl = true;
-                break;
-            default:
-                throw systemExit("Endpoint must start with http:// or https://: " + endpoint);
+                case "http":
+                    useSsl = false;
+                    break;
+                case "https":
+                    useSsl = true;
+                    break;
+                default:
+                    throw systemExit("Endpoint must start with http:// or https://: " + endpoint);
             }
             fragments = fragments[1].substring(2).split(":", 2);
         }
@@ -127,35 +121,21 @@ public abstract class ClientCommand
         headers.putAll(this.httpHeaders);
 
         return DigdagClient.builder()
-            .host(host)
-            .port(port)
-            .ssl(useSsl)
-            .headers(headers)
-            .build();
-    }
-
-    @Override
-    protected Properties loadSystemProperties()
-        throws IOException
-    {
-        Properties props = super.loadSystemProperties();
-
-        if (configPath != null) {
-            props.putAll(PropertyUtils.loadFile(new File(configPath)));
-        }
-
-        return props;
+                .host(host)
+                .port(port)
+                .ssl(useSsl)
+                .headers(headers)
+                .build();
     }
 
     public static void showCommonOptions()
     {
         System.err.println("    -e, --endpoint HOST[:PORT]       HTTP endpoint (default: http://127.0.0.1:65432)");
-        System.err.println("    -c, --config PATH.properties     additional config file to overwrite ~/.digdag/config");
         Main.showCommonOptions();
     }
 
     public long parseLongOrUsage(String arg)
-        throws SystemExitException
+            throws SystemExitException
     {
         try {
             return Long.parseLong(args.get(0));
@@ -166,7 +146,7 @@ public abstract class ClientCommand
     }
 
     public int parseIntOrUsage(String arg)
-        throws SystemExitException
+            throws SystemExitException
     {
         try {
             return Integer.parseInt(args.get(0));
@@ -182,7 +162,7 @@ public abstract class ClientCommand
     }
 
     private static final DateTimeFormatter formatter =
-        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss Z", ENGLISH);
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss Z", ENGLISH);
 
     public static String formatTime(Instant instant)
     {
@@ -213,14 +193,14 @@ public abstract class ClientCommand
     }
 
     private final DateTimeFormatter INSTANT_PARSER =
-        DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss Z", ENGLISH)
-        .withZone(ZoneId.systemDefault());
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss Z", ENGLISH)
+                    .withZone(ZoneId.systemDefault());
 
     private static final DateTimeFormatter LOCAL_TIME_PARSER =
-        DateTimeFormatter.ofPattern("yyyy-MM-dd[ HH:mm:ss]", ENGLISH);
+            DateTimeFormatter.ofPattern("yyyy-MM-dd[ HH:mm:ss]", ENGLISH);
 
     protected Instant parseTime(String s, String errorMessage)
-        throws SystemExitException
+            throws SystemExitException
     {
         try {
             Instant i = Instant.ofEpochSecond(Long.parseLong(s));
@@ -237,7 +217,7 @@ public abstract class ClientCommand
     }
 
     protected LocalDateTime parseLocalTime(String s, String errorMessage)
-        throws SystemExitException
+            throws SystemExitException
     {
         TemporalAccessor parsed;
         try {

--- a/digdag-tests/src/test/java/acceptance/ConfigIT.java
+++ b/digdag-tests/src/test/java/acceptance/ConfigIT.java
@@ -1,23 +1,20 @@
 package acceptance;
 
-import java.io.IOException;
-import com.google.common.io.Resources;
-import org.junit.Before;
+import io.digdag.cli.Main;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import io.digdag.cli.Main;
+import static acceptance.TestUtils.copyResource;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
-public class BasicIT
+public class ConfigIT
 {
     public static int main(String... args)
     {
@@ -32,18 +29,9 @@ public class BasicIT
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 
-    private Path definition;
-
     private Path root()
     {
         return folder.getRoot().toPath().toAbsolutePath();
-    }
-
-    private void copyResource(String resource, Path dest) throws IOException
-    {
-        try (InputStream input = Resources.getResource(resource).openStream()) {
-            Files.copy(input, dest);
-        }
     }
 
     private void fakeHome(String home, Action a) throws Exception
@@ -56,15 +44,6 @@ public class BasicIT
         finally {
             System.setProperty("user.home", orig);
         }
-    }
-
-    @Test
-    public void name() throws Exception
-    {
-        copyResource("acceptance/basic.yml", root().resolve("basic.yml"));
-        main("run", "-o", root().toString(), "-f", root().resolve("basic.yml").toString());
-        assertThat(Files.exists(root().resolve("foo.out")), is(true));
-        assertThat(Files.exists(root().resolve("bar.out")), is(true));
     }
 
     @Test

--- a/digdag-tests/src/test/java/acceptance/InitAndArchiveIT.java
+++ b/digdag-tests/src/test/java/acceptance/InitAndArchiveIT.java
@@ -4,7 +4,6 @@ import com.google.common.io.ByteStreams;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
-import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -16,12 +15,13 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 
-import static acceptance.BasicIT.main;
+import static acceptance.TestUtils.main;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
-public class InitAndArchiveIT {
+public class InitAndArchiveIT
+{
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 
@@ -29,13 +29,17 @@ public class InitAndArchiveIT {
     private Path archive;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp()
+            throws Exception
+    {
         project = folder.getRoot().toPath().resolve("foobar");
         archive = folder.getRoot().toPath().resolve("digdag.tar.gz");
     }
 
     @Test
-    public void archive() throws Exception {
+    public void archive()
+            throws Exception
+    {
         main("init", project.toString());
         main("archive",
                 "-f", project.resolve("digdag.yml").toString(),
@@ -50,7 +54,9 @@ public class InitAndArchiveIT {
         assertThat(entries, hasKey("foobar.yml"));
     }
 
-    private Map<String, byte[]> readEntries() throws IOException {
+    private Map<String, byte[]> readEntries()
+            throws IOException
+    {
         Map<String, byte[]> entries = new HashMap<>();
         try (TarArchiveInputStream s = new TarArchiveInputStream(
                 new GzipCompressorInputStream(Files.newInputStream(archive)))) {

--- a/digdag-tests/src/test/java/acceptance/InitPushIT.java
+++ b/digdag-tests/src/test/java/acceptance/InitPushIT.java
@@ -14,7 +14,7 @@ import java.time.Instant;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
-import static acceptance.BasicIT.main;
+import static acceptance.TestUtils.main;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.greaterThan;
@@ -22,13 +22,13 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertThat;
 
-public class InitPushIT {
+public class InitPushIT
+{
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 
     private ExecutorService executor;
-    private Path clientProperties;
-    private Path serverProperties;
+    private Path config;
     private Path projectDir;
 
     private String host;
@@ -36,12 +36,13 @@ public class InitPushIT {
     private String endpoint;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp()
+            throws Exception
+    {
         projectDir = folder.getRoot().toPath().resolve("foobar");
-        clientProperties = Files.createFile(folder.getRoot().toPath().resolve("client.properties"));
-        serverProperties = Files.createFile(folder.getRoot().toPath().resolve("server.properties"));
+        config = Files.createFile(folder.getRoot().toPath().resolve("config"));
         executor = Executors.newCachedThreadPool();
-        executor.execute(() -> main("server", "-m", "-c", serverProperties.toString()));
+        executor.execute(() -> main("server", "-m", "-c", config.toString()));
 
         host = "localhost";
         port = 65432;
@@ -56,7 +57,8 @@ public class InitPushIT {
             try {
                 client.getProjects();
                 break;
-            } catch (Exception e) {
+            }
+            catch (Exception e) {
                 System.out.println(".");
             }
             Thread.sleep(1000);
@@ -64,15 +66,20 @@ public class InitPushIT {
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown()
+            throws Exception
+    {
         executor.shutdownNow();
     }
 
     @Test
-    public void initAndPush() throws Exception {
+    public void initAndPush()
+            throws Exception
+    {
         main("init", projectDir.toString());
         main("push",
                 "foobar",
+                "-c", config.toString(),
                 "-f", projectDir.resolve("digdag.yml").toString(),
                 "-e", endpoint,
                 "-r", "4711");

--- a/digdag-tests/src/test/java/acceptance/RunIT.java
+++ b/digdag-tests/src/test/java/acceptance/RunIT.java
@@ -1,0 +1,33 @@
+package acceptance;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static acceptance.TestUtils.copyResource;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class RunIT
+{
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private Path root()
+    {
+        return folder.getRoot().toPath().toAbsolutePath();
+    }
+
+    @Test
+    public void testRun()
+            throws Exception
+    {
+        copyResource("acceptance/basic.yml", root().resolve("basic.yml"));
+        TestUtils.main("run", "-o", root().toString(), "-f", root().resolve("basic.yml").toString());
+        assertThat(Files.exists(root().resolve("foo.out")), is(true));
+        assertThat(Files.exists(root().resolve("bar.out")), is(true));
+    }
+}

--- a/digdag-tests/src/test/java/acceptance/TestUtils.java
+++ b/digdag-tests/src/test/java/acceptance/TestUtils.java
@@ -1,0 +1,24 @@
+package acceptance;
+
+import com.google.common.io.Resources;
+import io.digdag.cli.Main;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+class TestUtils
+{
+    static int main(String... args)
+    {
+        return new Main().cli(args);
+    }
+
+    static void copyResource(String resource, Path dest) throws IOException
+    {
+        try (InputStream input = Resources.getResource(resource).openStream()) {
+            Files.copy(input, dest);
+        }
+    }
+}


### PR DESCRIPTION
It must be possible to completely ignore ~/.digdag/config in order to be able to run e.g. tests and other scripts that invoke digdag in a safe and reproducible manner.
