### PR TITLE
ci: shard all tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,6 +102,25 @@ subprojects {
         testLogging {
             info.events = ["started", "passed", "skipped", "failed", "standardOut", "standardError"]
         }
+
+        // Shard test classes over CI workers
+        if (System.env.CI_NODE_INDEX != null) {
+            def n = Integer.parseInt(System.env.CI_NODE_TOTAL)
+            def i = Integer.parseInt(System.env.CI_NODE_INDEX)
+            include {
+                // Recurse into all packages
+                if (it.file.isDirectory()) {
+                    return true
+                }
+
+                // Include test class based on worker index
+                def included = Math.abs(it.file.hashCode()) % n == i
+                if (Boolean.parseBoolean(System.env.CI_DEBUG ?: 'false')) {
+                    logger.info("test '" + it.file + '" included: ' + included)
+                }
+                return included
+            }
+        }
     }
 
     javadoc {

--- a/digdag-tests/build.gradle
+++ b/digdag-tests/build.gradle
@@ -16,24 +16,8 @@ test {
     maxHeapSize = "256m"
     environment "DIGDAG_TEST_TEMP_SERVER_IN_PROCESS", "false"
 
-    // Shard test classes over CI workers
-    if (System.env.CI_NODE_INDEX != null && System.env.CI_ACCEPTANCE_TEST != null) {
-
-        // Exclude all acceptance tests if this is not an acceptance test run
-        if (!Boolean.valueOf(System.env.CI_ACCEPTANCE_TEST)) {
-            include { false }
-        } else {
-            def n = Integer.parseInt(System.env.CI_NODE_TOTAL)
-            def i = Integer.parseInt(System.env.CI_NODE_INDEX)
-            include {
-                // Recurse into all packages
-                if (it.file.isDirectory()) {
-                    return true
-                }
-
-                // Include test class based on worker index
-                return Math.abs(it.file.hashCode()) % n == i
-            }
-        }
+    // Exclude all acceptance tests if this is not an acceptance test run
+    if (System.env.CI_ACCEPTANCE_TEST == null || Boolean.valueOf(System.env.CI_ACCEPTANCE_TEST)) {
+        include { false }
     }
 }

--- a/digdag-tests/build.gradle
+++ b/digdag-tests/build.gradle
@@ -17,7 +17,7 @@ test {
     environment "DIGDAG_TEST_TEMP_SERVER_IN_PROCESS", "false"
 
     // Exclude all acceptance tests if this is not an acceptance test run
-    if (System.env.CI_ACCEPTANCE_TEST == null || Boolean.valueOf(System.env.CI_ACCEPTANCE_TEST)) {
-        include { false }
+    if (System.env.CI_ACCEPTANCE_TEST == null || !Boolean.valueOf(System.env.CI_ACCEPTANCE_TEST)) {
+        exclude { true }
     }
 }


### PR DESCRIPTION
... in all subproject, not just the tests in `digdag-tests`.