### PR TITLE
backfill command takes name and local time instead of id and zoned time

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/Main.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Main.java
@@ -248,7 +248,7 @@ public class Main
         err.println("    start <project-name> <name>      start a new session attempt of a workflow");
         err.println("    retry <attempt-id>               retry a session");
         err.println("    kill <attempt-id>                kill a running session attempt");
-        err.println("    backfill                         start sessions of a schedule for past times");
+        err.println("    backfill <project-name> <name>   start sessions of a schedule for past times");
         err.println("    reschedule                       skip sessions of a schedule to a future time");
         err.println("    log <attempt-id>                 show logs of a session attempt");
         err.println("    workflows [project-name] [name]  show registered workflow definitions");

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Backfill.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Backfill.java
@@ -7,6 +7,7 @@ import java.time.Instant;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
+import com.google.common.base.Optional;
 import io.digdag.cli.SystemExitException;
 import io.digdag.cli.TimeUtil;
 import io.digdag.client.DigdagClient;
@@ -28,6 +29,9 @@ public class Backfill
 
     @Parameter(names = {"--name"})
     String retryAttemptName;
+
+    @Parameter(names = {"-c", "--count"})
+    Integer count;
 
     // TODO -n for count
     // TODO -t for to-time
@@ -62,6 +66,7 @@ public class Backfill
         err.println("    -f, --from 'yyyy-MM-dd[ HH:mm:ss]'  timestamp to start backfill from (required)");
         err.println("        --name NAME                  retry attempt name");
         err.println("    -d, --dry-run                    tries to backfill and validates the results but does nothing");
+        err.println("    -c, --count N                    number of sessions to run from the time (default: all sessions until the next schedule time)");
         showCommonOptions();
         return systemExit(error);
     }
@@ -94,6 +99,7 @@ public class Backfill
                 sched.getId(),
                 truncatedTime.getSessionTime().toInstant(),
                 retryAttemptName,
+                Optional.fromNullable(count),
                 dryRun);
 
         ln("Session attempts:");

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Backfill.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Backfill.java
@@ -30,7 +30,7 @@ public class Backfill
     @Parameter(names = {"--name"})
     String retryAttemptName;
 
-    @Parameter(names = {"-c", "--count"})
+    @Parameter(names = {"--count"})
     Integer count;
 
     // TODO -n for count
@@ -52,8 +52,8 @@ public class Backfill
             throw usage(null);
         }
 
-        if (fromTimeString == null || retryAttemptName == null) {
-            throw new ParameterException("-f, --from option and -R, --attempt-name option are required");
+        if (fromTimeString == null) {
+            throw new ParameterException("--from option is required");
         }
 
         backfill(args.get(0), args.get(1));
@@ -66,7 +66,7 @@ public class Backfill
         err.println("    -f, --from 'yyyy-MM-dd[ HH:mm:ss]'  timestamp to start backfill from (required)");
         err.println("        --name NAME                  retry attempt name");
         err.println("    -d, --dry-run                    tries to backfill and validates the results but does nothing");
-        err.println("    -c, --count N                    number of sessions to run from the time (default: all sessions until the next schedule time)");
+        err.println("        --count N                    number of sessions to run from the time (default: all sessions until the next schedule time)");
         showCommonOptions();
         return systemExit(error);
     }

--- a/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
+++ b/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
@@ -502,7 +502,7 @@ public class DigdagClient
                 .resolveTemplate("id", scheduleId));
     }
 
