### PR TITLE
Fix docker mount command

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/DockerCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/DockerCommandExecutor.java
@@ -78,11 +78,11 @@ public class DockerCommandExecutor
 
             // mount
             if (buildImageName == null) {
-                // build image already includes /digdag
-            }
-            else {
                 command.add("-v").add(String.format(ENGLISH,
                             "%s:%s:rw", workspacePath.toAbsolutePath(), "/digdag"));
+            }
+            else {
+                // build image already includes /digdag
             }
 
             // workdir


### PR DESCRIPTION
Hi,
Docker api didn't run my environment.

* Mac OSX:10.11.5,docker:1.12.0-rc2-beta16

[digdag file]
```
timezone: UTC

_export:
  docker:
    image: ubuntu:14.04

+step1:
  sh>: tasks/shell_sample.sh
```

I think docker command option don't use "-v".

Please review PR.