### PR TITLE
add user info to revision

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/Check.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Check.java
@@ -129,10 +129,11 @@ public class Check
         final YamlMapper yamlMapper = injector.getInstance(YamlMapper.class);
         final WorkflowCompiler compiler = injector.getInstance(WorkflowCompiler.class);
         final SchedulerManager schedulerManager = injector.getInstance(SchedulerManager.class);
+        final ConfigFactory configFactory = injector.getInstance(ConfigFactory.class);
 
         ArchiveMetadata meta = project.getArchiveMetadata();
 
-        Revision rev = Revision.builderFromArchive("check", meta)
+        Revision rev = Revision.builderFromArchive("check", meta, configFactory.create())
             .archiveType(ArchiveType.NONE)
             .build();
 

--- a/digdag-core/src/main/java/io/digdag/core/LocalSite.java
+++ b/digdag-core/src/main/java/io/digdag/core/LocalSite.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import com.google.inject.Inject;
 import com.google.common.base.*;
 import com.google.common.collect.*;
+import io.digdag.client.config.ConfigFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import io.digdag.core.archive.ArchiveMetadata;
@@ -23,6 +24,7 @@ public class LocalSite
     private final AttemptBuilder attemptBuilder;
     private final WorkflowExecutor exec;
     private final SchedulerManager srm;
+    private final ConfigFactory cf;
 
     @Inject
     public LocalSite(
@@ -31,7 +33,8 @@ public class LocalSite
             SessionStoreManager sessionStoreManager,
             AttemptBuilder attemptBuilder,
             WorkflowExecutor exec,
-            SchedulerManager srm)
+            SchedulerManager srm,
+            ConfigFactory cf)
     {
         this.compiler = compiler;
         this.projectStore = projectStoreManager.getProjectStore(0);
@@ -39,6 +42,7 @@ public class LocalSite
         this.attemptBuilder = attemptBuilder;
         this.exec = exec;
         this.srm = srm;
+        this.cf = cf;
     }
 
     public AttemptBuilder getAttemptBuilder()
