### PR TITLE
Add shebang for Mac OS X to recognize this as valid executable

### DIFF
--- a/digdag-cli/src/main/sh/selfrun.sh
+++ b/digdag-cli/src/main/sh/selfrun.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 
 : <<BAT
 @echo off


### PR DESCRIPTION
OS X 10.9 cannot recognize digdag.jar as a valid executable without a shebang.
So that, add sh shebang.