-    public List<RestSessionAttempt> backfillSchedule(int scheduleId, Instant fromTime, String attemptName, boolean dryRun)
+    public List<RestSessionAttempt> backfillSchedule(int scheduleId, Instant fromTime, String attemptName, Optional<Integer> count, boolean dryRun)
     {
         return doPost(new GenericType<List<RestSessionAttempt>>() { },
                 RestScheduleBackfillRequest.builder()

--- a/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
+++ b/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
@@ -509,6 +509,7 @@ public class DigdagClient
                     .fromTime(fromTime)
                     .dryRun(dryRun)
                     .attemptName(attemptName)
+                    .count(count)
                     .build(),
                 target("/api/schedules/{id}/backfill")
                 .resolveTemplate("id", scheduleId));

--- a/digdag-client/src/main/java/io/digdag/client/api/RestScheduleBackfillRequest.java
+++ b/digdag-client/src/main/java/io/digdag/client/api/RestScheduleBackfillRequest.java
@@ -19,6 +19,8 @@ public abstract class RestScheduleBackfillRequest
 
     public abstract String getAttemptName();
 
+    public abstract Optional<Integer> getCount();
+
     public static ImmutableRestScheduleBackfillRequest.Builder builder()
     {
         return ImmutableRestScheduleBackfillRequest.builder();

--- a/digdag-core/src/main/java/io/digdag/core/schedule/ScheduleExecutor.java
+++ b/digdag-core/src/main/java/io/digdag/core/schedule/ScheduleExecutor.java
@@ -258,7 +258,6 @@ public class ScheduleExecutor
                 instants.add(time);
                 time = sr.nextScheduleTime(time).getTime();
             }
-            Collections.reverse(instants);  // submit from recent to old
 
             if (useCount && remaining > 0) {
                 throw new IllegalArgumentException(String.format(ENGLISH,

--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -493,19 +493,19 @@ backfill
 
 .. code-block:: console
 
-    $ digdag backfill <schedule-id>
+    $ digdag backfill <project-name> <workflow-name>
 
 Starts sessions of a schedule for past session times.
 
-:command:`-f, --from 'yyyy-MM-dd HH:mm:ss Z'`
+:command:`-f, --from 'yyyy-MM-dd[ HH:mm:ss]'`
   Timestamp to start backfill from (required). Sessions from this time (including this time) until current time will be started.
 
-  Example: --from '2016-01-01 00:00:00 -0800'
+  Example: --from '2016-01-01'
 
-:command:`--attempt-name NAME`
-  Unique retry attempt name of the new attempts (required). This name is used not to run backfill sessions twice accidentally.
+:command:`--name NAME`
+  Unique name of the new attempts (required). This name is used not to run backfill sessions twice accidentally.
 
-  Example: --attempt-name backfill1
+  Example: --name backfill1
 
 :command:`-d, --dry-run`
   Tries to backfill and validates the results but does nothing.

--- a/digdag-server/src/main/java/io/digdag/server/rs/ScheduleResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/ScheduleResource.java
@@ -132,7 +132,7 @@ public class ScheduleResource
     public List<RestSessionAttempt> backfillSchedule(@PathParam("id") int id, RestScheduleBackfillRequest request)
         throws ResourceNotFoundException, ResourceConflictException
     {
-        List<StoredSessionAttemptWithSession> attempts = exec.backfill(getSiteId(), id, request.getFromTime(), request.getAttemptName(), request.getDryRun());
+        List<StoredSessionAttemptWithSession> attempts = exec.backfill(getSiteId(), id, request.getFromTime(), request.getAttemptName(), request.getCount(), request.getDryRun());
 
         return RestModels.attemptModels(rm, getSiteId(), attempts);
     }

--- a/digdag-standards/src/main/java/io/digdag/standards/scheduler/CronScheduler.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/scheduler/CronScheduler.java
@@ -37,9 +37,9 @@ public class CronScheduler
         // truncate to seconds
         Instant truncated = Instant.ofEpochSecond(currentTime.getEpochSecond());
         if (truncated.equals(currentTime)) {
-            // in this particular case, plus 1 second to include this currentTime
+            // in this particular case, minus 1 second to include this currentTime
             // because Predictor doesn't include this time at "next"MatchingTime() method
-            truncated = truncated.plusSeconds(1);
+            truncated = truncated.minusSeconds(1);
         }
 
         return nextScheduleTime(truncated);

--- a/digdag-tests/src/test/java/acceptance/BackfillIT.java
+++ b/digdag-tests/src/test/java/acceptance/BackfillIT.java
@@ -11,7 +11,7 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import java.nio.file.Path;
-import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 import static acceptance.TestUtils.copyResource;
@@ -88,5 +88,17 @@ public class BackfillIT
                     "--count", "2");
             assertThat(cmd.errUtf8(), cmd.code(), is(0));
         }
+
+        // Verify that 2 sessions are started
+        List<RestSession> sessions = client.getSessions();
+        assertThat(sessions.size(), is(2));
+
+        // sessions API return results in reversed order
+
+        RestSession session1 = sessions.get(1);
+        assertThat(session1.getSessionTime(), is(OffsetDateTime.parse("2016-01-01T00:00:00+09:00")));
+
+        RestSession session2 = sessions.get(0);
+        assertThat(session2.getSessionTime(), is(OffsetDateTime.parse("2016-01-02T00:00:00+09:00")));
     }
 }

