### PR TITLE
Run acceptance test if -Dtest.single=PATTERN is set explicitly

### DIFF
--- a/digdag-tests/build.gradle
+++ b/digdag-tests/build.gradle
@@ -18,9 +18,9 @@ test {
 
     // Exclude all acceptance tests if this is not an acceptance test run
     if (System.env.CI_ACCEPTANCE_TEST == null || !Boolean.valueOf(System.env.CI_ACCEPTANCE_TEST)) {
-        // run tests if -Dtest.single is explicitly set
-        if (System.getProperty("test.single") == null) {
-            exclude { true }
+        exclude {
+            // run tests if --tests or -Dtest.single is explicitly set
+            System.getProperty("test.single") == null && filter.includePatterns.empty
         }
     }
 }

--- a/digdag-tests/build.gradle
+++ b/digdag-tests/build.gradle
@@ -18,6 +18,9 @@ test {
 
     // Exclude all acceptance tests if this is not an acceptance test run
     if (System.env.CI_ACCEPTANCE_TEST == null || !Boolean.valueOf(System.env.CI_ACCEPTANCE_TEST)) {
-        exclude { true }
+        // run tests if -Dtest.single is explicitly set
+        if (System.getProperty("test.single") == null) {
+            exclude { true }
+        }
     }
 }


### PR DESCRIPTION
Running a single acceptance test locally is useful to add an acceptance
test.