### PR TITLE
secret management

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,7 @@ subprojects {
         testCompile 'junit:junit:4.12'
         testCompile 'org.hamcrest:hamcrest-library:1.3'
         testCompile 'org.mockito:mockito-core:1.10.19'
+        testCompile 'pl.pragmatists:JUnitParams:1.0.5'
     }
 
     tasks.withType(JavaCompile) {

--- a/digdag-cli/build.gradle
+++ b/digdag-cli/build.gradle
@@ -9,5 +9,5 @@ dependencies {
     compile project(':digdag-standards')
     compile 'ch.qos.logback:logback-classic:1.1.5'
     compile 'org.fusesource.jansi:jansi:1.11'
-    compile 'com.beust:jcommander:1.48'
+    compile 'com.beust:jcommander:1.55'
 }

--- a/digdag-cli/src/main/java/io/digdag/cli/LocalSecretStoreManager.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/LocalSecretStoreManager.java
@@ -1,0 +1,35 @@
+package io.digdag.cli;
+
+import com.google.common.base.Optional;
+import com.google.inject.Inject;
+import io.digdag.client.config.Config;
+import io.digdag.spi.SecretAccessContext;
+import io.digdag.spi.SecretStore;
+import io.digdag.spi.SecretStoreManager;
+
+import java.util.Map;
+
+import static java.util.stream.Collectors.toMap;
+
+class LocalSecretStoreManager
+        implements SecretStoreManager
+{
+    private final Map<String, String> secrets;
+
+    @Inject
+    public LocalSecretStoreManager(Config systemConfig)
+    {
+        String prefix = "secrets.";
+        this.secrets = systemConfig.getKeys().stream()
+                .filter(k -> k.startsWith(prefix))
+                .collect(toMap(
+                        k -> k.substring(prefix.length(), k.length()),
+                        k -> systemConfig.get(k, String.class)));
+    }
+
+    @Override
+    public SecretStore getSecretStore(int siteId)
+    {
+        return (context, key) -> Optional.fromNullable(secrets.get(key));
+    }
+}

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Secrets.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Secrets.java
@@ -1,0 +1,247 @@
+package io.digdag.cli.client;
+
+import com.beust.jcommander.Parameter;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLParser;
+import com.google.common.io.CharStreams;
+import io.digdag.cli.SystemExitException;
+import io.digdag.client.DigdagClient;
+import io.digdag.client.api.RestProject;
+import io.digdag.client.api.RestSecretList;
+import io.digdag.core.Version;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.sun.mail.imap.protocol.SearchSequence.isAscii;
+import static io.digdag.cli.SystemExitException.systemExit;
+import static io.digdag.client.DigdagClient.objectMapper;
+import static io.digdag.client.api.SecretValidation.isValidSecretKey;
+import static io.digdag.client.api.SecretValidation.isValidSecretValue;
+import static java.lang.Boolean.TRUE;
+
+public class Secrets
+        extends ClientCommand
+{
+    @Parameter(names = {"--project"}, required = true)
+    String projectName = null;
+
+    @Parameter(names = {"--set"}, variableArity = true)
+    List<String> set = new ArrayList<>();
+
+    @Parameter(names = {"--delete"}, variableArity = true)
+    List<String> delete = new ArrayList<>();
+
+    private final InputStream in;
+
+    public Secrets(Version version, PrintStream out, PrintStream err, InputStream in)
+    {
+        super(version, out, err);
+        this.in = in;
+    }
+
+    @Override
+    public void mainWithClientException()
+            throws Exception
+    {
+        if (args.size() != 0) {
+            throw usage(null);
+        }
+
+        DigdagClient client = buildClient();
+        RestProject project = client.getProject(projectName);
+
+        if (!set.isEmpty() && !delete.isEmpty()) {
+            throw usage("Please specify only one of --set or --delete");
+        }
+
+        if (set.isEmpty() && delete.isEmpty()) {
+            listProjectSecrets(client, project.getId());
+        }
+        else if (!set.isEmpty()) {
+            setProjectSecrets(client, project.getId(), set);
+        }
+        else if (!delete.isEmpty()) {
+            deleteProjectSecrets(client, project.getId(), delete);
+        }
+        else {
+            throw new AssertionError();
+        }
+    }
+
+    private void deleteProjectSecrets(DigdagClient client, int projectId, List<String> delete)
+            throws SystemExitException
+    {
+        Map<String, Boolean> deleteSecrets = new LinkedHashMap<>();
+
+        for (String key : delete) {
+            if (key.isEmpty()) {
+                throw usage(null);
+            }
+            if (deleteSecrets.containsKey(key)) {
+                throw usage("Duplicate --delete secret key: '" + key + "'");
+            }
+            deleteSecrets.put(key, TRUE);
+        }
+
+        for (String key : deleteSecrets.keySet()) {
+            if (!isValidSecretKey(key)) {
+                throw usage("Invalid secret key: " + key);
+            }
+        }
+        // Delete secrets
+        for (String key : deleteSecrets.keySet()) {
+            client.deleteProjectSecret(projectId, key);
+            err.println("Secret '" + key + "' deleted");
+        }
+    }
+
+    private void setProjectSecrets(DigdagClient client, int projectId, List<String> set)
+            throws Exception
+    {
+        Map<String, String> setSecrets = new LinkedHashMap<>();
+
+        boolean inConsumed = false;
+
+        for (String s : set) {
+            if (s.isEmpty()) {
+                throw usage(null);
+            }
+
+            // Read a list of secrets from stdin or a file?
+            if (s.charAt(0) == '@') {
+                String filename = s.substring(1);
+                if (filename.isEmpty()) {
+                    throw usage(null);
+                }
+                Map<String, String> secrets;
+                String source;
+                if (filename.charAt(0) == '-') {
+                    // Read stdin as yaml (or json)
+                    if (filename.length() != 1) {
+                        throw usage(null);
+                    }
+                    if (inConsumed) {
+                        throw usage("Can only read once from stdin");
+                    }
+                    inConsumed = true;
+                    source = "stdin";
+
+                    YAMLFactory yaml = new YAMLFactory();
+                    YAMLParser parser = yaml.createParser(in);
+                    secrets = DigdagClient.objectMapper().readValue(parser, new TypeReference<Map<String, String>>() {});
+                }
+                else {
+                    // Read secrets from file
+                    source = "file: " + filename;
+                    Map<String, String> result;
+                    YAMLFactory yaml = new YAMLFactory();
+                    try (YAMLParser parser = yaml.createParser(Files.newInputStream(Paths.get(filename)))) {
+                        result = objectMapper().readValue(parser, new TypeReference<Map<String, String>>() {});
+                    }
+                    secrets = result;
+                }
+                for (Map.Entry<String, String> entry : secrets.entrySet()) {
+                    if (entry.getKey().isEmpty()) {
+                        throw usage("Invalid key/value in " + source);
+                    }
+                    if (setSecrets.containsKey(entry.getKey())) {
+                        throw usage("Duplicate secret key: '" + entry.getKey() + "' in " + source);
+                    }
+                    setSecrets.put(entry.getKey(), entry.getValue());
+                }
+                continue;
+            }
+
+            // key=value ?
+            int equalsIndex = s.indexOf('=');
+            if (equalsIndex != -1) {
+                String key = s.substring(0, equalsIndex);
+                String value = s.substring(equalsIndex + 1, s.length());
+                if (key.isEmpty()) {
+                    throw usage(null);
+                }
+                if (setSecrets.containsKey(key)) {
+                    throw usage("Duplicate --set secret key: '" + key + "'");
+                }
+
+                // Read value from file?
+                if (value.charAt(0) == '@') {
+                    String filename = value.substring(1);
+                    if (filename.isEmpty()) {
+                        throw usage(null);
+                    }
+                    Path path = Paths.get(filename);
+                    byte[] rawValue = Files.readAllBytes(path);
+                    value = new String(rawValue, StandardCharsets.UTF_8);
+                    setSecrets.put(key, value);
+                    continue;
+                }
+
+                // Read value from stdin?
+                if (value.charAt(0) == '-') {
+                    if (value.length() != 1) {
+                        throw usage(null);
+                    }
+                    if (inConsumed) {
+                        throw usage("Can only read once from stdin");
+                    }
+                    inConsumed = true;
+                    String input = CharStreams.toString(new InputStreamReader(in));
+                    setSecrets.put(key, input);
+                    continue;
+                }
+
+                // Just a regular key=value
+                setSecrets.put(key, value);
+                continue;
+            }
+
+            // Only the key name was specified. Read secret from console with echo disabled
+            if (inConsumed) {
+                throw usage("Stdin already read");
+            }
+            String value = new String(System.console().readPassword(s + ":"));
+            setSecrets.put(s, value);
+        }
+
+        // Validate keys and values
+        for (Map.Entry<String, String> entry : setSecrets.entrySet()) {
+            if (!isValidSecretKey(entry.getKey())) {
+                throw usage("Invalid secret key: " + entry.getKey());
+            }
+            if (!isValidSecretValue(entry.getValue())) {
+                throw usage("Invalid secret value for key: " + entry.getKey());
+            }
+        }
+
+        // Set secrets
+        for (Map.Entry<String, String> entry : setSecrets.entrySet()) {
+            client.setProjectSecret(projectId, entry.getKey(), entry.getValue());
+            err.println("Secret '" + entry.getKey() + "' set");
+        }
+    }
+
+    private void listProjectSecrets(DigdagClient client, int projectId)
+    {
+        RestSecretList secretList = client.listProjectSecrets(projectId);
+        secretList.secrets().forEach(s -> out.println(s.key()));
+    }
+
+    public SystemExitException usage(String error)
+    {
+        err.println("Usage: digdag secrets --project <project> [--set <key>=<value>] [--delete key]");
+        showCommonOptions();
+        return systemExit(error);
+    }
+}

--- a/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
+++ b/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
@@ -1,8 +1,8 @@
 package io.digdag.client;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import com.google.common.base.Optional;
@@ -15,18 +15,22 @@ import io.digdag.client.api.RestSchedule;
 import io.digdag.client.api.RestScheduleBackfillRequest;
 import io.digdag.client.api.RestScheduleSkipRequest;
 import io.digdag.client.api.RestScheduleSummary;
+import io.digdag.client.api.RestSecretList;
 import io.digdag.client.api.RestSession;
 import io.digdag.client.api.RestSessionAttempt;
 import io.digdag.client.api.RestSessionAttemptRequest;
+import io.digdag.client.api.RestSetSecretRequest;
 import io.digdag.client.api.RestTask;
 import io.digdag.client.api.RestWorkflowDefinition;
 import io.digdag.client.api.RestWorkflowSessionTime;
+import io.digdag.client.api.SecretValidation;
 import io.digdag.client.api.SessionTimeTruncate;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigFactory;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
 
 import javax.ws.rs.NotFoundException;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
@@ -549,6 +553,50 @@ public class DigdagClient implements AutoCloseable
     {
         return doGet(new GenericType<Map<String, Object>>() {},
                 target("/api/version"));
+    }
+
+    public void setProjectSecret(int projectId, String key, String value)
+    {
+        if (!SecretValidation.isValidSecret(key, value)) {
+            throw new IllegalArgumentException();
+        }
+
+        Response response = target("/api/projects/{id}/secrets/{key}")
+                .resolveTemplate("id", projectId)
+                .resolveTemplate("key", key)
+                .request()
+                .headers(headers.get())
+                .put(Entity.entity(RestSetSecretRequest.of(value), "application/json"));
+        if (response.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL) {
+            throw new WebApplicationException("Failed to set project secret: " + response.getStatusInfo());
+        }
+    }
+
+    public void deleteProjectSecret(int projectId, String key)
+    {
+        if (!SecretValidation.isValidSecretKey(key)) {
+            throw new IllegalArgumentException();
+        }
+
+        Response response = target("/api/projects/{id}/secrets/{key}")
+                .resolveTemplate("id", projectId)
+                .resolveTemplate("key", key)
+                .request()
+                .headers(headers.get())
+                .delete();
+
+        if (response.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL) {
+            throw new WebApplicationException("Failed to delete project secret: " + response.getStatusInfo());
+        }
+    }
+
+    public RestSecretList listProjectSecrets(int projectId)
+    {
+        return target("/api/projects/{id}/secrets")
+                .resolveTemplate("id", projectId)
+                .request("application/json")
+                .headers(headers.get())
+                .get(RestSecretList.class);
     }
 
     private WebTarget target(String path)

--- a/digdag-client/src/main/java/io/digdag/client/api/RestSecretList.java
+++ b/digdag-client/src/main/java/io/digdag/client/api/RestSecretList.java
@@ -1,0 +1,27 @@
+package io.digdag.client.api;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+import java.util.List;
+
+@Value.Immutable
+@Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+@JsonSerialize(as = ImmutableRestSecretList.class)
+@JsonDeserialize(as = ImmutableRestSecretList.class)
+public interface RestSecretList
+{
+    List<RestSecretMetadata> secrets();
+
+    static Builder builder() {
+        return ImmutableRestSecretList.builder();
+    }
+
+    interface Builder
+    {
+        Builder secrets(Iterable<? extends RestSecretMetadata> secrets);
+
+        RestSecretList build();
+    }
+}

--- a/digdag-client/src/main/java/io/digdag/client/api/RestSecretMetadata.java
+++ b/digdag-client/src/main/java/io/digdag/client/api/RestSecretMetadata.java
@@ -1,0 +1,31 @@
+package io.digdag.client.api;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+@JsonSerialize(as = ImmutableRestSecretMetadata.class)
+@JsonDeserialize(as = ImmutableRestSecretMetadata.class)
+public interface RestSecretMetadata
+{
+    String key();
+
+    static RestSecretMetadata of(String key)
+    {
+        return builder().key(key).build();
+    }
+
+    static Builder builder()
+    {
+        return ImmutableRestSecretMetadata.builder();
+    }
+
+    interface Builder
+    {
+        Builder key(String key);
+
+        RestSecretMetadata build();
+    }
+}

--- a/digdag-client/src/main/java/io/digdag/client/api/RestSetSecretRequest.java
+++ b/digdag-client/src/main/java/io/digdag/client/api/RestSetSecretRequest.java
@@ -1,0 +1,22 @@
+package io.digdag.client.api;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.base.Preconditions;
+import org.immutables.value.Value;
+
+import static com.google.common.base.Strings.isNullOrEmpty;
+
+@Value.Immutable
+@Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+@JsonSerialize(as = ImmutableRestSetSecretRequest.class)
+@JsonDeserialize(as = ImmutableRestSetSecretRequest.class)
+public interface RestSetSecretRequest
+{
+    String value();
+
+    static RestSetSecretRequest of(String value)
+    {
+        return ImmutableRestSetSecretRequest.builder().value(value).build();
+    }
+}

--- a/digdag-client/src/main/java/io/digdag/client/api/SecretValidation.java
+++ b/digdag-client/src/main/java/io/digdag/client/api/SecretValidation.java
@@ -1,0 +1,39 @@
+package io.digdag.client.api;
+
+import com.google.common.base.Preconditions;
+
+import java.util.regex.Pattern;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class SecretValidation
+{
+    private static final String SECRET_KEY_SEGMENT = "[a-zA-Z]|[a-zA-Z][a-zA-Z0-9_\\-]*[a-zA-Z0-9]";
+    private static final Pattern SECRET_KEY_PATTERN = Pattern.compile(
+            "^(" + SECRET_KEY_SEGMENT + ")(\\.(" + SECRET_KEY_SEGMENT + "))*$");
+
+    private static final int MAX_SECRET_KEY_LENGTH = 255;
+    private static final int MAX_SECRET_VALUE_LENGTH = 1024;
+
+    private SecretValidation()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    public static boolean isValidSecretKey(String key)
+    {
+        Preconditions.checkNotNull(key);
+        return key.length() <= MAX_SECRET_KEY_LENGTH && SECRET_KEY_PATTERN.matcher(key).matches();
+    }
+
+    public static boolean isValidSecretValue(String value)
+    {
+        Preconditions.checkNotNull(value);
+        return value.getBytes(UTF_8).length <= MAX_SECRET_VALUE_LENGTH;
+    }
+
+    public static boolean isValidSecret(String key, String value)
+    {
+        return isValidSecretKey(key) && isValidSecretValue(value);
+    }
+}

--- a/digdag-client/src/test/java/io/digdag/client/api/SecretValidationTest.java
+++ b/digdag-client/src/test/java/io/digdag/client/api/SecretValidationTest.java
@@ -1,0 +1,51 @@
+package io.digdag.client.api;
+
+import com.google.common.base.Strings;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class SecretValidationTest
+{
+    @Test
+    public void isValidSecretKey()
+            throws Exception
+    {
+        assertThat(SecretValidation.isValidSecretKey(""), is(false));
+        assertThat(SecretValidation.isValidSecretKey("."), is(false));
+        assertThat(SecretValidation.isValidSecretKey("0"), is(false));
+        assertThat(SecretValidation.isValidSecretKey("0.foo"), is(false));
+        assertThat(SecretValidation.isValidSecretKey("0234"), is(false));
+        assertThat(SecretValidation.isValidSecretKey("0bar"), is(false));
+        assertThat(SecretValidation.isValidSecretKey("012bar"), is(false));
+        assertThat(SecretValidation.isValidSecretKey("foo.0"), is(false));
+        assertThat(SecretValidation.isValidSecretKey("foo.1"), is(false));
+        assertThat(SecretValidation.isValidSecretKey("foo.1.baz"), is(false));
+        assertThat(SecretValidation.isValidSecretKey("foo..baz"), is(false));
+        assertThat(SecretValidation.isValidSecretKey("\u2603"), is(false));
+        assertThat(SecretValidation.isValidSecretKey("\uD83D\uDCA9"), is(false));
+        assertThat(SecretValidation.isValidSecretKey("r\u00e4ksm\u00f6rg\u00e5s"), is(false));
+
+        assertThat(SecretValidation.isValidSecretKey("f"), is(true));
+        assertThat(SecretValidation.isValidSecretKey("foo"), is(true));
+        assertThat(SecretValidation.isValidSecretKey("foo.b"), is(true));
+        assertThat(SecretValidation.isValidSecretKey("foo.bar"), is(true));
+        assertThat(SecretValidation.isValidSecretKey("foo.bar.baz"), is(true));
+        assertThat(SecretValidation.isValidSecretKey("a1.b2c.d3"), is(true));
+    }
+
+    @Test
+    public void isValidSecretValue()
+            throws Exception
+    {
+        assertThat(SecretValidation.isValidSecretValue(""), is(true));
+        assertThat(SecretValidation.isValidSecretValue("foobar"), is(true));
+        assertThat(SecretValidation.isValidSecretValue("\uD83D\uDCA9"), is(true));
+        assertThat(SecretValidation.isValidSecretValue("r\u00e4ksm\u00f6rg\u00e5s"), is(true));
+        assertThat(SecretValidation.isValidSecretValue(Strings.repeat(".", 1024)), is(true));
+
+        assertThat(SecretValidation.isValidSecretValue(Strings.repeat(".", 1025)), is(false));
+        assertThat(SecretValidation.isValidSecretValue(Strings.repeat("\u2603", 342)), is(false));
+    }
+}

--- a/digdag-core/src/main/java/io/digdag/core/LocalSecretAccessPolicy.java
+++ b/digdag-core/src/main/java/io/digdag/core/LocalSecretAccessPolicy.java
@@ -1,0 +1,15 @@
+package io.digdag.core;
+
+import io.digdag.spi.SecretAccessContext;
+import io.digdag.spi.SecretAccessPolicy;
+
+public class LocalSecretAccessPolicy
+        implements SecretAccessPolicy
+{
+    @Override
+    public boolean isSecretAccessible(SecretAccessContext context, String key)
+    {
+        // TODO: Restrict default access in local mode?
+        return true;
+    }
+}

--- a/digdag-core/src/main/java/io/digdag/core/agent/CallOperatorFactory.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/CallOperatorFactory.java
@@ -1,23 +1,15 @@
 package io.digdag.core.agent;
 
-import java.util.List;
-import java.util.stream.Collectors;
-import java.time.Instant;
-import java.time.ZoneId;
 import java.nio.file.Path;
-import com.google.common.base.*;
-import com.google.common.collect.*;
+
 import com.google.inject.Inject;
+import io.digdag.spi.TaskExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import io.digdag.spi.CommandExecutor;
 import io.digdag.spi.TaskRequest;
 import io.digdag.spi.TaskResult;
-import io.digdag.spi.TaskReport;
 import io.digdag.spi.Operator;
 import io.digdag.spi.OperatorFactory;
-import io.digdag.spi.TaskExecutionException;
-import io.digdag.util.RetryControl;
 import io.digdag.core.repository.ResourceNotFoundException;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigException;
@@ -62,7 +54,7 @@ public class CallOperatorFactory
         }
 
         @Override
