### PR TITLE
make td> and td_load> operators poll instead of block

### DIFF
--- a/digdag-plugin-utils/src/main/java/io/digdag/util/BaseOperator.java
+++ b/digdag-plugin-utils/src/main/java/io/digdag/util/BaseOperator.java
@@ -53,6 +53,16 @@ public abstract class BaseOperator
             }
         }
         catch (RuntimeException ex) {
+            // Propagate polling TaskExecutionException instances
+            if (ex instanceof TaskExecutionException) {
+                TaskExecutionException tex = (TaskExecutionException) ex;
+                boolean isPolling = !tex.isError();
+                if (isPolling) {
+                    // TODO: reset retry state params
+                    throw tex;
+                }
+            }
+
             boolean doRetry = retry.evaluate();
             if (doRetry) {
                 throw new TaskExecutionException(ex,

--- a/digdag-spi/src/main/java/io/digdag/spi/TaskExecutionException.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/TaskExecutionException.java
@@ -78,6 +78,10 @@ public class TaskExecutionException
         return error.transform(it -> it.toConfig(cf));
     }
 
+    public boolean isError() {
+        return error.isPresent();
+    }
+
     public Optional<Integer> getRetryInterval()
     {
         return retryInterval;

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TDClientFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TDClientFactory.java
@@ -1,6 +1,9 @@
 package io.digdag.standards.operator.td;
 
+import com.google.common.base.Optional;
+import com.treasuredata.client.ProxyConfig;
 import com.treasuredata.client.TDClient;
+import com.treasuredata.client.TDClientBuilder;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigException;
 
@@ -14,7 +17,15 @@ class TDClientFactory
             throw new ConfigException("Parameter 'apikey' is empty");
         }
 
-        TDClient client = TDClient.newBuilder(false)
+        TDClientBuilder builder = TDClient.newBuilder(false);
+
+        Config proxyConfig = params.getNestedOrGetEmpty("proxy");
+        boolean proxyEnabled = proxyConfig.get("enabled", Boolean.class, false);
+        if (proxyEnabled) {
+            builder.setProxy(proxyConfig(proxyConfig));
+        }
+
+        TDClient client = builder
                 .setEndpoint(params.get("endpoint", String.class, "api.treasuredata.com"))
                 .setUseSSL(params.get("use_ssl", boolean.class, true))
                 .setApiKey(apikey)
@@ -22,5 +33,32 @@ class TDClientFactory
                 .build();
 
         return client;
+    }
+
+    private static ProxyConfig proxyConfig(Config config)
+    {
+        ProxyConfig.ProxyConfigBuilder builder = new ProxyConfig.ProxyConfigBuilder();
+
+        Optional<String> host = config.getOptional("host", String.class);
+        if (host.isPresent()) {
+            builder.setHost(host.get());
+        }
+
+        Optional<Integer> port = config.getOptional("port", Integer.class);
+        if (port.isPresent()) {
+            builder.setPort(port.get());
+        }
+
+        Optional<String> user = config.getOptional("user", String.class);
+        if (user.isPresent()) {
+            builder.setUser(user.get());
+        }
+
+        Optional<String> password = config.getOptional("password", String.class);
+        if (password.isPresent()) {
+            builder.setPassword(password.get());
+        }
+
+        return builder.createProxyConfig();
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TDOperator.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TDOperator.java
@@ -176,6 +176,20 @@ public class TDOperator
         return newJobOperator(jobId);
     }
 
+    public TDJobOperator submitNewJobWithRetry(TDJobRequest req)
+    {
+        if (!req.getDomainKey().isPresent()) {
+            throw new IllegalArgumentException("domain key must be set");
+        }
+
+        try {
+            return defaultRetryExecutor.run(() -> submitNewJob(req));
+        }
+        catch (RetryGiveupException ex) {
+            throw Throwables.propagate(ex.getCause());
+        }
+    }
+
     public TDJobOperator submitExportJob(TDExportJobRequest request)
     {
         // TODO retry with an unique id and ignore conflict

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdForEachOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdForEachOperatorFactory.java
@@ -23,7 +23,6 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
-import static io.digdag.standards.operator.td.TdOperatorFactory.joinJob;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class TdForEachOperatorFactory
@@ -116,7 +115,7 @@ public class TdForEachOperatorFactory
                 TDJobOperator j = op.submitNewJob(req);
                 logger.info("Started {} job id={}:\n{}", engine, j.getJobId(), query);
 
-                joinJob(j);
+                j.joinJob();
 
                 return fetchRows(j);
             }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdLoadOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdLoadOperatorFactory.java
@@ -23,7 +23,6 @@ import io.digdag.client.config.ConfigException;
 import com.treasuredata.client.model.TDJobRequest;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static io.digdag.standards.operator.td.TdOperatorFactory.joinJob;
 
 public class TdLoadOperatorFactory
         implements OperatorFactory
@@ -123,7 +122,7 @@ public class TdLoadOperatorFactory
 
         private TaskResult join(TDJobOperator j)
         {
-            joinJob(j);
+            j.joinJob();
 
             Config storeParams = request.getConfig().getFactory().create()
                 .set("td", request.getConfig().getFactory().create()

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdLoadOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdLoadOperatorFactory.java
@@ -1,32 +1,46 @@
 package io.digdag.standards.operator.td;
 
-import java.nio.file.Path;
-import java.io.IOException;
-
-import com.google.common.base.Optional;
-import com.google.inject.Inject;
-import com.google.common.base.Throwables;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.base.Optional;
+import com.google.common.base.Throwables;
+import com.google.inject.Inject;
 import com.treasuredata.client.TDClient;
 import com.treasuredata.client.model.TDBulkLoadSessionStartResult;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import io.digdag.spi.TaskRequest;
-import io.digdag.spi.TaskResult;
+import com.treasuredata.client.model.TDJob;
+import com.treasuredata.client.model.TDJobRequest;
+import com.treasuredata.client.model.TDJobSummary;
+import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigElement;
+import io.digdag.client.config.ConfigException;
 import io.digdag.spi.Operator;
 import io.digdag.spi.OperatorFactory;
+import io.digdag.spi.TaskExecutionException;
+import io.digdag.spi.TaskRequest;
+import io.digdag.spi.TaskResult;
 import io.digdag.spi.TemplateEngine;
 import io.digdag.spi.TemplateException;
 import io.digdag.util.BaseOperator;
-import io.digdag.client.config.Config;
-import io.digdag.client.config.ConfigException;
-import com.treasuredata.client.model.TDJobRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import static io.digdag.spi.TaskExecutionException.buildExceptionErrorConfig;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class TdLoadOperatorFactory
         implements OperatorFactory
 {
+    private static final String JOB_ID = "jobId";
+    private static final String DOMAIN_KEY = "domainKey";
+    private static final String POLL_ITERATION = "pollIteration";
+
+    private static final Integer INITIAL_POLL_INTERVAL = 1;
+    private static final int MAX_POLL_INTERVAL = 30000;
+
     private static Logger logger = LoggerFactory.getLogger(TdLoadOperatorFactory.class);
 
     private final TemplateEngine templateEngine;
@@ -51,46 +65,152 @@ public class TdLoadOperatorFactory
     private class TdLoadOperator
             extends BaseOperator
     {
+        private final Config params;
+        private final Optional<Config> config;
+        private final Optional<String> name;
+        private final Optional<String> command;
+
+        private final Config state;
+        private final Optional<String> existingJobId;
+        private final Optional<String> existingDomainKey;
+
+        private final Optional<String> sessionName;
+        private final Optional<ObjectNode> embulkConfig;
+
         public TdLoadOperator(Path workspacePath, TaskRequest request)
         {
             super(workspacePath, request);
-        }
 
-        @Override
-        public TaskResult runTask()
-        {
-            Config params = request.getConfig().mergeDefault(
+            params = request.getConfig().mergeDefault(
                     request.getConfig().getNestedOrGetEmpty("td"));
 
-            Optional<Config> config = params.getOptionalNested("config");
-            Optional<String> name = params.getOptional("name", String.class);
-            Optional<String> command = params.getOptional("_command", String.class);
+            config = params.getOptionalNested("config");
+            name = params.getOptional("name", String.class);
+            command = params.getOptional("_command", String.class);
 
             if (config.isPresent() && name.isPresent()) {
                 throw new ConfigException("The parameters config and name cannot both be set");
             }
 
-            ObjectNode embulkConfig;
+            this.state = request.getLastStateParams().deepCopy();
+
+            this.existingJobId = state.getOptional(JOB_ID, String.class);
+            this.existingDomainKey = state.getOptional(DOMAIN_KEY, String.class);
+
+            if (Stream.of(command, name, config).filter(Optional::isPresent).count() > 1) {
+                throw new ConfigException("Only the command or one of the config and name params may be set");
+            }
+
             if (command.isPresent()) {
                 if (command.get().endsWith(".yml") || command.get().endsWith(".yaml")) {
-                    embulkConfig = compileEmbulkConfig(params, command.get());
-                    return executeBulkLoad(params, embulkConfig);
-                } else {
-                    return executeBulkLoadSession(params, command.get(), request);
+                    this.embulkConfig = Optional.of(compileEmbulkConfig(params, command.get()));
+                    this.sessionName = Optional.absent();
+                }
+                else {
+                    this.embulkConfig = Optional.absent();
+                    this.sessionName = Optional.of(command.get());
                 }
             }
             else if (name.isPresent()) {
-                return executeBulkLoadSession(params, name.get(), request);
+                this.embulkConfig = Optional.absent();
+                this.sessionName = name;
             }
             else if (config.isPresent()) {
-                embulkConfig = config.get().getInternalObjectNode();
-                return executeBulkLoad(params, embulkConfig);
-            } else {
-                throw new ConfigException("The parameters config and name cannot both be set");
+                this.embulkConfig = Optional.of(config.get().getInternalObjectNode());
+                this.sessionName = Optional.absent();
+            }
+            else {
+                throw new AssertionError();
             }
         }
 
-        private TaskResult executeBulkLoadSession(Config params, String name, TaskRequest request)
+        @Override
+        public TaskResult runTask()
+        {
+            // TODO: TDOperator requires database to be configured but the database param is not necessary when using a connector session
+
+            // TODO: A lot of code is duplicated from TDOperatorFactory. Refactor shared logic into reusable components.
+
+            try (TDOperator op = TDOperator.fromConfig(params)) {
+
+                // Generate and store domain key before starting the job
+                if (!existingDomainKey.isPresent()) {
+                    String domainKey = UUID.randomUUID().toString();
+                    state.set(DOMAIN_KEY, domainKey);
+                    throw TaskExecutionException.ofNextPolling(0, ConfigElement.copyOf(state));
+                }
+
+                // Start the job
+                if (!existingJobId.isPresent()) {
+                    String jobId = startJob(op);
+                    state.set(JOB_ID, jobId);
+                    state.set(POLL_ITERATION, 1);
+                    throw TaskExecutionException.ofNextPolling(INITIAL_POLL_INTERVAL, ConfigElement.copyOf(state));
+                }
+
+                // Check if the job is done
+                String jobId = existingJobId.get();
+                TDJobOperator job = op.newJobOperator(jobId);
+                TDJobSummary status = checkJobStatus(job);
+                boolean done = status.getStatus().isFinished();
+                if (!done) {
+                    int pollIteration = state.get(POLL_ITERATION, int.class, 1);
+                    state.set(POLL_ITERATION, pollIteration + 1);
+                    int pollInterval = (int) Math.min(INITIAL_POLL_INTERVAL * Math.pow(2, pollIteration), MAX_POLL_INTERVAL);
+                    throw TaskExecutionException.ofNextPolling(pollInterval, ConfigElement.copyOf(state));
+                }
+
+                // Get the job results
+                return processJobResult(op, job, status);
+            }
+        }
+
+        private TaskResult processJobResult(TDOperator op, TDJobOperator j, TDJobSummary summary)
+        {
+            Config storeParams = request.getConfig().getFactory().create()
+                    .set("td", request.getConfig().getFactory().create()
+                            .set("last_job_id", j.getJobId()));
+
+            return TaskResult.defaultBuilder(request)
+                    .storeParams(storeParams)
+                    .build();
+        }
+
+        private TDJobSummary checkJobStatus(TDJobOperator j)
+        {
+            try {
+                return j.ensureRunningOrSucceeded();
+            }
+            catch (TDJobException ex) {
+                try {
+                    TDJob job = j.getJobInfo();
+                    String message = job.getCmdOut() + "\n" + job.getStdErr();
+                    throw new TaskExecutionException(message, buildExceptionErrorConfig(ex));
+                }
+                catch (Exception getJobInfoFailed) {
+                    getJobInfoFailed.addSuppressed(ex);
+                    throw Throwables.propagate(getJobInfoFailed);
+                }
+            }
+            catch (InterruptedException ex) {
+                throw Throwables.propagate(ex);
+            }
+        }
+
+        private String startJob(TDOperator op)
+        {
+            assert Stream.of(embulkConfig, sessionName).filter(Optional::isPresent).count() == 1;
+
+            if (embulkConfig.isPresent()) {
+                return startBulkLoad(params, embulkConfig.get());
+            } else if (sessionName.isPresent()) {
+                return startBulkLoadSession(params, sessionName.get(), request);
+            } else {
+                throw new AssertionError();
+            }
+        }
+
+        private String startBulkLoadSession(Config params, String name, TaskRequest request)
         {
             try (TDClient client = TDClientFactory.clientFromConfig(params)) {
 
@@ -99,13 +219,11 @@ public class TdLoadOperatorFactory
 
                 logger.info("Started bulk load session job name={}, id={}", name, r.getJobId());
 
-                TDJobOperator jobOperator = new TDJobOperator(client, r.getJobId());
-
-                return join(jobOperator);
+                return r.getJobId();
             }
         }
 
-        private TaskResult executeBulkLoad(Config params, ObjectNode embulkConfig)
+        private String startBulkLoad(Config params, ObjectNode embulkConfig)
         {
             TableParam table = params.get("table", TableParam.class);
 
@@ -116,21 +234,8 @@ public class TdLoadOperatorFactory
                 TDJobOperator j = op.submitNewJob(req);
                 logger.info("Started bulk load job id={}", j.getJobId());
 
-                return join(j);
+                return j.getJobId();
             }
-        }
-
-        private TaskResult join(TDJobOperator j)
-        {
-            j.joinJob();
-
-            Config storeParams = request.getConfig().getFactory().create()
-                .set("td", request.getConfig().getFactory().create()
-                        .set("last_job_id", j.getJobId()));
-
-            return TaskResult.defaultBuilder(request)
-                .storeParams(storeParams)
-                .build();
         }
 
         private ObjectNode compileEmbulkConfig(Config params, String command)

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdOperatorFactory.java
@@ -147,7 +147,7 @@ public class TdOperatorFactory
                 if (!existingDomainKey.isPresent()) {
                     String domainKey = UUID.randomUUID().toString();
                     state.set(DOMAIN_KEY, domainKey);
-                    throw TaskExecutionException.ofNextPolling(0, ConfigElement.copyOf(state.deepCopy()));
+                    throw TaskExecutionException.ofNextPolling(0, ConfigElement.copyOf(state));
                 }
 
                 // Start the job
@@ -155,7 +155,7 @@ public class TdOperatorFactory
                     String jobId = startJob(op);
                     state.set(JOB_ID, jobId);
                     state.set(POLL_INTERVAL, INITIAL_POLL_INTERVAL);
-                    throw TaskExecutionException.ofNextPolling(INITIAL_POLL_INTERVAL, ConfigElement.copyOf(state.deepCopy()));
+                    throw TaskExecutionException.ofNextPolling(INITIAL_POLL_INTERVAL, ConfigElement.copyOf(state));
                 }
 
                 // Check if the job is done
@@ -167,7 +167,7 @@ public class TdOperatorFactory
                     int prevPollInterval = state.get(POLL_INTERVAL, int.class, INITIAL_POLL_INTERVAL);
                     int nextPollInterval = Math.min(MAX_POLL_INTERVAL, prevPollInterval * 2);
                     state.set(POLL_INTERVAL, nextPollInterval);
-                    throw TaskExecutionException.ofNextPolling(INITIAL_POLL_INTERVAL, ConfigElement.copyOf(state.deepCopy()));
+                    throw TaskExecutionException.ofNextPolling(INITIAL_POLL_INTERVAL, ConfigElement.copyOf(state));
                 }
 
                 // Get the job results

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdOperatorFactory.java
@@ -252,7 +252,7 @@ public class TdOperatorFactory
                     .setDomainKey(existingDomainKey.get())
                     .createTDJobRequest();
 
-            TDJobOperator j = op.submitNewJob(req);
+            TDJobOperator j = op.submitNewJobWithRetry(req);
             logger.info("Started {} job id={}:\n{}", engine, j.getJobId(), stmt);
 
             return j.getJobId();

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdRunOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdRunOperatorFactory.java
@@ -1,12 +1,9 @@
 package io.digdag.standards.operator.td;
 
 import java.util.Date;
-import java.util.List;
 import java.time.Instant;
 import java.nio.file.Path;
-import java.io.File;
-import java.io.BufferedWriter;
-import java.io.IOException;
+
 import com.google.inject.Inject;
 import com.google.common.base.Optional;
 import io.digdag.spi.TaskRequest;
@@ -17,15 +14,8 @@ import io.digdag.util.BaseOperator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import io.digdag.client.config.Config;
-import io.digdag.client.config.ConfigException;
-import com.treasuredata.client.model.TDJob;
 import com.treasuredata.client.model.TDJobSummary;
-import com.treasuredata.client.model.TDJobRequest;
-import com.treasuredata.client.model.TDJobRequestBuilder;
-import org.msgpack.value.Value;
-import org.msgpack.value.ArrayValue;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static io.digdag.standards.operator.td.TdOperatorFactory.joinJob;
+
 import static io.digdag.standards.operator.td.TdOperatorFactory.downloadJobResult;
 import static io.digdag.standards.operator.td.TdOperatorFactory.buildStoreParams;
 
@@ -73,7 +63,7 @@ public class TdRunOperatorFactory
                 TDJobOperator j = op.startSavedQuery(name, Date.from(sessionTime));
                 logger.info("Started a saved query name={} with time={}", name, sessionTime);
 
-                TDJobSummary summary = joinJob(j);
+                TDJobSummary summary = j.joinJob();
                 downloadJobResult(j, workspace, downloadFile);
 
                 if (preview) {

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdTableExportOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdTableExportOperatorFactory.java
@@ -4,10 +4,8 @@ import java.util.Date;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.time.format.DateTimeParseException;
 import java.time.format.DateTimeFormatter;
 import com.google.inject.Inject;
-import com.google.common.base.Throwables;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import io.digdag.spi.TaskRequest;
@@ -19,9 +17,8 @@ import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigException;
 import com.treasuredata.client.model.TDExportJobRequest;
 import com.treasuredata.client.model.TDExportFileFormatType;
-import org.msgpack.value.Value;
+
 import static java.util.Locale.ENGLISH;
-import static io.digdag.standards.operator.td.TdOperatorFactory.joinJob;
 
 public class TdTableExportOperatorFactory
         implements OperatorFactory
@@ -85,7 +82,7 @@ public class TdTableExportOperatorFactory
                 TDJobOperator j = op.submitExportJob(req);
                 logger.info("Started table export job id={}", j.getJobId());
 
-                joinJob(j);
+                j.joinJob();
 
                 Config storeParams = request.getConfig().getFactory().create()
                     .set("td", request.getConfig().getFactory().create()

--- a/digdag-tests/build.gradle
+++ b/digdag-tests/build.gradle
@@ -6,6 +6,7 @@ dependencies {
     testCompile 'com.squareup.okhttp3:okhttp:3.3.0'
     testCompile 'com.squareup.okhttp3:mockwebserver:3.3.1'
     testCompile 'pl.pragmatists:JUnitParams:1.0.5'
+    testCompile 'org.littleshoot:littleproxy:1.1.0'
 }
 
 test {

--- a/digdag-tests/src/test/java/acceptance/TdIT.java
+++ b/digdag-tests/src/test/java/acceptance/TdIT.java
@@ -54,8 +54,6 @@ public class TdIT
 
     private static final String TD_API_KEY = System.getenv("TD_API_KEY");
 
-    private static final String DOMAIN_KEY = "domain_key";
-
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 
@@ -292,7 +290,7 @@ public class TdIT
         FullHttpRequest copy = request.copy();
         ReferenceCountUtil.releaseLater(copy);
         HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(copy);
-        List<InterfaceHttpData> keyDatas = decoder.getBodyHttpDatas(DOMAIN_KEY);
+        List<InterfaceHttpData> keyDatas = decoder.getBodyHttpDatas("domain_key");
         assertThat(keyDatas, is(not(nullValue())));
         assertThat(keyDatas.size(), is(1));
         InterfaceHttpData domainKeyData = keyDatas.get(0);

--- a/digdag-tests/src/test/java/acceptance/TdIT.java
+++ b/digdag-tests/src/test/java/acceptance/TdIT.java
@@ -1,33 +1,60 @@
 package acceptance;
 
 import com.treasuredata.client.TDClient;
-import com.treasuredata.client.model.TDSaveQueryRequest;
-import com.treasuredata.client.model.TDSavedQuery;
-import org.hamcrest.Matchers;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.multipart.Attribute;
+import io.netty.handler.codec.http.multipart.HttpPostRequestDecoder;
+import io.netty.handler.codec.http.multipart.InterfaceHttpData;
+import io.netty.handler.codec.http.multipart.InterfaceHttpData.HttpDataType;
+import io.netty.util.ReferenceCountUtil;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.littleshoot.proxy.HttpFilters;
+import org.littleshoot.proxy.HttpFiltersAdapter;
+import org.littleshoot.proxy.HttpFiltersSourceAdapter;
+import org.littleshoot.proxy.HttpProxyServer;
+import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
 import static acceptance.TestUtils.copyResource;
 import static acceptance.TestUtils.main;
+import static io.netty.handler.codec.http.HttpHeaders.Names.CONNECTION;
+import static io.netty.handler.codec.http.HttpHeaders.Values.CLOSE;
+import static io.netty.handler.codec.http.HttpResponseStatus.INTERNAL_SERVER_ERROR;
+import static java.nio.file.StandardOpenOption.APPEND;
+import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assume.assumeThat;
 
 public class TdIT
 {
+    private static final Logger logger = LoggerFactory.getLogger(TdIT.class);
+
     private static final String TD_API_KEY = System.getenv("TD_API_KEY");
+
+    private static final String DOMAIN_KEY = "domain_key";
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
@@ -40,6 +67,8 @@ public class TdIT
 
     private Path outfile;
 
+    private HttpProxyServer proxyServer;
+
     @Before
     public void setUp()
             throws Exception
@@ -47,7 +76,7 @@ public class TdIT
         assumeThat(TD_API_KEY, not(isEmptyOrNullString()));
         projectDir = folder.getRoot().toPath().toAbsolutePath().normalize();
         config = folder.newFile().toPath();
-        Files.write(config, ("params.td.apikey = " + TD_API_KEY).getBytes("UTF-8"));
+        Files.write(config, asList("params.td.apikey = " + TD_API_KEY));
         outfile = projectDir.resolve("outfile");
 
         client = TDClient.newBuilder(false)
@@ -66,6 +95,16 @@ public class TdIT
         }
     }
 
+    @After
+    public void stopProxy()
+            throws Exception
+    {
+        if (proxyServer != null) {
+            proxyServer.stop();
+            proxyServer = null;
+        }
+    }
+
     @Test
     public void testRunQuery()
             throws Exception
@@ -81,6 +120,184 @@ public class TdIT
     {
         copyResource("acceptance/td/td/td_inline.dig", projectDir.resolve("workflow.dig"));
         runWorkflow();
+    }
+
+    @Test
+    public void testRetries()
+            throws Exception
+    {
+        int failures = 3;
+
+        List<FullHttpRequest> jobIssueRequests = Collections.synchronizedList(new ArrayList<>());
+
+        proxyServer = DefaultHttpProxyServer
+                .bootstrap()
+                .withPort(0)
+                .withFiltersSource(new HttpFiltersSourceAdapter()
+                {
+                    @Override
+                    public int getMaximumRequestBufferSizeInBytes()
+                    {
+                        return 1024 * 1024;
+                    }
+
+                    @Override
+                    public HttpFilters filterRequest(HttpRequest httpRequest, ChannelHandlerContext channelHandlerContext)
+                    {
+                        return new HttpFiltersAdapter(httpRequest)
+                        {
+                            @Override
+                            public HttpResponse clientToProxyRequest(HttpObject httpObject)
+                            {
+                                assert httpObject instanceof FullHttpRequest;
+                                FullHttpRequest fullHttpRequest = (FullHttpRequest) httpObject;
+                                if (httpRequest.getUri().contains("/v3/job/issue")) {
+                                    jobIssueRequests.add(fullHttpRequest.copy());
+                                    if (jobIssueRequests.size() < failures) {
+                                        logger.info("Simulating 500 INTERNAL SERVER ERROR for request: {}", httpRequest);
+                                        DefaultFullHttpResponse response = new DefaultFullHttpResponse(httpRequest.getProtocolVersion(), INTERNAL_SERVER_ERROR);
+                                        response.headers().set(CONNECTION, CLOSE);
+                                        return response;
+                                    }
+                                }
+                                logger.info("Passing request: {}", httpRequest);
+                                return null;
+                            }
+                        };
+                    }
+                }).start();
+
+        Files.write(config, asList(
+                "params.td.use_ssl = false",
+                "params.td.proxy.enabled = true",
+                "params.td.proxy.host = " + proxyServer.getListenAddress().getHostString(),
+                "params.td.proxy.port = " + proxyServer.getListenAddress().getPort()
+        ), APPEND);
+
+        copyResource("acceptance/td/td/td_inline.dig", projectDir.resolve("workflow.dig"));
+        runWorkflow();
+
+        for (FullHttpRequest request : jobIssueRequests) {
+            ReferenceCountUtil.releaseLater(request);
+        }
+
+        assertThat(jobIssueRequests.size(), is(not(0)));
+
+        // Verify that all job issue requests reuse the same domain key
+        verifyDomainKeys(jobIssueRequests);
+    }
+
+    @Test
+    public void testDomainKeyConflict()
+            throws Exception
+    {
+        List<FullHttpRequest> jobIssueRequests = Collections.synchronizedList(new ArrayList<>());
+        List<FullHttpResponse> jobIssueResponses = Collections.synchronizedList(new ArrayList<>());
+
+        proxyServer = DefaultHttpProxyServer
+                .bootstrap()
+                .withPort(0)
+                .withFiltersSource(new HttpFiltersSourceAdapter()
+                {
+                    @Override
+                    public int getMaximumRequestBufferSizeInBytes()
+                    {
+                        return 1024 * 1024;
+                    }
+
+                    @Override
+                    public int getMaximumResponseBufferSizeInBytes()
+                    {
+                        return 1024 * 1024;
+                    }
+
+                    @Override
+                    public HttpFilters filterRequest(HttpRequest httpRequest, ChannelHandlerContext channelHandlerContext)
+                    {
+                        return new HttpFiltersAdapter(httpRequest)
+                        {
+                            @Override
+                            public HttpResponse clientToProxyRequest(HttpObject httpObject)
+                            {
+                                assert httpObject instanceof FullHttpRequest;
+                                FullHttpRequest fullHttpRequest = (FullHttpRequest) httpObject;
+                                if (httpRequest.getUri().contains("/v3/job/issue")) {
+                                    jobIssueRequests.add(fullHttpRequest.copy());
+                                }
+                                return null;
+                            }
+
+                            @Override
+                            public HttpObject serverToProxyResponse(HttpObject httpObject)
+                            {
+                                assert httpObject instanceof FullHttpResponse;
+                                FullHttpResponse fullHttpResponse = (FullHttpResponse) httpObject;
+
+                                // Let the first issue request through so that the job is started and the domain key is recorded by the td api but
+                                // simulate a failure for the first request. The td operator will then retry starting the job with the same domain key
+                                // which will result in a conflict response. The td operator should then interpret that as the job having successfully been issued.
+                                if (httpRequest.getUri().contains("/v3/job/issue")) {
+                                    jobIssueResponses.add(fullHttpResponse);
+                                    if (jobIssueResponses.size() == 1) {
+                                        logger.info("Simulating 500 INTERNAL SERVER ERROR for request: {}", httpRequest);
+                                        DefaultFullHttpResponse response = new DefaultFullHttpResponse(httpRequest.getProtocolVersion(), INTERNAL_SERVER_ERROR);
+                                        response.headers().set(CONNECTION, CLOSE);
+                                        return response;
+                                    }
+                                }
+                                logger.info("Passing request: {}", httpRequest);
+                                return httpObject;
+                            }
+                        };
+                    }
+                }).start();
+
+        Files.write(config, asList(
+                "params.td.use_ssl = false",
+                "params.td.proxy.enabled = true",
+                "params.td.proxy.host = " + proxyServer.getListenAddress().getHostString(),
+                "params.td.proxy.port = " + proxyServer.getListenAddress().getPort()
+        ), APPEND);
+
+        copyResource("acceptance/td/td/td_inline.dig", projectDir.resolve("workflow.dig"));
+        runWorkflow();
+
+        for (FullHttpRequest request : jobIssueRequests) {
+            ReferenceCountUtil.releaseLater(request);
+        }
+
+        assertThat(jobIssueRequests.size(), is(not(0)));
+        assertThat(jobIssueResponses.size(), is(not(0)));
+
+        verifyDomainKeys(jobIssueRequests);
+    }
+
+    private void verifyDomainKeys(List<FullHttpRequest> jobIssueRequests)
+            throws IOException
+    {
+        // Verify that all job issue requests reuse the same domain key
+        FullHttpRequest firstRequest = jobIssueRequests.get(0);
+        String domainKey = domainKey(firstRequest);
+
+        for (int i = 0; i < jobIssueRequests.size(); i++) {
+            FullHttpRequest request = jobIssueRequests.get(i);
+            String requestDomainKey = domainKey(request);
+            assertThat(requestDomainKey, is(domainKey));
+        }
+    }
+
+    private String domainKey(FullHttpRequest request)
+            throws IOException
+    {
+        FullHttpRequest copy = request.copy();
+        ReferenceCountUtil.releaseLater(copy);
+        HttpPostRequestDecoder decoder = new HttpPostRequestDecoder(copy);
+        List<InterfaceHttpData> keyDatas = decoder.getBodyHttpDatas(DOMAIN_KEY);
+        assertThat(keyDatas, is(not(nullValue())));
+        assertThat(keyDatas.size(), is(1));
+        InterfaceHttpData domainKeyData = keyDatas.get(0);
+        assertThat(domainKeyData.getHttpDataType(), is(HttpDataType.Attribute));
+        return ((Attribute) domainKeyData).getValue();
     }
 
     private void runWorkflow()

--- a/digdag-tests/src/test/java/acceptance/TdLoadIT.java
+++ b/digdag-tests/src/test/java/acceptance/TdLoadIT.java
@@ -1,0 +1,107 @@
+package acceptance;
+
+import com.treasuredata.client.TDClient;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.UUID;
+
+import static acceptance.TestUtils.copyResource;
+import static acceptance.TestUtils.main;
+import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeThat;
+
+public class TdLoadIT
+{
+    private static final String TD_API_KEY = System.getenv("TD_API_KEY");
+    private static final String TD_LOAD_IT_SFTP_USER = System.getenv("TD_LOAD_IT_SFTP_USER");
+    private static final String TD_LOAD_IT_SFTP_PASSWORD = System.getenv("TD_LOAD_IT_SFTP_PASSWORD");
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private Path config;
+    private Path projectDir;
+
+    private TDClient client;
+    private String database;
+
+    private Path outfile;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        assumeThat(TD_API_KEY, not(isEmptyOrNullString()));
+        assumeThat(TD_LOAD_IT_SFTP_USER, not(isEmptyOrNullString()));
+        assumeThat(TD_LOAD_IT_SFTP_PASSWORD, not(isEmptyOrNullString()));
+
+        client = TDClient.newBuilder(false)
+                .setApiKey(TD_API_KEY)
+                .build();
+        database = "tmp_" + UUID.randomUUID().toString().replace('-', '_');
+        client.createDatabase(database);
+
+        client.createTable(database, "td_load_test");
+
+        projectDir = folder.getRoot().toPath().toAbsolutePath().normalize();
+        config = folder.newFile().toPath();
+        Files.write(config, asList(
+                "params.td.apikey = " + TD_API_KEY,
+                "params.td.database = " + database,
+                "params.td_load_sftp_user = " + TD_LOAD_IT_SFTP_USER,
+                "params.td_load_sftp_password = " + TD_LOAD_IT_SFTP_PASSWORD
+        ));
+        outfile = projectDir.resolve("outfile");
+    }
+
+    @After
+    public void deleteDatabase()
+            throws Exception
+    {
+        if (client != null && database != null) {
+            client.deleteDatabase(database);
+        }
+    }
+
+    @Test
+    public void testTdLoad()
+            throws Exception
+    {
+        copyResource("acceptance/td/td_load/td_load.dig", projectDir.resolve("workflow.dig"));
+        copyResource("acceptance/td/td_load/td_load_config.yml", projectDir.resolve("td_load_config.yml"));
+        runWorkflow();
+    }
+
+    @Test
+    public void testTdLoadSession()
+            throws Exception
+    {
+        copyResource("acceptance/td/td_load/td_load_session.dig", projectDir.resolve("workflow.dig"));
+        runWorkflow();
+    }
+
+    private void runWorkflow()
+    {
+        CommandStatus runStatus = main("run",
+                "-o", projectDir.toString(),
+                "--config", config.toString(),
+                "--project", projectDir.toString(),
+                "-p", "outfile=" + outfile,
+                "workflow.dig");
+        assertThat(runStatus.errUtf8(), runStatus.code(), is(0));
+
+        // TODO: verify the contents of the target table
+
+        assertThat(Files.exists(outfile), is(true));
+    }
+}

--- a/digdag-tests/src/test/java/io/digdag/util/BaseOperatorTest.java
+++ b/digdag-tests/src/test/java/io/digdag/util/BaseOperatorTest.java
@@ -1,0 +1,100 @@
+package io.digdag.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigElement;
+import io.digdag.client.config.ConfigFactory;
+import io.digdag.spi.TaskExecutionException;
+import io.digdag.spi.TaskRequest;
+import io.digdag.spi.TaskResult;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BaseOperatorTest
+{
+    private static final int INTERVAL = 4711;
+
+    @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Mock TaskRequest request;
+
+    private final ConfigFactory configFactory = new ConfigFactory(new ObjectMapper());
+    private Config config;
+    private Config state;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        config = configFactory.create();
+        state = configFactory.create();
+
+        when(request.getConfig()).thenReturn(config);
+        when(request.getLastStateParams()).thenReturn(state);
+    }
+
+    @Test
+    public void verifyPollingTaskExecutionExceptionIsNotSwallowed()
+            throws Exception
+    {
+        TaskExecutionException ex = TaskExecutionException.ofNextPolling(INTERVAL, ConfigElement.empty());
+
+        BaseOperator op = new BaseOperator(temporaryFolder.getRoot().toPath(), request)
+        {
+            @Override
+            public TaskResult runTask()
+            {
+                throw ex;
+            }
+        };
+
+        try {
+            op.run();
+            fail();
+        }
+        catch (TaskExecutionException e) {
+            assertThat(e, is(ex));
+            assertThat(e.isError(), is(false));
+            assertThat(e.getRetryInterval().get(), is(INTERVAL));
+        }
+    }
+
+    @Test
+    public void verifyPollingTaskExecutionExceptionIsNotSwallowedWhenRetriesAreEnabled()
+            throws Exception
+    {
+        config.set("_retry", 10);
+
+        TaskExecutionException ex = TaskExecutionException.ofNextPolling(INTERVAL, ConfigElement.empty());
+
+        BaseOperator op = new BaseOperator(temporaryFolder.getRoot().toPath(), request)
+        {
+            @Override
+            public TaskResult runTask()
+            {
+                throw ex;
+            }
+        };
+
+        try {
+            op.run();
+            fail();
+        }
+        catch (TaskExecutionException e) {
+            assertThat(e, is(ex));
+            assertThat(e.isError(), is(false));
+            assertThat(e.getRetryInterval().get(), is(INTERVAL));
+        }
+    }
+}

--- a/digdag-tests/src/test/resources/acceptance/td/td_load/td_load.dig
+++ b/digdag-tests/src/test/resources/acceptance/td/td_load/td_load.dig
@@ -1,0 +1,8 @@
+timezone: UTC
+
++run:
+  td_load>: td_load_config.yml
+  table: td_load_test
+
++post:
+  sh>: touch ${outfile}

--- a/digdag-tests/src/test/resources/acceptance/td/td_load/td_load_config.yml
+++ b/digdag-tests/src/test/resources/acceptance/td/td_load/td_load_config.yml
@@ -1,0 +1,42 @@
+in:
+  type: sftp
+  host: treasure.brickftp.com
+  port: 22
+  user: ${td_load_sftp_user}
+  password: ${td_load_sftp_password}
+  user_directory_is_root: true
+  timeout: 600
+  path_prefix: "/nasdaq_dataset_small_test.csv"
+  parser:
+    charset: UTF-8
+    newline: CRLF
+    type: csv
+    delimiter: ","
+    quote: "\""
+    escape: "\""
+    trim_if_not_quoted: false
+    skip_header_lines: 1
+    allow_extra_columns: false
+    allow_optional_columns: false
+    columns:
+    - name: symbol
+      type: string
+    - name: open
+      type: string
+    - name: volume
+      type: long
+    - name: high
+      type: string
+    - name: low
+      type: string
+    - name: close
+      type: string
+    - name: time
+      type: timestamp
+      format: "%Y%m%d%H"
+filters: []
+out:
+  mode: replace
+  exec: {}
+  type: td
+  time_column:

--- a/digdag-tests/src/test/resources/acceptance/td/td_load/td_load_session.dig
+++ b/digdag-tests/src/test/resources/acceptance/td/td_load/td_load_session.dig
@@ -1,0 +1,7 @@
+timezone: UTC
+
++run:
+  td_load>: td_load_test_session
+
++post:
+  sh>: touch ${outfile}


### PR DESCRIPTION
This is a first step towards making all the operators that start td jobs polling instead of blocking. Most of the polling logic should be possible to implement in a manner that it can be reused across all
td job operators.