### PR TITLE
First schedule time is expected to be calculated using next run time

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/TimeUtil.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/TimeUtil.java
@@ -54,7 +54,7 @@ public class TimeUtil
         }
     }
 
-    public static Instant parseTime(String s, String errorMessage)
+    public static Instant parseTime(String s, String optionName)
             throws SystemExitException
     {
         try {
@@ -65,7 +65,11 @@ public class TimeUtil
                 return Instant.from(INSTANT_PARSER.parse(s));
             }
             catch (DateTimeException ex) {
-                throw systemExit(errorMessage + ": " + s);
+                throw systemExit(String.format(ENGLISH,
+                            "%s option must be \"yyyy-MM-dd HH:mm:ss Z\" format or UNIX timestamp: %s" +
+                            "\nhint: current local time is \"%s\"",
+                            optionName, s,
+                            formatTime(Instant.now())));
             }
         }
     }

--- a/digdag-cli/src/main/java/io/digdag/cli/TimeUtil.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/TimeUtil.java
@@ -21,8 +21,7 @@ public class TimeUtil
             DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss Z", ENGLISH);
 
     private static final DateTimeFormatter INSTANT_PARSER =
-            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss Z", ENGLISH)
-                    .withZone(ZoneId.systemDefault());
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss Z", ENGLISH);
 
     private static final DateTimeFormatter LOCAL_TIME_PARSER =
             DateTimeFormatter.ofPattern("yyyy-MM-dd[ HH:mm:ss]", ENGLISH);

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Push.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Push.java
@@ -110,8 +110,7 @@ public class Push
             scheduleFrom = Optional.absent();
         }
         else {
-            scheduleFrom = Optional.of(TimeUtil.parseTime(scheduleFromString,
-                        "--schedule-from option must be \"yyyy-MM-dd HH:mm:ss Z\" format or UNIX timestamp (hint: run `date \"+%Y-%m-%d %H:%M:%S %z\"` command to show current local time)"));
+            scheduleFrom = Optional.of(TimeUtil.parseTime(scheduleFromString, "--schedule-from"));
         }
 
         // load project

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Reschedule.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Reschedule.java
@@ -69,15 +69,14 @@ public class Reschedule
         Instant now = Instant.now();
 
         Optional<Instant> runAt = runAtTime == null ? Optional.absent() : Optional.of(
-                TimeUtil.parseTime(runAtTime, "-a, --run-at option must be \"yyyy-MM-dd HH:mm:ss Z\" format or UNIX timestamp")
+                TimeUtil.parseTime(runAtTime, "-a, --run-at")
                 );
 
         DigdagClient client = buildClient();
         RestScheduleSummary updated;
         if (toTime != null) {
             updated = client.skipSchedulesToTime(schedId,
-                    TimeUtil.parseTime(toTime,
-                        "-t, --skip-to option must be \"yyyy-MM-dd HH:mm:ss Z\" format or UNIX timestamp"),
+                    TimeUtil.parseTime(toTime, "-t, --skip-to"),
                     runAt,
                     dryRun);
         }

--- a/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
+++ b/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
@@ -298,12 +298,29 @@ public class DigdagClient implements AutoCloseable
     public RestProject putProjectRevision(String projName, String revision, File body)
         throws IOException
     {
-        return doPut(RestProject.class,
-                "application/gzip",
-                body,
-                target("/api/projects")
-                .queryParam("project", projName)
-                .queryParam("revision", revision));
+        return putProjectRevision(projName, revision, body, Optional.absent());
+    }
+
+    public RestProject putProjectRevision(String projName, String revision, File body, Optional<Instant> scheduleFrom)
+        throws IOException
+    {
+        if (scheduleFrom.isPresent()) {
+            return doPut(RestProject.class,
+                    "application/gzip",
+                    body,
+                    target("/api/projects")
+                    .queryParam("project", projName)
+                    .queryParam("revision", revision)
+                    .queryParam("schedule_from", scheduleFrom.get().toString()));
+        }
+        else {
+            return doPut(RestProject.class,
+                    "application/gzip",
+                    body,
+                    target("/api/projects")
+                    .queryParam("project", projName)
+                    .queryParam("revision", revision));
+        }
     }
 
     // TODO getArchive with streaming

--- a/digdag-core/src/main/java/io/digdag/core/schedule/ScheduleExecutor.java
+++ b/digdag-core/src/main/java/io/digdag/core/schedule/ScheduleExecutor.java
@@ -80,7 +80,7 @@ public class ScheduleExecutor
     {
         try {
             sm.lockReadySchedules(Instant.now(), (store, storedSchedule) -> {
-                schedule(new ScheduleControl(store, storedSchedule));
+                runSchedule(new ScheduleControl(store, storedSchedule));
             });
         }
         catch (Throwable t) {
@@ -88,7 +88,7 @@ public class ScheduleExecutor
         }
     }
 