-        public TaskResult run()
+        public TaskResult run(TaskExecutionContext ctx)
         {
             Config config = request.getConfig();
 

--- a/digdag-core/src/main/java/io/digdag/core/agent/DefaultSecretProvider.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/DefaultSecretProvider.java
@@ -1,0 +1,104 @@
+package io.digdag.core.agent;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Joiner;
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+import com.google.common.collect.FluentIterable;
+import io.digdag.client.config.Config;
+import io.digdag.spi.SecretAccessContext;
+import io.digdag.spi.SecretAccessDeniedException;
+import io.digdag.spi.SecretAccessPolicy;
+import io.digdag.spi.SecretProvider;
+import io.digdag.spi.SecretStore;
+
+import java.util.List;
+
+class DefaultSecretProvider
+        implements SecretProvider
+{
+    private final SecretAccessContext context;
+    private final SecretAccessPolicy secretAccessPolicy;
+    private final Config grants;
+    private final SecretFilter operatorSecretFilter;
+    private final SecretStore secretStore;
+
+    DefaultSecretProvider(
+            SecretAccessContext context, SecretAccessPolicy secretAccessPolicy, Config grants, SecretFilter operatorSecretFilter, SecretStore secretStore)
+    {
+        this.context = context;
+        this.secretAccessPolicy = secretAccessPolicy;
+        this.grants = grants;
+        this.operatorSecretFilter = operatorSecretFilter;
+        this.secretStore = secretStore;
+    }
+
+    @Override
+    public Optional<String> getSecretOptional(String key)
+    {
+        // Sanity check key
+        String errorMessage = "Illegal key: '" + key + "'";
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(key), errorMessage);
+        Preconditions.checkArgument(key.indexOf('*') == -1, errorMessage);
+        List<String> segments = Splitter.on('.').splitToList(key);
+        segments.forEach(segment -> Preconditions.checkArgument(!Strings.isNullOrEmpty(segment)));
+
+        // Only allow operatorType to access pre-declared secrets
+        if (!operatorSecretFilter.match(key)) {
+            throw new SecretAccessDeniedException(key);
+        }
+
+        // If the key falls under the scope of an explicit grant, then fetch the secret identified by remounting the key path into the grant path.
+        JsonNode scope = grants.getInternalObjectNode();
+        int i = 0;
+
+        while (true) {
+            String segment = segments.get(i);
+            JsonNode node = scope.get(segment);
+            if (node == null) {
+                // Key falls outside the override scope. No override.
+                break;
+            }
+            if (node.isObject()) {
+                // Dig deeper
+                i++;
+                if (i >= segments.size()) {
+                    // Key ended before we reached a leaf. No override.
+                    break;
+                }
+                scope = node;
+            }
+            else if (node.isTextual()) {
+                // Reached a path-overriding grant leaf.
+                List<String> remainder = segments.subList(i + 1, segments.size());
+                List<String> base = Splitter.on('.').splitToList(node.asText());
+                String remounted = FluentIterable
+                        .from(base)
+                        .append(remainder)
+                        .join(Joiner.on('.'));
+                return fetchSecret(remounted);
+            }
+            else if (node.isBoolean() && node.asBoolean()) {
+                // Reached a grant leaf.
+                return fetchSecret(key);
+            }
+            else {
+                throw new AssertionError();
+            }
+        }
+
+        // No explicit grant. Check key against system acl to see if access is granted by default.
+        if (!secretAccessPolicy.isSecretAccessible(context, key)) {
+            throw new SecretAccessDeniedException(key);
+        }
+
+        return fetchSecret(key);
+    }
+
+    private Optional<String> fetchSecret(String key)
+    {
+        return secretStore.getSecret(context, key);
+    }
+}

--- a/digdag-core/src/main/java/io/digdag/core/agent/DefaultTaskExecutionContext.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/DefaultTaskExecutionContext.java
@@ -1,0 +1,21 @@
+package io.digdag.core.agent;
+
+import io.digdag.spi.SecretProvider;
+import io.digdag.spi.TaskExecutionContext;
+
+class DefaultTaskExecutionContext
+        implements TaskExecutionContext
+{
+    private SecretProvider secretProvider;
+
+    DefaultTaskExecutionContext(SecretProvider secretProvider)
+    {
+        this.secretProvider = secretProvider;
+    }
+
+    @Override
+    public SecretProvider secrets()
+    {
+        return secretProvider;
+    }
+}

--- a/digdag-core/src/main/java/io/digdag/core/agent/RequireOperatorFactory.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/RequireOperatorFactory.java
@@ -10,6 +10,7 @@ import io.digdag.core.repository.ResourceNotFoundException;
 import io.digdag.core.session.AttemptStateFlags;
 import io.digdag.spi.Operator;
 import io.digdag.spi.OperatorFactory;
+import io.digdag.spi.TaskExecutionContext;
 import io.digdag.spi.TaskExecutionException;
 import io.digdag.spi.TaskRequest;
 import io.digdag.spi.TaskResult;
@@ -60,7 +61,7 @@ public class RequireOperatorFactory
         }
 
         @Override
-        public TaskResult runTask()
+        public TaskResult runTask(TaskExecutionContext ctx)
         {
             Config config = request.getConfig();
             String workflowName = config.get("_command", String.class);

--- a/digdag-core/src/main/java/io/digdag/core/agent/SecretFilter.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/SecretFilter.java
@@ -1,0 +1,26 @@
+package io.digdag.core.agent;
+
+import com.google.common.collect.ImmutableList;
+import io.digdag.spi.SecretSelector;
+
+import java.util.List;
+
+class SecretFilter
+{
+    private final List<SecretSelector> selectors;
+
+    private SecretFilter(List<SecretSelector> selectors)
+    {
+        this.selectors = ImmutableList.copyOf(selectors);
+    }
+
+    boolean match(String key)
+    {
+        return selectors.stream().anyMatch(s -> s.match(key));
+    }
+
+    static SecretFilter of(List<SecretSelector> selectors)
+    {
+        return new SecretFilter(selectors);
+    }
+}

--- a/digdag-core/src/main/java/io/digdag/core/crypto/SecretCrypto.java
+++ b/digdag-core/src/main/java/io/digdag/core/crypto/SecretCrypto.java
@@ -1,0 +1,24 @@
+package io.digdag.core.crypto;
+
+public interface SecretCrypto
+{
+    /**
+     * Encrypt a secret value.
+     * @param plainText The value to encrypt.
+     * @return A base64 encoded encrypted secret.
+     */
+    String encryptSecret(String plainText);
+
+    /**
+     * Decrypt an encrypted secret.
+     * @param encryptedBase64 A base64 encoded encrypted secret to decrypt.
+     * @return The decrypted secret in plain text.
+     * @throws SecretCryptoException if the secret could not be decrypted due to e.g. crypto key mismatch or data corruption.
+     */
+    String decryptSecret(String encryptedBase64);
+
+    /**
+     * Get the name of this crypto implementation.
+     */
+    String getName();
+}

--- a/digdag-core/src/main/java/io/digdag/core/crypto/SecretCryptoException.java
+++ b/digdag-core/src/main/java/io/digdag/core/crypto/SecretCryptoException.java
@@ -1,0 +1,10 @@
+package io.digdag.core.crypto;
+
+public class SecretCryptoException
+        extends RuntimeException
+{
+    public SecretCryptoException(Throwable cause)
+    {
+        super(cause);
+    }
+}

--- a/digdag-core/src/main/java/io/digdag/core/crypto/SecretCryptoProvider.java
+++ b/digdag-core/src/main/java/io/digdag/core/crypto/SecretCryptoProvider.java
@@ -1,0 +1,37 @@
+package io.digdag.core.crypto;
+
+import com.google.common.base.Optional;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import io.digdag.client.config.Config;
+import io.digdag.core.database.AESGCMSecretCrypto;
+import io.digdag.core.database.DisabledSecretCrypto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class SecretCryptoProvider
+        implements Provider<SecretCrypto>
+{
+    private static final Logger logger = LoggerFactory.getLogger(SecretCryptoProvider.class);
+
+    private final SecretCrypto crypto;
+
+    @Inject
+    public SecretCryptoProvider(Config systemConfig)
+    {
+        Optional<String> encryptionKey = systemConfig.getOptional("digdag.secret-encryption-key", String.class);
+        if (encryptionKey.isPresent()) {
+            this.crypto = new AESGCMSecretCrypto(encryptionKey.get());
+        }
+        else {
+            this.crypto = new DisabledSecretCrypto();
+        }
+        logger.info("secret encryption engine: {}", this.crypto.getName());
+    }
+
+    @Override
+    public SecretCrypto get()
+    {
+        return crypto;
+    }
+}

--- a/digdag-core/src/main/java/io/digdag/core/database/AESGCMSecretCrypto.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/AESGCMSecretCrypto.java
@@ -1,0 +1,213 @@
+package io.digdag.core.database;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+import io.digdag.core.crypto.SecretCrypto;
+import io.digdag.core.crypto.SecretCryptoException;
+
+import javax.crypto.AEADBadTagException;
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+import java.nio.ByteBuffer;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Base64;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static javax.crypto.Cipher.ENCRYPT_MODE;
+
+/**
+ * A {@link SecretCrypto} implementation that encrypts secrets using AES in GCM mode, padding to hide the actual size of the secret.
+ *
+ * <p>The encrypted record format is (offsets in bytes):</p>
+ *
+ * <pre>
+ * 0          6         10     14      26                  2074      2090
+ * +-----------------------------------------------------------------+
+ * | "aesgcm" | version | term | nonce | encrypted payload | gcm tag |
+ * +-----------------------------------------------------------------+
+ *      6B        4B       4B      12B         2048B           16B
+ * </pre>
+ *
+ * <p>The encrypted payload contains a 32 bit length integer and 2044 Bytes of text + padding. Both the length and the text + padding is encrypted.</p>
+ *
+ */
+public class AESGCMSecretCrypto implements SecretCrypto
+{
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+
+    private static final String NAME = "aesgcm";
+    private static final byte[] NAME_BYTES = NAME.getBytes(UTF_8);
+
+    private final SecretKey sharedSecret;
+
+    private static final int AES_KEY_SIZE = 128;
+    private static final int GCM_NONCE_LENGTH = 12;
+    private static final int GCM_TAG_LENGTH = 16;
+
+    private static final int TERM = 1;
+    private static final int VERSION = 1;
+
+    private static final int MAX_PLAINTEXT_LENGTH = 1024;
+
+    private static final int RECORD_SIZE = 2048;
+    private static final int LENGTH_SIZE = 4;
+    private static final int TEXT_SIZE = RECORD_SIZE - LENGTH_SIZE;
+    private static final int NAME_SIZE = NAME_BYTES.length;
+    private static final int TERM_SIZE = 4;
+    private static final int VERSION_SIZE = 4;
+    private static final int OPAQUE_SIZE =
+            NAME_SIZE + VERSION_SIZE + TERM_SIZE + GCM_NONCE_LENGTH + RECORD_SIZE + GCM_TAG_LENGTH;
+
+    public AESGCMSecretCrypto(String sharedSecretBase64)
+    {
+        byte[] sharedSecretRaw = Base64.getDecoder().decode(sharedSecretBase64);
+        Preconditions.checkArgument(sharedSecretRaw.length * 8 == AES_KEY_SIZE);
+        this.sharedSecret = new SecretKeySpec(sharedSecretRaw, "AES");
+    }
+
+    @Override
+    public String encryptSecret(String plainText)
+    {
+        if (plainText.length() > MAX_PLAINTEXT_LENGTH) {
+            throw new IllegalArgumentException("Too long text");
+        }
+
+        byte[] nonce = generateNonce();
+
+        Cipher cipher = cipher(ENCRYPT_MODE, sharedSecret, nonce);
+
+        byte[] plainTextBytes = plainText.getBytes(UTF_8);
+
+        if (plainTextBytes.length > MAX_PLAINTEXT_LENGTH) {
+            throw new IllegalArgumentException("Too long text");
+        }
+
+        byte[] recordBytes = new byte[RECORD_SIZE];
+        ByteBuffer recordBuffer = ByteBuffer.wrap(recordBytes);
+        recordBuffer.putInt(plainTextBytes.length);
+        recordBuffer.put(plainTextBytes);
+
+        byte[] cipherText;
+        try {
+            cipherText = cipher.doFinal(recordBytes);
+        }
+        catch (IllegalBlockSizeException | BadPaddingException e) {
+            throw Throwables.propagate(e);
+        }
+
+        assert cipherText.length == RECORD_SIZE + GCM_TAG_LENGTH;
+
+        byte[] opaque = new byte[OPAQUE_SIZE];
+        ByteBuffer output = ByteBuffer.wrap(opaque);
+
+        output.put(NAME_BYTES);
+        output.putInt(VERSION);
+        output.putInt(TERM);
+        output.put(nonce);
+        output.put(cipherText);
+
+        assert output.remaining() == 0;
+
+        return Base64.getEncoder().encodeToString(opaque);
+    }
+
+    @Override
+    public String decryptSecret(String encryptedBase64)
+    {
+        byte[] encrypted = Base64.getDecoder().decode(encryptedBase64);
+        Preconditions.checkArgument(encrypted.length == OPAQUE_SIZE, "Bad size");
+
+        ByteBuffer buffer = ByteBuffer.wrap(encrypted);
+
+        byte[] nameBytes = new byte[NAME_SIZE];
+        buffer.get(nameBytes);
+        if (!Arrays.equals(NAME_BYTES, nameBytes)) {
+            throw new IllegalArgumentException("Crypto engine mismatch");
+        }
+
+        int version = buffer.getInt();
+        if (version != VERSION) {
+            throw new IllegalArgumentException("Bad version");
+        }
+
+        int term = buffer.getInt();
+        if (term != TERM) {
+            throw new IllegalArgumentException("Bad term");
+        }
+
+        byte[] nonce = new byte[GCM_NONCE_LENGTH];
+        buffer.get(nonce);
+
+        Cipher cipher = cipher(Cipher.DECRYPT_MODE, sharedSecret, nonce);
+
+        byte[] recordBytes;
+        try {
+            recordBytes = cipher.doFinal(encrypted, buffer.position(), buffer.remaining());
+        }
+        catch (AEADBadTagException e) {
+            throw new SecretCryptoException(e);
+        }
+        catch (IllegalBlockSizeException | BadPaddingException e) {
+            throw Throwables.propagate(e);
+        }
+
+        assert recordBytes.length == RECORD_SIZE;
+
+        ByteBuffer decryptedBuffer = ByteBuffer.wrap(recordBytes);
+        int length = decryptedBuffer.getInt();
+        if (length < -1 || length > MAX_PLAINTEXT_LENGTH) {
+            throw new IllegalArgumentException("Bad length");
+        }
+
+        decryptedBuffer.limit(decryptedBuffer.position() + length);
+
+        return UTF_8.decode(decryptedBuffer).toString();
+    }
+
+    @Override
+    public String getName()
+    {
+        return NAME;
+    }
+
+    private Cipher cipher(int encryptMode, SecretKey sharedSecret, byte[] nonce)
+    {
+        Cipher result;
+        try {
+            result = Cipher.getInstance("AES/GCM/NoPadding");
+        }
+        catch (NoSuchAlgorithmException | NoSuchPaddingException e1) {
+            throw Throwables.propagate(e1);
+        }
+        Cipher cipher = result;
+
+        GCMParameterSpec spec = new GCMParameterSpec(GCM_TAG_LENGTH * 8, nonce);
+        try {
+            cipher.init(encryptMode, sharedSecret, spec);
+        }
+        catch (InvalidKeyException | InvalidAlgorithmParameterException e) {
+            throw Throwables.propagate(e);
+        }
+        return cipher;
+    }
+
+    private byte[] generateNonce()
+    {
+        // The nonce need not be random, just unique. It is simply convenient to rely on
+        // SecureRandom (/dev/urandom) to give us a value which is very likely to (although
+        // of course not guaranteed) be unique.
+        byte[] nonce = new byte[GCM_NONCE_LENGTH];
+        SECURE_RANDOM.nextBytes(nonce);
+        return nonce;
+    }
+}

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseMigrator.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseMigrator.java
@@ -733,6 +733,33 @@ public class DatabaseMigrator
         }
     };
 