@@ -114,7 +118,7 @@ public class LocalSite
     {
         return storeLocalWorkflowsImpl(
                 projectName,
-                Revision.builderFromArchive(revisionName, archive)
+                Revision.builderFromArchive(revisionName, archive, cf.create())
                     .archiveType(ArchiveType.NONE)
                     .build(),
                 archive.getWorkflowList(),
@@ -130,7 +134,7 @@ public class LocalSite
     {
         return storeLocalWorkflowsImpl(
                 projectName,
-                Revision.builderFromArchive(revisionName, archive)
+                Revision.builderFromArchive(revisionName, archive, cf.create())
                     .archiveType(ArchiveType.NONE)
                     .build(),
                 archive.getWorkflowList(),

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseMigrator.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseMigrator.java
@@ -1,15 +1,12 @@
 package io.digdag.core.database;
 
-import java.util.List;
-import java.util.ArrayList;
 import com.google.inject.Inject;
-import java.sql.Connection;
-import java.sql.DatabaseMetaData;
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.exceptions.StatementException;
+
+import java.util.ArrayList;
+import java.util.List;
 
 public class DatabaseMigrator
 {
@@ -613,10 +610,27 @@ public class DatabaseMigrator
         }
     };
 
+    private final Migration MigrateAddUserInfoColumnToRevisions = new Migration()
+    {
+        @Override
+        public String getVersion()
+        {
+            return "20160623123456";
+        }
+
+        @Override
+        public void migrate(Handle handle)
+        {
+            handle.update("alter table revisions" +
+                    " add column user_info text");
+        }
+    };
+
     private final Migration[] migrations = {
         MigrateCreateTables,
         MigrateSessionsOnProjectIdIndexToDesc,
         MigrateCreateResumingTasks,
         MigrateMakeProjectsDeletable,
+        MigrateAddUserInfoColumnToRevisions,
     };
 }

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
@@ -382,7 +382,7 @@ public class DatabaseProjectStoreManager
             throws ResourceConflictException
         {
             int revId = catchConflict(() ->
-                dao.insertRevision(projId, revision.getName(), revision.getDefaultParams(), revision.getArchiveType().getName(), revision.getArchiveMd5().orNull(), revision.getArchivePath().orNull(), revision.getUserInfo().orNull()),
+                dao.insertRevision(projId, revision.getName(), revision.getDefaultParams(), revision.getArchiveType().getName(), revision.getArchiveMd5().orNull(), revision.getArchivePath().orNull(), revision.getUserInfo()),
                 "revision=%s in project id=%d", revision.getName(), projId);
             try {
                 return requiredResource(
@@ -788,7 +788,7 @@ public class DatabaseProjectStoreManager
                 .archiveType(ArchiveType.of(r.getString("archive_type")))
                 .archiveMd5(getOptionalBytes(r, "archive_md5"))
                 .archivePath(getOptionalString(r, "archive_path"))
-                .userInfo(cfm.fromResultSet(r, "user_info"))
+                .userInfo(cfm.fromResultSetOrEmpty(r, "user_info"))
                 .build();
         }
     }

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
@@ -1,39 +1,53 @@
 package io.digdag.core.database;
 
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.stream.Stream;
-import java.util.stream.Collectors;
-import java.nio.ByteBuffer;
-import java.time.ZoneId;
-import java.time.Instant;
-import java.sql.Timestamp;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import org.immutables.value.Value;
-import com.google.common.base.*;
-import com.google.common.collect.*;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.digdag.core.repository.*;
-import io.digdag.core.schedule.Schedule;
 import io.digdag.client.api.IdName;
+import io.digdag.client.config.Config;
+import io.digdag.core.repository.ArchiveType;
+import io.digdag.core.repository.ImmutableStoredProject;
+import io.digdag.core.repository.ImmutableStoredRevision;
+import io.digdag.core.repository.ImmutableStoredWorkflowDefinition;
+import io.digdag.core.repository.ImmutableStoredWorkflowDefinitionWithProject;
+import io.digdag.core.repository.Project;
+import io.digdag.core.repository.ProjectControlStore;
+import io.digdag.core.repository.ProjectMap;
+import io.digdag.core.repository.ProjectStore;
+import io.digdag.core.repository.ProjectStoreManager;
+import io.digdag.core.repository.ResourceConflictException;
+import io.digdag.core.repository.ResourceNotFoundException;
+import io.digdag.core.repository.Revision;
+import io.digdag.core.repository.StoredProject;
+import io.digdag.core.repository.StoredRevision;
+import io.digdag.core.repository.StoredWorkflowDefinition;
+import io.digdag.core.repository.StoredWorkflowDefinitionWithProject;
+import io.digdag.core.repository.TimeZoneMap;
+import io.digdag.core.repository.WorkflowDefinition;
+import io.digdag.core.schedule.Schedule;
+import org.immutables.value.Value;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
-import org.skife.jdbi.v2.sqlobject.SqlQuery;
-import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.GetGeneratedKeys;
-import org.skife.jdbi.v2.StatementContext;
-import org.skife.jdbi.v2.sqlobject.customizers.Mapper;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
-import io.digdag.client.config.Config;
-import static java.util.Locale.ENGLISH;
+
+import java.nio.ByteBuffer;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static com.google.common.base.Preconditions.checkArgument;
 
 public class DatabaseProjectStoreManager
         extends BasicDatabaseStoreManager<DatabaseProjectStoreManager.Dao>
@@ -368,7 +382,7 @@ public class DatabaseProjectStoreManager
             throws ResourceConflictException
         {
             int revId = catchConflict(() ->
-                dao.insertRevision(projId, revision.getName(), revision.getDefaultParams(), revision.getArchiveType().getName(), revision.getArchiveMd5().orNull(), revision.getArchivePath().orNull()),
+                dao.insertRevision(projId, revision.getName(), revision.getDefaultParams(), revision.getArchiveType().getName(), revision.getArchiveMd5().orNull(), revision.getArchivePath().orNull(), revision.getUserInfo().orNull()),
                 "revision=%s in project id=%d", revision.getName(), projId);
             try {
                 return requiredResource(
@@ -646,10 +660,10 @@ public class DatabaseProjectStoreManager
         int insertWorkflowConfig(@Bind("projId") int projId, @Bind("config") String config, @Bind("timezone") String timezone, @Bind("configDigest") long configDigest);
 
         @SqlUpdate("insert into revisions" +
-                " (project_id, name, default_params, archive_type, archive_md5, archive_path, created_at)" +
-                " values (:projId, :name, :defaultParams, :archiveType, :archiveMd5, :archivePath, now())")
+                " (project_id, name, default_params, archive_type, archive_md5, archive_path, user_info, created_at)" +
+                " values (:projId, :name, :defaultParams, :archiveType, :archiveMd5, :archivePath, :userInfo, now())")
         @GetGeneratedKeys
-        int insertRevision(@Bind("projId") int projId, @Bind("name") String name, @Bind("defaultParams") Config defaultParams, @Bind("archiveType") String archiveType, @Bind("archiveMd5") byte[] archiveMd5, @Bind("archivePath") String archivePath);
+        int insertRevision(@Bind("projId") int projId, @Bind("name") String name, @Bind("defaultParams") Config defaultParams, @Bind("archiveType") String archiveType, @Bind("archiveMd5") byte[] archiveMd5, @Bind("archivePath") String archivePath, @Bind("userInfo") Config userInfo);
 
         @SqlQuery("select wd.*, wc.config, wc.timezone from workflow_definitions wd" +
                 " join revisions rev on rev.id = wd.revision_id" +
@@ -774,6 +788,7 @@ public class DatabaseProjectStoreManager
                 .archiveType(ArchiveType.of(r.getString("archive_type")))
                 .archiveMd5(getOptionalBytes(r, "archive_md5"))
                 .archivePath(getOptionalString(r, "archive_path"))
+                .userInfo(cfm.fromResultSet(r, "user_info"))
                 .build();
         }
     }

--- a/digdag-core/src/main/java/io/digdag/core/repository/Revision.java
+++ b/digdag-core/src/main/java/io/digdag/core/repository/Revision.java
@@ -19,6 +19,8 @@ public abstract class Revision
 
     public abstract Optional<String> getArchivePath();
 
+    public abstract Optional<Config> getUserInfo();
+
     public static Revision copyOf(Revision other)
     {
         return ImmutableRevision.builder().from(other).build();

--- a/digdag-core/src/main/java/io/digdag/core/repository/Revision.java
+++ b/digdag-core/src/main/java/io/digdag/core/repository/Revision.java
@@ -19,18 +19,19 @@ public abstract class Revision
 
     public abstract Optional<String> getArchivePath();
 
-    public abstract Optional<Config> getUserInfo();
+    public abstract Config getUserInfo();
 
     public static Revision copyOf(Revision other)
     {
         return ImmutableRevision.builder().from(other).build();
     }
 
-    public static ImmutableRevision.Builder builderFromArchive(String name, ArchiveMetadata meta)
+    public static ImmutableRevision.Builder builderFromArchive(String name, ArchiveMetadata meta, Config userInfo)
     {
         return ImmutableRevision.builder()
             .name(name)
-            .defaultParams(meta.getDefaultParams().deepCopy());
+            .defaultParams(meta.getDefaultParams().deepCopy())
+            .userInfo(userInfo);
     }
 
     @Value.Check

--- a/digdag-core/src/test/java/io/digdag/core/database/DatabaseTestingUtils.java
+++ b/digdag-core/src/test/java/io/digdag/core/database/DatabaseTestingUtils.java
@@ -160,6 +160,7 @@ public class DatabaseTestingUtils
             .name(name)
             .defaultParams(createConfig())
             .archiveType(ArchiveType.NONE)
+            .userInfo(createConfig())
             .build();
     }
 

--- a/digdag-server/src/main/java/io/digdag/server/AuthRequestFilter.java
+++ b/digdag-server/src/main/java/io/digdag/server/AuthRequestFilter.java
@@ -32,6 +32,7 @@ public class AuthRequestFilter
         Authenticator.Result result = auth.authenticate(requestContext);
         if (result.isAccepted()) {
             requestContext.setProperty("siteId", result.getSiteId());
+            requestContext.setProperty("userInfo", result.getUserInfo());
         }
         else {
             requestContext.abortWith(errorResultHandler.toResponse(result.getErrorMessage()));

--- a/digdag-server/src/main/java/io/digdag/server/rs/AuthenticatedResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/AuthenticatedResource.java
@@ -1,7 +1,10 @@
 package io.digdag.server.rs;
 
-import javax.ws.rs.core.Context;
+import com.google.common.base.Optional;
+import io.digdag.client.config.Config;
+
 import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.core.Context;
 
 public abstract class AuthenticatedResource
 {
@@ -13,5 +16,10 @@ public abstract class AuthenticatedResource
         // siteId is set by JwtAuthInterceptor
         // TODO validate before causing NPE. Improve guice-rs to call @PostConstruct
         return (int) request.getAttribute("siteId");
+    }
+
+    protected Optional<Config> getUserInfo()
+    {
+        return Optional.fromNullable((Config) request.getAttribute("userInfo"));
     }
 }

--- a/digdag-server/src/main/java/io/digdag/server/rs/AuthenticatedResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/AuthenticatedResource.java
@@ -18,8 +18,8 @@ public abstract class AuthenticatedResource
         return (int) request.getAttribute("siteId");
     }
 
-    protected Optional<Config> getUserInfo()
+    protected Config getUserInfo()
     {
-        return Optional.fromNullable((Config) request.getAttribute("userInfo"));
+        return (Config) request.getAttribute("userInfo");
     }
 }

--- a/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
@@ -428,6 +428,7 @@ public class ProjectResource
                                         .archiveType(ArchiveType.DB)
                                         .archivePath(Optional.absent())
                                         .archiveMd5(Optional.of(md5))
+                                        .userInfo(getUserInfo())
                                         .build()
                                     );
                             lockedProj.insertRevisionArchiveData(rev.getId(), data);
@@ -439,6 +440,7 @@ public class ProjectResource
                                         .archiveType(location.getArchiveType())
                                         .archivePath(Optional.of(location.getPath()))
                                         .archiveMd5(Optional.of(md5))
+                                        .userInfo(getUserInfo())
                                         .build()
                                     );
                         }

