### PR TITLE
allow specifying custom notification senders

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/DigdagEmbed.java
+++ b/digdag-core/src/main/java/io/digdag/core/DigdagEmbed.java
@@ -17,6 +17,7 @@ import com.google.inject.Module;
 import com.google.inject.Scopes;
 import com.google.inject.util.Modules;
 import com.google.inject.multibindings.Multibinder;
+import io.digdag.core.notification.NotificationModule;
 import io.digdag.core.queue.QueueModule;
 import io.digdag.core.log.NullLogServerFactory;
 import io.digdag.core.log.LocalFileLogServerFactory;
@@ -149,6 +150,7 @@ public class DigdagEmbed
                     new ConfigModule(),
                     new WorkflowModule(),
                     new QueueModule(),
+                    new NotificationModule(),
                     (binder) -> {
                         binder.bind(ProjectArchiveLoader.class);
                         binder.bind(ConfigElement.class).toInstance(systemConfig);

--- a/digdag-core/src/main/java/io/digdag/core/agent/AgentModule.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/AgentModule.java
@@ -3,6 +3,8 @@ package io.digdag.core.agent;
 import com.google.inject.Module;
 import com.google.inject.Binder;
 import com.google.inject.Scopes;
+import com.google.inject.name.Names;
+import io.digdag.spi.NotificationSender;
 import io.digdag.spi.Notifier;
 import io.digdag.spi.TemplateEngine;
 import io.digdag.spi.CommandLogger;
@@ -17,10 +19,6 @@ public class AgentModule
 
         binder.bind(ConfigEvalEngine.class).in(Scopes.SINGLETON);
         binder.bind(TemplateEngine.class).to(ConfigEvalEngine.class).in(Scopes.SINGLETON);
-        binder.bind(HttpNotificationSender.class);
-        binder.bind(MailNotificationSender.class);
-        binder.bind(ShellNotificationSender.class);
-        binder.bind(Notifier.class).to(DefaultNotifier.class).in(Scopes.SINGLETON);
 
         // log
         binder.bind(CommandLogger.class).to(TaskContextCommandLogger.class).in(Scopes.SINGLETON);

--- a/digdag-core/src/main/java/io/digdag/core/notification/DefaultNotifier.java
+++ b/digdag-core/src/main/java/io/digdag/core/notification/DefaultNotifier.java
@@ -1,9 +1,11 @@
-package io.digdag.core.agent;
+package io.digdag.core.notification;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.name.Names;
 import io.digdag.client.config.Config;
 import io.digdag.spi.Notification;
 import io.digdag.spi.NotificationException;
@@ -19,9 +21,6 @@ public class DefaultNotifier
         implements Notifier
 {
     private static final String NOTIFICATION_TYPE = "notification.type";
-    private static final String NOTIFICATION_TYPE_MAIL = "mail";
-    private static final String NOTIFICATION_TYPE_HTTP = "http";
-    private static final String NOTIFICATION_TYPE_SHELL = "shell";
 
     private static final String NOTIFICATION_RETRIES = "notification.retries";
     private static final String NOTIFICATION_MIN_RETRY_WAIT = "notification.min_retry_wait";
@@ -51,17 +50,7 @@ public class DefaultNotifier
 
     private NotificationSender sender(String type)
     {
-        // TODO: use key instead?
-        switch (type) {
-            case NOTIFICATION_TYPE_MAIL:
-                return injector.getInstance(MailNotificationSender.class);
-            case NOTIFICATION_TYPE_HTTP:
-                return injector.getInstance(HttpNotificationSender.class);
-            case NOTIFICATION_TYPE_SHELL:
-                return injector.getInstance(ShellNotificationSender.class);
-            default:
-                throw new IllegalArgumentException("Unknown notification type: " + type);
-        }
+        return injector.getInstance(Key.get(NotificationSender.class, Names.named(type)));
     }
 
     @Override

--- a/digdag-core/src/main/java/io/digdag/core/notification/HttpNotificationSender.java
+++ b/digdag-core/src/main/java/io/digdag/core/notification/HttpNotificationSender.java
@@ -1,4 +1,4 @@
-package io.digdag.core.agent;
+package io.digdag.core.notification;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;

--- a/digdag-core/src/main/java/io/digdag/core/notification/MailNotificationSender.java
+++ b/digdag-core/src/main/java/io/digdag/core/notification/MailNotificationSender.java
@@ -1,4 +1,4 @@
-package io.digdag.core.agent;
+package io.digdag.core.notification;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/digdag-core/src/main/java/io/digdag/core/notification/NotificationModule.java
+++ b/digdag-core/src/main/java/io/digdag/core/notification/NotificationModule.java
@@ -1,0 +1,21 @@
+package io.digdag.core.notification;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import com.google.inject.name.Names;
+import io.digdag.spi.NotificationSender;
+import io.digdag.spi.Notifier;
+
+public class NotificationModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(NotificationSender.class).annotatedWith(Names.named("http")).to(HttpNotificationSender.class);
+        binder.bind(NotificationSender.class).annotatedWith(Names.named("mail")).to(MailNotificationSender.class);
+        binder.bind(NotificationSender.class).annotatedWith(Names.named("shell")).to(ShellNotificationSender.class);
+        binder.bind(Notifier.class).to(DefaultNotifier.class).in(Scopes.SINGLETON);
+    }
+}

--- a/digdag-core/src/main/java/io/digdag/core/notification/ShellNotificationSender.java
+++ b/digdag-core/src/main/java/io/digdag/core/notification/ShellNotificationSender.java
@@ -1,4 +1,4 @@
-package io.digdag.core.agent;
+package io.digdag.core.notification;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;


### PR DESCRIPTION
* Look up sender class for `notification.type` using @Named annotation.

* Move notification implementation from agent module to separate
  notification module.