+    private final Migration MigrateAddSecretsTable = new Migration()
+    {
+        @Override
+        public String getVersion()
+        {
+            return "20160817123456";
+        }
+
+        @Override
+        public void migrate(Handle handle)
+        {
+            handle.update(
+                    new CreateTableBuilder("secrets")
+                            .addLongId("id")
+                            .addLong("site_id", "not null")
+                            .addLong("project_id", "not null references projects (id)")
+                            .addString("scope", "not null")
+                            .addString("engine", "not null")
+                            .addString("key", "not null")
+                            .addLongText("value", "not null")
+                            .addTimestamp("updated_at", "not null")
+                            .build());
+
+            handle.update("create index secrets_on_site_id_and_project_id_and_scope_and_key on secrets (site_id, project_id, scope, key)");
+        }
+    };
+
     private final Migration[] migrations = {
         MigrateCreateTables,
         MigrateSessionsOnProjectIdIndexToDesc,
@@ -740,5 +767,6 @@ public class DatabaseMigrator
         MigrateMakeProjectsDeletable,
         MigrateAddUserInfoColumnToRevisions,
         MigrateQueueRearchitecture,
+        MigrateAddSecretsTable,
     };
 }

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSecretControlStore.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSecretControlStore.java
@@ -1,0 +1,69 @@
+package io.digdag.core.database;
+
+import io.digdag.core.crypto.SecretCrypto;
+import io.digdag.spi.SecretControlStore;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+
+import java.util.List;
+
+class DatabaseSecretControlStore
+        extends BasicDatabaseStoreManager<DatabaseSecretControlStore.Dao>
+        implements SecretControlStore
+{
+    private final int siteId;
+    private final SecretCrypto crypto;
+
+    DatabaseSecretControlStore(DatabaseConfig config, DBI dbi, int siteId, SecretCrypto crypto)
+    {
+        super(config.getType(), Dao.class, dbi);
+        this.siteId = siteId;
+        this.crypto = crypto;
+    }
+
+    @Override
+    public void setProjectSecret(int projectId, String scope, String key, String value)
+    {
+        String encrypted = crypto.encryptSecret(value);
+        String engine = crypto.getName();
+
+        transaction((handle, dao, ts) -> {
+            dao.deleteProjectSecret(siteId, projectId, scope, key);
+            dao.insertProjectSecret(siteId, projectId, scope, key, engine, encrypted);
+            return null;
+        });
+    }
+
+    @Override
+    public void deleteProjectSecret(int projectId, String scope, String key)
+    {
+        transaction((handle, dao, ts) -> {
+            dao.deleteProjectSecret(siteId, projectId, scope, key);
+            return null;
+        });
+    }
+
+    @Override
+    public List<String> listProjectSecrets(int projectId, String scope)
+    {
+        return transaction((handle, dao, ts) -> dao.listProjectSecrets(siteId, projectId, scope));
+    }
+
+    interface Dao
+    {
+        @SqlQuery("select key from secrets" +
+                " where site_id = :siteId and project_id = :projectId and scope = :scope")
+        List<String> listProjectSecrets(@Bind("siteId") int siteId, @Bind("projectId") int projectId, @Bind("scope") String scope);
+
+        @SqlUpdate("delete from secrets" +
+                " where site_id = :siteId and project_id = :projectId and scope = :scope and key = :key")
+        int deleteProjectSecret(@Bind("siteId") int siteId, @Bind("projectId") int projectId, @Bind("scope") String scope, @Bind("key") String key);
+
+        @SqlUpdate("insert into secrets" +
+                " (site_id, project_id, scope, key, engine, value, updated_at)" +
+                " values (:siteId, :projectId, :scope, :key, :engine, :value, now())")
+        int insertProjectSecret(@Bind("siteId") int siteId, @Bind("projectId") int projectId, @Bind("scope") String scope, @Bind("key") String key, @Bind("engine") String engine, @Bind("value") String value);
+    }
+}

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSecretControlStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSecretControlStoreManager.java
@@ -1,0 +1,32 @@
+package io.digdag.core.database;
+
+import com.google.inject.Inject;
+import io.digdag.client.config.Config;
+import io.digdag.core.crypto.SecretCrypto;
+import io.digdag.spi.SecretControlStore;
+import io.digdag.spi.SecretControlStoreManager;
+import org.skife.jdbi.v2.DBI;
+
+public class DatabaseSecretControlStoreManager
+        implements SecretControlStoreManager
+{
+    private final Config systemConfig;
+    private final DatabaseConfig config;
+    private final DBI dbi;
+    private final SecretCrypto crypto;
+
+    @Inject
+    public DatabaseSecretControlStoreManager(Config systemConfig, DatabaseConfig config, DBI dbi, SecretCrypto crypto)
+    {
+        this.systemConfig = systemConfig;
+        this.config = config;
+        this.dbi = dbi;
+        this.crypto = crypto;
+    }
+
+    @Override
+    public SecretControlStore getSecretControlStore(int siteId)
+    {
+        return new DatabaseSecretControlStore(config, dbi, siteId, crypto);
+    }
+}

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSecretStore.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSecretStore.java
@@ -1,0 +1,100 @@
+package io.digdag.core.database;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
+import io.digdag.core.crypto.SecretCrypto;
+import io.digdag.spi.SecretAccessContext;
+import io.digdag.spi.SecretAccessDeniedException;
+import io.digdag.spi.SecretScopes;
+import io.digdag.spi.SecretStore;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.tweak.ResultSetMapper;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.List;
+import java.util.Map;
+
+class DatabaseSecretStore
+        extends BasicDatabaseStoreManager<DatabaseSecretStore.Dao>
+        implements SecretStore
+{
+    private static final Map<String, Integer> PRIORITIES = ImmutableMap.of(
+            SecretScopes.PROJECT, 0,
+            SecretScopes.PROJECT_DEFAULT, 1);
+
+    private final int siteId;
+
+    private final SecretCrypto crypto;
+
+    DatabaseSecretStore(DatabaseConfig config, DBI dbi, int siteId, SecretCrypto crypto)
+    {
+        super(config.getType(), Dao.class, dbi);
+        this.siteId = siteId;
+        this.crypto = crypto;
+        dbi.registerMapper(new ScopedSecretMapper());
+    }
+
+    @Override
+    public Optional<String> getSecret(SecretAccessContext context, String key)
+    {
+        if (context.siteId() != siteId) {
+            throw new SecretAccessDeniedException("Site id mismatch");
+        }
+
+        List<ScopedSecret> secrets = autoCommit((handle, dao) -> dao.getProjectSecrets(siteId, context.projectId(), key));
+
+        if (secrets.isEmpty()) {
+            return Optional.absent();
+        }
+
+        ScopedSecret secret = secrets.stream()
+                .filter(s -> PRIORITIES.containsKey(s.scope))
+                .sorted((a, b) -> PRIORITIES.get(a.scope) - PRIORITIES.get(b.scope))
+                .findFirst().orElseThrow(AssertionError::new);
+
+        // TODO: look up crypto engine using name
+        if (!crypto.getName().equals(crypto.getName())) {
+            throw new AssertionError("Crypto engine mismatch");
+        }
+
+        String decrypted = crypto.decryptSecret(secret.value);
+
+        return Optional.of(decrypted);
+    }
+
+    interface Dao
+    {
+        @SqlQuery("select scope, engine, value from secrets" +
+                " where site_id = :siteId and project_id = :projectId and key = :key")
+        List<ScopedSecret> getProjectSecrets(@Bind("siteId") int siteId, @Bind("projectId") int projectId, @Bind("key") String key);
+    }
+
+    private static class ScopedSecret
+    {
+        private final String scope;
+        private final String engine;
+        private final String value;
+
+        private ScopedSecret(String scope, String engine, String value)
+        {
+            this.scope = scope;
+            this.engine = engine;
+            this.value = value;
+        }
+    }
+
+    private class ScopedSecretMapper
+            implements ResultSetMapper<ScopedSecret>
+    {
+        @Override
+        public ScopedSecret map(int index, ResultSet r, StatementContext ctx)
+                throws SQLException
+        {
+            return new ScopedSecret(r.getString("scope"), r.getString("engine"), r.getString("value"));
+        }
+    }
+}

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSecretStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSecretStoreManager.java
@@ -1,0 +1,29 @@
+package io.digdag.core.database;
+
+import com.google.inject.Inject;
+import io.digdag.core.crypto.SecretCrypto;
+import io.digdag.spi.SecretStore;
+import io.digdag.spi.SecretStoreManager;
+import org.skife.jdbi.v2.DBI;
+
+public class DatabaseSecretStoreManager
+        implements SecretStoreManager
+{
+    private final DatabaseConfig config;
+    private final DBI dbi;
+    private final SecretCrypto crypto;
+
+    @Inject
+    public DatabaseSecretStoreManager(DatabaseConfig config, DBI dbi, SecretCrypto crypto)
+    {
+        this.config = config;
+        this.dbi = dbi;
+        this.crypto = crypto;
+    }
+
+    @Override
+    public SecretStore getSecretStore(int siteId)
+    {
+        return new DatabaseSecretStore(config, dbi, siteId, crypto);
+    }
+}

--- a/digdag-core/src/main/java/io/digdag/core/database/DisabledSecretCrypto.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DisabledSecretCrypto.java
@@ -1,0 +1,25 @@
+package io.digdag.core.database;
+
+import io.digdag.core.crypto.SecretCrypto;
+
+public class DisabledSecretCrypto
+        implements SecretCrypto
+{
+    @Override
+    public String encryptSecret(String plainText)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String decryptSecret(String encryptedBase64)
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getName()
+    {
+        return "disabled";
+    }
+}

--- a/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowCompiler.java
+++ b/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowCompiler.java
@@ -30,7 +30,8 @@ public class WorkflowCompiler
         "_error",
         "_check",
         "_retry",
-        "_export"
+        "_export",
+        "_secrets"
     ));
 
     public WorkflowCompiler()

--- a/digdag-core/src/test/java/io/digdag/core/agent/DefaultSecretProviderTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/agent/DefaultSecretProviderTest.java
@@ -1,0 +1,130 @@
+package io.digdag.core.agent;
+
+import com.google.common.base.Optional;
+import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigFactory;
+import io.digdag.core.config.YamlConfigLoader;
+import io.digdag.spi.SecretAccessContext;
+import io.digdag.spi.SecretAccessDeniedException;
+import io.digdag.spi.SecretAccessPolicy;
+import io.digdag.spi.SecretStore;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static io.digdag.core.database.DatabaseTestingUtils.createConfig;
+import static io.digdag.core.database.DatabaseTestingUtils.createConfigFactory;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+@RunWith(JUnitParamsRunner.class)
+public class DefaultSecretProviderTest
+{
+    private static final YamlConfigLoader YAML_CONFIG_LOADER = new YamlConfigLoader();
+    private static final ConfigFactory CONFIG_FACTORY = createConfigFactory();
+
+    @Rule public final ExpectedException exception = ExpectedException.none();
+
+    @Mock SecretAccessPolicy secretAccessPolicy;
+    @Mock SecretStore secretStore;
+    @Mock SecretFilter secretFilter;
+    @Mock SecretAccessContext secretAccessContext;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void verifyUndeclaredAccessIsDenied()
+            throws Exception
+    {
+        String key = "foo";
+        Config grants = createConfig();
+
+        when(secretFilter.match(anyString())).thenReturn(false);
+
+        DefaultSecretProvider provider = new DefaultSecretProvider(secretAccessContext, secretAccessPolicy, grants, secretFilter, secretStore);
+
+        try {
+            provider.getSecret(key);
+            fail("Expected " + SecretAccessDeniedException.class.getName());
+        }
+        catch (SecretAccessDeniedException e) {
+            assertThat(e.getKey(), is(key));
+        }
+
+        verify(secretFilter).match(key);
+
+        verifyNoMoreInteractions(secretStore);
+        verifyNoMoreInteractions(secretAccessPolicy);
+    }
+
+    @Test
+    public void testDefaultAccessibleSecret()
+            throws Exception
+    {
+        String expectedSecret = "foo-secret";
+        String key = "foo";
+        Config grants = createConfig();
+
+        when(secretStore.getSecret(secretAccessContext, key)).thenReturn(Optional.of(expectedSecret));
+        when(secretAccessPolicy.isSecretAccessible(any(SecretAccessContext.class), anyString())).thenReturn(true);
+        when(secretFilter.match(key)).thenReturn(true);
+
+        DefaultSecretProvider provider = new DefaultSecretProvider(secretAccessContext, secretAccessPolicy, grants, secretFilter, secretStore);
+
+        String secret = provider.getSecret(key);
+
+        verify(secretFilter).match(key);
+        verify(secretAccessPolicy).isSecretAccessible(secretAccessContext, key);
+        verify(secretStore).getSecret(secretAccessContext, key);
+
+        assertThat(secret, is(expectedSecret));
+    }
+
+    @Test
+    @Parameters({
+            "foo        | foo: true                  | foo",
+            "foo        | foo: bar                   | bar",
+            "foo.secret | foo: true                  | foo.secret",
+            "foo.secret | foo: bar                   | bar.secret",
+            "foo.a.b    | foo: {a: true}             | foo.a.b",
+            "foo.a.b    | foo: {a: bar.a\\, b: quux} | bar.a.b"
+    })
+    public void testGrantedSecret(String key, String grantsYaml, String expectedKey)
+            throws Exception
+    {
+        String expectedSecret = "the-secret";
+
+        when(secretStore.getSecret(secretAccessContext, expectedKey)).thenReturn(Optional.of(expectedSecret));
+        when(secretAccessPolicy.isSecretAccessible(any(SecretAccessContext.class), anyString())).thenReturn(false);
+        when(secretFilter.match(key)).thenReturn(true);
+
+        Config grants = YAML_CONFIG_LOADER.loadString(grantsYaml).toConfig(CONFIG_FACTORY);
+
+        DefaultSecretProvider provider = new DefaultSecretProvider(secretAccessContext, secretAccessPolicy, grants, secretFilter, secretStore);
+
+        String secret = provider.getSecret(key);
+
+        verify(secretFilter).match(key);
+        verifyNoMoreInteractions(secretAccessPolicy);
+        verify(secretStore).getSecret(secretAccessContext, expectedKey);
+
+        assertThat(secret, is(expectedSecret));
+    }
+}

--- a/digdag-core/src/test/java/io/digdag/core/agent/SecretFilterTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/agent/SecretFilterTest.java
@@ -1,0 +1,43 @@
+package io.digdag.core.agent;
+
+import com.google.common.collect.ImmutableList;
+import io.digdag.spi.SecretSelector;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static java.util.Collections.emptyList;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SecretFilterTest
+{
+    @Mock SecretSelector matchingSelector;
+    @Mock SecretSelector nonMatchingSelector;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        when(matchingSelector.match(anyString())).thenReturn(true);
+        when(nonMatchingSelector.match(anyString())).thenReturn(false);
+    }
+
+    @Test
+    public void match()
+            throws Exception
+    {
+        assertThat(SecretFilter.of(emptyList()).match("foobar"), is(false));
+        assertThat(SecretFilter.of(ImmutableList.of(nonMatchingSelector)).match("bar"), is(false));
+        assertThat(SecretFilter.of(ImmutableList.of(nonMatchingSelector, nonMatchingSelector)).match("bar"), is(false));
+
+        assertThat(SecretFilter.of(ImmutableList.of(matchingSelector)).match("bar"), is(true));
+        assertThat(SecretFilter.of(ImmutableList.of(nonMatchingSelector, matchingSelector)).match("bar"), is(true));
+        assertThat(SecretFilter.of(ImmutableList.of(matchingSelector, nonMatchingSelector)).match("bar"), is(true));
+    }
+}

--- a/digdag-core/src/test/java/io/digdag/core/agent/SecretSelectorTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/agent/SecretSelectorTest.java
@@ -1,0 +1,21 @@
+package io.digdag.core.agent;
+
+import io.digdag.spi.SecretSelector;
+import org.junit.Test;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class SecretSelectorTest
+{
+    @Test
+    public void match()
+            throws Exception
+    {
+        assertThat(SecretSelector.of("foo").match("foo"), is(true));
+        assertThat(SecretSelector.of("foo").match("bar"), is(false));
+        assertThat(SecretSelector.of("foo.*").match("foo.bar"), is(true));
+        assertThat(SecretSelector.of("foo.*").match("foo"), is(false));
+        assertThat(SecretSelector.of("foo.*").match("bar"), is(false));
+    }
+}

--- a/digdag-core/src/test/java/io/digdag/core/database/AESGCMSecretCryptoTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/database/AESGCMSecretCryptoTest.java
@@ -1,0 +1,65 @@
+package io.digdag.core.database;
+
+import com.google.common.base.Strings;
+import io.digdag.core.crypto.SecretCryptoException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.util.Base64;
+import java.util.concurrent.ThreadLocalRandom;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class AESGCMSecretCryptoTest
+{
+    @Rule public ExpectedException expectedException = ExpectedException.none();
+
+    private final static byte[] KEY1 = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
+    private final static String KEY1_BASE64 = Base64.getEncoder().encodeToString(KEY1);
+
+    private final static byte[] KEY2 = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2};
+    private final static String KEY2_BASE64 = Base64.getEncoder().encodeToString(KEY2);
+
+    private AESGCMSecretCrypto crypto1;
+    private AESGCMSecretCrypto crypto2;
+
+    private static final String TEXT = "Hello Secret World!";
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        crypto1 = new AESGCMSecretCrypto(KEY1_BASE64);
+        crypto2 = new AESGCMSecretCrypto(KEY2_BASE64);
+    }
+
+    @Test
+    public void testEncryptDecrypt()
+            throws Exception
+    {
+        String encrypted = crypto1.encryptSecret(TEXT);
+        String decrypted = crypto1.decryptSecret(encrypted);
+        assertThat(decrypted, is(TEXT));
+    }
+
+    @Test
+    public void verifyCannotDecryptWithWrongKey()
+            throws Exception
+    {
+        String encrypted = crypto1.encryptSecret(TEXT);
+        expectedException.expect(SecretCryptoException.class);
+        crypto2.decryptSecret(encrypted);
+    }
+
+    @Test
+    public void verifyTextSizeLimit()
+            throws Exception
+    {
+        crypto1.encryptSecret(Strings.repeat(".", 1024));
+        expectedException.expect(IllegalArgumentException.class);
+        crypto1.encryptSecret(Strings.repeat(".", 1024 + 1));
+    }
+}

--- a/digdag-core/src/test/java/io/digdag/core/workflow/EchoOperatorFactory.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/EchoOperatorFactory.java
@@ -6,6 +6,7 @@ import java.nio.file.Path;
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.inject.Inject;
+import io.digdag.spi.TaskExecutionContext;
 import io.digdag.spi.TaskRequest;
 import io.digdag.spi.TaskResult;
 import io.digdag.spi.Operator;
@@ -13,7 +14,6 @@ import io.digdag.spi.OperatorFactory;
 import io.digdag.client.config.Config;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.StandardOpenOption.CREATE;
-import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
 import static java.nio.file.StandardOpenOption.WRITE;
 import static java.nio.file.StandardOpenOption.APPEND;
 
@@ -48,7 +48,7 @@ public class EchoOperatorFactory
         }
 
         @Override
-        public TaskResult run()
+        public TaskResult run(TaskExecutionContext ctx)
         {
             Config params = request.getConfig();
 

--- a/digdag-core/src/test/java/io/digdag/core/workflow/FailOperatorFactory.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/FailOperatorFactory.java
@@ -1,19 +1,14 @@
 package io.digdag.core.workflow;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
-import com.google.common.base.Optional;
-import com.google.common.base.Throwables;
+
 import com.google.inject.Inject;
+import io.digdag.spi.TaskExecutionContext;
 import io.digdag.spi.TaskRequest;
 import io.digdag.spi.TaskResult;
 import io.digdag.spi.Operator;
 import io.digdag.spi.OperatorFactory;
 import io.digdag.client.config.Config;
-import static java.nio.charset.StandardCharsets.UTF_8;
-import static java.nio.file.StandardOpenOption.CREATE;
-import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
-import static java.nio.file.StandardOpenOption.APPEND;
 
 public class FailOperatorFactory
         implements OperatorFactory
@@ -46,7 +41,7 @@ public class FailOperatorFactory
         }
 
         @Override
-        public TaskResult run()
+        public TaskResult run(TaskExecutionContext ctx)
         {
             Config params = request.getConfig();
 

--- a/digdag-core/src/test/java/io/digdag/core/workflow/NoopOperatorFactory.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/NoopOperatorFactory.java
@@ -2,6 +2,7 @@ package io.digdag.core.workflow;
 
 import java.nio.file.Path;
 import com.google.inject.Inject;
+import io.digdag.spi.TaskExecutionContext;
 import io.digdag.spi.TaskRequest;
 import io.digdag.spi.TaskResult;
 import io.digdag.spi.Operator;
@@ -36,7 +37,7 @@ public class NoopOperatorFactory
         }
 
         @Override
-        public TaskResult run()
+        public TaskResult run(TaskExecutionContext ctx)
         {
             return TaskResult.empty(request);
         }

--- a/digdag-core/src/test/java/io/digdag/core/workflow/WorkflowTestingUtils.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/WorkflowTestingUtils.java
@@ -1,29 +1,36 @@
 package io.digdag.core.workflow;
 
-import com.google.inject.Inject;
-import com.google.inject.Scopes;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
+import com.google.inject.Scopes;
 import com.google.inject.multibindings.Multibinder;
 import io.digdag.client.config.Config;
-import io.digdag.spi.OperatorFactory;
-import io.digdag.spi.CommandExecutor;
-import io.digdag.spi.SchedulerFactory;
-import io.digdag.spi.ScheduleTime;
 import io.digdag.core.DigdagEmbed;
+import io.digdag.core.LocalSecretAccessPolicy;
 import io.digdag.core.LocalSite;
-import io.digdag.core.database.DatabaseConfig;
+import io.digdag.core.crypto.SecretCrypto;
+import io.digdag.core.crypto.SecretCryptoProvider;
 import io.digdag.core.archive.ArchiveMetadata;
 import io.digdag.core.archive.WorkflowFile;
-import io.digdag.core.repository.ResourceNotFoundException;
+import io.digdag.core.database.DatabaseConfig;
+import io.digdag.core.database.DatabaseSecretStoreManager;
 import io.digdag.core.repository.ResourceConflictException;
