### PR TITLE
Add server.jmx.port option to start JMX agent

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -214,6 +214,9 @@ project(':digdag-cli') {
             // undertow is using ServiceLoader to find ExchangeAttributeBuilder
             // which is used by access logger.
         }
+        // force org.weakref.jmx to use unshaded guava to keep binary size small
+        exclude 'org/weakref/jmx/internal/guava/**/*'
+        relocate 'org.weakref.jmx.internal.guava', 'com.google.common'
     }
 
     task classpath(type: Copy, dependsOn: ['jar']) {

--- a/digdag-core/build.gradle
+++ b/digdag-core/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     compile 'org.postgresql:postgresql:9.4.1208'
     compile 'org.yaml:snakeyaml:1.14'
     compile 'com.google.code.findbugs:annotations:3.0.1'
+    compile 'org.weakref:jmxutils:1.19'
 
     // mail
     compile 'javax.mail:javax.mail-api:1.5.5'

--- a/digdag-core/src/main/java/io/digdag/core/queue/QueueModule.java
+++ b/digdag-core/src/main/java/io/digdag/core/queue/QueueModule.java
@@ -8,6 +8,7 @@ import com.google.inject.multibindings.Multibinder;
 import io.digdag.spi.TaskQueueFactory;
 import io.digdag.core.database.DatabaseTaskQueueFactory;
 import io.digdag.core.workflow.TaskQueueDispatcher;
+import static org.weakref.jmx.guice.ExportBinder.newExporter;
 
 public class QueueModule
         implements Module
@@ -21,5 +22,7 @@ public class QueueModule
         // built-in queue
         Multibinder<TaskQueueFactory> taskQueueBinder = Multibinder.newSetBinder(binder, TaskQueueFactory.class);
         taskQueueBinder.addBinding().to(DatabaseTaskQueueFactory.class).in(Scopes.SINGLETON);
+
+        newExporter(binder).export(TaskQueueDispatcher.class).withGeneratedName();
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/queue/QueueTaskQueueDispatcher.java
+++ b/digdag-core/src/main/java/io/digdag/core/queue/QueueTaskQueueDispatcher.java
@@ -11,10 +11,14 @@ import io.digdag.core.agent.AgentId;
 import io.digdag.core.repository.ResourceNotFoundException;
 import io.digdag.core.repository.ResourceConflictException;
 import io.digdag.core.workflow.TaskQueueDispatcher;
+import org.weakref.jmx.Managed;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class QueueTaskQueueDispatcher
         implements TaskQueueDispatcher
 {
+    private final AtomicLong enqueueCount = new AtomicLong(0L);
+
     private final QueueSettingStoreManager queueManager;
     private final TaskQueueServer taskQueueServer;
 
@@ -27,10 +31,18 @@ public class QueueTaskQueueDispatcher
         this.taskQueueServer = queueServerManager.getTaskQueueServer();
     }
 
+    @Managed
+    public long getEnqueueCount()
+    {
+        return enqueueCount.get();
+    }
+
     @Override
     public void dispatch(int siteId, Optional<String> queueName, TaskQueueRequest request)
         throws ResourceNotFoundException, TaskConflictException
     {
+        enqueueCount.incrementAndGet();
+
         if (queueName.isPresent()) {
             int queueId = queueManager.getQueueIdByName(siteId, queueName.get());
             taskQueueServer.enqueueQueueBoundTask(queueId, request);

--- a/digdag-server/src/main/java/io/digdag/server/JmxModule.java
+++ b/digdag-server/src/main/java/io/digdag/server/JmxModule.java
@@ -1,0 +1,116 @@
+package io.digdag.server;
+
+import com.google.common.base.Throwables;
+import com.google.inject.Binder;
+import com.google.inject.Inject;
+import com.google.inject.Injector;
+import com.google.inject.Module;
+import com.google.inject.Provider;
+import com.google.inject.Scopes;
+import com.google.inject.TypeLiteral;
+import com.google.inject.spi.InjectionListener;
+import com.google.inject.spi.TypeEncounter;
+import com.google.inject.spi.TypeListener;
+import com.google.inject.matcher.AbstractMatcher;
+
+import io.digdag.client.config.ConfigElement;
+
+import java.lang.management.ManagementFactory;
+import java.lang.reflect.Field;
+import java.net.MalformedURLException;
+import java.rmi.server.RemoteObject;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.management.MBeanServer;
+import javax.management.remote.JMXServiceURL;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.weakref.jmx.guice.MBeanModule;
+
+public class JmxModule
+    implements Module
+{
+    private static final Logger logger = LoggerFactory.getLogger(JmxModule.class);
+
+    @Override
+    public void configure(Binder binder)
+    {
+        new MBeanModule().configure(binder);
+        binder.bind(MBeanServer.class).toInstance(ManagementFactory.getPlatformMBeanServer());
+        binder.bind(JmxAgent.class).asEagerSingleton();
+    }
+
+    private static class JmxAgent
+    {
+        private final boolean enabled;
+        private final int port;
+
+        @Inject
+        public JmxAgent(ServerConfig config)
+        {
+            this.enabled = config.getJmxPort().isPresent();
+            this.port = config.getJmxPort().or(0);
+        }
+
+        @PostConstruct
+        public void start()
+        {
+            if (enabled) {
+                startAgent(port);
+            }
+        }
+
+        private static void startAgent(int port)
+        {
+            System.setProperty("com.sun.management.jmxremote", "true");
+            System.setProperty("com.sun.management.jmxremote.port", Integer.toString(port));
+            System.setProperty("com.sun.management.jmxremote.rmi.port", Integer.toString(port));
+            System.setProperty("com.sun.management.jmxremote.authenticate", "false");
+            System.setProperty("com.sun.management.jmxremote.ssl", "false");
+
+            try {
+                sun.management.Agent.startAgent();
+            }
+            catch (Exception e) {
+                throw Throwables.propagate(e);
+            }
+
+            logger.info("JMX agent started on port {}", getJmxRegistryPort(port));
+        }
+
+        private static int getJmxRegistryPort(int defaultPort)
+        {
+            try {
+                Object jmxServer = getField(sun.management.Agent.class, "jmxServer");
+                if (jmxServer == null) {
+                    logger.warn("Failed to determine JMX port: sun.management.Agent.jmxServer field is null");
+                }
+                else {
+                    Object registry = getField(sun.management.jmxremote.ConnectorBootstrap.class, "registry");
+                    if (registry == null) {
+                        logger.warn("Failed to determine JMX port: sun.management.jmxremote.ConnectorBootstrap.registry field is null");
+                    }
+                    else {
+                        return sun.rmi.server.UnicastRef.class.cast(RemoteObject.class.cast(registry).getRef()).getLiveRef().getPort();
+                    }
+                }
+                return defaultPort;
+            }
+            catch (Exception e) {
+                logger.warn("Failed to determine JMX port", e);
+                return defaultPort;
+            }
+        }
+
+        private static Object getField(Class<?> clazz, String name)
+                throws ReflectiveOperationException
+        {
+            Field field = clazz.getDeclaredField(name);
+            field.setAccessible(true);
+            return field.get(clazz);
+        }
+
+        // Agent class doesn't have methods to stop agent
+    }
+}

--- a/digdag-server/src/main/java/io/digdag/server/ServerBootstrap.java
+++ b/digdag-server/src/main/java/io/digdag/server/ServerBootstrap.java
@@ -123,7 +123,7 @@ public class ServerBootstrap
             .addModules((binder) -> {
                 binder.bind(ServerConfig.class).toInstance(serverConfig);
             })
-            .addModules(new ServerModule());
+            .addModules(new JmxModule(), new ServerModule());
     }
 
     private static final InheritableThreadLocal<GuiceRsServerControl> servletServerControl = new InheritableThreadLocal<>();

--- a/digdag-server/src/main/java/io/digdag/server/ServerConfig.java
+++ b/digdag-server/src/main/java/io/digdag/server/ServerConfig.java
@@ -33,6 +33,8 @@ public interface ServerConfig
 
     public Optional<String> getAccessLogPath();
 
+    public Optional<Integer> getJmxPort();
+
     public String getAccessLogPattern();
 
     public boolean getExecutorEnabled();
@@ -68,6 +70,7 @@ public interface ServerConfig
             .serverRuntimeInfoPath(config.getOptional("server.runtime-info.path", String.class))
             .accessLogPath(config.getOptional("server.access-log.path", String.class))
             .accessLogPattern(config.get("server.access-log.pattern", String.class, DEFAULT_ACCESS_LOG_PATTERN))
+            .jmxPort(config.getOptional("server.jmx.port", Integer.class))
             .executorEnabled(config.get("server.executor.enabled", boolean.class, true))
             .headers(headers)
             .systemConfig(ConfigElement.copyOf(config))  // systemConfig needs to include other keys such as server.port so that ServerBootstrap.initialize can recover ServerConfig from this systemConfig

--- a/digdag-tests/src/test/java/acceptance/ServerJmxIT.java
+++ b/digdag-tests/src/test/java/acceptance/ServerJmxIT.java
@@ -1,0 +1,49 @@
+package acceptance;
+
+import org.junit.Rule;
+import org.junit.Test;
+import utils.TemporaryDigdagServer;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.management.remote.JMXServiceURL;
+import javax.management.remote.JMXConnector;
+import javax.management.remote.JMXConnectorFactory;
+import javax.management.MBeanServerConnection;
+import javax.management.ObjectName;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+
+public class ServerJmxIT
+{
+    public static final Pattern JMX_PORT_PATTERN = Pattern.compile("\\s*JMX agent started on port (\\d+)\\s*");
+
+    @Rule
+    public TemporaryDigdagServer server = TemporaryDigdagServer.builder()
+            .inProcess(false)
+            .configuration(
+                    "server.jmx.port=0")
+            .build();
+
+    @Test
+    public void scheduleStartTime()
+            throws Exception
+    {
+        Matcher matcher = JMX_PORT_PATTERN.matcher(server.outUtf8());
+        assertThat(matcher.find(), is(true));
+        int port = Integer.parseInt(matcher.group(1));
+
+        JMXServiceURL url = new JMXServiceURL("service:jmx:rmi:///jndi/rmi://:" + port + "/jmxrmi");
+        try (JMXConnector con = JMXConnectorFactory.connect(url, null)) {
+            MBeanServerConnection beans = con.getMBeanServerConnection();
+
+            Object uptime = beans.getAttribute(ObjectName.getInstance("java.lang", "type", "Runtime"), "Uptime");
+            assertThat(uptime, instanceOf(Long.class));
+
+            Object enqueueCount = beans.getAttribute(ObjectName.getInstance("io.digdag.core.workflow", "name", "TaskQueueDispatcher"), "EnqueueCount");
+            assertThat(enqueueCount, is(0L));
+        }
+    }
+}


### PR DESCRIPTION
Main goal is to get GC status using JMX. It's also possible to export
custom metrics by adding `@Managed` to an injected class and
exposing the class using `ExportBinder.newExporter` method.