### PR TITLE
fix td create table command insertion

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdOperatorFactory.java
@@ -226,8 +226,6 @@ public class TdOperatorFactory
 
     private final static Pattern INSERT_LINE_PATTERN = Pattern.compile("(\\A|\\r?\\n)\\-\\-\\s*DIGDAG_INSERT_LINE(?:(?!\\n|\\z).)*");
 
-    private final static Pattern COMMENT_BLOCK_PATTERN = Pattern.compile("(?:(?:\\A|\\r?\\n)\\-\\-(?:(?!\\n|\\z).)*)+");
-
     @VisibleForTesting
     static String insertCommandStatement(String command, String original)
     {
@@ -235,14 +233,6 @@ public class TdOperatorFactory
         Matcher ml = INSERT_LINE_PATTERN.matcher(original);
         if (ml.find()) {
             return ml.replaceAll(ml.group(1) + command);
-        }
-
-        // try to insert command after comments
-        Matcher mc = COMMENT_BLOCK_PATTERN.matcher(original);
-        if (mc.find()) {
-            return mc.group() +
-                "\n" +
-                command + original.substring(mc.group().length());
         }
 
         // add command at the head

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/td/TdOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/td/TdOperatorFactoryTest.java
@@ -28,15 +28,15 @@ public class TdOperatorFactoryTest
                 insertCommandStatement("INSERT",
                     "with a as (select 1)\n--DIGDAG_INSERT_LINE\n-- comment\nselect 1"));
 
-        assertEquals("-- comment\nINSERT\nselect 1",
+        assertEquals("INSERT\n-- comment\nselect 1",
                 insertCommandStatement("INSERT",
                     "-- comment\nselect 1"));
 
-        assertEquals("-- comment\nINSERT\r\nselect 1",
+        assertEquals("INSERT\n-- comment\r\nselect 1",
                 insertCommandStatement("INSERT",
                     "-- comment\r\nselect 1"));
 
-        assertEquals("-- comment1\n--comment2\nINSERT\nselect 1",
+        assertEquals("INSERT\n-- comment1\n--comment2\nselect 1",
                 insertCommandStatement("INSERT",
                     "-- comment1\n--comment2\nselect 1"));
 


### PR DESCRIPTION
Inserting commands after comments in a query breaks if the comments are
in the body of the query. E.g.:

```
SELECT
-- comment
1;
```