+import io.digdag.core.repository.ResourceNotFoundException;
 import io.digdag.core.repository.StoredWorkflowDefinition;
 import io.digdag.core.repository.WorkflowDefinitionList;
 import io.digdag.core.session.StoredSessionAttemptWithSession;
+import io.digdag.spi.CommandExecutor;
+import io.digdag.spi.OperatorFactory;
+import io.digdag.spi.ScheduleTime;
+import io.digdag.spi.SchedulerFactory;
+import io.digdag.spi.SecretAccessPolicy;
+import io.digdag.spi.SecretStoreManager;
+
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
+
 import static io.digdag.core.database.DatabaseTestingUtils.cleanDatabase;
 import static io.digdag.core.database.DatabaseTestingUtils.getEnvironmentDatabaseConfig;
 
@@ -37,6 +44,10 @@ public class WorkflowTestingUtils
             .withExtensionLoader(false)
             .addModules((binder) -> {
                 binder.bind(CommandExecutor.class).to(SimpleCommandExecutor.class).in(Scopes.SINGLETON);
+
+                binder.bind(SecretCrypto.class).toProvider(SecretCryptoProvider.class).in(Scopes.SINGLETON);
+                binder.bind(SecretStoreManager.class).to(DatabaseSecretStoreManager.class).in(Scopes.SINGLETON);
+                binder.bind(SecretAccessPolicy.class).to(LocalSecretAccessPolicy.class);
 
                 Multibinder<SchedulerFactory> schedulerFactoryBinder = Multibinder.newSetBinder(binder, SchedulerFactory.class);
 

--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -629,6 +629,72 @@ Deletes a project. Sessions of the deleted project are kept retained so that we 
 
     $ digdag delete myproj
 
+secrets
+~~~~~~~
+
+Digdag provides basic secret management that can be used to securely provide e.g. passwords and api keys etc to operators.
+
+Secrets are handled separately from normal workflow parameters and are stored encrypted by the server. Workflow operators
+can only access secrets that they are permitted access to by server policy or explicitly granted access to by the workflow
+author using the `_secrets` directive.
+
+.. code-block:: console
+
+    $ digdag secrets --project <project>
+
+List secrets set for a project. This will only list the secret keys and will not show the actual secret values.
+
+.. code-block:: console
+
+    $ digdag secrets --project <project> --set key
+
+Set a secret key value for a project. The cli will prompt for the secret value to be entered in the terminal. The entered
+value will not be displayed.
+
+Multiple secrets can be entered by listing multiple keys.
+
+It is also possible to read a secret value from a file. Note that the entire raw file contents are read and used as the
+secret value. Any whitespace and newlines etc are included as-is.
+
+.. code-block:: console
+
+    $ cat secret.txt
+    foobar
+
+    $ digdag secrets --project <project> --set key=@secret.txt
+
+Multiple secrets can be read from a single file in JSON format.
+
+.. code-block:: console
+
+    $ cat secrets.json
+    {
+        "foo": "secret1",
+        "bar": "secret2"
+    }
+
+    $ digdag secrets --project <project> --set @secrets.json
+
+Secrets can also be read from stdin. The below command would set the secret key `foo` to the value `bar`.
+
+.. code-block:: console
+
+    $ echo -n 'bar' | digdag secrets --project <project> --set foo=-
+
+Note that only one secret value can be read using the above command. To read multiple secrets from stdin, omit the secret key
+name on the command line and provide secret keys and values on stdin in JSON format.
+
+.. code-block:: console
+
+    $ echo -n '{"foo": "secret1", "bar": "secret2"}' | digdag secrets --project <project> --set -
+
+    $ cat secrets.json | digdag secrets --project <project> --set -
+
+To delete secrets, use the `--delete` command.
+
+.. code-block:: console
+
+    $ digdag secrets --project <project> --delete foo bar
 
 Common options
 ----------------------------------

--- a/digdag-plugin-utils/src/main/java/io/digdag/util/BaseOperator.java
+++ b/digdag-plugin-utils/src/main/java/io/digdag/util/BaseOperator.java
@@ -3,6 +3,8 @@ package io.digdag.util;
 import java.util.List;
 import java.util.ArrayList;
 import java.nio.file.Path;
+
+import io.digdag.spi.TaskExecutionContext;
 import io.digdag.spi.TaskResult;
 import io.digdag.spi.TaskRequest;
 import io.digdag.client.config.Config;
@@ -41,12 +43,12 @@ public abstract class BaseOperator
     }
 
     @Override
-    public TaskResult run()
+    public TaskResult run(TaskExecutionContext ctx)
     {
         RetryControl retry = RetryControl.prepare(request.getConfig(), request.getLastStateParams(), false);
         try {
             try {
-                return runTask();
+                return runTask(ctx);
             }
             finally {
                 workspace.close();
@@ -76,5 +78,13 @@ public abstract class BaseOperator
         }
     }
 
-    public abstract TaskResult runTask();
+    // TODO: scrap backwards compatibility?
+    @Deprecated
+    public TaskResult runTask() {
+        throw new UnsupportedOperationException();
+    }
+
+    public TaskResult runTask(TaskExecutionContext ctx) {
+        return runTask();
+    }
 }

--- a/digdag-plugin-utils/src/main/java/io/digdag/util/DurationParam.java
+++ b/digdag-plugin-utils/src/main/java/io/digdag/util/DurationParam.java
@@ -24,15 +24,36 @@ public class DurationParam
         return new DurationParam(Durations.parseDuration(expr));
     }
 
+    public static DurationParam of(Duration duration)
+    {
+        return new DurationParam(duration);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DurationParam that = (DurationParam) o;
+
+        return duration != null ? duration.equals(that.duration) : that.duration == null;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return duration != null ? duration.hashCode() : 0;
+    }
+
     @Override
     @JsonValue
     public String toString()
     {
         return Durations.formatDuration(duration);
-    }
-
-    public static DurationParam of(Duration duration)
-    {
-        return new DurationParam(duration);
     }
 }

--- a/digdag-plugin-utils/src/test/java/io/digdag/util/BaseOperatorTest.java
+++ b/digdag-plugin-utils/src/test/java/io/digdag/util/BaseOperatorTest.java
@@ -4,6 +4,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigElement;
 import io.digdag.client.config.ConfigFactory;
+import io.digdag.spi.SecretProvider;
+import io.digdag.spi.TaskExecutionContext;
 import io.digdag.spi.TaskExecutionException;
 import io.digdag.spi.TaskRequest;
 import io.digdag.spi.TaskResult;
@@ -28,6 +30,7 @@ public class BaseOperatorTest
     @Rule public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Mock TaskRequest request;
+    @Mock TaskExecutionContext taskExecutionContext;
 
     private final ConfigFactory configFactory = new ConfigFactory(new ObjectMapper());
     private Config config;
@@ -53,14 +56,14 @@ public class BaseOperatorTest
         BaseOperator op = new BaseOperator(temporaryFolder.getRoot().toPath(), request)
         {
             @Override
-            public TaskResult runTask()
+            public TaskResult runTask(TaskExecutionContext ctx)
             {
                 throw ex;
             }
         };
 
         try {
-            op.run();
+            op.run(taskExecutionContext);
             fail();
         }
         catch (TaskExecutionException e) {
@@ -81,14 +84,14 @@ public class BaseOperatorTest
         BaseOperator op = new BaseOperator(temporaryFolder.getRoot().toPath(), request)
         {
             @Override
-            public TaskResult runTask()
+            public TaskResult runTask(TaskExecutionContext ctx)
             {
                 throw ex;
             }
         };
 
         try {
-            op.run();
+            op.run(taskExecutionContext);
             fail();
         }
         catch (TaskExecutionException e) {

--- a/digdag-server/src/main/java/io/digdag/server/AuthRequestFilter.java
+++ b/digdag-server/src/main/java/io/digdag/server/AuthRequestFilter.java
@@ -5,6 +5,11 @@ import javax.ws.rs.ext.Provider;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.Response;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Supplier;
+import com.google.common.base.Suppliers;
+import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import io.digdag.client.config.ConfigFactory;
 
@@ -36,6 +41,7 @@ public class AuthRequestFilter
         if (result.isAccepted()) {
             requestContext.setProperty("siteId", result.getSiteId());
             requestContext.setProperty("userInfo", result.getUserInfo().or(cf.create()));
+            requestContext.setProperty("secrets", result.getSecrets().or(Suppliers.ofInstance(ImmutableMap.of())));
         }
         else {
             requestContext.abortWith(errorResultHandler.toResponse(result.getErrorMessage()));

--- a/digdag-server/src/main/java/io/digdag/server/Authenticator.java
+++ b/digdag-server/src/main/java/io/digdag/server/Authenticator.java
@@ -3,11 +3,14 @@ package io.digdag.server;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.common.base.Optional;
+import com.google.common.base.Supplier;
 import io.digdag.client.config.Config;
 import org.immutables.value.Value;
 
 import javax.annotation.Nullable;
 import javax.ws.rs.container.ContainerRequestContext;
+
+import java.util.Map;
 
 import static org.immutables.value.Value.Style.ImplementationVisibility.PACKAGE;
 
@@ -57,6 +60,19 @@ public interface Authenticator
         String getErrorMessage();
 
         Optional<Config> getUserInfo();
+
+        Optional<Supplier<Map<String, String>>> getSecrets();
+
+        static Builder builder() {
+            return ImmutableResult.builder();
+        }
+
+        interface Builder {
+            Builder siteId(int siteId);
+            Builder userInfo(Config userInfo);
+            Builder secrets(Supplier<Map<String, String>> secrets);
+            Result build();
+        }
     }
 
     Result authenticate(ContainerRequestContext requestContext);

--- a/digdag-server/src/main/java/io/digdag/server/DefaultSecretAccessPolicy.java
+++ b/digdag-server/src/main/java/io/digdag/server/DefaultSecretAccessPolicy.java
@@ -1,0 +1,103 @@
+package io.digdag.server;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLParser;
+import com.google.common.base.Optional;
+import com.google.inject.Inject;
+import io.digdag.client.config.Config;
+import io.digdag.server.ServerSecretAccessPolicy.OperatorSecretAccessPolicy;
+import io.digdag.spi.SecretAccessContext;
+import io.digdag.spi.SecretAccessPolicy;
+import io.digdag.spi.SecretSelector;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class DefaultSecretAccessPolicy
+        implements SecretAccessPolicy
+{
+    private static final Logger logger = LoggerFactory.getLogger(DefaultSecretAccessPolicy.class);
+
+    private final ServerSecretAccessPolicy policy;
+
+    @Inject
+    public DefaultSecretAccessPolicy(Config systemConfig, ObjectMapper mapper)
+            throws IOException
+    {
+        this.policy = loadPolicy(systemConfig, mapper);
+    }
+
+    @Override
+    public boolean isSecretAccessible(SecretAccessContext context, String key)
+    {
+        if (policy == null) {
+            return false;
+        }
+
+        OperatorSecretAccessPolicy operatorPolicy = this.policy.operators().get(context.operatorType());
+        if (operatorPolicy == null) {
+            return false;
+        }
+
+        for (SecretSelector selector : operatorPolicy.secrets()) {
+            if (selector.match(key)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static ServerSecretAccessPolicy loadPolicy(Config systemConfig, ObjectMapper mapper)
+            throws IOException
+    {
+        ServerSecretAccessPolicy.Builder builder;
+        Optional<String> policyFilename = systemConfig.getOptional("digdag.secret-access-policy-file", String.class);
+        if (policyFilename.isPresent()) {
+            builder = ServerSecretAccessPolicy.builder().from(readPolicy(mapper, Paths.get(policyFilename.get())));
+        }
+        else {
+            builder = ServerSecretAccessPolicy.builder();
+        }
+
+        Pattern pattern = Pattern.compile("^secret-access-policy\\.operators\\.(\\w+)\\.secrets$");
+
+        for (String key : systemConfig.getKeys()) {
+            Matcher m = pattern.matcher(key);
+            if (m.find()) {
+                String operatorType = m.group(1);
+                String value = systemConfig.get(key, String.class);
+                List<SecretSelector> selectors = mapper.readValue(value, new TypeReference<List<SecretSelector>>() {});
+                builder.putOperators(operatorType, OperatorSecretAccessPolicy.of(selectors));
+            }
+        }
+
+        ServerSecretAccessPolicy policy = builder.build();
+
+        logger.info("loaded secret access policy: {}", policy);
+
+        return policy;
+    }
+
+    private static ServerSecretAccessPolicy readPolicy(ObjectMapper mapper, Path path)
+            throws IOException
+    {
+        ServerSecretAccessPolicy policy;
+        try (InputStream in = Files.newInputStream(path)) {
+            YAMLParser parser = new YAMLFactory().createParser(in);
+            policy = mapper.readValue(parser, ServerSecretAccessPolicy.class);
+        }
+        return policy;
+    }
+
+}

--- a/digdag-server/src/main/java/io/digdag/server/ServerSecretAccessPolicy.java
+++ b/digdag-server/src/main/java/io/digdag/server/ServerSecretAccessPolicy.java
@@ -1,0 +1,66 @@
+package io.digdag.server;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import io.digdag.spi.SecretSelector;
+import org.immutables.value.Value;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.immutables.value.Value.Style.ImplementationVisibility.PACKAGE;
+
+@Value.Immutable
+@Value.Style(visibility = PACKAGE)
+@JsonSerialize(as = ImmutableServerSecretAccessPolicy.class)
+@JsonDeserialize(as = ImmutableServerSecretAccessPolicy.class)
+interface ServerSecretAccessPolicy
+{
+    Map<String, OperatorSecretAccessPolicy> operators();
+
+    static Builder builder()
+    {
+        return ImmutableServerSecretAccessPolicy.builder();
+    }
+
+    @Value.Immutable
+    @Value.Style(visibility = PACKAGE)
+    @JsonSerialize(as = ImmutableOperatorSecretAccessPolicy.class)
+    @JsonDeserialize(as = ImmutableOperatorSecretAccessPolicy.class)
+    interface OperatorSecretAccessPolicy
+    {
+        List<SecretSelector> secrets();
+
+        static Builder builder()
+        {
+            return ImmutableOperatorSecretAccessPolicy.builder();
+        }
+
+        interface Builder
+        {
+            Builder secrets(Iterable<? extends SecretSelector> selectors);
+
+            OperatorSecretAccessPolicy build();
+        }
+
+        static OperatorSecretAccessPolicy of(List<SecretSelector> selectors)
+        {
+            return builder().secrets(selectors).build();
+        }
+    }
+
+    interface Builder
+    {
+        Builder putOperators(String key, OperatorSecretAccessPolicy value);
+
+        Builder putOperators(Map.Entry<String, ? extends OperatorSecretAccessPolicy> entry);
+
+        Builder operators(Map<String, ? extends OperatorSecretAccessPolicy> entries);
+
+        Builder putAllOperators(Map<String, ? extends OperatorSecretAccessPolicy> entries);
+
+        Builder from(ServerSecretAccessPolicy policy);
+
+        ServerSecretAccessPolicy build();
+    }
+}

--- a/digdag-server/src/main/java/io/digdag/server/rs/AuthenticatedResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/AuthenticatedResource.java
@@ -1,10 +1,12 @@
 package io.digdag.server.rs;
 
-import com.google.common.base.Optional;
+import com.google.common.base.Supplier;
 import io.digdag.client.config.Config;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Context;
+
+import java.util.Map;
 
 public abstract class AuthenticatedResource
 {
@@ -21,5 +23,13 @@ public abstract class AuthenticatedResource
     protected Config getUserInfo()
     {
         return (Config) request.getAttribute("userInfo");
+    }
+
+    /**
+     * Get request context default secrets.
+     */
+    protected Supplier<Map<String, String>> getSecrets()
+    {
+        return (Supplier<Map<String, String>>) request.getAttribute("secrets");
     }
 }

--- a/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
@@ -27,38 +27,87 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.InternalServerErrorException;
 import javax.ws.rs.core.StreamingOutput;
 import javax.ws.rs.core.Response;
+
+import com.google.common.base.Supplier;
 import com.google.inject.Inject;
 import com.google.common.base.Throwables;
 import com.google.common.collect.*;
 import com.google.common.io.ByteStreams;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.ByteStreams;
+import com.google.inject.Inject;
+import io.digdag.client.api.RestProject;
+import io.digdag.client.api.RestRevision;
+import io.digdag.client.api.RestSecretList;
+import io.digdag.client.api.RestSecretMetadata;
+import io.digdag.client.api.RestSession;
+import io.digdag.client.api.RestSetSecretRequest;
+import io.digdag.client.api.RestWorkflowDefinition;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigFactory;
+import io.digdag.core.TempFileManager;
+import io.digdag.core.TempFileManager.TempDir;
+import io.digdag.core.TempFileManager.TempFile;
 import io.digdag.core.archive.ArchiveMetadata;
+import io.digdag.core.config.YamlConfigLoader;
+import io.digdag.core.repository.ArchiveType;
+import io.digdag.core.repository.Project;
+import io.digdag.core.repository.ProjectControl;
+import io.digdag.core.repository.ProjectStore;
+import io.digdag.core.repository.ProjectStoreManager;
+import io.digdag.core.repository.ResourceConflictException;
+import io.digdag.core.repository.ResourceNotFoundException;
+import io.digdag.core.repository.Revision;
+import io.digdag.core.repository.StoredProject;
+import io.digdag.core.repository.StoredRevision;
+import io.digdag.core.repository.StoredWorkflowDefinition;
+import io.digdag.core.schedule.ScheduleStoreManager;
+import io.digdag.core.schedule.SchedulerManager;
 import io.digdag.core.session.SessionStore;
 import io.digdag.core.session.SessionStoreManager;
 import io.digdag.core.session.StoredSessionWithLastAttempt;
-import io.digdag.core.workflow.*;
-import io.digdag.core.repository.*;
-import io.digdag.core.schedule.*;
-import io.digdag.core.config.YamlConfigLoader;
 import io.digdag.core.storage.ArchiveManager;
-import io.digdag.core.TempFileManager;
-import io.digdag.core.TempFileManager.TempFile;
-import io.digdag.core.TempFileManager.TempDir;
-import io.digdag.client.api.*;
-import io.digdag.spi.StorageObject;
-import io.digdag.spi.StorageFileNotFoundException;
-import io.digdag.spi.DirectDownloadHandle;
-import io.digdag.util.Md5CountInputStream;
+import io.digdag.core.workflow.WorkflowCompiler;
 import io.digdag.server.GenericJsonExceptionHandler;
-import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import io.digdag.spi.SecretControlStore;
+import io.digdag.spi.SecretControlStoreManager;
+import io.digdag.spi.SecretScopes;
+import io.digdag.client.api.SecretValidation;
+import io.digdag.spi.StorageFileNotFoundException;
+import io.digdag.spi.StorageObject;
+import io.digdag.util.Md5CountInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.HeaderParam;
+import javax.ws.rs.InternalServerErrorException;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import static io.digdag.server.rs.RestModels.sessionModels;
-import static io.digdag.util.Md5CountInputStream.digestMd5;
 import static java.util.Locale.ENGLISH;
 
 @Path("/")
@@ -79,6 +128,9 @@ public class ProjectResource
     // GET  /api/projects/{id}/archive                   # download archive file of the latest revision of a project
     // GET  /api/projects/{id}/archive?revision=<name>   # download archive file of a former revision of a project
     // PUT  /api/projects?project=<name>&revision=<name> # create a new revision (also create a project if it doesn't exist)
+    // GET  /api/projects/{id}/secrets                   # list secrets for a project
+    // PUT  /api/projects/{id}/secrets/<key>             # set a secret for a project
+    // DEL  /api/projects/{id}/secrets/<key>             # delete a secret for a project
     //
     // Deprecated:
     // GET  /api/project?name=<name>                     # lookup a project by name
@@ -97,6 +149,7 @@ public class ProjectResource
     private final SchedulerManager srm;
     private final TempFileManager tempFiles;
     private final SessionStoreManager ssm;
+    private final SecretControlStoreManager scsp;
 
     @Inject
     public ProjectResource(
@@ -108,7 +161,8 @@ public class ProjectResource
             ScheduleStoreManager sm,
             SchedulerManager srm,
             TempFileManager tempFiles,
-            SessionStoreManager ssm)
+            SessionStoreManager ssm,
+            SecretControlStoreManager scsp)
     {
         this.cf = cf;
         this.rawLoader = rawLoader;
@@ -119,6 +173,7 @@ public class ProjectResource
         this.sm = sm;
         this.tempFiles = tempFiles;
         this.ssm = ssm;
+        this.scsp = scsp;
     }
 
     private static StoredProject ensureNotDeletedProject(StoredProject proj)
@@ -424,7 +479,7 @@ public class ProjectResource
                 }
             }
 
-            return rm.getProjectStore(getSiteId()).putAndLockProject(
+            RestProject restProject = rm.getProjectStore(getSiteId()).putAndLockProject(
                     Project.of(name),
                     (store, storedProject) -> {
                         ProjectControl lockedProj = new ProjectControl(store, storedProject);
@@ -440,22 +495,22 @@ public class ProjectResource
                             }
                             rev = lockedProj.insertRevision(
                                     Revision.builderFromArchive(revision, meta, getUserInfo())
-                                        .archiveType(ArchiveType.DB)
-                                        .archivePath(Optional.absent())
-                                        .archiveMd5(Optional.of(md5))
-                                        .build()
-                                    );
+                                            .archiveType(ArchiveType.DB)
+                                            .archivePath(Optional.absent())
+                                            .archiveMd5(Optional.of(md5))
+                                            .build()
+                            );
                             lockedProj.insertRevisionArchiveData(rev.getId(), data);
                         }
                         else {
                             // store location of the uploaded file in db
                             rev = lockedProj.insertRevision(
                                     Revision.builderFromArchive(revision, meta, getUserInfo())
-                                        .archiveType(location.getArchiveType())
-                                        .archivePath(Optional.of(location.getPath()))
-                                        .archiveMd5(Optional.of(md5))
-                                        .build()
-                                    );
+                                            .archiveType(location.getArchiveType())
+                                            .archivePath(Optional.of(location.getPath()))
+                                            .archiveMd5(Optional.of(md5))
+                                            .build()
+                            );
                         }
 
                         List<StoredWorkflowDefinition> defs =
@@ -464,6 +519,11 @@ public class ProjectResource
                                     srm, scheduleFrom);
                         return RestModels.project(storedProject, rev);
                     });
