### PR TITLE
Fixed typo

### DIFF
--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -334,7 +334,7 @@ Client-mode common options:
 
 You can include following parameters in ~/.config/digdag/config file:
 
-* cilent.http.endpoint = http://HOST:PORT or https://HOST:PORT
+* client.http.endpoint = http://HOST:PORT or https://HOST:PORT
 * client.http.headers.KEY = VALUE (set custom HTTP header)
 
 


### PR DESCRIPTION
Found the typo on configuration setting.
Please check and merge it.

cilent -> client