### PR TITLE
Support deleting a project

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/Main.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Main.java
@@ -10,6 +10,7 @@ import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import io.digdag.cli.client.Archive;
 import io.digdag.cli.client.Backfill;
+import io.digdag.cli.client.Delete;
 import io.digdag.cli.client.Kill;
 import io.digdag.cli.client.Push;
 import io.digdag.cli.client.Reschedule;
@@ -105,6 +106,7 @@ public class Main
         jc.addCommand("kill", new Kill(version, out, err));
         jc.addCommand("task", new ShowTask(version, out, err), "tasks");
         jc.addCommand("schedule", new ShowSchedule(version, out, err), "schedules");
+        jc.addCommand("delete", new Delete(version, out, err));
         jc.addCommand("version", new Version(version, out, err), "version");
 
         jc.addCommand("selfupdate", new SelfUpdate(out, err));
@@ -261,6 +263,7 @@ public class Main
         err.println("    attempts <session-id>            show attempts for a session");
         err.println("    attempt  <attempt-id>            show a single attempt");
         err.println("    tasks <attempt-id>               show tasks of a session attempt");
+        err.println("    delete <project-name>            delete a project");
         err.println("    version                          show client and server version");
         err.println("");
         err.println("  Options:");

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Delete.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Delete.java
@@ -1,0 +1,67 @@
+package io.digdag.cli.client;
+
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+import java.util.HashMap;
+import java.io.File;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.DynamicParameter;
+import com.google.inject.Injector;
+import com.google.inject.Scopes;
+import io.digdag.cli.Run;
+import io.digdag.cli.StdErr;
+import io.digdag.cli.StdOut;
+import io.digdag.cli.SystemExitException;
+import io.digdag.cli.YamlMapper;
+import io.digdag.client.DigdagClient;
+import io.digdag.client.api.RestProject;
+import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigFactory;
+import io.digdag.core.DigdagEmbed;
+import io.digdag.core.Version;
+import io.digdag.core.config.ConfigLoaderManager;
+
+import static io.digdag.cli.Arguments.loadParams;
+import static io.digdag.cli.SystemExitException.systemExit;
+
+public class Delete
+    extends ClientCommand
+{
+    public Delete(Version version, PrintStream out, PrintStream err)
+    {
+        super(version, out, err);
+    }
+
+    @Override
+    public void mainWithClientException()
+        throws Exception
+    {
+        if (args.size() != 1) {
+            throw usage(null);
+        }
+        delete(args.get(0));
+    }
+
+    public SystemExitException usage(String error)
+    {
+        err.println("Usage: digdag delete <project>");
+        err.println("  Options:");
+        showCommonOptions();
+        return systemExit(error);
+    }
+
+    private void delete(String projName)
+        throws Exception
+    {
+        DigdagClient client = buildClient();
+
+        RestProject proj = client.getProject(projName);
+
+        client.deleteProject(proj.getId());
+        err.println("Project '" + projName + "' is deleted.");
+    }
+}

--- a/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
+++ b/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
@@ -202,6 +202,13 @@ public class DigdagClient
                 .resolveTemplate("id", projId));
     }
 
+    public void deleteProject(int projId)
+    {
+        doDelete(RestProject.class,
+                target("/api/projects/{id}")
+                .resolveTemplate("id", projId));
+    }
+
     public List<RestRevision> getRevisions(int projId, Optional<Integer> lastId)
     {
         return doGet(new GenericType<List<RestRevision>>() { },
@@ -558,5 +565,12 @@ public class DigdagClient
         return target.request("application/json")
             .headers(headers.get())
             .post(Entity.entity(body, "application/json"), type);
+    }
+
+    private <T> T doDelete(Class<T> type, WebTarget target)
+    {
+        return target.request("application/json")
+            .headers(headers.get())
+            .get(type);
     }
 }

--- a/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
+++ b/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
@@ -204,8 +204,7 @@ public class DigdagClient
 
     public void deleteProject(int projId)
     {
-        doDelete(RestProject.class,
-                target("/api/projects/{id}")
+        doDelete(target("/api/projects/{id}")
                 .resolveTemplate("id", projId));
     }
 
@@ -567,10 +566,17 @@ public class DigdagClient
             .post(Entity.entity(body, "application/json"), type);
     }
 
+    private void doDelete(WebTarget target)
+    {
+        target.request("application/json")
+            .headers(headers.get())
+            .delete();
+    }
+
     private <T> T doDelete(Class<T> type, WebTarget target)
     {
         return target.request("application/json")
             .headers(headers.get())
-            .get(type);
+            .delete(type);
     }
 }

--- a/digdag-client/src/main/java/io/digdag/client/api/RestProject.java
+++ b/digdag-client/src/main/java/io/digdag/client/api/RestProject.java
@@ -21,6 +21,8 @@ public abstract class RestProject
 
     public abstract Instant getUpdatedAt();
 
+    public abstract Optional<Instant> getDeletedAt();
+
     public abstract String getArchiveType();
 
     public abstract Optional<byte[]> getArchiveMd5();

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseMigrator.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseMigrator.java
@@ -584,9 +584,39 @@ public class DatabaseMigrator
         }
     };
 