-    public boolean schedule(ScheduleControl lockedSched)
+    private boolean runSchedule(ScheduleControl lockedSched)
     {
         StoredSchedule sched = lockedSched.get();
 

--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -609,6 +609,11 @@ Creates a project archive and upload it to the server. This command uploads work
 
   Example: -r f40172ebc58f58087b6132085982147efa9e81fb
 
+:command:`--schedule-from "yyyy-MM-dd HH:mm:ss Z"`
+  Start schedules from this time. If this is not set, system time of the server is used. Parameter must include time zone offset. You can run ``date \"+%Y-%m-%d %H:%M:%S %z\"`` command to get current local time.
+
+  Example: --schedule-from "2017-07-29 00:00:00 +0200"
+
 
 delete
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/digdag-spi/src/main/java/io/digdag/spi/ScheduleTime.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/ScheduleTime.java
@@ -10,8 +10,21 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 @JsonDeserialize(as = ImmutableScheduleTime.class)
 public interface ScheduleTime
 {
+    /**
+     * Actual execution time of a scheduled attempt.
+     */
     Instant getRunTime();
 
+    /**
+     * The session_time variable of a scheduled attempt.
+     *
+     * A session attempt has session_time variable which may not be same with
+     * actual run time because a lot of scheduled workflows has a target time.
+     * Target time is usually exact time (e.g. 00:00:00 every day), while actual
+     * run time usually has some delay (e.g. 00:00:13) because a workflow may
+     * want to wait for other components to be prepared before starting, session
+     * could be created using backfill, or queuing of an attempt may be delayed.
+     */
     Instant getTime();
 
     static ScheduleTime of(Instant time, Instant runTime)

--- a/digdag-spi/src/main/java/io/digdag/spi/Scheduler.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/Scheduler.java
@@ -7,15 +7,15 @@ public interface Scheduler
 {
     ZoneId getTimeZone();
 
-    // align this time with the last schedule time.
-    // returned value is same with currentTime or after currentTime.
+    // align given time with the last time of this schedule.
+    // getRunTime of returned ScheduleTime is same or after currentTime.
     ScheduleTime getFirstScheduleTime(Instant currentTime);
 
-    // align this time with the next schedule time.
-    // returned value is after lastScheduleTime.
+    // align given time with the next schedule time.
+    // getTime of returned ScheduleTime is after lastScheduleTime.
     ScheduleTime nextScheduleTime(Instant lastScheduleTime);
 
-    // align this time with the last schedule time.
-    // returned value is before currentScheduleTime.
+    // align given time with the last schedule time.
+    // getTime of returned ScheduleTime is before currentScheduleTime.
     ScheduleTime lastScheduleTime(Instant currentScheduleTime);
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/scheduler/CronScheduler.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/scheduler/CronScheduler.java
@@ -18,7 +18,15 @@ public class CronScheduler
 
     CronScheduler(String cronPattern, ZoneId timeZone, long delaySeconds)
     {
-        this.pattern = new SchedulingPattern(cronPattern);
+        this.pattern = new SchedulingPattern(cronPattern) {
+            // workaround for a bug of cron4j:
+            // https://gist.github.com/frsyuki/618c4e6c1f5f876e4ee74b9da2fd37c0
+            @Override
+            public boolean match(long millis)
+            {
+                return match(TimeZone.getTimeZone(timeZone), millis);
+            }
+        };
         this.timeZone = timeZone;
         this.delaySeconds = delaySeconds;
     }

--- a/digdag-standards/src/main/java/io/digdag/standards/scheduler/CronScheduler.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/scheduler/CronScheduler.java
@@ -41,8 +41,9 @@ public class CronScheduler
             // because Predictor doesn't include this time at "next"MatchingTime() method
             truncated = truncated.minusSeconds(1);
         }
+        Instant lastTime = truncated.minusSeconds(delaySeconds);
 
-        return nextScheduleTime(truncated);
+        return nextScheduleTime(lastTime);
     }
 
     @Override

--- a/digdag-standards/src/test/java/io/digdag/standards/scheduler/DailySchedulerTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/scheduler/DailySchedulerTest.java
@@ -1,0 +1,222 @@
+package io.digdag.standards.scheduler;
+
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigFactory;
+import io.digdag.spi.Scheduler;
+import io.digdag.spi.ScheduleTime;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.Before;
+import org.junit.After;
+import static java.util.Locale.ENGLISH;
+import static io.digdag.client.DigdagClient.objectMapper;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class DailySchedulerTest
+{
+    static Config newConfig()
+    {
+        return new ConfigFactory(objectMapper()).create();
+    }
+
+    static Scheduler newScheduler(String pattern, String timeZone)
+    {
+        return new DailySchedulerFactory().newScheduler(newConfig().set("_command", pattern), ZoneId.of(timeZone));
+    }
+
+    private static DateTimeFormatter TIME_FORMAT =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss Z", ENGLISH);
+
+    static Instant instant(String time)
+    {
+        return Instant.from(TIME_FORMAT.parse(time));
+    }
+
+    @Test
+    public void firstScheduleTimeUtc()
+    {
+        // current time is 09:00:00
+        // schedule is 10:00:00 every day
+        // schedule at today 01:00:00
+        Instant currentTime1 = instant("2016-02-03 09:00:00 +0000");
+        assertThat(
+                newScheduler("10:00:00", "UTC").getFirstScheduleTime(currentTime1),
+                is(ScheduleTime.of(
+                        instant("2016-02-03 00:00:00 +0000"),
+                        instant("2016-02-03 10:00:00 +0000"))));
+
+        // current time is 16:00:00
+        // schedule is 10:00:00 every day
+        // schedule at tomorrow 01:00:00
+        Instant currentTime2 = instant("2016-02-03 16:00:00 +0000");
+        assertThat(
+                newScheduler("10:00:00", "UTC").getFirstScheduleTime(currentTime2),
+                is(ScheduleTime.of(
+                        instant("2016-02-04 00:00:00 +0000"),
+                        instant("2016-02-04 10:00:00 +0000"))));
+    }
+
+    @Test
+    public void firstScheduleTimeTz()
+    {
+        // same with firstScheduleTimeUtc but with TZ=Asia/Tokyo
+
+        Instant currentTime1 = instant("2016-02-03 09:00:00 +0900");
+        assertThat(
+                newScheduler("10:00:00", "Asia/Tokyo").getFirstScheduleTime(currentTime1),
+                is(ScheduleTime.of(
+                        instant("2016-02-03 00:00:00 +0900"),
+                        instant("2016-02-03 10:00:00 +0900"))));
+
+        Instant currentTime2 = instant("2016-02-03 16:00:00 +0900");
+        assertThat(
+                newScheduler("10:00:00", "Asia/Tokyo").getFirstScheduleTime(currentTime2),
+                is(ScheduleTime.of(
+                        instant("2016-02-04 00:00:00 +0900"),
+                        instant("2016-02-04 10:00:00 +0900"))));
+    }
+
+    @Test
+    public void firstScheduleTimeDst()
+    {
+        // America/Los_Angeles begins DST at 2016-03-13 03:00:00 -0700
+        // (== 2016-03-13 02:00:00 -0800)
+
+        // This is an exceptional case with DST...
+        // "daily> 10:00:00" means 10 hour later than 00:00:00.
+        // 00:00:00 -08:00 plus 10 hours is 11:00:00 -07:00.
+        Instant currentTime1 = instant("2016-03-13 09:00:00 -0700");
+        assertThat(
+                newScheduler("10:00:00", "America/Los_Angeles").getFirstScheduleTime(currentTime1),
+                is(ScheduleTime.of(
+                        instant("2016-03-13 00:00:00 -0800"),
+                        instant("2016-03-13 11:00:00 -0700"))));  // schedule runs at 10:00:00 although definition is "daily> 10:00:00"
+
+        Instant currentTime2 = instant("2016-03-13 16:00:00 -0700");
+        assertThat(
+                newScheduler("10:00:00", "America/Los_Angeles").getFirstScheduleTime(currentTime2),
+                is(ScheduleTime.of(
+                        instant("2016-03-14 00:00:00 -0700"),
+                        instant("2016-03-14 10:00:00 -0700"))));
+    }
+
+    @Test
+    public void firstScheduleTimeExact1()
+    {
+        Instant currentTime1 = instant("2016-03-13 00:00:00 +0000");
+        assertThat(
+                newScheduler("10:00:00", "UTC").getFirstScheduleTime(currentTime1),
+                is(ScheduleTime.of(
+                        instant("2016-03-13 00:00:00 +0000"),
+                        instant("2016-03-13 10:00:00 +0000"))));
+
+        Instant currentTime2 = instant("2016-03-13 10:00:00 +0000");
+        assertThat(
+                newScheduler("10:00:00", "UTC").getFirstScheduleTime(currentTime2),
+                is(ScheduleTime.of(
+                        instant("2016-03-13 00:00:00 +0000"),
+                        instant("2016-03-13 10:00:00 +0000"))));
+
+        Instant currentTime3 = instant("2016-03-13 00:00:00 +0000");
+        assertThat(
+                newScheduler("00:00:00", "UTC").getFirstScheduleTime(currentTime3),
+                is(ScheduleTime.of(
+                        instant("2016-03-13 00:00:00 +0000"),
+                        instant("2016-03-13 00:00:00 +0000"))));
+    }
+
+    @Test
+    public void nextScheduleTimeUtc()
+    {
+        // last schedule time is 00:00:00
+        // schedule is 10:00:00 every day
+        // next schedule time is at tomorrow 00:00:00
+        Instant lastScheduleTime1 = instant("2016-02-03 00:00:00 +0000");
+        assertThat(
+                newScheduler("10:00:00", "UTC").nextScheduleTime(lastScheduleTime1),
+                is(ScheduleTime.of(
+                        instant("2016-02-04 00:00:00 +0000"),
+                        instant("2016-02-04 10:00:00 +0000"))));
+    }
+
+    @Test
+    public void nextScheduleTimeTz()
+    {
+        // same with nextScheduleTimeUtc but with TZ=Asia/Tokyo
+
+        Instant lastScheduleTime1 = instant("2016-02-03 00:00:00 +0900");
+        assertThat(
+                newScheduler("10:00:00", "Asia/Tokyo").nextScheduleTime(lastScheduleTime1),
+                is(ScheduleTime.of(
+                        instant("2016-02-04 00:00:00 +0900"),
+                        instant("2016-02-04 10:00:00 +0900"))));
+    }
+
+    @Test
+    public void nextScheduleTimeDst()
+    {
+        Instant lastScheduleTime1 = instant("2016-03-12 00:00:00 -0800");
+        assertThat(
+                newScheduler("10:00:00", "America/Los_Angeles").nextScheduleTime(lastScheduleTime1),
+                is(ScheduleTime.of(
+                        instant("2016-03-13 00:00:00 -0800"),
+                        instant("2016-03-13 10:00:00 -0800"))));
+
+        Instant lastScheduleTime2 = instant("2016-03-13 00:00:00 -0800");
+        assertThat(
+                newScheduler("10:00:00", "America/Los_Angeles").nextScheduleTime(lastScheduleTime2),
+                is(ScheduleTime.of(
+                        instant("2016-03-14 00:00:00 -0700"),
+                        instant("2016-03-14 10:00:00 -0700"))));
+    }
+
+    @Test
+    public void lastScheduleTimeUtc()
+    {
+        // last schedule time is 00:00:00
+        // schedule is 10:00:00 every day
+        // next schedule time is at tomorrow 00:00:00
+        Instant currentScheduleTime1 = instant("2016-02-03 00:00:00 +0000");
+        assertThat(
+                newScheduler("10:00:00", "UTC").lastScheduleTime(currentScheduleTime1),
+                is(ScheduleTime.of(
+                        instant("2016-02-02 00:00:00 +0000"),
+                        instant("2016-02-02 10:00:00 +0000"))));
+    }
+
+    @Test
+    public void lastScheduleTimeTz()
+    {
+        // same with lastScheduleTimeUtc but with TZ=Asia/Tokyo
+
+        Instant currentScheduleTime1 = instant("2016-02-03 00:00:00 +0900");
+        assertThat(
+                newScheduler("10:00:00", "Asia/Tokyo").lastScheduleTime(currentScheduleTime1),
+                is(ScheduleTime.of(
+                        instant("2016-02-02 00:00:00 +0900"),
+                        instant("2016-02-02 10:00:00 +0900"))));
+    }
+
+    @Test
+    public void lastScheduleTimeDst()
+    {
+        Instant currentScheduleTime1 = instant("2016-03-13 00:00:00 -0800");
+        assertThat(
+                newScheduler("10:00:00", "America/Los_Angeles").lastScheduleTime(currentScheduleTime1),
+                is(ScheduleTime.of(
+                        instant("2016-03-12 00:00:00 -0800"),
+                        instant("2016-03-12 10:00:00 -0800"))));
+
+        Instant currentScheduleTime2 = instant("2016-03-14 00:00:00 -0700");
+        assertThat(
+                newScheduler("10:00:00", "America/Los_Angeles").lastScheduleTime(currentScheduleTime2),
+                is(ScheduleTime.of(
+                        instant("2016-03-13 00:00:00 -0800"),
+                        instant("2016-03-13 10:00:00 -0800"))));
+    }
+}

--- a/digdag-standards/src/test/java/io/digdag/standards/scheduler/DailySchedulerTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/scheduler/DailySchedulerTest.java
@@ -42,7 +42,7 @@ public class DailySchedulerTest
     {
         // current time is 09:00:00
         // schedule is 10:00:00 every day
-        // schedule at today 01:00:00
+        // schedule at today 10:00:00
         Instant currentTime1 = instant("2016-02-03 09:00:00 +0000");
         assertThat(
                 newScheduler("10:00:00", "UTC").getFirstScheduleTime(currentTime1),
@@ -52,7 +52,7 @@ public class DailySchedulerTest
 
         // current time is 16:00:00
         // schedule is 10:00:00 every day
-        // schedule at tomorrow 01:00:00
+        // schedule at tomorrow 10:00:00
         Instant currentTime2 = instant("2016-02-03 16:00:00 +0000");
         assertThat(
                 newScheduler("10:00:00", "UTC").getFirstScheduleTime(currentTime2),

--- a/digdag-tests/src/test/java/acceptance/ServerScheduleIT.java
+++ b/digdag-tests/src/test/java/acceptance/ServerScheduleIT.java
@@ -1,0 +1,92 @@
+package acceptance;
+
+import com.google.common.base.Optional;
+import io.digdag.client.DigdagClient;
+import io.digdag.client.api.RestSchedule;
+import io.digdag.client.api.RestSession;
+import io.digdag.client.api.RestSessionAttempt;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import utils.CommandStatus;
+import utils.TemporaryDigdagServer;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static utils.TestUtils.copyResource;
+import static utils.TestUtils.getAttemptId;
+import static utils.TestUtils.getSessionId;
+import static utils.TestUtils.main;
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.junit.Assert.assertThat;
+
+public class ServerScheduleIT
+{
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Rule
+    public TemporaryDigdagServer server = TemporaryDigdagServer.of();
+
+    private Path config;
+    private Path projectDir;
+    private DigdagClient client;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        projectDir = folder.getRoot().toPath().resolve("foobar");
+        config = folder.newFile().toPath();
+
+        client = DigdagClient.builder()
+                .host(server.host())
+                .port(server.port())
+                .build();
+    }
+
+    @Test
+    public void scheduleStartTime()
+            throws Exception
+    {
+        // Create a new project
+        CommandStatus initStatus = main("init",
+                "-c", config.toString(),
+                projectDir.toString());
+        assertThat(initStatus.code(), is(0));
+
+        copyResource("acceptance/schedule/schedule.dig", projectDir.resolve("schedule.dig"));
+
+        // Push the project starting schedules from at 2291-02-06 10:00:00 +0000
+        {
+            {
+                CommandStatus pushStatus = main("push",
+                        "--project", projectDir.toString(),
+                        "foobar",
+                        "-c", config.toString(),
+                        "-e", server.endpoint(),
+                        "-r", "4711",
+                        "--schedule-from", "2291-02-06 10:00:00 +0000");
+                assertThat(pushStatus.errUtf8(), pushStatus.code(), is(0));
+            }
+
+            List<RestSchedule> scheds = client.getSchedules();
+            assertThat(scheds.size(), is(1));
+            RestSchedule sched = scheds.get(0);
+
+            assertThat(sched.getProject().getName(), is("foobar"));
+            assertThat(sched.getNextRunTime(), is(Instant.parse("2291-02-06T10:00:00Z")));
+            assertThat(sched.getNextScheduleTime(), is(OffsetDateTime.parse("2291-02-06T00:00:00Z")));
+        }
+    }
+}

--- a/digdag-tests/src/test/resources/acceptance/schedule/schedule.dig
+++ b/digdag-tests/src/test/resources/acceptance/schedule/schedule.dig
@@ -1,0 +1,8 @@
+timezone: UTC
+
+schedule:
+  daily>: 10:00:00
+
++foo:
+  sh>: "touch foo.out"
+


### PR DESCRIPTION
First schedule time was calculated using next session time. But it's
expected to be calculated using next run time instead as an issue filed
at [#149].

For example, a workflow has `daily>: 10:00:00` schedule and current time is at 8am. Current behavior is that first run time becomes tomorrow 10:00:00. This is because today's "schedule time" (that is 00:00:00) is already passed.
This PR changes it to be today 10:00:00 because today's "run time" (that is 10:00:00) is not passed yet.

This PR also adds `--schedule-from` option to `digdag push` command so that test cases can be independent from the environment's current time.
