### PR TITLE
run temp server in separate process by default

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/Main.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Main.java
@@ -30,9 +30,7 @@ import org.slf4j.LoggerFactory;
 import java.io.PrintStream;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
 import static io.digdag.cli.SystemExitException.systemExit;
 

--- a/digdag-cli/src/test/java/io/digdag/cli/client/ClientBuildingTest.java
+++ b/digdag-cli/src/test/java/io/digdag/cli/client/ClientBuildingTest.java
@@ -2,7 +2,6 @@ package io.digdag.cli.client;
 
 import java.lang.reflect.Field;
 
-import io.digdag.core.*;
 import org.junit.Test;
 
 import io.digdag.client.DigdagClient;

--- a/digdag-core/src/main/java/io/digdag/core/Version.java
+++ b/digdag-core/src/main/java/io/digdag/core/Version.java
@@ -9,6 +9,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class Version
 {
+    public static final String VERSION_PROPERTY = Version.class.getName() + ".version";
+
     private final String version;
 
     private Version(String version)
@@ -18,11 +20,18 @@ public class Version
 
     public static Version buildVersion()
     {
-        return Version.of(loadVersionString());
+        return Version.of(versionString());
     }
 
-    private static String loadVersionString()
+    private static String versionString()
     {
+        // First read version from system property
+        String propertyVersion = System.getProperty(VERSION_PROPERTY);
+        if (propertyVersion != null) {
+            return propertyVersion;
+        }
+
+        // Then read version file
         try {
             return Resources.toString(Resources.getResource(Version.class, "version.txt"), UTF_8).trim();
         }

--- a/digdag-tests/build.gradle
+++ b/digdag-tests/build.gradle
@@ -13,4 +13,5 @@ test {
     maxParallelForks = 2
     minHeapSize = "256m"
     maxHeapSize = "256m"
+    environment "DIGDAG_TEST_TEMP_SERVER_IN_PROCESS", "false"
 }

--- a/digdag-tests/src/test/java/acceptance/TdWaitIT.java
+++ b/digdag-tests/src/test/java/acceptance/TdWaitIT.java
@@ -90,7 +90,7 @@ public class TdWaitIT
                 .put("database", "sample_datasets")
                 .put("outfile", outfile.toString())
                 .build());
-        expect(Duration.ofSeconds(30), attemptFailure(server.endpoint(), attemptId));
+        expect(Duration.ofSeconds(300), attemptFailure(server.endpoint(), attemptId));
         assertThat(Files.exists(outfile), is(false));
     }
 
@@ -104,7 +104,7 @@ public class TdWaitIT
                 .put("wait_rows", "1")
                 .put("database", "sample_datasets")
                 .build());
-        expect(Duration.ofSeconds(30), attemptSuccess(server.endpoint(), attemptId));
+        expect(Duration.ofSeconds(300), attemptSuccess(server.endpoint(), attemptId));
     }
 
     @Test
@@ -119,7 +119,7 @@ public class TdWaitIT
                 .put("database", "sample_datasets")
                 .put("outfile", outfile.toString())
                 .build());
-        expect(Duration.ofSeconds(30), attemptSuccess(server.endpoint(), attemptId));
+        expect(Duration.ofSeconds(300), attemptSuccess(server.endpoint(), attemptId));
     }
 
     @Test
@@ -275,7 +275,7 @@ public class TdWaitIT
                 .put("database", "sample_datasets")
                 .put("outfile", outfile.toString())
                 .build());
-        expect(Duration.ofSeconds(30), attemptFailure(server.endpoint(), attemptId));
+        expect(Duration.ofSeconds(300), attemptFailure(server.endpoint(), attemptId));
         CommandStatus logStatus = main("log",
                 "-c", "/dev/null",
                 "-e", server.endpoint(),

--- a/digdag-tests/src/test/java/acceptance/TemporaryDigdagServer.java
+++ b/digdag-tests/src/test/java/acceptance/TemporaryDigdagServer.java
@@ -59,7 +59,7 @@ import static org.junit.Assert.fail;
 public class TemporaryDigdagServer
         implements TestRule
 {
-    private static final boolean IN_PROCESS_DEFAULT = Boolean.valueOf(System.getenv().getOrDefault("DIGDAG_TEST_TEMP_SERVER_IN_PROCESS", "false"));
+    private static final boolean IN_PROCESS_DEFAULT = Boolean.valueOf(System.getenv().getOrDefault("DIGDAG_TEST_TEMP_SERVER_IN_PROCESS", "true"));
 
     private static final String POSTGRESQL = System.getenv("DIGDAG_TEST_POSTGRESQL");
 

--- a/digdag-tests/src/test/java/acceptance/TemporaryDigdagServer.java
+++ b/digdag-tests/src/test/java/acceptance/TemporaryDigdagServer.java
@@ -23,6 +23,7 @@ import javax.sql.DataSource;
 import javax.ws.rs.ProcessingException;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.StringReader;
 import java.lang.management.ManagementFactory;
@@ -83,6 +84,7 @@ public class TemporaryDigdagServer
 
     private final boolean inProcess;
 
+    private Path workdir;
     private Process serverProcess;
 
     private Path configDirectory;
@@ -275,6 +277,7 @@ public class TemporaryDigdagServer
             });
         }
         else {
+            File workdir = temporaryFolder.newFolder();
             String home = System.getProperty("java.home");
             String classPath = System.getProperty("java.class.path");
             Path java = Paths.get(home, "bin", "java").toAbsolutePath().normalize();
@@ -293,6 +296,7 @@ public class TemporaryDigdagServer
             ProcessBuilder processBuilder = new ProcessBuilder(processArgs);
             processBuilder.redirectError(ProcessBuilder.Redirect.INHERIT);
             processBuilder.redirectOutput(ProcessBuilder.Redirect.INHERIT);
+            processBuilder.directory(workdir);
             serverProcess = processBuilder.start();
         }
 

--- a/digdag-tests/src/test/resources/logback.xml
+++ b/digdag-tests/src/test/resources/logback.xml
@@ -1,0 +1,19 @@
+<configuration>
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss Z} [%level] (%thread\) %class: %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.zaxxer.hikari" level="WARN"/>
+    <logger name="org.apache" level="WARN"/>
+    <logger name="org.jboss" level="WARN"/>
+
+    <appender name="digdag-context" class="io.digdag.cli.LogbackTaskContextLoggerBridgeAppender">
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="console"/>
+        <appender-ref ref="digdag-context"/>
+    </root>
+</configuration>

--- a/digdag-tests/src/test/resources/logback.xml
+++ b/digdag-tests/src/test/resources/logback.xml
@@ -5,14 +5,12 @@
         </encoder>
     </appender>
 
-    <logger name="com.zaxxer.hikari" level="WARN"/>
-    <logger name="org.apache" level="WARN"/>
-    <logger name="org.jboss" level="WARN"/>
+    <logger name="io.digdag" level="DEBUG"/>
 
     <appender name="digdag-context" class="io.digdag.cli.LogbackTaskContextLoggerBridgeAppender">
     </appender>
 
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="console"/>
         <appender-ref ref="digdag-context"/>
     </root>


### PR DESCRIPTION
Configurable by using `TemporaryDigdagServer.Builder.inProcess()` method
or setting env var `DIGDAG_TEST_TEMP_SERVER_IN_PROCESS=true`.

Child server process terminates if parent process exits.

Also forcibly drop temp server postgres db after test finishes.