+    private final Migration MigrateMakeProjectsDeletable = new Migration() {
+        @Override
+        public String getVersion()
+        {
+            return "20160610154832";
+        }
+
+        @Override
+        public void migrate(Handle handle)
+        {
+            if (isPostgres()) {
+                handle.update("alter table projects" +
+                        " add column deleted_at timestamp with time zone");
+                handle.update("alter table projects" +
+                        " add column deleted_name text");
+                handle.update("alter table projects" +
+                        " alter column name drop not null");
+            }
+            else {
+                handle.update("alter table projects" +
+                        " add column deleted_at timestamp");
+                handle.update("alter table projects" +
+                        " add column deleted_name varchar(255)");
+                handle.update("alter table projects" +
+                        " alter column name drop not null");
+            }
+        }
+    };
+
     private final Migration[] migrations = {
         MigrateCreateTables,
         MigrateSessionsOnProjectIdIndexToDesc,
         MigrateCreateResumingTasks,
+        MigrateMakeProjectsDeletable,
     };
 }

--- a/digdag-core/src/main/java/io/digdag/core/repository/ProjectControl.java
+++ b/digdag-core/src/main/java/io/digdag/core/repository/ProjectControl.java
@@ -26,7 +26,7 @@ public class ProjectControl
     public static <T> T deleteProject(ProjectStore rs, int projId, DeleteProjectAction<T> callback)
         throws ResourceNotFoundException
     {
-        return rs.obsoleteProject(projId, (store, proj) -> {
+        return rs.deleteProject(projId, (store, proj) -> {
             ProjectControl control = new ProjectControl(store, proj);
             T res = callback.call(control, proj);
             control.deleteSchedules();

--- a/digdag-core/src/main/java/io/digdag/core/repository/ProjectControlStore.java
+++ b/digdag-core/src/main/java/io/digdag/core/repository/ProjectControlStore.java
@@ -17,7 +17,7 @@ public interface ProjectControlStore
         throws ResourceConflictException;
 
     void updateSchedules(int projId, List<Schedule> schedules)
-            throws ResourceConflictException;
+        throws ResourceConflictException;
 
-    //void deleteProject(int projId);  // set deleted_at to project, and delete schedules
+    void deleteSchedules(int projId);
 }

--- a/digdag-core/src/main/java/io/digdag/core/repository/ProjectStore.java
+++ b/digdag-core/src/main/java/io/digdag/core/repository/ProjectStore.java
@@ -26,6 +26,15 @@ public interface ProjectStore
     <T> T putAndLockProject(Project project, ProjectLockAction<T> func)
         throws ResourceConflictException;
 
+    interface ProjectObsoleteAction <T>
+    {
+        T call(ProjectControlStore store, StoredProject storedProject)
+            throws ResourceNotFoundException;
+    }
+
+    <T> T obsoleteProject(int projId, ProjectObsoleteAction<T> func)
+        throws ResourceNotFoundException;
+
 
     StoredRevision getRevisionById(int revId)
         throws ResourceNotFoundException;

--- a/digdag-core/src/main/java/io/digdag/core/repository/ProjectStore.java
+++ b/digdag-core/src/main/java/io/digdag/core/repository/ProjectStore.java
@@ -32,7 +32,7 @@ public interface ProjectStore
             throws ResourceNotFoundException;
     }
 
-    <T> T obsoleteProject(int projId, ProjectObsoleteAction<T> func)
+    <T> T deleteProject(int projId, ProjectObsoleteAction<T> func)
         throws ResourceNotFoundException;
 
 

--- a/digdag-core/src/main/java/io/digdag/core/repository/StoredProject.java
+++ b/digdag-core/src/main/java/io/digdag/core/repository/StoredProject.java
@@ -1,6 +1,7 @@
 package io.digdag.core.repository;
 
 import java.time.Instant;
+import com.google.common.base.Optional;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.immutables.value.Value;
@@ -17,5 +18,5 @@ public abstract class StoredProject
 
     public abstract Instant getCreatedAt();
 
-    //public abstract Optional<Instant> getDeletedAt();
+    public abstract Optional<Instant> getDeletedAt();
 }

--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -617,7 +617,7 @@ delete
 
     $ digdag delete <project> [options...]
 
-Deletes a project. Sessinos of the deleted project are kept remained so that we can review status of past executions later.
+Deletes a project. Sessions of the deleted project are kept retained so that we can review status of past executions later.
 
 .. code-block:: console
 

--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -610,6 +610,20 @@ Creates a project archive and upload it to the server. This command uploads work
   Example: -r f40172ebc58f58087b6132085982147efa9e81fb
 
 
+delete
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: console
+
+    $ digdag delete <project> [options...]
+
+Deletes a project. Sessinos of the deleted project are kept remained so that we can review status of past executions later.
+
+.. code-block:: console
+
+    $ digdag delete myproj
+
+
 Common options
 ----------------------------------
 

--- a/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
@@ -16,6 +16,8 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.PUT;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.POST;
 import javax.ws.rs.GET;
 import com.google.inject.Inject;
 import com.google.common.base.Throwables;
@@ -277,6 +279,18 @@ public class ProjectResource
             rev = rs.getRevisionByName(proj.getId(), revName);
         }
         return rs.getRevisionArchiveData(rev.getId());
+    }
+
+    @DELETE
+    @Path("/api/projects/{id}")
+    public RestProject deleteProject(@PathParam("id") int projId)
+        throws ResourceNotFoundException
+    {
+        ProjectStore rs = rm.getProjectStore(getSiteId());
+        return ProjectControl.deleteProject(rs, projId, (control, proj) -> {
+            StoredRevision rev = rs.getLatestRevision(proj.getId());
+            return RestModels.project(proj, rev);
+        });
     }
 
     @PUT