--- a/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
@@ -424,11 +424,10 @@ public class ProjectResource
                                 throw new InternalServerErrorException("Failed to load archive data in memory", ex);
                             }
                             rev = lockedProj.insertRevision(
-                                    Revision.builderFromArchive(revision, meta)
+                                    Revision.builderFromArchive(revision, meta, getUserInfo())
                                         .archiveType(ArchiveType.DB)
                                         .archivePath(Optional.absent())
                                         .archiveMd5(Optional.of(md5))
-                                        .userInfo(getUserInfo())
                                         .build()
                                     );
                             lockedProj.insertRevisionArchiveData(rev.getId(), data);
@@ -436,11 +435,10 @@ public class ProjectResource
                         else {
                             // store location of the uploaded file in db
                             rev = lockedProj.insertRevision(
-                                    Revision.builderFromArchive(revision, meta)
+                                    Revision.builderFromArchive(revision, meta, getUserInfo())
                                         .archiveType(location.getArchiveType())
                                         .archivePath(Optional.of(location.getPath()))
                                         .archiveMd5(Optional.of(md5))
-                                        .userInfo(getUserInfo())
                                         .build()
                                     );
                         }


### PR DESCRIPTION
Authenticators can use this to annotate revisions with arbitrary user
information that can then be used by e.g. custom notification senders.