### PR TITLE
Add session_attempts.finished_at

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/client/ShowAttempt.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/ShowAttempt.java
@@ -75,6 +75,7 @@ public class ShowAttempt
         ln("  retry attempt name: %s", attempt.getRetryAttemptName().or(""));
         ln("  params: %s", attempt.getParams());
         ln("  created at: %s", TimeUtil.formatTime(attempt.getCreatedAt()));
+        ln("  finished at: %s", attempt.getFinishedAt().transform(TimeUtil::formatTime).or(""));
         ln("  kill requested: %s", attempt.getCancelRequested());
         ln("  status: %s", status);
         ln("");

--- a/digdag-cli/src/main/java/io/digdag/cli/client/ShowAttempts.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/ShowAttempts.java
@@ -99,6 +99,7 @@ public class ShowAttempts
         ln("  retry attempt name: %s", attempt.getRetryAttemptName().or(""));
         ln("  params: %s", attempt.getParams());
         ln("  created at: %s", TimeUtil.formatTime(attempt.getCreatedAt()));
+        ln("  finished at: %s", attempt.getFinishedAt().transform(TimeUtil::formatTime).or(""));
         ln("  kill requested: %s", attempt.getCancelRequested());
         ln("  status: %s", status);
         ln("");

--- a/digdag-client/src/main/java/io/digdag/client/api/RestSession.java
+++ b/digdag-client/src/main/java/io/digdag/client/api/RestSession.java
@@ -33,7 +33,6 @@ public interface RestSession
     @JsonDeserialize(as = ImmutableRestSession.Attempt.class)
     interface Attempt
     {
-
         long getId();
 
         Optional<String> getRetryAttemptName();
@@ -47,6 +46,8 @@ public interface RestSession
         Config getParams();
 
         Instant getCreatedAt();
+
+        Optional<Instant> getFinishedAt();
 
         static ImmutableRestSession.Attempt.Builder builder()
         {

--- a/digdag-client/src/main/java/io/digdag/client/api/RestSessionAttempt.java
+++ b/digdag-client/src/main/java/io/digdag/client/api/RestSessionAttempt.java
@@ -40,6 +40,8 @@ public interface RestSessionAttempt
 
     Instant getCreatedAt();
 
+    Optional<Instant> getFinishedAt();
+
     static ImmutableRestSessionAttempt.Builder builder()
     {
         return ImmutableRestSessionAttempt.builder();

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseMigrator.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseMigrator.java
@@ -733,6 +733,27 @@ public class DatabaseMigrator
         }
     };
 
+    private final Migration MigrateAddFinishedAtToSessionAttempts = new Migration() {
+        @Override
+        public String getVersion()
+        {
+            return "20160816021018";
+        }
+
+        @Override
+        public void migrate(Handle handle)
+        {
+            if (isPostgres()) {
+                handle.update("alter table session_attempts" +
+                        " add column finished_at timestamp with time zone");
+            }
+            else {
+                handle.update("alter table session_attempts" +
+                        " add column finished_at timestamp");
+            }
+        }
+    };
+
     private final Migration[] migrations = {
         MigrateCreateTables,
         MigrateSessionsOnProjectIdIndexToDesc,
@@ -740,5 +761,6 @@ public class DatabaseMigrator
         MigrateMakeProjectsDeletable,
         MigrateAddUserInfoColumnToRevisions,
         MigrateQueueRearchitecture,
+        MigrateAddFinishedAtToSessionAttempts,
     };
 }

--- a/digdag-core/src/main/java/io/digdag/core/schedule/ScheduleExecutor.java
+++ b/digdag-core/src/main/java/io/digdag/core/schedule/ScheduleExecutor.java
@@ -294,6 +294,7 @@ public class ScheduleExecutor
                                     .stateFlags(AttemptStateFlags.empty())
                                     .sessionId(0L)
                                     .createdAt(Instant.now())
+                                    .finishedAt(Optional.absent())
                                     .build()
                             )
                         );

--- a/digdag-core/src/main/java/io/digdag/core/session/StoredSessionAttempt.java
+++ b/digdag-core/src/main/java/io/digdag/core/session/StoredSessionAttempt.java
@@ -1,6 +1,7 @@
 package io.digdag.core.session;
 
 import java.time.Instant;
+import com.google.common.base.Optional;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.immutables.value.Value;
@@ -16,6 +17,8 @@ public abstract class StoredSessionAttempt
     public abstract long getSessionId();
 
     public abstract Instant getCreatedAt();
+
+    public abstract Optional<Instant> getFinishedAt();
 
     public static StoredSessionAttempt copyOf(StoredSessionAttempt o) {
         return ImmutableStoredSessionAttempt.builder().from(o).build();

--- a/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java
+++ b/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java
@@ -381,9 +381,9 @@ public class WorkflowExecutor
             Instant date = sm.getStoreTime();
             propagateAllBlockedToReady();
             retryRetryWaitingTasks();
-            propagateSessionArchive();
             enqueueReadyTasks(queuer);  // TODO enqueue all (not only first 100)
             propagateAllPlannedToDone();
+            propagateSessionArchive();
 
             //IncrementalStatusPropagator prop = new IncrementalStatusPropagator(date);  // TODO doesn't work yet
             int waitMsec = INITIAL_INTERVAL;
@@ -397,11 +397,13 @@ public class WorkflowExecutor
 
                 propagateAllBlockedToReady();
                 retryRetryWaitingTasks();
-                propagateSessionArchive();
                 enqueueReadyTasks(queuer);
                 boolean someDone = propagateAllPlannedToDone();
 
-                if (!someDone) {
+                if (someDone) {
+                    propagateSessionArchive();
+                }
+                else {
                     propagatorLock.lock();
                     try {
                         if (propagatorNotice) {

--- a/digdag-server/src/main/java/io/digdag/server/rs/RestModels.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/RestModels.java
@@ -146,6 +146,7 @@ public final class RestModels
                         .cancelRequested(attempt.getStateFlags().isCancelRequested())
                         .params(attempt.getParams())
                         .createdAt(attempt.getCreatedAt())
+                        .finishedAt(attempt.getFinishedAt())
                         .build())
                 .build();
     }
@@ -175,6 +176,7 @@ public final class RestModels
             .cancelRequested(attempt.getStateFlags().isCancelRequested())
             .params(attempt.getParams())
             .createdAt(attempt.getCreatedAt())
+            .finishedAt(attempt.getFinishedAt())
             .build();
     }
 

--- a/digdag-tests/src/test/java/acceptance/InitPushStartIT.java
+++ b/digdag-tests/src/test/java/acceptance/InitPushStartIT.java
@@ -229,7 +229,16 @@ public class InitPushStartIT
                 }
                 Thread.sleep(1000);
             }
+
+            // Verify that the success is reflected to the REST API
             assertThat(attempt.getSuccess(), is(true));
+            assertThat(attempt.getFinishedAt().isPresent(), is(true));
+            {
+                RestSession done = client.getSession(sessionId);
+                assertThat(done.getLastAttempt().get().getDone(), is(true));
+                assertThat(done.getLastAttempt().get().getSuccess(), is(true));
+                assertThat(done.getLastAttempt().get().getFinishedAt().isPresent(), is(true));
+            }
         }
 
         // Verify that the success is reflected in the cli


### PR DESCRIPTION
The main purpose is making it possible to know how much time attempts are taking. This sort of metrics is useful to know how users are interacting with digdag.
It needed to parse JSON stored in task_archives table to know finish time.
Feature requested by @diana-shealy.