+
+            SecretControlStore secretControlStore = scsp.getSecretControlStore(getSiteId());
+            Supplier<Map<String, String>> secrets = getSecrets();
+            secrets.get().forEach((k, v) -> secretControlStore.setProjectSecret(restProject.getId(), SecretScopes.PROJECT_DEFAULT, k, v));
+            return restProject;
         }
     }
 
@@ -524,5 +584,63 @@ public class ProjectResource
                         "Size of a file in the archive exceeds limit (%d > %d bytes): %s",
                         entry.getSize(), ARCHIVE_FILE_SIZE_LIMIT, entry.getName()));
         }
+    }
+
+    @PUT
+    @Consumes("application/json")
+    @Path("/api/projects/{id}/secrets/{key}")
+    public void putProjectSecret(@PathParam("id") int projectId, @PathParam("key") String key, RestSetSecretRequest request)
+            throws IOException, ResourceConflictException, ResourceNotFoundException
+    {
+        if (!SecretValidation.isValidSecret(key, request.value())) {
+            throw new IllegalArgumentException("Invalid secret");
+        }
+
+        // Verify that the project exists
+        ProjectStore projectStore = rm.getProjectStore(getSiteId());
+        StoredProject project = projectStore.getProjectById(projectId);
+        ensureNotDeletedProject(project);
+
+        SecretControlStore store = scsp.getSecretControlStore(getSiteId());
+
+        store.setProjectSecret(projectId, SecretScopes.PROJECT, key, request.value());
+    }
+
+    @DELETE
+    @Path("/api/projects/{id}/secrets/{key}")
+    public void deleteProjectSecret(@PathParam("id") int projectId, @PathParam("key") String key)
+            throws IOException, ResourceConflictException, ResourceNotFoundException
+    {
+        if (!SecretValidation.isValidSecretKey(key)) {
+            throw new IllegalArgumentException("Invalid secret");
+        }
+
+        // Verify that the project exists
+        ProjectStore projectStore = rm.getProjectStore(getSiteId());
+        StoredProject project = projectStore.getProjectById(projectId);
+        ensureNotDeletedProject(project);
+
+        SecretControlStore store = scsp.getSecretControlStore(getSiteId());
+
+        store.deleteProjectSecret(projectId, SecretScopes.PROJECT, key);
+    }
+
+    @GET
+    @Path("/api/projects/{id}/secrets")
+    @Produces("application/json")
+    public RestSecretList getProjectSecrets(@PathParam("id") int projectId)
+            throws IOException, ResourceConflictException, ResourceNotFoundException
+    {
+        // Verify that the project exists
+        ProjectStore projectStore = rm.getProjectStore(getSiteId());
+        StoredProject project = projectStore.getProjectById(projectId);
+        ensureNotDeletedProject(project);
+
+        SecretControlStore store = scsp.getSecretControlStore(getSiteId());
+        List<String> keys = store.listProjectSecrets(projectId, SecretScopes.PROJECT);
+
+        return RestSecretList.builder()
+                .secrets(keys.stream().map(RestSecretMetadata::of).collect(Collectors.toList()))
+                .build();
     }
 }

--- a/digdag-spi/src/main/java/io/digdag/spi/Operator.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/Operator.java
@@ -1,6 +1,30 @@
 package io.digdag.spi;
 
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
 public interface Operator
 {
-    TaskResult run();
+    // TODO: scrap backwards compatibility?
+    @Deprecated
+    default TaskResult run()
+    {
+        throw new UnsupportedOperationException();
+    }
+
+    default TaskResult run(TaskExecutionContext ctx)
+    {
+        return run();
+    }
+
+    /**
+     * Get a list of secret selectors that describe the namespace(s) of secret keys that this
+     * operator intends to access. An attempt to access a secret using a key not covered by
+     * one of these selectors will result in a {@link SecretAccessDeniedException}.
+     */
+    default List<String> secretSelectors()
+    {
+        return ImmutableList.of();
+    }
 }

--- a/digdag-spi/src/main/java/io/digdag/spi/SecretAccessContext.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/SecretAccessContext.java
@@ -1,0 +1,48 @@
+package io.digdag.spi;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+import static org.immutables.value.Value.Style.ImplementationVisibility.PACKAGE;
+
+@Value.Immutable
+@Value.Style(visibility = PACKAGE)
+@JsonSerialize(as = ImmutableSecretAccessContext.class)
+@JsonDeserialize(as = ImmutableSecretAccessContext.class)
+public interface SecretAccessContext
+{
+    int siteId();
+
+    int projectId();
+
+    String revision();
+
+    String workflowName();
+
+    String taskName();
+
+    String operatorType();
+
+    static Builder builder()
+    {
+        return ImmutableSecretAccessContext.builder();
+    }
+
+    interface Builder
+    {
+        Builder siteId(int siteId);
+
+        Builder projectId(int projectId);
+
+        Builder revision(String revision);
+
+        Builder workflowName(String workflowName);
+
+        Builder taskName(String taskName);
+
+        Builder operatorType(String operatorType);
+
+        SecretAccessContext build();
+    }
+}

--- a/digdag-spi/src/main/java/io/digdag/spi/SecretAccessDeniedException.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/SecretAccessDeniedException.java
@@ -1,0 +1,18 @@
+package io.digdag.spi;
+
+public class SecretAccessDeniedException
+        extends RuntimeException
+{
+    private String key;
+
+    public SecretAccessDeniedException(String key)
+    {
+        super("Access denied for key: '" + key + "'");
+        this.key = key;
+    }
+
+    public String getKey()
+    {
+        return key;
+    }
+}

--- a/digdag-spi/src/main/java/io/digdag/spi/SecretAccessPolicy.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/SecretAccessPolicy.java
@@ -1,0 +1,6 @@
+package io.digdag.spi;
+
+public interface SecretAccessPolicy
+{
+    boolean isSecretAccessible(SecretAccessContext context, String key);
+}

--- a/digdag-spi/src/main/java/io/digdag/spi/SecretControlStore.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/SecretControlStore.java
@@ -1,0 +1,12 @@
+package io.digdag.spi;
+
+import java.util.List;
+
+public interface SecretControlStore
+{
+    void setProjectSecret(int projectId, String scope, String key, String value);
+
+    void deleteProjectSecret(int projectId, String scope, String key);
+
+    List<String> listProjectSecrets(int projectId, String scope);
+}

--- a/digdag-spi/src/main/java/io/digdag/spi/SecretControlStoreManager.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/SecretControlStoreManager.java
@@ -1,0 +1,6 @@
+package io.digdag.spi;
+
+public interface SecretControlStoreManager
+{
+    SecretControlStore getSecretControlStore(int siteId);
+}

--- a/digdag-spi/src/main/java/io/digdag/spi/SecretNotFoundException.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/SecretNotFoundException.java
@@ -1,0 +1,22 @@
+package io.digdag.spi;
+
+/**
+ * An exception thrown for secret accesses that would be accessible under the
+ * access policies in effect but for which a matching secret could not be found.
+ */
+public class SecretNotFoundException
+        extends RuntimeException
+{
+    private final String key;
+
+    public SecretNotFoundException(String key)
+    {
+        super("Secret not found for key: '" + key + "'");
+        this.key = key;
+    }
+
+    public String getKey()
+    {
+        return key;
+    }
+}

--- a/digdag-spi/src/main/java/io/digdag/spi/SecretProvider.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/SecretProvider.java
@@ -1,0 +1,64 @@
+package io.digdag.spi;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import io.digdag.client.api.SecretValidation;
+
+/**
+ * A VFS style secret access interface.
+ */
+public interface SecretProvider
+{
+    /**
+     * Get a secret identified by a key.
+     *
+     * @param key A key identifing the secret to get.
+     * @return A secret.
+     * @throws SecretAccessDeniedException if access to the secret was not permitted.
+     * @throws SecretNotFoundException if no matching secret was found.
+     */
+    default String getSecret(String key) {
+        return getSecretOptional(key).or(() -> {
+            throw new SecretNotFoundException(key);
+        });
+    }
+
+    /**
+     * Get a secret identified by a key.
+     *
+     * @param key A key identifing the secret to get.
+     * @return {@link Optional#of(Object)} with a secret or {@link Optional#absent()} if no matching secret was found.
+     * @throws SecretAccessDeniedException if access to the secret was not permitted.
+     */
+    Optional<String> getSecretOptional(String key);
+
+    /**
+     * Get a view of a subtree of the secret VFS. All secret accesses by the returned {@link SecretProvider} are prefixed by the specified path.
+     */
+    default SecretProvider getSecrets(String path) {
+        return new ScopedSecretProvider(this, path);
+    }
+
+    /**
+     * A secret provider that implements a virtual subtree view.
+     */
+    class ScopedSecretProvider
+            implements SecretProvider
+    {
+        private final SecretProvider delegate;
+        private final String path;
+
+        ScopedSecretProvider(SecretProvider delegate, String path) {
+            this.delegate = Preconditions.checkNotNull(delegate, "delegate");
+            this.path = Preconditions.checkNotNull(path, "path");
+            Preconditions.checkArgument(SecretValidation.isValidSecretKey(path), "invalid path: %s", path);
+        }
+
+        @Override
+        public Optional<String> getSecretOptional(String key)
+        {
+            Preconditions.checkArgument(SecretValidation.isValidSecretKey(key), "invalid key: %s", key);
+            return delegate.getSecretOptional(this.path + '.' + key);
+        }
+    }
+}

--- a/digdag-spi/src/main/java/io/digdag/spi/SecretRequest.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/SecretRequest.java
@@ -1,0 +1,31 @@
+package io.digdag.spi;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+@Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+public interface SecretRequest
+{
+    SecretAccessContext context();
+
+    String key();
+
+    static SecretRequest of(SecretAccessContext context, String key)
+    {
+        return builder().context(context).key(key).build();
+    }
+
+    static Builder builder()
+    {
+        return ImmutableSecretRequest.builder();
+    }
+
+    interface Builder
+    {
+        Builder context(SecretAccessContext context);
+
+        Builder key(String key);
+
+        SecretRequest build();
+    }
+}

--- a/digdag-spi/src/main/java/io/digdag/spi/SecretScopes.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/SecretScopes.java
@@ -1,0 +1,7 @@
+package io.digdag.spi;
+
+public interface SecretScopes
+{
+    String PROJECT = "project";
+    String PROJECT_DEFAULT = "project-default";
+}

--- a/digdag-spi/src/main/java/io/digdag/spi/SecretSelector.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/SecretSelector.java
@@ -1,0 +1,57 @@
+package io.digdag.spi;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import org.immutables.value.Value;
+
+import java.util.regex.Pattern;
+
+import static org.immutables.value.Value.Style.ImplementationVisibility.PACKAGE;
+
+@Value.Immutable
+@Value.Style(visibility = PACKAGE)
+@JsonSerialize(as = ImmutableSecretSelector.class)
+@JsonDeserialize(as = ImmutableSecretSelector.class)
+public interface SecretSelector
+{
+    Pattern VALID_PATTERN = Pattern.compile("^(\\w+\\.)*\\w+(\\.\\*)?$");
+
+    String pattern();
+
+    @Value.Check
+    default void check()
+    {
+        Preconditions.checkState(VALID_PATTERN.matcher(pattern()).matches(), "Bad secret selector: '" + pattern() + "'");
+    }
+
+    default boolean match(String key)
+    {
+        Preconditions.checkArgument(!Strings.isNullOrEmpty(key), "key");
+        if (pattern().endsWith(".*")) {
+            String prefix = pattern().substring(0, pattern().length() - 1);
+            return key.startsWith(prefix);
+        }
+        else {
+            return pattern().equals(key);
+        }
+    }
+
+    static SecretSelector of(String pattern)
+    {
+        return builder().pattern(pattern).build();
+    }
+
+    static Builder builder()
+    {
+        return ImmutableSecretSelector.builder();
+    }
+
+    interface Builder
+    {
+        Builder pattern(String pattern);
+
+        SecretSelector build();
+    }
+}

--- a/digdag-spi/src/main/java/io/digdag/spi/SecretStore.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/SecretStore.java
@@ -1,0 +1,8 @@
+package io.digdag.spi;
+
+import com.google.common.base.Optional;
+
+public interface SecretStore
+{
+    Optional<String> getSecret(SecretAccessContext context, String key);
+}

--- a/digdag-spi/src/main/java/io/digdag/spi/SecretStoreManager.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/SecretStoreManager.java
@@ -1,0 +1,6 @@
+package io.digdag.spi;
+
+public interface SecretStoreManager
+{
+    SecretStore getSecretStore(int siteId);
+}

--- a/digdag-spi/src/main/java/io/digdag/spi/TaskExecutionContext.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/TaskExecutionContext.java
@@ -1,0 +1,6 @@
+package io.digdag.spi;
+
+public interface TaskExecutionContext
+{
+    SecretProvider secrets();
+}

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/EchoOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/EchoOperatorFactory.java
@@ -4,6 +4,7 @@ import com.google.inject.Inject;
 import io.digdag.client.config.Config;
 import io.digdag.spi.Operator;
 import io.digdag.spi.OperatorFactory;
+import io.digdag.spi.TaskExecutionContext;
 import io.digdag.spi.TaskRequest;
 import io.digdag.spi.TaskResult;
 
@@ -38,7 +39,7 @@ public class EchoOperatorFactory
         }
 
         @Override
-        public TaskResult run()
+        public TaskResult run(TaskExecutionContext ctx)
         {
             Config params = request.getConfig();
 

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/EmbulkOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/EmbulkOperatorFactory.java
@@ -1,15 +1,11 @@
 package io.digdag.standards.operator;
 
-import java.util.List;
 import java.io.InputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Files;
 import com.google.common.io.ByteStreams;
-import com.google.common.io.CharStreams;
 import com.google.common.base.Throwables;
 import com.google.inject.Inject;
 import com.fasterxml.jackson.core.JsonEncoding;
@@ -17,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
 import io.digdag.spi.CommandExecutor;
+import io.digdag.spi.TaskExecutionContext;
 import io.digdag.spi.TemplateEngine;
 import io.digdag.spi.TemplateException;
 import io.digdag.spi.TaskRequest;
@@ -69,7 +66,7 @@ public class EmbulkOperatorFactory
         }
 
         @Override
-        public TaskResult runTask()
+        public TaskResult runTask(TaskExecutionContext ctx)
         {
             Config params = request.getConfig().mergeDefault(
                     request.getConfig().getNestedOrGetEmpty("embulk"));

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/FailOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/FailOperatorFactory.java
@@ -4,12 +4,12 @@ import java.nio.file.Path;
 import com.google.inject.Inject;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigElement;
+import io.digdag.spi.TaskExecutionContext;
 import io.digdag.spi.TaskRequest;
 import io.digdag.spi.TaskResult;
 import io.digdag.spi.Operator;
 import io.digdag.spi.OperatorFactory;
 import io.digdag.spi.TaskExecutionException;
-import io.digdag.util.BaseOperator;
 
 public class FailOperatorFactory
         implements OperatorFactory
@@ -42,7 +42,7 @@ public class FailOperatorFactory
         }
 
         @Override
-        public TaskResult run()
+        public TaskResult run(TaskExecutionContext ctx)
         {
             Config params = request.getConfig();
 

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/ForEachOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/ForEachOperatorFactory.java
@@ -9,6 +9,7 @@ import io.digdag.client.config.ConfigFactory;
 import io.digdag.core.Limits;
 import io.digdag.spi.Operator;
 import io.digdag.spi.OperatorFactory;
+import io.digdag.spi.TaskExecutionContext;
 import io.digdag.spi.TaskRequest;
 import io.digdag.spi.TaskResult;
 import io.digdag.util.BaseOperator;
@@ -52,7 +53,7 @@ public class ForEachOperatorFactory
         }
 
         @Override
-        public TaskResult runTask()
+        public TaskResult runTask(TaskExecutionContext ctx)
         {
             Config params = request.getConfig();
 

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/IfOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/IfOperatorFactory.java
@@ -3,6 +3,7 @@ package io.digdag.standards.operator;
 import java.nio.file.Path;
 import com.google.inject.Inject;
 import io.digdag.client.config.Config;
+import io.digdag.spi.TaskExecutionContext;
 import io.digdag.spi.TaskRequest;
 import io.digdag.spi.TaskResult;
 import io.digdag.spi.Operator;
@@ -36,7 +37,7 @@ public class IfOperatorFactory
         }
 
         @Override
-        public TaskResult runTask()
+        public TaskResult runTask(TaskExecutionContext ctx)
         {
             Config params = request.getConfig();
 

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/LoopOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/LoopOperatorFactory.java
@@ -1,22 +1,14 @@
 package io.digdag.standards.operator;
 
-import java.util.List;
-import java.util.Properties;
-import java.util.stream.Collectors;
-import java.io.IOException;
 import java.nio.file.Path;
 import com.google.inject.Inject;
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
 import io.digdag.core.Limits;
-import io.digdag.core.workflow.TaskLimitExceededException;
+import io.digdag.spi.TaskExecutionContext;
 import io.digdag.spi.TaskRequest;
 import io.digdag.spi.TaskResult;
-import io.digdag.spi.TemplateEngine;
 import io.digdag.spi.Operator;
 import io.digdag.spi.OperatorFactory;
 import io.digdag.util.BaseOperator;
-import org.immutables.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import io.digdag.client.config.Config;
@@ -52,7 +44,7 @@ public class LoopOperatorFactory
         }
 
         @Override
