### PR TITLE
use jetty-client 9.3.11.v20160721

### DIFF
--- a/digdag-standards/build.gradle
+++ b/digdag-standards/build.gradle
@@ -20,4 +20,12 @@ dependencies {
 
     // postgresql
     compile 'org.postgresql:postgresql:9.4.1208'
+
+    // Newer version of jetty-client with some important bugfixes.
+    // jetty-client is used by td-client-java, and ideally we would bump the version there but
+    // td-client-java still targets JDK 7 and jetty-client 9.3.x targets JDK 8.
+    // https://github.com/treasure-data/td-client-java/pull/68
+    // https://bugs.eclipse.org/bugs/show_bug.cgi?id=475546
+    // https://github.com/eclipse/jetty.project/issues/416
+    compile 'org.eclipse.jetty:jetty-client:9.3.11.v20160721'
 }


### PR DESCRIPTION
Includes fixes for some important proxy bugs:

* https://bugs.eclipse.org/bugs/show_bug.cgi?id=475546
* https://github.com/eclipse/jetty.project/issues/416