### PR TITLE
Disable HTTP contents logging that may include security information

### DIFF
--- a/digdag-cli/src/main/resources/digdag/cli/logback-color.xml
+++ b/digdag-cli/src/main/resources/digdag/cli/logback-color.xml
@@ -64,6 +64,10 @@
 
   <logger name="com.zaxxer.hikari" level="WARN"/>
 
+  <!-- disable header and content logging by default that may leak security information -->
+  <logger name="org.apache.http.wire" level="WARN"/>
+  <logger name="org.apache.http.headers" level="WARN"/>
+
   <root level="${digdag.log.level}">
     <appender-ref ref="console-error"/>
     <appender-ref ref="console-warn"/>

--- a/digdag-cli/src/main/resources/digdag/cli/logback-console.xml
+++ b/digdag-cli/src/main/resources/digdag/cli/logback-console.xml
@@ -7,6 +7,10 @@
 
   <logger name="com.zaxxer.hikari" level="WARN"/>
 
+  <!-- disable header and content logging by default that may leak security information -->
+  <logger name="org.apache.http.wire" level="WARN"/>
+  <logger name="org.apache.http.headers" level="WARN"/>
+
   <appender name="digdag-context" class="io.digdag.cli.LogbackTaskContextLoggerBridgeAppender">
   </appender>
 


### PR DESCRIPTION
Apache httpclient logs HTTP headers and contents in DEBUG level by
default. But headers and contents may include security information. It
makes it difficult for users to use debug-level logging (`-l debug`).
Hesitation of using debug level logging makes debugging hard.
Debug logging should is useful as like #192.