-        public TaskResult runTask()
+        public TaskResult runTask(TaskExecutionContext ctx)
         {
             Config params = request.getConfig();
 

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/MailOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/MailOperatorFactory.java
@@ -6,6 +6,7 @@ import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigException;
 import io.digdag.spi.Operator;
 import io.digdag.spi.OperatorFactory;
+import io.digdag.spi.TaskExecutionContext;
 import io.digdag.spi.TaskRequest;
 import io.digdag.spi.TaskResult;
 import io.digdag.spi.TemplateEngine;
@@ -79,7 +80,7 @@ public class MailOperatorFactory
         }
 
         @Override
-        public TaskResult runTask()
+        public TaskResult runTask(TaskExecutionContext ctx)
         {
             Config bodyParams = request.getConfig().mergeDefault(
                     request.getConfig().getNestedOrGetEmpty("mail"));

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/NopOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/NopOperatorFactory.java
@@ -1,9 +1,9 @@
 package io.digdag.standards.operator;
 
-import com.google.inject.Inject;
 import io.digdag.client.config.Config;
 import io.digdag.spi.Operator;
 import io.digdag.spi.OperatorFactory;
+import io.digdag.spi.TaskExecutionContext;
 import io.digdag.spi.TaskRequest;
 import io.digdag.spi.TaskResult;
 import io.digdag.util.BaseOperator;
@@ -37,7 +37,7 @@ public class NopOperatorFactory
         }
 
         @Override
-        public TaskResult runTask()
+        public TaskResult runTask(TaskExecutionContext ctx)
         {
             Config params = request.getConfig()
                     .mergeDefault(request.getConfig().getNestedOrGetEmpty("nop"));

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/NotifyOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/NotifyOperatorFactory.java
@@ -8,6 +8,7 @@ import io.digdag.spi.NotificationException;
 import io.digdag.spi.Notifier;
 import io.digdag.spi.Operator;
 import io.digdag.spi.OperatorFactory;
+import io.digdag.spi.TaskExecutionContext;
 import io.digdag.spi.TaskExecutionException;
 import io.digdag.spi.TaskRequest;
 import io.digdag.spi.TaskResult;
@@ -51,7 +52,7 @@ public class NotifyOperatorFactory
         }
 
         @Override
-        public TaskResult run()
+        public TaskResult run(TaskExecutionContext ctx)
         {
             Config params = request.getConfig();
 

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/PyOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/PyOperatorFactory.java
@@ -1,12 +1,9 @@
 package io.digdag.standards.operator;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import java.io.Writer;
 import java.io.BufferedWriter;
-import java.io.InputStream;
 import java.io.OutputStreamWriter;
-import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -15,10 +12,10 @@ import java.nio.charset.StandardCharsets;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.io.ByteStreams;
 import com.google.common.io.CharStreams;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
+import io.digdag.spi.TaskExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import io.digdag.spi.CommandExecutor;
@@ -81,7 +78,7 @@ public class PyOperatorFactory
         }
 
         @Override
-        public TaskResult runTask()
+        public TaskResult runTask(TaskExecutionContext ctx)
         {
             Config params = request.getConfig()
                 .mergeDefault(request.getConfig().getNestedOrGetEmpty("py"))

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/RbOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/RbOperatorFactory.java
@@ -1,12 +1,9 @@
 package io.digdag.standards.operator;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import java.io.Writer;
 import java.io.BufferedWriter;
-import java.io.InputStream;
 import java.io.OutputStreamWriter;
-import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -16,10 +13,10 @@ import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.io.ByteStreams;
 import com.google.common.io.CharStreams;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.Inject;
+import io.digdag.spi.TaskExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import io.digdag.spi.CommandExecutor;
@@ -82,7 +79,7 @@ public class RbOperatorFactory
         }
 
         @Override
-        public TaskResult runTask()
+        public TaskResult runTask(TaskExecutionContext ctx)
         {
             Config params = request.getConfig()
                 .mergeDefault(request.getConfig().getNestedOrGetEmpty("rb"))

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/pg/PgConnectionConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/pg/PgConnectionConfig.java
@@ -1,14 +1,15 @@
 package io.digdag.standards.operator.pg;
 
-import java.util.Properties;
-import java.time.Duration;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import io.digdag.client.config.Config;
-import org.immutables.value.Value;
-import io.digdag.util.DurationParam;
+import io.digdag.spi.SecretProvider;
 import io.digdag.standards.operator.jdbc.AbstractJdbcConnectionConfig;
+import io.digdag.util.DurationParam;
+import org.immutables.value.Value;
+
+import java.time.Duration;
+import java.util.Properties;
 
 @Value.Immutable
 public abstract class PgConnectionConfig
@@ -17,24 +18,21 @@ public abstract class PgConnectionConfig
     public abstract Optional<String> schema();
 
     @VisibleForTesting
-    public static PgConnectionConfig configure(Config params)
+    public static PgConnectionConfig configure(SecretProvider secrets, Config params)
     {
         return ImmutablePgConnectionConfig.builder()
-
-            .host(params.get("host", String.class))
-            .port(params.get("port", int.class, 5432))
-            .user(params.get("user", String.class))
-            .password(params.getOptional("password", String.class))
-            .database(params.get("database", String.class))
-            .ssl(params.get("ssl", boolean.class, false))
-            .connectTimeout(params.get("connect_timeout", DurationParam.class,
-                DurationParam.of(Duration.ofSeconds(30))))
-            .socketTimeout(params.get("socket_timeout", DurationParam.class,
-                DurationParam.of(Duration.ofSeconds(1800))))
-
-            .schema(params.getOptional("schema", String.class))
-
-            .build();
+                .host(secrets.getSecretOptional("host").or(() -> params.get("host", String.class)))
+                .port(secrets.getSecretOptional("port").transform(Integer::parseInt).or(() -> params.get("port", int.class, 5432)))
+                .user(secrets.getSecretOptional("user").or(() -> params.get("user", String.class)))
+                .password(secrets.getSecretOptional("password").or(params.getOptional("password", String.class)))
+                .database(secrets.getSecretOptional("database").or(() -> params.get("database", String.class)))
+                .ssl(secrets.getSecretOptional("ssl").transform(Boolean::parseBoolean).or(() -> params.get("ssl", boolean.class, false)))
+                .connectTimeout(secrets.getSecretOptional("connect_timeout").transform(DurationParam::parse).or(() ->
+                        params.get("connect_timeout", DurationParam.class, DurationParam.of(Duration.ofSeconds(30)))))
+                .socketTimeout(secrets.getSecretOptional("socket_timeout").transform(DurationParam::parse).or(() ->
+                        params.get("socket_timeout", DurationParam.class, DurationParam.of(Duration.ofSeconds(1800)))))
+                .schema(secrets.getSecretOptional("schema").or(params.getOptional("schema", String.class)))
+                .build();
     }
 
     @Override
@@ -72,5 +70,12 @@ public abstract class PgConnectionConfig
         props.setProperty("applicationName", "digdag");
 
         return props;
+    }
+
+    @Override
+    public String toString()
+    {
+        // Omit credentials in toString output
+        return url();
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/pg/PgOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/pg/PgOperatorFactory.java
@@ -4,6 +4,7 @@ import com.google.inject.Inject;
 import io.digdag.client.config.Config;
 import io.digdag.spi.Operator;
 import io.digdag.spi.OperatorFactory;
+import io.digdag.spi.SecretProvider;
 import io.digdag.spi.TaskRequest;
 import io.digdag.spi.TemplateEngine;
 import io.digdag.standards.operator.jdbc.AbstractJdbcOperator;
@@ -40,9 +41,9 @@ public class PgOperatorFactory
         }
 
         @Override
-        protected PgConnectionConfig configure(Config params)
+        protected PgConnectionConfig configure(SecretProvider secrets, Config params)
         {
-            return PgConnectionConfig.configure(params);
+            return PgConnectionConfig.configure(secrets, params);
         }
 
         @Override

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/BaseTdJobOperator.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/BaseTdJobOperator.java
@@ -1,12 +1,15 @@
 package io.digdag.standards.operator.td;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import io.digdag.client.config.Config;
+import io.digdag.spi.TaskExecutionContext;
 import io.digdag.spi.TaskRequest;
 import io.digdag.spi.TaskResult;
 import io.digdag.util.BaseOperator;
 
 import java.nio.file.Path;
+import java.util.List;
 
 abstract class BaseTdJobOperator
         extends BaseOperator
@@ -27,9 +30,15 @@ abstract class BaseTdJobOperator
     }
 
     @Override
