### PR TITLE
Fix docker build command option

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/DockerCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/DockerCommandExecutor.java
@@ -61,11 +61,14 @@ public class DockerCommandExecutor
 
         String buildImageName = null;
         if (dockerConfig.has("build")) {
-            buildImageName = String.format(ENGLISH, "rev-%d-%s",
+            buildImageName = String.format(ENGLISH, "rev-%d/%s",
+                    request.getProjectId(),
+                    request.getRevision().or(UUID.randomUUID().toString()).replaceAll(":", "-").toLowerCase());
+            String dockerFileName = String.format(ENGLISH, "rev-%d-%s",
                     request.getProjectId(),
                     request.getRevision().or(UUID.randomUUID().toString()));
 
-            buildImage(workspacePath, dockerConfig, image, buildImageName);
+            buildImage(workspacePath, dockerConfig, image, buildImageName, dockerFileName);
         }
 
         ImmutableList.Builder<String> command = ImmutableList.builder();
@@ -133,7 +136,7 @@ public class DockerCommandExecutor
         }
     }
 
-    private void buildImage(Path workspacePath, Config dockerConfig, String image, String buildImageName) {
+    private void buildImage(Path workspacePath, Config dockerConfig, String image, String buildImageName, String dockerFileName) {
         try {
             Pattern pattern = Pattern.compile("\n" + Pattern.quote(buildImageName) + " ");
 
@@ -169,7 +172,7 @@ public class DockerCommandExecutor
             // create Dockerfile
             Path tmpPath = workspacePath.resolve(".digdag/tmp");  // TODO this should not be workspacePath. This should go to a configured working directory
             Files.createDirectories(tmpPath);
-            Path dockerFilePath = tmpPath.resolve("Dockerfile." + buildImageName);
+            Path dockerFilePath = tmpPath.resolve("Dockerfile." + dockerFileName);
 
             List<String> buildCommands = dockerConfig.getList("build", String.class);
             try (BufferedWriter out = Files.newBufferedWriter(dockerFilePath)) {


### PR DESCRIPTION
Hi,
Docker build command occurred error.

[digdag file]
```
timezone: UTC

_export:
  docker:
    image: ubuntu:14.04
    build: ["echo hello world"]

+step1:
  sh>: tasks/shell_sample.sh
```

[error]
```
2016-06-26 15:46:33 +0900: Digdag v0.8.2
2016-06-26 15:46:35 +0900 [WARN] (main): Reusing the last session time 2016-06-24T00:00:00+00:00.
2016-06-26 15:46:35 +0900 [INFO] (main): Using session .digdag/status/20160624T000000+0000.
2016-06-26 15:46:35 +0900 [INFO] (main): Starting a new session project id=1 workflow name=digdag-docker session_time=2016-06-24T00:00:00+00:00
2016-06-26 15:46:35 +0900 [INFO] (0019@+digdag-docker+step1): sh>: tasks/shell_sample.sh
invalid argument "rev-1-2016-06-26T06:46:34.954Z" for t: Error parsing reference: "rev-1-2016-06-26T06:46:34.954Z" is not a valid repository/tag
See 'docker build --help'.
2016-06-26 15:46:35 +0900 [ERROR] (0019@+digdag-docker+step1): Task failed with unexpected error: Docker build failed
java.lang.RuntimeException: Docker build failed
	at io.digdag.standards.command.DockerCommandExecutor.buildImage(DockerCommandExecutor.java:207)
	at io.digdag.standards.command.DockerCommandExecutor.startWithDocker(DockerCommandExecutor.java:68)
	at io.digdag.standards.command.DockerCommandExecutor.start(DockerCommandExecutor.java:50)
	at io.digdag.standards.operator.ShOperatorFactory$ShOperator.runTask(ShOperatorFactory.java:104)
	at io.digdag.util.BaseOperator.run(BaseOperator.java:49)
	at io.digdag.core.agent.OperatorManager.callExecutor(OperatorManager.java:265)
	at io.digdag.cli.Run$OperatorManagerWithSkip.callExecutor(Run.java:658)
	at io.digdag.core.agent.OperatorManager.runWithWorkspace(OperatorManager.java:231)
	at io.digdag.core.agent.OperatorManager.lambda$runWithHeartbeat$1(OperatorManager.java:124)
	at io.digdag.core.agent.NoopWorkspaceManager.withExtractedArchive(NoopWorkspaceManager.java:20)
	at io.digdag.core.agent.OperatorManager.runWithHeartbeat(OperatorManager.java:122)
	at io.digdag.core.agent.OperatorManager.run(OperatorManager.java:106)
	at io.digdag.cli.Run$OperatorManagerWithSkip.run(Run.java:640)
	at io.digdag.core.agent.LocalAgent.lambda$run$0(LocalAgent.java:70)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
2016-06-26 15:46:35 +0900 [INFO] (0019@+digdag-docker^failure-alert): type: notify
error: 
  * +digdag-docker+step1:
    Docker build failed
```
Docker tag reference is "repository/tag".
And, I think docker container tag don't use uppercase and colon.

Please review PR.