### PR TITLE
Fix an example of python task

### DIFF
--- a/digdag-cli/src/main/resources/digdag/cli/tasks/__init__.py
+++ b/digdag-cli/src/main/resources/digdag/cli/tasks/__init__.py
@@ -4,5 +4,5 @@ class MyWorkflow(object):
         pass
 
     def step3(self, session_time = None):
-        print "Step3 of session %s" % session_time
+        print("Step3 of session {0}".format(session_time))
 


### PR DESCRIPTION
When I tried digdag at first, I failed my init project due to python's version.

```
$ digdag init mydigdag
$ cd mydigdag
$ digdag run mydigdag.dig
```

The original python print method doesn't work on python3.
print(format) method works on python2 and python 3.

Python 2.7.11 (default, Jan 13 2016, 19:51:48)

```
>>> print("Step3 of session {0}".format('1'))
Step3 of session 1
>>> print "Step3 of session %s" % '1'
Step3 of session 1
```

Python 3.5.1 (default, Jan 13 2016, 19:58:59)
```
>>> print("Step3 of session {0}".format('1'))
Step3 of session 1
>>> print "Step3 of session %s" % '1'
  File "<stdin>", line 1
    print "Step3 of session %s" % '1'
                              ^
SyntaxError: Missing parentheses in call to 'print'
```

Also, I think it would be better to show recommended python version.
