### PR TITLE
Add extensible access logging mechanism

### DIFF
--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -273,6 +273,7 @@ In the config file, following parameters are available
 * server.bind (ip address)
 * server.port (integer)
 * server.access-log.path (string. same with --access-log)
+* server.access-log.pattern (string, "json", "combined" or "common")
 * database.type (enum, "h2" or "postgresql")
 * database.user (string)
 * database.password (string)

--- a/digdag-server/src/main/java/io/digdag/server/JsonLogFormatter.java
+++ b/digdag-server/src/main/java/io/digdag/server/JsonLogFormatter.java
@@ -1,0 +1,98 @@
+package io.digdag.server;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.io.IOException;
+import java.io.StringWriter;
+import com.google.common.base.Throwables;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import io.undertow.server.HttpServerExchange;
+import io.undertow.attribute.ReadOnlyAttributeException;
+import io.undertow.attribute.ExchangeAttribute;
+import io.undertow.attribute.ExchangeAttributeParser;
+import io.undertow.attribute.ExchangeAttributes;
+
+public class JsonLogFormatter
+{
+    private static final String DEFAULT_PATTERN = "json{time:%{time,yyyy-MM-dd'T'HH:mm:ss.SSSZ} host:%h forwardedfor:%{i,X-Forwarded-For} method:%m uri:%U%q protocol:%H status:%s size:%B referer:%{i,Referer} ua:%{i,User-Agent} vhost:%{i,Host} reqtime:%T}";
+
+    private JsonLogFormatter()
+    { }
+
+    public static boolean isJsonPattern(String pattern)
+    {
+        return pattern.equals("json") || (pattern.startsWith("json{") && pattern.endsWith("}"));
+    }
+
+    public static ExchangeAttribute buildExchangeAttribute(String pattern, ClassLoader classLoader)
+    {
+        if (pattern.equals("json")) {
+            pattern = DEFAULT_PATTERN;
+        }
+
+        String body = pattern.substring("json{".length(), pattern.length() - "}".length());
+
+        Map<String, ExchangeAttribute> map = new LinkedHashMap<>();
+        ExchangeAttributeParser parser = ExchangeAttributes.parser(classLoader);
+
+        String[] kvs = body.split(" ");
+        for (String kv : kvs) {
+            String[] fragments = kv.split(":", 2);
+            if (fragments.length != 2) {
+                throw new IllegalArgumentException("JSON access log pattern includes an invalid fragment: " + kv);
+            }
+            String key = fragments[0];
+            String value = fragments[1];
+
+            map.put(key, parser.parse(value));
+        }
+
+        return new JsonExchangeAttribute(map);
+    }
+
+    private static class JsonExchangeAttribute
+            implements ExchangeAttribute
+    {
+        private final Map<String, ExchangeAttribute> map;
+        private final JsonFactory jsonFactory = new JsonFactory();
+
+        public JsonExchangeAttribute(Map<String, ExchangeAttribute> map)
+        {
+            this.map = map;
+        }
+
+        @Override
+        public String readAttribute(HttpServerExchange exchange)
+        {
+            StringWriter writer = new StringWriter();
+            try (JsonGenerator gen = jsonFactory.createGenerator(writer)) {
+                gen.writeStartObject();
+                for (Map.Entry<String, ExchangeAttribute> pair : map.entrySet()) {
+                    gen.writeFieldName(pair.getKey());
+                    gen.writeString(pair.getValue().readAttribute(exchange));
+                }
+
+                Map<String, String> appAttributes = ThreadLocalAccessLogs.resetAttributes();
+                for (Map.Entry<String, String> pair : appAttributes.entrySet()) {
+                    gen.writeFieldName(pair.getKey());
+                    gen.writeString(pair.getValue());
+                }
+
+                gen.writeEndObject();
+            }
+            catch (IOException ex) {
+                throw Throwables.propagate(ex);
+            }
+            return writer.toString();
+        }
+
+        @Override
+        public void writeAttribute(HttpServerExchange exchange, String newValue)
+            throws ReadOnlyAttributeException
+        {
+            throw new ReadOnlyAttributeException();
+        }
+    }
+}

--- a/digdag-server/src/main/java/io/digdag/server/ServerConfig.java
+++ b/digdag-server/src/main/java/io/digdag/server/ServerConfig.java
@@ -20,12 +20,15 @@ public interface ServerConfig
 {
     public static final int DEFAULT_PORT = 65432;
     public static final String DEFAULT_BIND = "127.0.0.1";
+    public static final String DEFAULT_ACCESS_LOG_PATTERN = "json";
 
     public int getPort();
 
     public String getBind();
 
     public Optional<String> getAccessLogPath();
+
+    public String getAccessLogPattern();
 
     public ConfigElement getSystemConfig();
 
@@ -47,6 +50,7 @@ public interface ServerConfig
             .port(config.get("server.port", int.class, DEFAULT_PORT))
             .bind(config.get("server.bind", String.class, DEFAULT_BIND))
             .accessLogPath(config.getOptional("server.access-log.path", String.class))
+            .accessLogPattern(config.get("server.access-log.pattern", String.class, DEFAULT_ACCESS_LOG_PATTERN))
             .systemConfig(ConfigElement.copyOf(config))  // systemConfig needs to include other keys such as server.port so that ServerBootstrap.initialize can recover ServerConfig from this systemConfig
             .build();
     }

--- a/digdag-server/src/main/java/io/digdag/server/ThreadLocalAccessLogs.java
+++ b/digdag-server/src/main/java/io/digdag/server/ThreadLocalAccessLogs.java
@@ -1,0 +1,32 @@
+package io.digdag.server;
+
+import java.util.Map;
+import java.util.HashMap;
+import io.undertow.server.HttpServerExchange;
+
+public class ThreadLocalAccessLogs
+{
+    private static final ThreadLocal<Map<String, String>> THREAD_LOCAL =
+        new ThreadLocal<Map<String, String>>()
+        {
+            @Override
+            protected Map<String, String> initialValue() {
+                return new HashMap<>();
+            }
+        };
+
+    private ThreadLocalAccessLogs()
+    { }
+
+    public static void putAttribute(String key, String value)
+    {
+        THREAD_LOCAL.get().put(key, value);
+    }
+
+    public static Map<String, String> resetAttributes()
+    {
+        Map<String, String> map = THREAD_LOCAL.get();
+        THREAD_LOCAL.remove();
+        return map;
+    }
+}


### PR DESCRIPTION
JsonLogFormatter and ThreadLocalAccessLogs let an application add custom
fields to access logs. An application calls
`ThreadLocalAccessLogs.putAttribute` in JAX-RS task thread to add
attributes.

Example output is:

```
{"time":"2016-04-20T14:11:34.076-0700","host":"127.0.0.1","forwardedfor":null,"method":"PUT","uri":"/api/projects?project=project1&revision=1","protocol":"HTTP/1.1","status":"200","size":"170","referer":null,"ua":null,"vhost":"127.0.0.1:65432","reqtime":null,"site_id":"0"}
```

(site_id is an example custom attribute)

This implementation is using very ad-hoc code based on ThreadLocal.
If there're better implementations (such as injecting
io.undertow.server.HttpServerExchange to JAX-RS resources), code
should be replaced.

Field names follow this rule: http://ltsv.org/
