### PR TITLE
Fix symlink handling in project archive

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/archive/ProjectArchive.java
+++ b/digdag-core/src/main/java/io/digdag/core/archive/ProjectArchive.java
@@ -9,6 +9,7 @@ import org.immutables.value.Value;
 import io.digdag.client.config.Config;
 import io.digdag.core.repository.WorkflowDefinitionList;
 import static java.util.Locale.ENGLISH;
+import static com.google.common.base.Preconditions.checkArgument;
 
 public class ProjectArchive
 {
@@ -16,7 +17,7 @@ public class ProjectArchive
 
     public interface PathConsumer
     {
-        public void accept(String resourceName, Path path) throws IOException;
+        public void accept(String resourceName, Path absolutePath) throws IOException;
     }
 
     private final Path projectPath;
@@ -24,6 +25,7 @@ public class ProjectArchive
 
     ProjectArchive(Path projectPath, ArchiveMetadata metadata)
     {
+        checkArgument(projectPath.isAbsolute(), "project path must be absolute: %s", projectPath);
         this.projectPath = projectPath;
         this.metadata = metadata;
     }
@@ -51,6 +53,9 @@ public class ProjectArchive
 
     static String realPathToResourceName(Path projectPath, Path realPath)
     {
+        checkArgument(projectPath.isAbsolute(), "project path must be absolute: %s", projectPath);
+        checkArgument(realPath.isAbsolute(), "real path must be absolute: %s", realPath);
+
         if (!realPath.startsWith(projectPath)) {
             throw new IllegalArgumentException(String.format(ENGLISH,
                         "Given path '%s' is outside of project directory '%s'",

--- a/digdag-tests/src/test/java/acceptance/InitAndArchiveIT.java
+++ b/digdag-tests/src/test/java/acceptance/InitAndArchiveIT.java
@@ -8,10 +8,13 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import utils.CommandStatus;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -19,9 +22,16 @@ import static utils.TestUtils.main;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeTrue;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class InitAndArchiveIT
 {
+    private interface IoBiConsumer<T, U>
+    {
+        void accept(T t, U u) throws IOException;
+    }
+
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 
@@ -47,16 +57,16 @@ public class InitAndArchiveIT
 
         assertThat(Files.exists(archive), is(true));
 
-        Map<String, byte[]> entries = readEntries();
+        Map<String, byte[]> entries = new HashMap<>();
+        forEachArchiveEntry((entry, in) -> entries.put(entry.getName(), ByteStreams.toByteArray(in)));
 
         // TODO (dano): add more exhaustive verification of archive contents
         assertThat(entries, hasKey("foobar.dig"));
     }
 
-    private Map<String, byte[]> readEntries()
+    private void forEachArchiveEntry(IoBiConsumer<TarArchiveEntry, InputStream> consumer)
             throws IOException
     {
-        Map<String, byte[]> entries = new HashMap<>();
         try (TarArchiveInputStream s = new TarArchiveInputStream(
                 new GzipCompressorInputStream(Files.newInputStream(archive)))) {
             while (true) {
@@ -64,9 +74,132 @@ public class InitAndArchiveIT
                 if (entry == null) {
                     break;
                 }
-                entries.put(entry.getName(), ByteStreams.toByteArray(s));
+                consumer.accept(entry, s);
             }
         }
-        return entries;
+    }
+
+    private void assumeSymlinkSupported()
+            throws IOException
+    {
+        try {
+            Files.createSymbolicLink(folder.getRoot().toPath().resolve("target"), folder.getRoot().toPath().resolve("tmp"));
+        } catch (UnsupportedOperationException ex) {
+            assumeTrue(false);
+        }
+    }
+
+    @Test
+    public void normalizeSymlinksToRelative()
+            throws Exception
+    {
+        assumeSymlinkSupported();
+
+        Path projectDir = Files.createDirectories(project);
+
+        Path subDir = Files.createDirectories(projectDir.resolve("sub1"));
+        Path subSubDir = Files.createDirectories(subDir.resolve("sub2"));
+
+        Files.write(projectDir.resolve("proj.file"), "proj".getBytes(UTF_8));
+        Files.write(subDir.resolve("sub.file"), "sub".getBytes(UTF_8));
+        Files.write(subSubDir.resolve("subsub.file"), "subsub".getBytes(UTF_8));
+
+        Files.createSymbolicLink(projectDir.resolve("sym_proj.file"), Paths.get("proj.file"));
+        Files.createSymbolicLink(subDir.resolve("sym_proj.file"), Paths.get("../proj.file"));
+        Files.createSymbolicLink(subSubDir.resolve("sym_proj.file"), Paths.get("../../proj.file"));
+
+        Files.createSymbolicLink(projectDir.resolve("sym_sub.file"), Paths.get("sub1/sub.file"));
+        Files.createSymbolicLink(subDir.resolve("sym_sub.file"), Paths.get("sub.file"));
+        Files.createSymbolicLink(subSubDir.resolve("sym_sub.file"), Paths.get("../sub.file"));
+
+        Files.createSymbolicLink(projectDir.resolve("sym_subsub.file"), Paths.get("sub1/sub2/subsub.file"));
+        Files.createSymbolicLink(subDir.resolve("sym_subsub.file"), Paths.get("sub2/subsub.file"));
+        Files.createSymbolicLink(subSubDir.resolve("sym_subsub.file"), Paths.get("subsub.file"));
+
+        // project dir name should be removed because the dir path won't be same name on a server
+        Files.createSymbolicLink(projectDir.resolve("sym_proj_through_parent.file"), Paths.get("../foobar/proj.file"));
+        Files.createSymbolicLink(subDir.resolve("sym_proj_through_parent.file"), Paths.get("../../foobar/proj.file"));
+        Files.createSymbolicLink(subSubDir.resolve("sym_proj_through_parent.file"), Paths.get("../../../foobar/proj.file"));
+
+        // absolute path shouldn't be normalized to a relative path because the dir path won't be same name on a server
+        Files.createSymbolicLink(projectDir.resolve("sym_proj_absolute.file"), projectDir.resolve("proj.file"));
+        Files.createSymbolicLink(subDir.resolve("sym_proj_absolute.file"), projectDir.resolve("proj.file"));
+        Files.createSymbolicLink(subSubDir.resolve("sym_proj_absolute.file"), projectDir.resolve("proj.file"));
+
+        Files.createSymbolicLink(projectDir.resolve("sym_sub_absolute.file"), subDir.resolve("sub.file"));
+        Files.createSymbolicLink(subDir.resolve("sym_sub_absolute.file"), subDir.resolve("sub.file"));
+        Files.createSymbolicLink(subSubDir.resolve("sym_sub_absolute.file"), subDir.resolve("sub.file"));
+
+        Files.createSymbolicLink(projectDir.resolve("sym_subsub_absolute.file"), subSubDir.resolve("subsub.file"));
+        Files.createSymbolicLink(subDir.resolve("sym_subsub_absolute.file"), subSubDir.resolve("subsub.file"));
+        Files.createSymbolicLink(subSubDir.resolve("sym_subsub_absolute.file"), subSubDir.resolve("subsub.file"));
+
+        CommandStatus command = main("archive",
+                "--project", projectDir.toString(),
+                "-o", archive.toString());
+        assertThat(command.errUtf8(), command.code(), is(0));
+
+        Map<String, TarArchiveEntry> entries = new HashMap<>();
+        forEachArchiveEntry((entry, in) -> entries.put(entry.getName(), entry));
+
+        assertThat(entries.get("sym_proj.file").getLinkName(), is("proj.file"));
+        assertThat(entries.get("sub1/sym_proj.file").getLinkName(), is("../proj.file"));
+        assertThat(entries.get("sub1/sub2/sym_proj.file").getLinkName(), is("../../proj.file"));
+
+        assertThat(entries.get("sym_sub.file").getLinkName(), is("sub1/sub.file"));
+        assertThat(entries.get("sub1/sym_sub.file").getLinkName(), is("sub.file"));
+        assertThat(entries.get("sub1/sub2/sym_sub.file").getLinkName(), is("../sub.file"));
+
+        assertThat(entries.get("sym_subsub.file").getLinkName(), is("sub1/sub2/subsub.file"));
+        assertThat(entries.get("sub1/sym_subsub.file").getLinkName(), is("sub2/subsub.file"));
+        assertThat(entries.get("sub1/sub2/sym_subsub.file").getLinkName(), is("subsub.file"));
+
+        // through-parent paths
+        assertThat(entries.get("sym_proj_through_parent.file").getLinkName(), is("proj.file"));
+        assertThat(entries.get("sub1/sym_proj_through_parent.file").getLinkName(), is("../proj.file"));
+        assertThat(entries.get("sub1/sub2/sym_proj_through_parent.file").getLinkName(), is("../../proj.file"));
+
+        // absolute paths
+        assertThat(entries.get("sym_proj_absolute.file").getLinkName(), is("proj.file"));
+        assertThat(entries.get("sub1/sym_proj_absolute.file").getLinkName(), is("../proj.file"));
+        assertThat(entries.get("sub1/sub2/sym_proj_absolute.file").getLinkName(), is("../../proj.file"));
+
+        assertThat(entries.get("sym_sub_absolute.file").getLinkName(), is("sub1/sub.file"));
+        assertThat(entries.get("sub1/sym_sub_absolute.file").getLinkName(), is("sub.file"));
+        assertThat(entries.get("sub1/sub2/sym_sub_absolute.file").getLinkName(), is("../sub.file"));
+
+        assertThat(entries.get("sym_subsub_absolute.file").getLinkName(), is("sub1/sub2/subsub.file"));
+        assertThat(entries.get("sub1/sym_subsub_absolute.file").getLinkName(), is("sub2/subsub.file"));
+        assertThat(entries.get("sub1/sub2/sym_subsub_absolute.file").getLinkName(), is("subsub.file"));
+    }
+
+    @Test
+    public void rejectOuterRelativeSymlinks()
+            throws Exception
+    {
+        assumeSymlinkSupported();
+
+        Path projectDir = Files.createDirectories(project);
+        Files.createSymbolicLink(projectDir.resolve("invalid_link.file"), Paths.get("../parent"));
+
+        CommandStatus command = main("archive",
+                "--project", projectDir.toString(),
+                "-o", archive.toString());
+        assertThat(command.errUtf8(), command.code(), is(1));
+    }
+
+    @Test
+    public void rejectOuterAbsoluteSymlinks()
+            throws Exception
+    {
+        assumeSymlinkSupported();
+
+        Path projectDir = Files.createDirectories(project);
+        Files.createSymbolicLink(projectDir.resolve("invalid_link.file"), projectDir.resolve("../sibling"));
+
+        CommandStatus command = main("archive",
+                "--project", projectDir.toString(),
+                "-o", archive.toString());
+        assertThat(command.errUtf8(), command.code(), is(1));
     }
 }


### PR DESCRIPTION
`digdag archive` was converting symlinks to absolute links but absolute
links will be invalid when the archive is extracted on a server.

Symlinks must be converted into relative links.