### PR TITLE
td: set scheduled time to session time

### DIFF
--- a/digdag-standards/build.gradle
+++ b/digdag-standards/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compile 'com.sun.mail:javax.mail:1.5.5'   // 'com.sun.mail:smtp' doesn't work because enabling mail.debug property throws java.lang.NoClassDefFoundError: com/sun/mail/util/MailLogger
 
     // td
-    compile 'com.treasuredata.client:td-client:0.7.12'
+    compile 'com.treasuredata.client:td-client:0.7.13'
     compile 'org.msgpack:msgpack-core:0.8.2'
     compile 'org.yaml:snakeyaml:1.14'
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdOperatorFactory.java
@@ -155,6 +155,7 @@ public class TdOperatorFactory
                     .setQuery(stmt)
                     .setRetryLimit(jobRetry)
                     .setPriority(priority)
+                    .setScheduledTime(request.getSessionTime().getEpochSecond())
                     .createTDJobRequest();
 
                 TDJobOperator j = op.submitNewJob(req);


### PR DESCRIPTION
This ensures that `TD_SCHEDULED_TIME()` will return the timestamp corresponding to the session time of the digdag workflow session.

Note that this requires a yet unreleased version of td-client.