-    public final TaskResult runTask()
+    public List<String> secretSelectors()
     {
-        try (TDOperator op = TDOperator.fromConfig(params)) {
+        return ImmutableList.of("td.*");
+    }
+
+    @Override
+    public final TaskResult runTask(TaskExecutionContext ctx)
+    {
+        try (TDOperator op = TDOperator.fromConfig(params, ctx.secrets().getSecrets("td"))) {
 
             Optional<String> doneJobId = state.getOptional(DONE_JOB_ID, String.class);
             TDJobOperator job;

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TDClientFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TDClientFactory.java
@@ -7,58 +7,60 @@ import com.treasuredata.client.TDClient;
 import com.treasuredata.client.TDClientBuilder;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigException;
+import io.digdag.spi.SecretProvider;
 
 class TDClientFactory
 {
     @VisibleForTesting
-    static TDClientBuilder clientBuilderFromConfig(Config params)
+    static TDClientBuilder clientBuilderFromConfig(Config params, SecretProvider secrets)
     {
-        String apikey = params.get("apikey", String.class).trim();
+        TDClientBuilder builder = TDClient.newBuilder(false);
+
+        SecretProvider proxySecrets = secrets.getSecrets("proxy");
+        Config proxyConfig = params.getNestedOrGetEmpty("proxy");
+        boolean proxyEnabled = proxySecrets.getSecretOptional("enabled").transform(Boolean::parseBoolean).or(() -> proxyConfig.get("enabled", Boolean.class, false));
+        if (proxyEnabled) {
+            builder.setProxy(proxyConfig(proxyConfig, proxySecrets));
+        }
+
+        String apikey = secrets.getSecretOptional("apikey").or(() -> params.get("apikey", String.class)).trim();
         if (apikey.isEmpty()) {
             throw new ConfigException("Parameter 'apikey' is empty");
         }
-
-        TDClientBuilder builder = TDClient.newBuilder(false);
-
-        Config proxyConfig = params.getNestedOrGetEmpty("proxy");
-        boolean proxyEnabled = proxyConfig.get("enabled", Boolean.class, false);
-        if (proxyEnabled) {
-            builder.setProxy(proxyConfig(proxyConfig));
-        }
-
+        
         return builder
-                .setEndpoint(params.get("endpoint", String.class, "api.treasuredata.com"))
-                .setUseSSL(params.get("use_ssl", boolean.class, true))
+                .setEndpoint(secrets.getSecretOptional("endpoint").or(() -> params.get("endpoint", String.class, "api.treasuredata.com")))
+                .setUseSSL(secrets.getSecretOptional("use_ssl").transform(Boolean::parseBoolean).or(() -> params.get("use_ssl", boolean.class, true)))
                 .setApiKey(apikey)
                 .setRetryLimit(0)  // disable td-client's retry mechanism
                 ;
     }
 
-    static TDClient clientFromConfig(Config params)
+    static TDClient clientFromConfig(Config params, SecretProvider secrets)
     {
-        return clientBuilderFromConfig(params).build();
+        return clientBuilderFromConfig(params, secrets).build();
     }
 
-    private static ProxyConfig proxyConfig(Config config)
+    private static ProxyConfig proxyConfig(Config config, SecretProvider secrets)
     {
         ProxyConfig.ProxyConfigBuilder builder = new ProxyConfig.ProxyConfigBuilder();
 
-        Optional<String> host = config.getOptional("host", String.class);
+        Optional<String> host = secrets.getSecretOptional("host").or(config.getOptional("host", String.class));
         if (host.isPresent()) {
             builder.setHost(host.get());
         }
 
-        Optional<Integer> port = config.getOptional("port", Integer.class);
+        Optional<Integer> port = secrets.getSecretOptional("port").transform(Integer::parseInt).or(config.getOptional("port", Integer.class));
         if (port.isPresent()) {
             builder.setPort(port.get());
         }
 
-        Optional<String> user = config.getOptional("user", String.class);
+        Optional<String> user = secrets.getSecretOptional("user").or(config.getOptional("user", String.class));
         if (user.isPresent()) {
             builder.setUser(user.get());
         }
 
-        Optional<String> password = config.getOptional("password", String.class);
+        Optional<String> password = secrets.getSecretOptional("password").or(config.getOptional("password", String.class));
         if (password.isPresent()) {
             builder.setPassword(password.get());
         }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TableParam.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TableParam.java
@@ -38,6 +38,32 @@ public class TableParam
     }
 
     @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        TableParam that = (TableParam) o;
+
+        if (database != null ? !database.equals(that.database) : that.database != null) {
+            return false;
+        }
+        return table != null ? table.equals(that.table) : that.table == null;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = database != null ? database.hashCode() : 0;
+        result = 31 * result + (table != null ? table.hashCode() : 0);
+        return result;
+    }
+
+    @Override
     @JsonValue
     public String toString()
     {

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdDdlOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdDdlOperatorFactory.java
@@ -2,8 +2,13 @@ package io.digdag.standards.operator.td;
 
 import java.util.List;
 import java.nio.file.Path;
+
+import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import com.google.common.collect.Iterables;
+import io.digdag.client.config.ConfigException;
+import io.digdag.spi.SecretNotFoundException;
+import io.digdag.spi.TaskExecutionContext;
 import io.digdag.spi.TaskRequest;
 import io.digdag.spi.TaskResult;
 import io.digdag.spi.Operator;
@@ -12,9 +17,6 @@ import io.digdag.util.BaseOperator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import io.digdag.client.config.Config;
-import io.digdag.client.config.ConfigException;
-import com.treasuredata.client.model.TDJobRequest;
-import com.treasuredata.client.model.TDJobRequestBuilder;
 
 public class TdDdlOperatorFactory
         implements OperatorFactory
@@ -45,7 +47,13 @@ public class TdDdlOperatorFactory
         }
 
         @Override
-        public TaskResult runTask()
+        public List<String> secretSelectors()
+        {
+            return ImmutableList.of("td.*");
+        }
+
+        @Override
+        public TaskResult runTask(TaskExecutionContext ctx)
         {
             Config params = request.getConfig().mergeDefault(
                     request.getConfig().getNestedOrGetEmpty("td"));
@@ -54,7 +62,7 @@ public class TdDdlOperatorFactory
             List<String> createDatabaseList = params.getListOrEmpty("create_databases", String.class);
             List<String> emptyDatabaseList = params.getListOrEmpty("empty_databases", String.class);
 
-            try (TDOperator op = TDOperator.fromConfig(params)) {
+            try (TDOperator op = TDOperator.fromConfig(params, ctx.secrets().getSecrets("td"))) {
                 for (String d : Iterables.concat(dropDatabaseList, emptyDatabaseList)) {
                     logger.info("Deleting TD database {}.{}", d);
                     op.withDatabase(d).ensureDatabaseDeleted(d);
@@ -69,7 +77,7 @@ public class TdDdlOperatorFactory
             List<TableParam> createTableList = params.getListOrEmpty("create_tables", TableParam.class);
             List<TableParam> emptyTableList = params.getListOrEmpty("empty_tables", TableParam.class);
 
-            try (TDOperator op = TDOperator.fromConfig(params)) {
+            try (TDOperator op = TDOperator.fromConfig(params, ctx.secrets().getSecrets("td"))) {
                 for (TableParam t : Iterables.concat(dropTableList, emptyTableList)) {
                     logger.info("Deleting TD table {}.{}", op.getDatabase(), t);
                     op.withDatabase(t.getDatabase().or(op.getDatabase())).ensureTableDeleted(t.getTable());

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdLoadOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdLoadOperatorFactory.java
@@ -3,6 +3,7 @@ package io.digdag.standards.operator.td;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import com.treasuredata.client.model.TDBulkLoadSessionStartRequest;
 import com.treasuredata.client.model.TDJob;

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdPartialDeleteOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdPartialDeleteOperatorFactory.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.List;
 
 public class TdPartialDeleteOperatorFactory
         implements OperatorFactory

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdWaitOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdWaitOperatorFactory.java
@@ -1,6 +1,7 @@
 package io.digdag.standards.operator.td;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import com.treasuredata.client.model.TDJobRequest;
 import com.treasuredata.client.model.TDJobRequestBuilder;
@@ -9,6 +10,7 @@ import io.digdag.client.config.ConfigElement;
 import io.digdag.client.config.ConfigException;
 import io.digdag.spi.Operator;
 import io.digdag.spi.OperatorFactory;
+import io.digdag.spi.TaskExecutionContext;
 import io.digdag.spi.TaskExecutionException;
 import io.digdag.spi.TaskRequest;
 import io.digdag.spi.TaskResult;
@@ -20,6 +22,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.nio.file.Path;
+import java.util.List;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -80,9 +83,15 @@ public class TdWaitOperatorFactory
         }
 
         @Override
-        public TaskResult runTask()
+        public List<String> secretSelectors()
         {
-            try (TDOperator op = TDOperator.fromConfig(params)) {
+            return ImmutableList.of("td.*");
+        }
+
+        @Override
+        public TaskResult runTask(TaskExecutionContext ctx)
+        {
+            try (TDOperator op = TDOperator.fromConfig(params, ctx.secrets().getSecrets("td"))) {
 
                 TDJobOperator job = op.runJob(state, POLL_JOB, this::startJob);
                 state.remove(POLL_JOB);

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdWaitTableOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdWaitTableOperatorFactory.java
@@ -1,6 +1,7 @@
 package io.digdag.standards.operator.td;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import com.treasuredata.client.model.TDJobRequest;
 import com.treasuredata.client.model.TDJobRequestBuilder;
@@ -9,6 +10,8 @@ import io.digdag.client.config.ConfigElement;
 import io.digdag.client.config.ConfigException;
 import io.digdag.spi.Operator;
 import io.digdag.spi.OperatorFactory;
+import io.digdag.spi.SecretNotFoundException;
+import io.digdag.spi.TaskExecutionContext;
 import io.digdag.spi.TaskExecutionException;
 import io.digdag.spi.TaskRequest;
 import io.digdag.spi.TaskResult;
@@ -22,6 +25,7 @@ import org.slf4j.LoggerFactory;
 
 import java.math.BigInteger;
 import java.nio.file.Path;
+import java.util.List;
 
 public class TdWaitTableOperatorFactory
         extends AbstractWaitOperatorFactory
@@ -82,9 +86,15 @@ public class TdWaitTableOperatorFactory
         }
 
         @Override
-        public TaskResult runTask()
+        public List<String> secretSelectors()
         {
-            try (TDOperator op = TDOperator.fromConfig(params)) {
+            return ImmutableList.of("td.*");
+        }
+
+        @Override
+        public TaskResult runTask(TaskExecutionContext ctx)
+        {
+            try (TDOperator op = TDOperator.fromConfig(params, ctx.secrets().getSecrets("td"))) {
 
                 // Check if table exists using rest api
                 if (!state.get(TABLE_EXISTS, Boolean.class, false)) {

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TimestampParam.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TimestampParam.java
@@ -42,15 +42,36 @@ public class TimestampParam
         return new TimestampParam(timestamp);
     }
 
+    public static TimestampParam of(LocalTimeOrInstant timestamp)
+    {
+        return new TimestampParam(timestamp);
+    }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        TimestampParam that = (TimestampParam) o;
+
+        return timestamp != null ? timestamp.equals(that.timestamp) : that.timestamp == null;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return timestamp != null ? timestamp.hashCode() : 0;
+    }
+
     @Override
     @JsonValue
     public String toString()
     {
         return timestamp.toString();
-    }
-
-    public static TimestampParam of(LocalTimeOrInstant timestamp)
-    {
-        return new TimestampParam(timestamp);
     }
 }

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/jdbc/JdbcOpTestHelper.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/jdbc/JdbcOpTestHelper.java
@@ -50,7 +50,7 @@ public class JdbcOpTestHelper
         return Files.createTempDirectory("jdbc_op_test");
     }
 
-    public Config createConfig(Map<String, Object> configInput)
+    public Config createConfig(Map<String, ?> configInput)
             throws IOException
     {
         return configFactory.create(configInput);

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/pg/PgConnectionConfigTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/pg/PgConnectionConfigTest.java
@@ -1,6 +1,8 @@
 package io.digdag.standards.operator.pg;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
 import io.digdag.standards.operator.jdbc.JdbcOpTestHelper;
 import org.junit.Before;
 import org.junit.Test;
@@ -11,40 +13,62 @@ import java.util.Properties;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 
 public class PgConnectionConfigTest
 {
     private final JdbcOpTestHelper jdbcOpTestHelper = new JdbcOpTestHelper();
+
     private PgConnectionConfig connConfigWithDefaultValue;
     private PgConnectionConfig connConfigWithCustomValue;
+    private PgConnectionConfig connConfigWithDefaultValueFromSecrets;
+    private PgConnectionConfig connConfigWithCustomValueFromSecrets;
 
     @Before
     public void setUp()
             throws IOException
     {
-        {
-            Map<String, Object> configInput = ImmutableMap.of(
-                    "host", "foobar0.org",
-                    "user", "user0",
-                    "database", "database0"
-            );
-            this.connConfigWithDefaultValue = PgConnectionConfig.configure(jdbcOpTestHelper.createConfig(configInput));
-        }
+        Map<String, String> defaultConfigValues = ImmutableMap.of(
+                "host", "foobar0.org",
+                "user", "user0",
+                "database", "database0"
+        );
+        Map<String, String> ignoredDefaultConfigValues = Maps.transformValues(defaultConfigValues, key -> "ignore");
+        Map<String, String> customConfigValues = ImmutableMap.<String, String>builder().
+                put("host", "foobar1.org").
+                put("port", "6543").
+                put("user", "user1").
+                put("password", "password1").
+                put("database", "database1").
+                put("ssl", "true").
+                put("connect_timeout", "15s").
+                put("socket_timeout", "12 m").
+                put("schema", "myschema").build();
+        Map<String, String> ignoredCustomConfigValues = Maps.transformValues(customConfigValues, key -> "ignore");
 
-        {
-            Map<String, Object> configInput = ImmutableMap.<String, Object>builder().
-                    put("host", "foobar1.org").
-                    put("port", "6543").
-                    put("user", "user1").
-                    put("password", "password1").
-                    put("database", "database1").
-                    put("ssl", "true").
-                    put("connect_timeout", "15s").
-                    put("socket_timeout", "12 m").
-                    put("schema", "myschema").build();
-            this.connConfigWithCustomValue = PgConnectionConfig.configure(jdbcOpTestHelper.createConfig(configInput));
-        }
+        this.connConfigWithDefaultValue = PgConnectionConfig.configure(
+                key -> Optional.absent(), jdbcOpTestHelper.createConfig(defaultConfigValues)
+        );
+
+        this.connConfigWithDefaultValueFromSecrets = PgConnectionConfig.configure(
+                key -> Optional.fromNullable(defaultConfigValues.get(key)), jdbcOpTestHelper.createConfig(ignoredDefaultConfigValues)
+        );
+
+        this.connConfigWithCustomValue = PgConnectionConfig.configure(
+                key -> Optional.absent(), jdbcOpTestHelper.createConfig(customConfigValues)
+        );
+
+        this.connConfigWithCustomValueFromSecrets = PgConnectionConfig.configure(
+                key -> Optional.fromNullable(customConfigValues.get(key)), jdbcOpTestHelper.createConfig(ignoredCustomConfigValues)
+        );
+    }
+
+    @Test
+    public void paramsVsSecretsEquals()
+            throws Exception
+    {
+        assertThat(connConfigWithDefaultValue, is(connConfigWithDefaultValueFromSecrets));
+        assertThat(connConfigWithCustomValue, is(connConfigWithCustomValueFromSecrets));
     }
 
     @Test
@@ -63,38 +87,45 @@ public class PgConnectionConfigTest
     public void url()
     {
         assertThat(connConfigWithDefaultValue.url(), is("jdbc:postgresql://foobar0.org:5432/database0"));
+        assertThat(connConfigWithDefaultValueFromSecrets.url(), is("jdbc:postgresql://foobar0.org:5432/database0"));
         assertThat(connConfigWithCustomValue.url(), is("jdbc:postgresql://foobar1.org:6543/database1"));
+        assertThat(connConfigWithCustomValueFromSecrets.url(), is("jdbc:postgresql://foobar1.org:6543/database1"));
     }
 
     @Test
     public void buildProperties()
     {
-        {
-            Properties properties = connConfigWithDefaultValue.buildProperties();
-            assertThat(properties.get("user"), is("user0"));
-            assertThat(properties.get("password"), is(nullValue()));
-            assertThat(properties.get("currentSchema"), is(nullValue()));
-            assertThat(properties.get("loginTimeout"), is("30"));
-            assertThat(properties.get("connectTimeout"), is("30"));
-            assertThat(properties.get("socketTimeout"), is("1800"));
-            assertThat(properties.get("tcpKeepAlive"), is("true"));
-            assertThat(properties.get("ssl"), is(nullValue()));
-            assertThat(properties.get("sslfactory"), is(nullValue()));
-            assertThat(properties.get("applicationName"), is("digdag"));
-        }
+        validateDefaultValueProperties(connConfigWithDefaultValue.buildProperties());
+        validateDefaultValueProperties(connConfigWithDefaultValueFromSecrets.buildProperties());
+        validateCustomValueProperties(connConfigWithCustomValue.buildProperties());
+        validateCustomValueProperties(connConfigWithCustomValueFromSecrets.buildProperties());
+    }
 
-        {
-            Properties properties = connConfigWithCustomValue.buildProperties();
-            assertThat(properties.get("user"), is("user1"));
-            assertThat(properties.get("password"), is("password1"));
-            assertThat(properties.get("currentSchema"), is("myschema"));
-            assertThat(properties.get("loginTimeout"), is("15"));
-            assertThat(properties.get("connectTimeout"), is("15"));
-            assertThat(properties.get("socketTimeout"), is("720"));
-            assertThat(properties.get("tcpKeepAlive"), is("true"));
-            assertThat(properties.get("ssl"), is("true"));
-            assertThat(properties.get("sslfactory"), is("org.postgresql.ssl.NonValidatingFactory"));
-            assertThat(properties.get("applicationName"), is("digdag"));
-        }
+    private void validateCustomValueProperties(Properties properties)
+    {
+        assertThat(properties.get("user"), is("user1"));
+        assertThat(properties.get("password"), is("password1"));
+        assertThat(properties.get("currentSchema"), is("myschema"));
+        assertThat(properties.get("loginTimeout"), is("15"));
+        assertThat(properties.get("connectTimeout"), is("15"));
+        assertThat(properties.get("socketTimeout"), is("720"));
+        assertThat(properties.get("tcpKeepAlive"), is("true"));
+        assertThat(properties.get("ssl"), is("true"));
+        assertThat(properties.get("sslfactory"), is("org.postgresql.ssl.NonValidatingFactory"));
+        assertThat(properties.get("applicationName"), is("digdag"));
+    }
+
+    private void validateDefaultValueProperties(Properties properties)
+    {
+        assertThat(properties.get("user"), is("user0"));
+        assertThat(properties.get("password"), is(nullValue()));
+        assertThat(properties.get("currentSchema"), is(nullValue()));
+        assertThat(properties.get("loginTimeout"), is("30"));
+        assertThat(properties.get("connectTimeout"), is("30"));
+        assertThat(properties.get("socketTimeout"), is("1800"));
+        assertThat(properties.get("tcpKeepAlive"), is("true"));
+        assertThat(properties.get("ssl"), is(nullValue()));
+        assertThat(properties.get("sslfactory"), is(nullValue()));
+        assertThat(properties.get("applicationName"), is("digdag"));
     }
 }

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/td/TDClientFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/td/TDClientFactoryTest.java
@@ -3,6 +3,7 @@ package io.digdag.standards.operator.td;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
 import com.treasuredata.client.TDClientBuilder;
 import com.treasuredata.client.TDClientConfig;
 import io.digdag.client.api.JacksonTimeModule;
@@ -31,7 +32,6 @@ public class TDClientFactoryTest
     public void testProxyConfig()
     {
         Config config = newConfig()
-                .set("apikey", "foobar")
                 .set("proxy",
                         newConfig()
                                 .set("enabled", "true")
@@ -41,7 +41,8 @@ public class TDClientFactoryTest
                                 .set("password", "'(#%")
                                 .set("use_ssl", true));
 
-        TDClientBuilder builder = TDClientFactory.clientBuilderFromConfig(config);
+        TDClientBuilder builder = TDClientFactory.clientBuilderFromConfig(
+                config, key -> Optional.fromNullable(ImmutableMap.of("apikey", "foobar").get(key)));
         TDClientConfig clientConfig = builder.buildConfig();
 
         assertThat(clientConfig.proxy.get().getUser(), is(Optional.of("me")));

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/td/TDOperatorTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/td/TDOperatorTest.java
@@ -30,6 +30,8 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class TDOperatorTest
 {
+    // TODO: update these tests to use secrets
+
     @Rule public final ExpectedException exception = ExpectedException.none();
 
     @Mock TDClient client;

--- a/digdag-tests/build.gradle
+++ b/digdag-tests/build.gradle
@@ -5,7 +5,6 @@ dependencies {
     testCompile 'org.subethamail:subethasmtp:3.1.7'
     testCompile 'com.squareup.okhttp3:okhttp:3.3.0'
     testCompile 'com.squareup.okhttp3:mockwebserver:3.3.1'
-    testCompile 'pl.pragmatists:JUnitParams:1.0.5'
     testCompile 'org.littleshoot:littleproxy:1.1.0'
 }
 

--- a/digdag-tests/src/test/java/acceptance/RunIT.java
+++ b/digdag-tests/src/test/java/acceptance/RunIT.java
@@ -3,6 +3,7 @@ package acceptance;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import utils.CommandStatus;
 import utils.TestUtils;
 
 import java.nio.file.Files;
@@ -11,6 +12,7 @@ import java.nio.file.Path;
 import static utils.TestUtils.copyResource;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static utils.TestUtils.main;
 
 public class RunIT
 {
@@ -27,7 +29,8 @@ public class RunIT
             throws Exception
     {
         copyResource("acceptance/basic.dig", root().resolve("basic.dig"));
-        TestUtils.main("run", "-o", root().toString(), "--project", root().toString(), "basic.dig");
+        CommandStatus status = main("run", "-o", root().toString(), "--project", root().toString(), "basic.dig");
+        assertThat(status.errUtf8(), status.code(), is(0));
         assertThat(Files.exists(root().resolve("foo.out")), is(true));
         assertThat(Files.exists(root().resolve("bar.out")), is(true));
     }

--- a/digdag-tests/src/test/java/acceptance/SecretsIT.java
+++ b/digdag-tests/src/test/java/acceptance/SecretsIT.java
@@ -1,0 +1,326 @@
+package acceptance;
+
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.CharSource;
+import io.digdag.client.DigdagClient;
+import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.apache.commons.lang3.RandomUtils;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import utils.CommandStatus;
+import utils.TemporaryDigdagServer;
+import utils.TestUtils;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Base64;
+import java.util.List;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static utils.TestUtils.attemptFailure;
+import static utils.TestUtils.attemptSuccess;
+import static utils.TestUtils.copyResource;
+import static utils.TestUtils.expect;
+import static utils.TestUtils.getAttemptLogs;
+import static utils.TestUtils.main;
+import static utils.TestUtils.pushProject;
+import static utils.TestUtils.startWorkflow;
+
+public class SecretsIT
+{
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Rule
+    public TemporaryDigdagServer server = TemporaryDigdagServer.builder()
+            .configuration("digdag.secret-encryption-key = " + Base64.getEncoder().encodeToString(RandomUtils.nextBytes(16)))
+            .build();
+
+    private Path config;
+    private Path projectDir;
+    private DigdagClient client;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        projectDir = folder.newFolder().toPath().toAbsolutePath().normalize();
+        config = folder.newFile().toPath();
+
+        client = DigdagClient.builder()
+                .host(server.host())
+                .port(server.port())
+                .build();
+    }
+
+    @Test
+    public void testSetListDeleteProjectSecrets()
+            throws Exception
+    {
+        String projectName = "test";
+
+        // Push the project
+        CommandStatus pushStatus = main("push",
+                "--project", projectDir.toString(),
+                projectName,
+                "-c", config.toString(),
+                "-e", server.endpoint());
+        assertThat(pushStatus.errUtf8(), pushStatus.code(), is(0));
+
+        // Command line args
+        String key1 = "key1";
+        String value1 = "value1";
+        String key2 = "key2";
+        String value2 = "value2";
+
+        // Single file value
+        String key3 = "key3";
+        String value3 = "value3";
+
+        // Single stdin value
+        String key4 = "key4";
+        String value4 = "value4";
+
+        // Multiple stdin values
+        String key5 = "key5";
+        String value5 = "value5";
+        String key6 = "key6";
+        String value6 = "value6";
+
+        // Multiple file values
+        String key7 = "key7";
+        String value7 = "value7";
+        String key8 = "key8";
+        String value8 = "value8";
+
+        Path value3File = folder.newFile().toPath();
+        Files.write(value3File, ImmutableList.of(value3));
+
+        // Set secrets on command line and from file
+        {
+            CommandStatus setStatus = main("secrets",
+                    "-c", config.toString(),
+                    "-e", server.endpoint(),
+                    "--project", projectName,
+                    "--set",
+                    key1 + '=' + value1,
+                    key2 + '=' + value2,
+                    key3 + "=@" + value3File.toString());
+            assertThat(setStatus.errUtf8(), setStatus.code(), is(0));
+            assertThat(setStatus.errUtf8(), containsString("Secret '" + key1 + "' set"));
+            assertThat(setStatus.errUtf8(), containsString("Secret '" + key2 + "' set"));
+            assertThat(setStatus.errUtf8(), containsString("Secret '" + key3 + "' set"));
+        }
+
+        // Set secret from stdin
+        {
+            InputStream in = new ByteArrayInputStream(value4.getBytes(US_ASCII));
+            CommandStatus setStatus = main(
+                    in,
+                    "secrets",
+                    "-c", config.toString(),
+                    "-e", server.endpoint(),
+                    "--project", projectName,
+                    "--set",
+                    key4 + "=-");
+            assertThat(setStatus.errUtf8(), setStatus.code(), is(0));
+            assertThat(setStatus.errUtf8(), containsString("Secret '" + key4 + "' set"));
+        }
+
+        YAMLFactory yamlFactory = new YAMLFactory();
+
+        // Set secrets from stdin
+        {
+            ByteArrayOutputStream yaml = new ByteArrayOutputStream();
+            YAMLGenerator generator = yamlFactory.createGenerator(yaml);
+            TestUtils.objectMapper().writeValue(generator, ImmutableMap.of(key5, value5, key6, value6));
+            InputStream in = new ByteArrayInputStream(yaml.toByteArray());
+
+            CommandStatus setStatus = main(
+                    in,
+                    "secrets",
+                    "-c", config.toString(),
+                    "-e", server.endpoint(),
+                    "--project", projectName,
+                    "--set", "@-");
+            assertThat(setStatus.errUtf8(), setStatus.code(), is(0));
+            assertThat(setStatus.errUtf8(), containsString("Secret '" + key5 + "' set"));
+            assertThat(setStatus.errUtf8(), containsString("Secret '" + key6 + "' set"));
+        }
+
+        // Set secrets from file
+        Path secretsFileYaml = folder.newFolder().toPath().resolve("secrets.yaml");
+        try (OutputStream o = Files.newOutputStream(secretsFileYaml)) {
+            YAMLGenerator generator = yamlFactory.createGenerator(o);
+            TestUtils.objectMapper().writeValue(generator, ImmutableMap.of(key7, value7, key8, value8));
+
+            CommandStatus setStatus = main(
+                    "secrets",
+                    "-c", config.toString(),
+                    "-e", server.endpoint(),
+                    "--project", projectName,
+                    "--set", "@" + secretsFileYaml);
+            assertThat(setStatus.errUtf8(), setStatus.code(), is(0));
+            assertThat(setStatus.errUtf8(), containsString("Secret '" + key7 + "' set"));
+            assertThat(setStatus.errUtf8(), containsString("Secret '" + key8 + "' set"));
+        }
+
+        // List secrets
+        CommandStatus listStatus = main("secrets",
+                "-c", config.toString(),
+                "-e", server.endpoint(),
+                "--project", projectName);
+        assertThat(listStatus.errUtf8(), listStatus.code(), is(0));
+
+        List<String> listedKeys = CharSource.wrap(listStatus.outUtf8()).readLines();
+        assertThat(listedKeys, containsInAnyOrder(key1, key2, key3, key4, key5, key6, key7, key8));
+
+        // Delete secrets
+        CommandStatus deleteStatus = main("secrets",
+                "-c", config.toString(),
+                "-e", server.endpoint(),
+                "--project", projectName,
+                "--delete", key1,
+                "--delete", key2, key3);
+        assertThat(deleteStatus.errUtf8(), deleteStatus.code(), is(0));
+        assertThat(deleteStatus.errUtf8(), containsString("Secret 'key1' deleted"));
+        assertThat(deleteStatus.errUtf8(), containsString("Secret 'key2' deleted"));
+        assertThat(deleteStatus.errUtf8(), containsString("Secret 'key3' deleted"));
+
+        // List secrets after deletion
+        CommandStatus listStatus2 = main("secrets",
+                "-c", config.toString(),
+                "-e", server.endpoint(),
+                "--project", projectName);
+        assertThat(listStatus2.errUtf8(), listStatus2.code(), is(0));
+
+        List<String> listedKeys2 = CharSource.wrap(listStatus2.outUtf8()).readLines();
+        assertThat(listedKeys2, containsInAnyOrder(key4, key5, key6, key7, key8));
+    }
+
+    @Test
+    public void testUseProjectSecret()
+            throws Exception
+    {
+        String projectName = "test";
+
+        // Push the project
+        {
+            copyResource("acceptance/secrets/echo_secret.dig", projectDir);
+            copyResource("acceptance/secrets/echo_secret_parameterized.dig", projectDir);
+            pushProject(server.endpoint(), projectDir, projectName);
+        }
+
+        String key1 = "key1";
+        String key2 = "key2";
+
+        String value1 = "value1";
+        String value2 = "value2";
+
+        // Set secrets
+        {
+            CommandStatus setStatus = main("secrets",
+                    "-c", config.toString(),
+                    "-e", server.endpoint(),
+                    "--project", projectName,
+                    "--set", key1 + '=' + value1, key2 + '=' + value2);
+            assertThat(setStatus.errUtf8(), setStatus.code(), is(0));
+        }
+
+        // Start workflows using secrets
+        {
+            Path outfile = folder.newFolder().toPath().toAbsolutePath().normalize().resolve("out");
+            Path outfileParameterized = folder.newFolder().toPath().toAbsolutePath().normalize().resolve("out-parameterized");
+
+            long attemptId = startWorkflow(
+                    server.endpoint(), projectName, "echo_secret",
+                    ImmutableMap.of("OUTFILE", outfile.toString()));
+
+            long attemptIdParameterized = startWorkflow(
+                    server.endpoint(), projectName, "echo_secret_parameterized",
+                    ImmutableMap.of("secret_key", "key2",
+                            "OUTFILE", outfileParameterized.toString()));
+
+            expect(Duration.ofMinutes(5), attemptSuccess(server.endpoint(), attemptId));
+            expect(Duration.ofMinutes(5), attemptSuccess(server.endpoint(), attemptIdParameterized));
+
+            List<String> output = Files.readAllLines(outfile);
+            assertThat(output, contains(value1));
+
+            List<String> outputParameterized = Files.readAllLines(outfileParameterized);
+            assertThat(outputParameterized, contains(value2));
+        }
+
+        // Delete a secret
+        {
+            CommandStatus deleteStatus = main("secrets",
+                    "-c", config.toString(),
+                    "-e", server.endpoint(),
+                    "--project", projectName,
+                    "--delete", key1);
+            assertThat(deleteStatus.errUtf8(), deleteStatus.code(), is(0));
+            assertThat(deleteStatus.errUtf8(), containsString("Secret 'key1' deleted"));
+        }
+
+        // Attempt to run a workflow that uses the deleted secret
+        {
+            Path outfile = folder.newFolder().toPath().toAbsolutePath().normalize().resolve("out");
+
+            long attemptId = startWorkflow(
+                    server.endpoint(), projectName, "echo_secret",
+                    ImmutableMap.of("OUTFILE", outfile.toString()));
+
+            expect(Duration.ofMinutes(5), attemptFailure(server.endpoint(), attemptId));
+
+            String logs = getAttemptLogs(client, attemptId);
+            assertThat(logs, containsString("Secret not found for key: 'key1'"));
+        }
+    }
+
+    @Test
+    public void verifyInvalidSecretUseFails()
+            throws Exception
+    {
+        String projectName = "test";
+
+        // Push the project
+        copyResource("acceptance/secrets/invalid_secret_use.dig", projectDir);
+        copyResource("acceptance/secrets/echo_secret_parameterized.dig", projectDir);
+        pushProject(server.endpoint(), projectDir, projectName);
+
+        String key1 = "key1";
+        String key2 = "key2";
+
+        String value1 = "value1";
+        String value2 = "value2";
+
+        // Set secrets
+        CommandStatus setStatus = main("secrets",
+                "-c", config.toString(),
+                "-e", server.endpoint(),
+                "--project", projectName,
+                "--set", key1 + '=' + value1, key2 + '=' + value2);
+        assertThat(setStatus.errUtf8(), setStatus.code(), is(0));
+
+        long attemptId = startWorkflow(server.endpoint(), projectName, "invalid_secret_use", ImmutableMap.of());
+
+        expect(Duration.ofMinutes(5), attemptFailure(server.endpoint(), attemptId));
+
+        String logs = getAttemptLogs(client, attemptId);
+        assertThat(logs, containsString("\"key1\" is not defined"));
+    }
+}

--- a/digdag-tests/src/test/java/acceptance/td/Secrets.java
+++ b/digdag-tests/src/test/java/acceptance/td/Secrets.java
@@ -1,0 +1,33 @@
+package acceptance.td;
+
+import com.amazonaws.util.Base64;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Collection;
+import java.util.concurrent.ThreadLocalRandom;
+
+public class Secrets
+{
+    static final String TD_API_KEY = System.getenv().getOrDefault("TD_API_KEY", "");
+    static final byte[] ENCRYPTION_KEY_BYTES = new byte[128 / 8];
+    {
+        ThreadLocalRandom.current().nextBytes(ENCRYPTION_KEY_BYTES);
+    }
+
+    static final String ENCRYPTION_KEY = Base64.encodeAsString(ENCRYPTION_KEY_BYTES);
+
+    static Collection<String> secretsServerConfiguration()
+    {
+        return ImmutableList.of(
+                "secrets.td.apikey = " + TD_API_KEY,
+                "digdag.secret-encryption-key = " + ENCRYPTION_KEY,
+                "secret-access-policy.operators.td.secrets = [\"td.*\"]",
+                "secret-access-policy.operators.td_ddl.secrets = [\"td.*\"]",
+                "secret-access-policy.operators.td_for_each.secrets = [\"td.*\"]",
+                "secret-access-policy.operators.td_load.secrets = [\"td.*\"]",
+                "secret-access-policy.operators.td_table_export.secrets = [\"td.*\"]",
+                "secret-access-policy.operators.td_wait.secrets = [\"td.*\"]",
+                "secret-access-policy.operators.td_wait_table.secrets = [\"td.*\"]"
+        );
+    }
+}

--- a/digdag-tests/src/test/java/acceptance/td/TdForEachIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/TdForEachIT.java
@@ -9,6 +9,7 @@ import org.junit.rules.TemporaryFolder;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import static acceptance.td.Secrets.TD_API_KEY;
 import static utils.TestUtils.copyResource;
 import static utils.TestUtils.main;
 import static org.hamcrest.Matchers.is;
@@ -20,8 +21,6 @@ import static org.junit.Assume.assumeThat;
 
 public class TdForEachIT
 {
-    private static final String TD_API_KEY = System.getenv("TD_API_KEY");
-
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 
@@ -35,7 +34,7 @@ public class TdForEachIT
         assumeThat(TD_API_KEY, not(isEmptyOrNullString()));
         projectDir = folder.getRoot().toPath();
         config = folder.newFile().toPath();
-        Files.write(config, ("params.td.apikey = " + TD_API_KEY).getBytes("UTF-8"));
+        Files.write(config, ("secrets.td.apikey = " + TD_API_KEY).getBytes("UTF-8"));
     }
 
     @Test

--- a/digdag-tests/src/test/java/acceptance/td/TdIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/TdIT.java
@@ -35,6 +35,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
+import static acceptance.td.Secrets.TD_API_KEY;
 import static utils.TestUtils.copyResource;
 import static utils.TestUtils.main;
 import static io.netty.handler.codec.http.HttpHeaders.Names.CONNECTION;
@@ -52,8 +53,6 @@ import static org.junit.Assume.assumeThat;
 public class TdIT
 {
     private static final Logger logger = LoggerFactory.getLogger(TdIT.class);
-
-    private static final String TD_API_KEY = System.getenv("TD_API_KEY");
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
@@ -75,7 +74,7 @@ public class TdIT
         assumeThat(TD_API_KEY, not(isEmptyOrNullString()));
         projectDir = folder.getRoot().toPath().toAbsolutePath().normalize();
         config = folder.newFile().toPath();
-        Files.write(config, asList("params.td.apikey = " + TD_API_KEY));
+        Files.write(config, asList("secrets.td.apikey = " + TD_API_KEY));
         outfile = projectDir.resolve("outfile");
 
         client = TDClient.newBuilder(false)
@@ -129,6 +128,20 @@ public class TdIT
         copyResource("acceptance/td/td/td_preview_create_table.dig", projectDir.resolve("workflow.dig"));
         copyResource("acceptance/td/td/query.sql", projectDir.resolve("query.sql"));
         runWorkflow("td.database=" + database);
+    }
+
+    @Test
+    public void testRunQueryLegacyApikeyParam()
+            throws Exception
+    {
+        // TODO: Remove this test when the legacy support for td.apikey param is removed
+
+        // Replace the "secrets.td.apikey" entry with the legacy "params.td.apikey" entry
+        Files.write(config, asList("params.td.apikey = " + TD_API_KEY));
+
+        copyResource("acceptance/td/td/td.dig", projectDir.resolve("workflow.dig"));
+        copyResource("acceptance/td/td/query.sql", projectDir.resolve("query.sql"));
+        runWorkflow();
     }
 
     @Test

--- a/digdag-tests/src/test/java/acceptance/td/TdLoadIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/TdLoadIT.java
@@ -12,6 +12,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.UUID;
 
+import static acceptance.td.Secrets.TD_API_KEY;
 import static utils.TestUtils.copyResource;
 import static utils.TestUtils.main;
 import static java.util.Arrays.asList;
@@ -23,7 +24,6 @@ import static org.junit.Assume.assumeThat;
 
 public class TdLoadIT
 {
-    private static final String TD_API_KEY = System.getenv("TD_API_KEY");
     private static final String TD_LOAD_IT_SFTP_USER = System.getenv("TD_LOAD_IT_SFTP_USER");
     private static final String TD_LOAD_IT_SFTP_PASSWORD = System.getenv("TD_LOAD_IT_SFTP_PASSWORD");
 
@@ -57,7 +57,7 @@ public class TdLoadIT
         projectDir = folder.getRoot().toPath().toAbsolutePath().normalize();
         config = folder.newFile().toPath();
         Files.write(config, asList(
-                "params.td.apikey = " + TD_API_KEY,
+                "secrets.td.apikey = " + TD_API_KEY,
                 "params.td.database = " + database,
                 "params.td_load_sftp_user = " + TD_LOAD_IT_SFTP_USER,
                 "params.td_load_sftp_password = " + TD_LOAD_IT_SFTP_PASSWORD

--- a/digdag-tests/src/test/java/acceptance/td/TdPartialDeleteIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/TdPartialDeleteIT.java
@@ -67,7 +67,7 @@ public class TdPartialDeleteIT
         assumeThat(TD_API_KEY, not(isEmptyOrNullString()));
         projectDir = folder.getRoot().toPath().toAbsolutePath().normalize();
         config = folder.newFile().toPath();
-        Files.write(config, asList("params.td.apikey = " + TD_API_KEY));
+        Files.write(config, asList("secrets.td.apikey = " + TD_API_KEY));
         outfile = projectDir.resolve("outfile");
 
         client = TDClient.newBuilder(false)

--- a/digdag-tests/src/test/java/acceptance/td/TdRunIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/TdRunIT.java
@@ -1,5 +1,6 @@
 package acceptance.td;
 
+import com.google.common.collect.ImmutableList;
 import utils.CommandStatus;
 import com.treasuredata.client.TDClient;
 import com.treasuredata.client.model.TDJob;
@@ -50,7 +51,7 @@ public class TdRunIT
         assumeThat(TD_API_KEY, not(isEmptyOrNullString()));
         projectDir = folder.getRoot().toPath().toAbsolutePath().normalize();
         config = folder.newFile().toPath();
-        Files.write(config, ("params.td.apikey = " + TD_API_KEY).getBytes("UTF-8"));
+        Files.write(config, ImmutableList.of("secrets.td.apikey = " + TD_API_KEY));
         outfile = projectDir.resolve("outfile");
 
         client = TDClient.newBuilder(false)

--- a/digdag-tests/src/test/java/utils/DevServer.java
+++ b/digdag-tests/src/test/java/utils/DevServer.java
@@ -13,7 +13,7 @@ public class DevServer
             throws IOException
     {
         Path logdir = Files.createTempDirectory("digdag-task-logs");
-        Main main = new Main(Version.buildVersion(), System.out, System.err);
+        Main main = new Main(Version.buildVersion(), System.out, System.err, System.in);
         main.cli("server",
                 "-c", "/dev/null",
                 "-m",

--- a/digdag-tests/src/test/java/utils/TestUtils.java
+++ b/digdag-tests/src/test/java/utils/TestUtils.java
@@ -1,5 +1,6 @@
 package utils;
 
+import com.amazonaws.util.StringInputStream;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -9,6 +10,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Resources;
 import io.digdag.cli.Main;
+import io.digdag.cli.YamlMapper;
 import io.digdag.client.DigdagClient;
 import io.digdag.client.api.JacksonTimeModule;
 import io.digdag.client.api.RestLogFileHandle;
@@ -19,12 +21,14 @@ import org.apache.commons.io.FileUtils;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.junit.Assert;
+import org.junit.rules.TemporaryFolder;
 import org.subethamail.wiser.Wiser;
-import utils.NopDispatcher;
 
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.UnsupportedEncodingException;
 import java.net.ServerSocket;
@@ -41,12 +45,14 @@ import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 
 import static io.digdag.core.Version.buildVersion;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static java.util.Arrays.asList;
+import static java.util.stream.Collectors.toMap;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
@@ -67,9 +73,16 @@ public class TestUtils
 
     public static final Pattern ATTEMPT_ID_PATTERN = Pattern.compile("\\s*attempt id:\\s*(\\d+)\\s*");
 
+    public static final Pattern PROJECT_ID_PATTERN = Pattern.compile("\\s*id:\\s*(\\d+)\\s*");
+
     public static CommandStatus main(String... args)
     {
         return main(buildVersion(), args);
+    }
+
+    public static CommandStatus main(InputStream in, String... args)
+    {
+        return main(buildVersion(), in, asList(args));
     }
 
     public static CommandStatus main(Collection<String> args)
@@ -82,35 +95,44 @@ public class TestUtils
         return main(localVersion, asList(args));
     }
 
-    public static CommandStatus main(Version localVersion, Collection<String> args)
-    {
-        final ByteArrayOutputStream out = new ByteArrayOutputStream();
-        final ByteArrayOutputStream err = new ByteArrayOutputStream();
-        return main(localVersion, args, out, err);
+    public static CommandStatus main(Version localVersion, Collection<String> args) {
+        InputStream in = new ByteArrayInputStream(new byte[0]);
+        return main(localVersion, in, args);
     }
 
-    public static CommandStatus main(Version localVersion, Collection<String> args, ByteArrayOutputStream out, ByteArrayOutputStream err)
+    public static CommandStatus main(Version localVersion, InputStream in, Collection<String> args)
     {
-        final int code;
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ByteArrayOutputStream err = new ByteArrayOutputStream();
+        int code = main(localVersion, args, out, err, in);
+        return CommandStatus.of(code, out.toByteArray(), err.toByteArray());
+    }
+
+    public static int main(Version localVersion, Collection<String> args, OutputStream out, OutputStream err, InputStream in)
+    {
         try (
                 PrintStream outp = new PrintStream(out, true, "UTF-8");
                 PrintStream errp = new PrintStream(err, true, "UTF-8");
         ) {
-            code = new Main(localVersion, outp, errp).cli(args.stream().toArray(String[]::new));
+            return new Main(localVersion, outp, errp, in).cli(args.stream().toArray(String[]::new));
         }
         catch (RuntimeException | UnsupportedEncodingException e) {
             e.printStackTrace();
             Assert.fail();
             throw Throwables.propagate(e);
         }
-        return CommandStatus.of(code, out.toByteArray(), err.toByteArray());
     }
 
     public static void copyResource(String resource, Path dest)
             throws IOException
     {
-        try (InputStream input = Resources.getResource(resource).openStream()) {
-            Files.copy(input, dest, REPLACE_EXISTING);
+        if (Files.isDirectory(dest)) {
+            Path name = Paths.get(resource).getFileName();
+            copyResource(resource, dest.resolve(name));
+        } else {
+            try (InputStream input = Resources.getResource(resource).openStream()) {
+                Files.copy(input, dest, REPLACE_EXISTING);
+            }
         }
     }
 
@@ -270,19 +292,18 @@ public class TestUtils
         String projectName = project.getFileName().toString();
 
         // Push the project
-        CommandStatus pushStatus = main("push",
-                "--project", project.toString(),
-                projectName,
-                "-c", "/dev/null",
-                "-e", endpoint,
-                "-r", "4711");
-        assertThat(pushStatus.errUtf8(), pushStatus.code(), is(0));
+        pushProject(endpoint, project, projectName);
 
+        return startWorkflow(endpoint, projectName, workflow, params);
+    }
+
+    public static long startWorkflow(String endpoint, String projectName, String workflow, Map<String, String> params)
+    {
         List<String> startCommand = new ArrayList<>(asList("start",
-                "-c", "/dev/null",
-                "-e", endpoint,
-                projectName, workflow,
-                "--session", "now"));
+            "-c", "/dev/null",
+            "-e", endpoint,
+            projectName, workflow,
+            "--session", "now"));
 
         params.forEach((k, v) -> startCommand.addAll(asList("-p", k + "=" + v)));
 
@@ -291,6 +312,20 @@ public class TestUtils
         assertThat(startStatus.errUtf8(), startStatus.code(), is(0));
 
         return getAttemptId(startStatus);
+    }
+
+    public static int pushProject(String endpoint, Path project, String projectName)
+    {
+        CommandStatus pushStatus = main("push",
+                "--project", project.toString(),
+                projectName,
+                "-c", "/dev/null",
+                "-e", endpoint);
+        assertThat(pushStatus.errUtf8(), pushStatus.code(), is(0));
+        Matcher matcher = PROJECT_ID_PATTERN.matcher(pushStatus.outUtf8());
+        boolean found = matcher.find();
+        assertThat(found, is(true));
+        return Integer.valueOf(matcher.group(1));
     }
 
     public static void addWorkflow(Path project, String resource)
@@ -306,14 +341,25 @@ public class TestUtils
         copyResource(resource, project.resolve(workflowName));
     }
 
-    public static void runWorkflow(String resource, ImmutableMap<String, String> params)
+    public static void runWorkflow(TemporaryFolder folder, String resource, Map<String, String> params)
+            throws IOException
+    {
+        runWorkflow(folder, resource, params, ImmutableMap.of());
+    }
+
+    public static void runWorkflow(TemporaryFolder folder, String resource, Map<String, String> params, Map<String, String> config)
             throws IOException
     {
         Path workflow = Paths.get(resource);
-        Path tempdir = Files.createTempDirectory("digdag-test");
+        Path tempdir = folder.newFolder().toPath();
         Path file = tempdir.resolve(workflow.getFileName());
+        Path configFile = folder.newFolder().toPath().resolve("config");
+        List<String> configLines = config.entrySet().stream()
+                .map(e -> e.getKey() + " = " + e.getValue())
+                .collect(Collectors.toList());
+        Files.write(configFile, configLines);
         List<String> runCommand = new ArrayList<>(asList("run",
-                "-c", "/dev/null",
+                "-c", configFile.toAbsolutePath().normalize().toString(),
                 "-o", tempdir.toString(),
                 "--project", tempdir.toString(),
                 workflow.getFileName().toString()));
@@ -331,6 +377,11 @@ public class TestUtils
     public static ObjectMapper objectMapper()
     {
         return OBJECT_MAPPER;
+    }
+
+    public static YamlMapper yamlMapper()
+    {
+        return new YamlMapper(OBJECT_MAPPER);
     }
 
     public static ConfigFactory configFactory()

--- a/digdag-tests/src/test/resources/acceptance/secrets/echo_secret.dig
+++ b/digdag-tests/src/test/resources/acceptance/secrets/echo_secret.dig
@@ -1,0 +1,7 @@
++echo:
+  _secrets:
+    key1: true
+  _env:
+    FOO:
+      secret: key1
+  sh>: echo $FOO > ${OUTFILE}

--- a/digdag-tests/src/test/resources/acceptance/secrets/echo_secret_parameterized.dig
+++ b/digdag-tests/src/test/resources/acceptance/secrets/echo_secret_parameterized.dig
@@ -1,0 +1,7 @@
++echo:
+  _secrets:
+    some_secret: ${secret_key}
+  _env:
+    VALUE:
+      secret: some_secret
+  sh>: echo $VALUE > ${OUTFILE}

--- a/digdag-tests/src/test/resources/acceptance/secrets/invalid_secret_use.dig
+++ b/digdag-tests/src/test/resources/acceptance/secrets/invalid_secret_use.dig
@@ -1,0 +1,5 @@
++echo:
+  _secrets:
+    key1: true
+  # It is not possible to refer to secrets using param reference syntax like below
+  sh>: echo ${key1}


### PR DESCRIPTION
* Separate secrets from parameters.
* Add a pluggable secret storage facility with a default implementation that encrypts and stores secrets in a database table.
* Allow Authenticator implementations to provide a set of request context default secrets.
* Add REST api endpoints that can be used to set/delete/list secrets.
* Add a secrets cli command that can be used to set/delete/list secrets.