### PR TITLE
Remove ${session_id} because sessions.id is an internal information

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/agent/RuntimeParams.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/RuntimeParams.java
@@ -20,7 +20,6 @@ public class RuntimeParams
         params.set("timezone", timeZone);
 
         // session_*
-        params.set("session_id", request.getSessionId());
         params.set("session_uuid", request.getSessionUuid().toString());
         params.set("session_time", formatSessionTime(request.getSessionTime(), timeZone));
         setTimeParameters(params, "session_", timeZone, request.getSessionTime());

--- a/digdag-docs/src/workflow_definition.rst
+++ b/digdag-docs/src/workflow_definition.rst
@@ -64,7 +64,6 @@ Here is the list of built-in variables:
 Name                            Description                                 Example
 =============================== =========================================== ==========================
 **timezone**                    Timezone of this workflow                   America/Los_Angeles
-**session_id**                  Unique ID of this session                   32
 **session_uuid**                Unique UUID of this session                 414a8b9e-b365-4394-916a-f0ed9987bd2b
 **session_time**                Time of this session with time zone         2016-01-30T00:00:00-08:00
 **session_date**                Date part of session_time                   2016-01-30

--- a/digdag-tests/src/test/java/acceptance/BuiltInVariablesIT.java
+++ b/digdag-tests/src/test/java/acceptance/BuiltInVariablesIT.java
@@ -59,7 +59,6 @@ public class BuiltInVariablesIT
                 .put("last_session_date", is("2016-01-02"))
                 .put("session_date_compact", is("20160102"))
                 .put("last_session_time", is("2016-01-02T00:00:00+00:00"))
-                .put("session_id", is("1"))
                 .put("session_unixtime", is("1451703845"))
                 .put("last_session_date_compact", is("20160102"))
                 .put("session_date", is("2016-01-02"))

--- a/digdag-tests/src/test/resources/acceptance/built_in_variables/built_in_variables.dig
+++ b/digdag-tests/src/test/resources/acceptance/built_in_variables/built_in_variables.dig
@@ -10,8 +10,6 @@ schedule:
   _parallel: true
   +timezone:
     sh>: "echo timezone: \\'${timezone}\\' >> output.yml"
-  +session_id:
-    sh>: "echo session_id: \\'${session_id}\\' >> output.yml"
   +session_uuid:
     sh>: "echo session_uuid: \\'${session_uuid}\\' >> output.yml"
   +session_time:


### PR DESCRIPTION
At least for now, sessions.id is an internal hidden information.
digdag-cli doesn't expose it. Thus users won't be aware of it. This
change removes ${session_id} parameter to avoid confusion from
 session attempt id.

Adding ${session_attempt_id} is a next step.