--- a/digdag-tests/src/test/java/acceptance/BackfillIT.java
+++ b/digdag-tests/src/test/java/acceptance/BackfillIT.java
@@ -1,0 +1,92 @@
+package acceptance;
+
+import com.google.common.base.Optional;
+import io.digdag.client.DigdagClient;
+import io.digdag.client.api.RestProject;
+import io.digdag.client.api.RestSession;
+import io.digdag.client.api.RestSessionAttempt;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+
+import static acceptance.TestUtils.copyResource;
+import static acceptance.TestUtils.getAttemptId;
+import static acceptance.TestUtils.getSessionId;
+import static acceptance.TestUtils.main;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertThat;
+
+public class BackfillIT
+{
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Rule
+    public TemporaryDigdagServer server = TemporaryDigdagServer.of();
+
+    private Path config;
+    private Path projectDir;
+    private DigdagClient client;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        projectDir = folder.getRoot().toPath().resolve("foobar");
+        config = folder.newFile().toPath();
+
+        client = DigdagClient.builder()
+                .host(server.host())
+                .port(server.port())
+                .build();
+    }
+
+    @Test
+    public void initPushBackfill()
+            throws Exception
+    {
+        // Create new project
+        {
+            CommandStatus cmd = main("init",
+                    "-c", config.toString(),
+                    projectDir.toString());
+            assertThat(cmd.code(), is(0));
+        }
+
+        copyResource("acceptance/backfill/backfill.dig", projectDir.resolve("backfill.dig"));
+
+        // Push
+        {
+            CommandStatus cmd = main("push",
+                    "-c", config.toString(),
+                    "-e", server.endpoint(),
+                    "--project", projectDir.toString(),
+                    "backfill-test");
+            assertThat(cmd.errUtf8(), cmd.code(), is(0));
+        }
+
+        copyResource("acceptance/backfill/backfill.dig", projectDir.resolve("backfill.dig"));
+
+        // Backfill the workflow
+        {
+            CommandStatus cmd = main("backfill",
+                    "-c", config.toString(),
+                    "-e", server.endpoint(),
+                    "backfill-test", "backfill",
+                    "--from", "2016-01-01",
+                    "--count", "2");
+            assertThat(cmd.errUtf8(), cmd.code(), is(0));
+        }
+    }
+}

--- a/digdag-tests/src/test/resources/acceptance/backfill/backfill.dig
+++ b/digdag-tests/src/test/resources/acceptance/backfill/backfill.dig
@@ -1,0 +1,8 @@
+timezone: UTC
+
+schedule:
+  daily>: 09:00:00
+
++say_ok:
+  echo>: ok
+

--- a/digdag-tests/src/test/resources/acceptance/backfill/backfill.dig
+++ b/digdag-tests/src/test/resources/acceptance/backfill/backfill.dig
@@ -1,4 +1,4 @@
-timezone: UTC
+timezone: +09:00
 
 schedule:
   daily>: 09:00:00


### PR DESCRIPTION
`start` command takes workflow name and local time. It calls REST API to convert names (project name + workflow name) to ID, and local time ("yyyy-MM-dd" or "yyyy-MM-dd HH:mm:SS") to instant ("yyyy-MM-dd HH:mm:SS Z").
This PR changes `backfill` command to do the same thing.