### PR TITLE
Fix typo

### DIFF
--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -240,7 +240,7 @@ Runs a digdag server. --memory or --database option is required. Examples:
 :command:`-n, --port PORT`
   Port number to listen for web interface and api clients (default: 65432).
 
-  Example: -p 8080
+  Example: -n 8080
 
 :command:`-b, --bind ADDRESS`
   IP address to listen HTTP clients (default: 127.0.0.1).


### PR DESCRIPTION
I found a typo in ./digdag-docs/src folder.