### PR TITLE
move ~/.digdag/ to ~/.config/digdag/

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/Arguments.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Arguments.java
@@ -27,7 +27,7 @@ public class Arguments
     {
         Config overwriteParams = cf.create();
 
-        // ~/.digdag/config and JVM system properties
+        // ~/.config/digdag/config and JVM system properties
         for (String key : systemProps.stringPropertyNames()) {
             if (key.startsWith("params.")) {
                 setDotNestedKey(overwriteParams, key.substring("params.".length()), systemProps.getProperty(key));

--- a/digdag-cli/src/main/java/io/digdag/cli/Command.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Command.java
@@ -2,7 +2,8 @@ package io.digdag.cli;
 
 import java.io.File;
 import java.io.PrintStream;
-import java.nio.file.Path;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Paths;
 import java.util.Properties;
 import java.util.Map;
 import java.util.HashMap;
@@ -10,7 +11,7 @@ import java.util.List;
 import java.util.ArrayList;
 import java.io.IOException;
 import java.io.FileNotFoundException;
-import java.nio.file.Paths;
+
 import io.digdag.core.config.PropertyUtils;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.DynamicParameter;
@@ -52,10 +53,6 @@ public abstract class Command
 
     public abstract SystemExitException usage(String error);
 
-    protected static Path defaultConfigPath() {
-        return Paths.get(System.getProperty("user.home")).resolve(".digdag").resolve("config");
-    }
-
     protected Properties loadSystemProperties()
         throws IOException
     {
@@ -63,18 +60,19 @@ public abstract class Command
 
         // Load specific configuration file, if specified.
         if (configPath != null) {
-            props = PropertyUtils.loadFile(new File(configPath));
+            props = PropertyUtils.loadFile(Paths.get(configPath));
         } else {
             // If no configuration file was specified, load the default configuration, if it exists.
             try {
-                props = PropertyUtils.loadFile(defaultConfigPath().toFile());
+                props = PropertyUtils.loadFile(ConfigUtil.defaultConfigPath());
             }
-            catch (FileNotFoundException ex) {
+            catch (NoSuchFileException ex) {
                 log.trace("configuration file not found: {}", configPath, ex);
                 props = new Properties();
             }
         }
 
+        // Override properties from config file with system properties
         props.putAll(System.getProperties());
 
         return props;

--- a/digdag-cli/src/main/java/io/digdag/cli/ConfigUtil.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/ConfigUtil.java
@@ -1,0 +1,21 @@
+package io.digdag.cli;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+class ConfigUtil
+{
+    static Path defaultConfigPath()
+    {
+        return configHome().resolve("digdag").resolve("config");
+    }
+
+    private static Path configHome()
+    {
+        String configHome = System.getenv("XDG_CONFIG_HOME");
+        if (configHome != null) {
+            return Paths.get(configHome);
+        }
+        return Paths.get(System.getProperty("user.home"), ".config");
+    }
+}

--- a/digdag-cli/src/main/java/io/digdag/cli/Main.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Main.java
@@ -34,7 +34,7 @@ import java.util.Set;
 
 import static io.digdag.cli.SystemExitException.systemExit;
 
-import static io.digdag.cli.Command.defaultConfigPath;
+import static io.digdag.cli.ConfigUtil.defaultConfigPath;
 import static io.digdag.core.Version.buildVersion;
 
 public class Main

--- a/digdag-core/src/main/java/io/digdag/core/config/PropertyUtils.java
+++ b/digdag-core/src/main/java/io/digdag/core/config/PropertyUtils.java
@@ -1,5 +1,8 @@
 package io.digdag.core.config;
 
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Properties;
 import java.io.File;
 import java.io.FileInputStream;
@@ -15,11 +18,11 @@ public class PropertyUtils
     private PropertyUtils()
     { }
 
-    public static Properties loadFile(File file)
+    public static Properties loadFile(Path file)
         throws IOException
     {
         Properties props = new Properties();
-        try (FileInputStream in = new FileInputStream(file)) {
+        try (InputStream in = Files.newInputStream(file)) {
             props.load(in);
         }
         return props;

--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -303,13 +303,11 @@ Client-mode common options:
   Add a custom HTTP header. Use multiple times to set multiple headers.
 
 :command:`-c, --config PATH`
-  Configuration file path in addition to ~/.digdag/config to overwrite.
+  Configuration file to load. (default: ~/.config/digdag/config)
 
   Example: -c digdag-server/client.properties
 
-You can include following promerters in ~/.digdag/config file:
-
-In the config file, following parameters are available
+You can include following parameters in ~/.config/digdag/config file:
 
 * cilent.http.endpoint = http://HOST:PORT or https://HOST:PORT
 * client.http.headers.KEY = VALUE (set custom HTTP header)

--- a/digdag-tests/src/test/java/acceptance/ConfigIT.java
+++ b/digdag-tests/src/test/java/acceptance/ConfigIT.java
@@ -31,7 +31,8 @@ public class ConfigIT
     {
         copyResource("acceptance/params.yml", root().resolve("params.yml"));
         TestUtils.fakeHome(root().resolve("home").toString(), () -> {
-            Files.write(root().resolve("home").resolve(".digdag").resolve("config"), "params.mysql.password=secret".getBytes(UTF_8));
+            Path configFile = root().resolve("home").resolve(".config").resolve("digdag").resolve("config");
+            Files.write(configFile, "params.mysql.password=secret".getBytes(UTF_8));
             main("run", "-o", root().toString(), "-f", root().resolve("params.yml").toString());
         });
         assertThat(Files.readAllBytes(root().resolve("foo.out")), is("secret\n".getBytes(UTF_8)));
@@ -43,7 +44,8 @@ public class ConfigIT
     {
         copyResource("acceptance/params.yml", root().resolve("params.yml"));
         TestUtils.fakeHome(root().resolve("home").toString(), () -> {
-            Files.write(root().resolve("home").resolve(".digdag").resolve("config"), "params.mysql.password=secret".getBytes(UTF_8));
+            Path configFile = root().resolve("home").resolve(".config").resolve("digdag").resolve("config");
+            Files.write(configFile, "params.mysql.password=secret".getBytes(UTF_8));
             main("run",
                     "-o", root().toString(),
                     "-f", root().resolve("params.yml").toString(),

--- a/digdag-tests/src/test/java/acceptance/InitPushStartConfigIT.java
+++ b/digdag-tests/src/test/java/acceptance/InitPushStartConfigIT.java
@@ -58,7 +58,7 @@ public class InitPushStartConfigIT
     {
         Path tempdir = folder.getRoot().toPath().toAbsolutePath();
         Path homedir = folder.newFolder("home").toPath();
-        Path configDir = homedir.resolve(".digdag");
+        Path configDir = homedir.resolve(".config").resolve("digdag");
         Files.createDirectories(configDir);
         Path configFile = configDir.resolve("config");
         Path projectDir = tempdir.resolve("echo_params");

--- a/digdag-tests/src/test/java/acceptance/TestUtils.java
+++ b/digdag-tests/src/test/java/acceptance/TestUtils.java
@@ -52,7 +52,7 @@ class TestUtils
     {
         String orig = System.setProperty("user.home", home);
         try {
-            Files.createDirectories(Paths.get(home).resolve(".digdag"));
+            Files.createDirectories(Paths.get(home).resolve(".config").resolve("digdag"));
             a.run();
         }
         finally {


### PR DESCRIPTION
This follows the XDG Base Directory Specification, avoids cluttering the user $HOME directory and resolves the future issue where $HOME would be considered a digdag project after implementing these project structure changes: https://github.com/treasure-data/digdag/issues/70

https://standards.freedesktop.org/basedir-spec/latest/index.html