--- a/digdag-server/src/main/java/io/digdag/server/rs/RestModels.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/RestModels.java
@@ -55,6 +55,7 @@ public final class RestModels
             .revision(lastRevision.getName())
             .createdAt(proj.getCreatedAt())
             .updatedAt(lastRevision.getCreatedAt())
+            .deletedAt(proj.getDeletedAt())
             .archiveType(lastRevision.getArchiveType())
             .archiveMd5(lastRevision.getArchiveMd5())
             .build();

--- a/digdag-tests/src/test/java/acceptance/DeleteProjectIT.java
+++ b/digdag-tests/src/test/java/acceptance/DeleteProjectIT.java
@@ -65,7 +65,8 @@ public class DeleteProjectIT
             CommandStatus deleteStatus = main("delete",
                     "-c", config.toString(),
                     "-e", server.endpoint(),
-                    "foobar");
+                    "foobar",
+                    "--force");
             assertThat(deleteStatus.errUtf8(), deleteStatus.code(), is(0));
         }
 

--- a/digdag-tests/src/test/java/acceptance/DeleteProjectIT.java
+++ b/digdag-tests/src/test/java/acceptance/DeleteProjectIT.java
@@ -40,7 +40,7 @@ public class DeleteProjectIT
     }
 
     @Test
-    public void initPushStart()
+    public void deleteProject()
             throws Exception
     {
         // Create new project
@@ -76,7 +76,7 @@ public class DeleteProjectIT
                     "-e", server.endpoint(),
                     "foobar", "foobar",
                     "--session", "now");
-            assertThat(startStatus.code(), is(not(1)));
+            assertThat(startStatus.code(), is(not(0)));
         }
     }
 }

--- a/digdag-tests/src/test/java/acceptance/DeleteProjectIT.java
+++ b/digdag-tests/src/test/java/acceptance/DeleteProjectIT.java
@@ -1,0 +1,83 @@
+package acceptance;
+
+import io.digdag.client.DigdagClient;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.nio.file.Path;
+
+import static acceptance.TestUtils.copyResource;
+import static acceptance.TestUtils.main;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+public class DeleteProjectIT
+{
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Rule
+    public TemporaryDigdagServer server = TemporaryDigdagServer.of();
+
+    private Path config;
+    private Path projectDir;
+    private DigdagClient client;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        projectDir = folder.getRoot().toPath().resolve("foobar");
+        config = folder.newFile().toPath();
+
+        client = DigdagClient.builder()
+                .host(server.host())
+                .port(server.port())
+                .build();
+    }
+
+    @Test
+    public void initPushStart()
+            throws Exception
+    {
+        // Create new project
+        CommandStatus initStatus = main("init",
+                "-c", config.toString(),
+                projectDir.toString());
+        assertThat(initStatus.code(), is(0));
+
+        copyResource("acceptance/basic.dig", projectDir.resolve("foobar.dig"));
+
+        // Push the project
+        CommandStatus pushStatus = main("push",
+                "--project", projectDir.toString(),
+                "foobar",
+                "-c", config.toString(),
+                "-e", server.endpoint(),
+                "-r", "4711");
+        assertThat(pushStatus.errUtf8(), pushStatus.code(), is(0));
+
+        // Delete the project
+        {
+            CommandStatus deleteStatus = main("delete",
+                    "-c", config.toString(),
+                    "-e", server.endpoint(),
+                    "foobar");
+            assertThat(deleteStatus.errUtf8(), deleteStatus.code(), is(0));
+        }
+
+        // Starting a workflow should fail
+        {
+            CommandStatus startStatus = main("start",
+                    "-c", config.toString(),
+                    "-e", server.endpoint(),
+                    "foobar", "foobar",
+                    "--session", "now");
+            assertThat(startStatus.code(), is(not(1)));
+        }
+    }
+}
+


### PR DESCRIPTION
* Add projects.deleted_at and projects.deleted_name columns.

* Deleting a project actually doesn't delete the project from the DB so
  that past sessions and attempts can still be remained.

* Deleted project is accessible by id but not by name or index. This is
  applicable both for internal API and REST API.

* Deleting a project move projects.name to projects.deleted_name so that
  a new project can reuse the same name.

* Starting a new session of a deleted project is rejected.

* Added a new "delete" command.