### PR TITLE
fix typo for ruby operator

### DIFF
--- a/digdag-docs/src/operators.rst
+++ b/digdag-docs/src/operators.rst
@@ -83,7 +83,7 @@ See `Ruby API documents <ruby_api.html>`_ for details including best practices h
 .. code-block:: yaml
 
     _export:
-      ruby:
+      rb:
         require: tasks/my_workflow
 
     +step1:


### PR DESCRIPTION
related to https://github.com/treasure-data/digdag-docs/pull/3