### PR TITLE
rebrandable cli + refactoring

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/Check.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Check.java
@@ -1,44 +1,43 @@
 package io.digdag.cli;
 
-import java.io.PrintStream;
-import java.io.IOException;
-import java.util.Map;
-import java.util.Set;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.time.Instant;
-import java.time.ZoneId;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import com.beust.jcommander.Parameter;
 import com.beust.jcommander.DynamicParameter;
+import com.beust.jcommander.Parameter;
 import com.google.common.base.Optional;
 import com.google.inject.Injector;
 import com.google.inject.Scopes;
+import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigFactory;
 import io.digdag.core.DigdagEmbed;
+import io.digdag.core.archive.ArchiveMetadata;
 import io.digdag.core.archive.ProjectArchive;
 import io.digdag.core.archive.ProjectArchiveLoader;
-import io.digdag.core.archive.ArchiveMetadata;
+import io.digdag.core.config.ConfigLoaderManager;
 import io.digdag.core.repository.ArchiveType;
 import io.digdag.core.repository.Revision;
 import io.digdag.core.repository.WorkflowDefinition;
 import io.digdag.core.repository.WorkflowDefinitionList;
-import io.digdag.core.workflow.WorkflowCompiler;
-import io.digdag.core.workflow.Workflow;
-import io.digdag.core.workflow.WorkflowTask;
 import io.digdag.core.schedule.SchedulerManager;
-import io.digdag.core.config.ConfigLoaderManager;
-import io.digdag.spi.Scheduler;
+import io.digdag.core.workflow.Workflow;
+import io.digdag.core.workflow.WorkflowCompiler;
+import io.digdag.core.workflow.WorkflowTask;
 import io.digdag.spi.ScheduleTime;
-import io.digdag.client.config.Config;
-import io.digdag.client.config.ConfigFactory;
-import static io.digdag.cli.TimeUtil.formatTime;
-import static io.digdag.cli.TimeUtil.formatTimeDiff;
+import io.digdag.spi.Scheduler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
 import static io.digdag.cli.Arguments.loadParams;
 import static io.digdag.cli.Arguments.loadProject;
 import static io.digdag.cli.Arguments.normalizeWorkflowName;
 import static io.digdag.cli.SystemExitException.systemExit;
+import static io.digdag.cli.TimeUtil.formatTimeDiff;
 
 public class Check
     extends Command
@@ -56,11 +55,6 @@ public class Check
 
     //@Parameter(names = {"-G", "--graph"})
     //String visualizePath = null;
-
-    public Check(Map<String, String> env, PrintStream out, PrintStream err)
-    {
-        super(env, out, err);
-    }
 
     @Override
     public void main()
@@ -80,7 +74,7 @@ public class Check
 
     public SystemExitException usage(String error)
     {
-        err.println("Usage: digdag check [workflow.dig] [options...]");
+        err.println("Usage: " + programName + " check [workflow.dig] [options...]");
         err.println("  Options:");
         err.println("        --project DIR                use this directory as the project directory (default: current directory)");
         err.println("    -p, --param KEY=VALUE            overwrite a parameter (use multiple times to set many parameters)");

--- a/digdag-cli/src/main/java/io/digdag/cli/Command.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Command.java
@@ -1,33 +1,40 @@
 package io.digdag.cli;
 
+import com.beust.jcommander.DynamicParameter;
+import com.beust.jcommander.Parameter;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import io.digdag.core.Environment;
+import io.digdag.core.Version;
+import io.digdag.core.config.PropertyUtils;
+import io.digdag.core.plugin.PluginSet;
+import io.digdag.core.plugin.RemotePluginLoader;
+import io.digdag.core.plugin.Spec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintStream;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Properties;
-import java.util.Map;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.ArrayList;
-import java.io.IOException;
-
-import com.google.common.collect.ImmutableList;
-import io.digdag.core.config.PropertyUtils;
-import io.digdag.core.plugin.Spec;
-import io.digdag.core.plugin.PluginSet;
-import io.digdag.core.plugin.RemotePluginLoader;
-import com.beust.jcommander.Parameter;
-import com.beust.jcommander.DynamicParameter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.util.Map;
+import java.util.Properties;
 
 public abstract class Command
 {
     private static final Logger log = LoggerFactory.getLogger(Command.class);
 
-    protected final Map<String, String> env;
-    protected final PrintStream out;
-    protected final PrintStream err;
+    @Inject @Environment protected Map<String, String> env;
+    @Inject protected Version version;
+    @Inject @ProgramName protected String programName;
+    @Inject @StdIn protected InputStream in;
+    @Inject @StdOut protected PrintStream out;
+    @Inject @StdErr protected PrintStream err;
 
     @Parameter()
     protected List<String> args = new ArrayList<>();
@@ -46,13 +53,6 @@ public abstract class Command
 
     @Parameter(names = {"-help", "--help"}, help = true, hidden = true)
     protected boolean help;
-
-    protected Command(Map<String, String> env, PrintStream out, PrintStream err)
-    {
-        this.env = env;
-        this.out = out;
-        this.err = err;
-    }
 
     public abstract void main() throws Exception;
 

--- a/digdag-cli/src/main/java/io/digdag/cli/Init.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Init.java
@@ -1,31 +1,26 @@
 package io.digdag.cli;
 
-import java.io.PrintStream;
-import java.util.Map;
+import com.google.common.io.ByteStreams;
+import io.digdag.client.config.ConfigFactory;
+import io.digdag.core.repository.WorkflowDefinition;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.ZoneId;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.IOException;
+import java.util.Map;
 
-import com.google.common.io.ByteStreams;
-import io.digdag.client.config.ConfigFactory;
-import io.digdag.core.repository.WorkflowDefinition;
-import static java.nio.charset.StandardCharsets.UTF_8;
+import static io.digdag.cli.SystemExitException.systemExit;
 import static io.digdag.client.DigdagClient.objectMapper;
 import static io.digdag.core.archive.ProjectArchive.WORKFLOW_FILE_SUFFIX;
-import static io.digdag.cli.SystemExitException.systemExit;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class Init
     extends Command
 {
-    public Init(Map<String, String> env, PrintStream out, PrintStream err)
-    {
-        super(env, out, err);
-    }
-
     @Override
     public void main()
         throws Exception
@@ -39,11 +34,11 @@ public class Init
     @Override
     public SystemExitException usage(String error)
     {
-        err.println("Usage: digdag init <dir>");
+        err.println("Usage: " + programName + " init <dir>");
         err.println("  Options:");
         Main.showCommonOptions(env, err);
         err.println("  Example:");
-        err.println("    $ digdag init mydag");
+        err.println("    $ " + programName + " init mydag");
         return systemExit(error);
     }
 
@@ -84,10 +79,10 @@ public class Init
             gen.cp("query.sql", "query.sql");
             gen.cp("workflow.dig", workflowFileName);
             if (isCurrentDirectory) {
-                out.println("Done. Type `digdag run " + workflowFileName + "` to run the workflow. Enjoy!");
+                out.println("Done. Type `" + programName + " run " + workflowFileName + "` to run the workflow. Enjoy!");
             }
             else {
-                out.println("Done. Type `cd " + destDir + "` and then `digdag run " + workflowFileName + "` to run the workflow. Enjoy!");
+                out.println("Done. Type `cd " + destDir + "` and then `" + programName + " run " + workflowFileName + "` to run the workflow. Enjoy!");
             }
         }
     }

--- a/digdag-cli/src/main/java/io/digdag/cli/ProgramName.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/ProgramName.java
@@ -1,0 +1,18 @@
+package io.digdag.cli;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@BindingAnnotation
+@Target({FIELD, PARAMETER, METHOD})
+@Retention(RUNTIME)
+public @interface ProgramName
+{
+}

--- a/digdag-cli/src/main/java/io/digdag/cli/Run.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Run.java
@@ -1,88 +1,87 @@
 package io.digdag.cli;
 
-import java.io.PrintStream;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.ArrayList;
-import java.util.Properties;
-import java.util.HashMap;
-import java.util.Comparator;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.time.LocalDate;
-import java.time.temporal.ChronoUnit;
-import java.time.ZonedDateTime;
-import java.time.DateTimeException;
-import java.time.format.DateTimeFormatter;
-import java.time.format.DateTimeParseException;
-import java.time.temporal.TemporalAccessor;
-import java.io.IOException;
-import java.nio.file.DirectoryStream;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.Files;
-import java.nio.file.NoSuchFileException;
-
-import io.digdag.client.DigdagClient;
-import io.digdag.core.LocalSecretAccessPolicy;
-import io.digdag.core.config.PropertyUtils;
-import io.digdag.spi.SecretAccessPolicy;
-import io.digdag.spi.SecretStoreManager;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import com.beust.jcommander.Parameter;
 import com.beust.jcommander.DynamicParameter;
-import com.google.common.base.Optional;
+import com.beust.jcommander.Parameter;
 import com.google.common.base.Function;
+import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Scopes;
-import io.digdag.core.DigdagEmbed;
-import io.digdag.core.LocalSite;
-import io.digdag.core.LocalSite.StoreWorkflowResult;
-import io.digdag.core.archive.ArchiveMetadata;
-import io.digdag.core.archive.ProjectArchive;
-import io.digdag.core.archive.ProjectArchiveLoader;
-import io.digdag.core.repository.StoredRevision;
-import io.digdag.core.repository.StoredWorkflowDefinition;
-import io.digdag.core.repository.ResourceNotFoundException;
-import io.digdag.core.repository.ResourceConflictException;
-import io.digdag.core.session.ArchivedTask;
-import io.digdag.core.session.StoredSessionAttemptWithSession;
-import io.digdag.core.session.TaskStateCode;
-import io.digdag.core.session.TaskRelation;
-import io.digdag.core.schedule.SchedulerManager;
-import io.digdag.core.agent.OperatorManager;
-import io.digdag.core.agent.OperatorRegistry;
-import io.digdag.core.agent.TaskCallbackApi;
-import io.digdag.core.agent.SetThreadName;
-import io.digdag.core.agent.ConfigEvalEngine;
-import io.digdag.core.agent.WorkspaceManager;
-import io.digdag.core.agent.AgentId;
-import io.digdag.core.agent.AgentConfig;
-import io.digdag.core.workflow.AttemptBuilder;
-import io.digdag.core.workflow.AttemptRequest;
-import io.digdag.core.workflow.Workflow;
-import io.digdag.core.workflow.WorkflowExecutor;
-import io.digdag.core.workflow.WorkflowCompiler;
-import io.digdag.core.workflow.WorkflowTaskList;
-import io.digdag.core.workflow.SessionAttemptConflictException;
-import io.digdag.core.workflow.TaskTree;
-import io.digdag.core.workflow.TaskMatchPattern;
-import io.digdag.core.config.ConfigLoaderManager;
-import io.digdag.spi.TaskRequest;
-import io.digdag.spi.TaskResult;
-import io.digdag.spi.ScheduleTime;
-import io.digdag.spi.Scheduler;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigException;
 import io.digdag.client.config.ConfigFactory;
+import io.digdag.core.DigdagEmbed;
+import io.digdag.core.LocalSecretAccessPolicy;
+import io.digdag.core.LocalSite;
+import io.digdag.core.LocalSite.StoreWorkflowResult;
+import io.digdag.core.agent.AgentConfig;
+import io.digdag.core.agent.AgentId;
+import io.digdag.core.agent.ConfigEvalEngine;
+import io.digdag.core.agent.OperatorManager;
+import io.digdag.core.agent.OperatorRegistry;
+import io.digdag.core.agent.SetThreadName;
+import io.digdag.core.agent.TaskCallbackApi;
+import io.digdag.core.agent.WorkspaceManager;
+import io.digdag.core.archive.ArchiveMetadata;
+import io.digdag.core.archive.ProjectArchive;
+import io.digdag.core.archive.ProjectArchiveLoader;
+import io.digdag.core.config.ConfigLoaderManager;
+import io.digdag.core.config.PropertyUtils;
+import io.digdag.core.repository.ResourceConflictException;
+import io.digdag.core.repository.ResourceNotFoundException;
+import io.digdag.core.repository.StoredRevision;
+import io.digdag.core.repository.StoredWorkflowDefinition;
+import io.digdag.core.schedule.SchedulerManager;
+import io.digdag.core.session.ArchivedTask;
+import io.digdag.core.session.StoredSessionAttemptWithSession;
+import io.digdag.core.session.TaskRelation;
+import io.digdag.core.session.TaskStateCode;
+import io.digdag.core.workflow.AttemptBuilder;
+import io.digdag.core.workflow.AttemptRequest;
+import io.digdag.core.workflow.SessionAttemptConflictException;
+import io.digdag.core.workflow.TaskMatchPattern;
+import io.digdag.core.workflow.TaskTree;
+import io.digdag.core.workflow.Workflow;
+import io.digdag.core.workflow.WorkflowCompiler;
+import io.digdag.core.workflow.WorkflowExecutor;
+import io.digdag.core.workflow.WorkflowTaskList;
+import io.digdag.spi.ScheduleTime;
+import io.digdag.spi.Scheduler;
+import io.digdag.spi.SecretAccessPolicy;
+import io.digdag.spi.SecretStoreManager;
+import io.digdag.spi.TaskRequest;
+import io.digdag.spi.TaskResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.DateTimeException;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAccessor;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
 import static io.digdag.cli.Arguments.loadParams;
 import static io.digdag.cli.Arguments.loadProject;
 import static io.digdag.cli.Arguments.normalizeWorkflowName;
@@ -139,11 +138,6 @@ public class Run
 
     private Path resumeStatePath;
 
-    public Run(Map<String, String> env, PrintStream out, PrintStream err)
-    {
-        super(env, out, err);
-    }
-
     @Override
     public void main()
             throws Exception
@@ -184,7 +178,7 @@ public class Run
 
     public SystemExitException usage(String error)
     {
-        err.println("Usage: digdag run <workflow.dig> [+task] [options...]");
+        err.println("Usage: " + programName + " run <workflow.dig> [+task] [options...]");
         err.println("  Options:");
         err.println("        --project DIR                use this directory as the project directory (default: current directory)");
         err.println("    -a, --rerun                      ignores status files saved at .digdag/status and re-runs all tasks");
@@ -229,7 +223,7 @@ public class Run
                     binder.bind(SecretStoreManager.class).to(LocalSecretStoreManager.class).in(Scopes.SINGLETON);
                     binder.bind(ResumeStateManager.class).in(Scopes.SINGLETON);
                     binder.bind(YamlMapper.class).in(Scopes.SINGLETON);  // used by ResumeStateManager
-                    binder.bind(Run.class).toInstance(this);  // used by OperatorManagerWithSkip
+                    binder.bind(Run.class).toProvider(() -> this);  // used by OperatorManagerWithSkip
                 })
                 .overrideModulesWith((binder) -> {
                     binder.bind(OperatorManager.class).to(OperatorManagerWithSkip.class).in(Scopes.SINGLETON);

--- a/digdag-cli/src/main/java/io/digdag/cli/Sched.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Sched.java
@@ -1,34 +1,32 @@
 package io.digdag.cli;
 
-import java.io.PrintStream;
-import java.util.Map;
-import java.util.Properties;
-
-import javax.servlet.ServletException;
-import javax.servlet.ServletContext;
-
-import io.digdag.core.Version;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import com.beust.jcommander.Parameter;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Scopes;
-import io.digdag.guice.rs.GuiceRsServerControl;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigFactory;
-import io.digdag.core.config.ConfigLoaderManager;
+import io.digdag.core.DigdagEmbed;
+import io.digdag.core.Version;
+import io.digdag.core.agent.NoopWorkspaceManager;
+import io.digdag.core.agent.WorkspaceManager;
 import io.digdag.core.archive.ProjectArchive;
 import io.digdag.core.archive.ProjectArchiveLoader;
-import io.digdag.core.DigdagEmbed;
-import io.digdag.core.agent.WorkspaceManager;
-import io.digdag.core.agent.NoopWorkspaceManager;
+import io.digdag.core.config.ConfigLoaderManager;
+import io.digdag.guice.rs.GuiceRsServerControl;
 import io.digdag.server.ServerBootstrap;
 import io.digdag.server.ServerConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import static io.digdag.cli.SystemExitException.systemExit;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+
+import java.util.Properties;
+
 import static io.digdag.cli.Arguments.loadParams;
 import static io.digdag.cli.Arguments.loadProject;
+import static io.digdag.cli.SystemExitException.systemExit;
 
 public class Sched
     extends Server
@@ -42,11 +40,6 @@ public class Sched
     String projectDirName = null;
 
     // TODO no-schedule mode
-
-    public Sched(Version version, Map<String, String> env, PrintStream out, PrintStream err)
-    {
-        super(version, env, out, err);
-    }
 
     @Override
     public void main()
@@ -64,7 +57,7 @@ public class Sched
     @Override
     public SystemExitException usage(String error)
     {
-        err.println("Usage: digdag sched [options...]");
+        err.println("Usage: " + programName + " sched [options...]");
         err.println("  Options:");
         err.println("        --project DIR                use this directory as the project directory (default: current directory)");
         err.println("    -n, --port PORT                  port number to listen for web interface and api clients (default: 65432)");
@@ -106,7 +99,7 @@ public class Sched
             props.setProperty(SYSTEM_CONFIG_LOCAL_OVERWRITE_PARAMS, overwriteParams.toString());
         }
 
-        ServerBootstrap.startServer(localVersion, props, SchedulerServerBootStrap.class);
+        ServerBootstrap.startServer(version, props, SchedulerServerBootStrap.class);
     }
 
     public static class SchedulerServerBootStrap

--- a/digdag-cli/src/main/java/io/digdag/cli/SelfUpdate.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/SelfUpdate.java
@@ -1,23 +1,24 @@
 package io.digdag.cli;
 
-import java.io.PrintStream;
-import java.util.Map;
-import java.util.regex.Pattern;
-import java.util.regex.Matcher;
+import com.beust.jcommander.Parameter;
+import com.google.common.io.ByteStreams;
+import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.core.Response;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URISyntaxException;
+import java.nio.file.AccessDeniedException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.Files;
-import java.nio.file.AccessDeniedException;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.Invocation;
-import com.google.common.io.ByteStreams;
-import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
-import com.beust.jcommander.Parameter;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import static io.digdag.cli.SystemExitException.systemExit;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static java.util.Locale.ENGLISH;
@@ -28,11 +29,6 @@ public class SelfUpdate
 {
     @Parameter(names = {"-e", "--endpoint"})
     String endpoint = "http://dl.digdag.io";
-
-    public SelfUpdate(Map<String, String> env, PrintStream out, PrintStream err)
-    {
-        super(env, out, err);
-    }
 
     @Override
     public void main()
@@ -53,13 +49,13 @@ public class SelfUpdate
     @Override
     public SystemExitException usage(String error)
     {
-        err.println("Usage: digdag selfupdate [version]]");
+        err.println("Usage: " + programName + " selfupdate [version]]");
         err.println("  Options:");
         Main.showCommonOptions(env, err);
         err.println("");
         err.println("  Examples:");
-        err.println("    $ digdag selfupdate");
-        err.println("    $ digdag selfupdate 0.8.11-SNAPSHOT");
+        err.println("    $ " + programName + " selfupdate");
+        err.println("    $ " + programName + " selfupdate 0.8.11-SNAPSHOT");
         err.println("");
         return systemExit(error);
     }

--- a/digdag-cli/src/main/java/io/digdag/cli/Server.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Server.java
@@ -1,27 +1,26 @@
 package io.digdag.cli;
 
-import java.io.PrintStream;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Properties;
-import java.io.IOException;
-import java.nio.file.Paths;
-import javax.servlet.ServletException;
-
 import com.beust.jcommander.DynamicParameter;
 import com.beust.jcommander.Parameter;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigFactory;
-import io.digdag.core.Version;
 import io.digdag.core.config.ConfigLoaderManager;
 import io.digdag.core.config.YamlConfigLoader;
 import io.digdag.server.ServerBootstrap;
 
+import javax.servlet.ServletException;
+
+import java.io.IOException;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
 import static io.digdag.cli.Arguments.loadParams;
 import static io.digdag.cli.SystemExitException.systemExit;
 import static io.digdag.client.DigdagClient.objectMapper;
-import static io.digdag.server.ServerConfig.DEFAULT_PORT;
 import static io.digdag.server.ServerConfig.DEFAULT_BIND;
+import static io.digdag.server.ServerConfig.DEFAULT_PORT;
 
 public class Server
     extends Command
@@ -62,14 +61,6 @@ public class Server
     @Parameter(names = {"-P", "--params-file"})
     String paramsFile = null;
 
-    protected final Version localVersion;
-
-    public Server(Version localVersion, Map<String, String> env, PrintStream out, PrintStream err)
-    {
-        super(env, out, err);
-        this.localVersion = localVersion;
-    }
-
     @Override
     public void main()
             throws Exception
@@ -93,7 +84,7 @@ public class Server
     @Override
     public SystemExitException usage(String error)
     {
-        err.println("Usage: digdag server [options...]");
+        err.println("Usage: " + programName + " server [options...]");
         err.println("  Options:");
         err.println("    -n, --port PORT                  port number to listen for web interface and api clients (default: " + DEFAULT_PORT + ")");
         err.println("    -b, --bind ADDRESS               IP address to listen HTTP clients (default: " + DEFAULT_BIND + ")");
@@ -115,7 +106,7 @@ public class Server
     private void startServer()
             throws ServletException, IOException
     {
-        ServerBootstrap.startServer(localVersion, buildServerProperties(), ServerBootstrap.class);
+        ServerBootstrap.startServer(version, buildServerProperties(), ServerBootstrap.class);
     }
 
     protected Properties buildServerProperties()

--- a/digdag-cli/src/main/java/io/digdag/cli/Show.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Show.java
@@ -1,19 +1,19 @@
 package io.digdag.cli;
 
-import java.io.PrintStream;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.io.File;
-import com.google.inject.Injector;
 import com.beust.jcommander.Parameter;
+import com.google.inject.Injector;
+import io.digdag.client.config.ConfigFactory;
 import io.digdag.core.DigdagEmbed;
+import io.digdag.core.config.ConfigLoaderManager;
 import io.digdag.core.repository.WorkflowDefinition;
 import io.digdag.core.repository.WorkflowDefinitionList;
 import io.digdag.core.workflow.Workflow;
 import io.digdag.core.workflow.WorkflowCompiler;
-import io.digdag.core.config.ConfigLoaderManager;
-import io.digdag.client.config.ConfigFactory;
+
+import java.io.File;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import static io.digdag.cli.SystemExitException.systemExit;
 
 public class Show
@@ -23,11 +23,6 @@ public class Show
     String output = "digdag.png";
 
     // TODO support -p option? for jinja template rendering
-
-    public Show(Map<String, String> env, PrintStream out, PrintStream err)
-    {
-        super(env, out, err);
-    }
 
     @Override
     public void main()
@@ -42,7 +37,7 @@ public class Show
     @Override
     public SystemExitException usage(String error)
     {
-        err.println("Usage: digdag show <digdag.dig> [options...]");
+        err.println("Usage: " + programName + " show <digdag.dig> [options...]");
         err.println("  Options:");
         err.println("    -s, --show PATH.png              store a PNG file to this path (default: digdag.png)");
         Main.showCommonOptions(env, err);

--- a/digdag-cli/src/main/java/io/digdag/cli/StdIn.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/StdIn.java
@@ -1,0 +1,16 @@
+package io.digdag.cli;
+
+import com.google.inject.BindingAnnotation;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@BindingAnnotation @Target({ FIELD, PARAMETER, METHOD }) @Retention(RUNTIME)
+public @interface StdIn
+{
+}

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Archive.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Archive.java
@@ -1,23 +1,23 @@
 package io.digdag.cli.client;
 
-import java.nio.file.Path;
 import com.beust.jcommander.DynamicParameter;
 import com.beust.jcommander.Parameter;
 import com.google.inject.Injector;
 import com.google.inject.Scopes;
-import io.digdag.core.DigdagEmbed;
-import io.digdag.core.config.ConfigLoaderManager;
-import io.digdag.client.config.Config;
-import io.digdag.client.config.ConfigFactory;
 import io.digdag.cli.Command;
 import io.digdag.cli.Main;
 import io.digdag.cli.StdErr;
 import io.digdag.cli.StdOut;
 import io.digdag.cli.SystemExitException;
 import io.digdag.cli.YamlMapper;
+import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigFactory;
+import io.digdag.core.DigdagEmbed;
+import io.digdag.core.config.ConfigLoaderManager;
 
 import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
@@ -40,11 +40,6 @@ public class Archive
     @Parameter(names = {"-o", "--output"})
     String output = "digdag.archive.tar.gz";
 
-    public Archive(Map<String, String> env, PrintStream out, PrintStream err)
-    {
-        super(env, out, err);
-    }
-
     @Override
     public void main()
             throws Exception
@@ -58,7 +53,7 @@ public class Archive
     @Override
     public SystemExitException usage(String error)
     {
-        err.println("Usage: digdag archive [options...]");
+        err.println("Usage: " + programName + " archive [options...]");
         err.println("  Options:");
         err.println("        --project DIR                use this directory as the project directory (default: current directory)");
         err.println("    -f, --file PATH                  use this file to load a project (default: digdag.dig)");
@@ -101,11 +96,11 @@ public class Archive
         injector.getInstance(Archiver.class).createArchive(projectPath, Paths.get(output), overwriteParams);
 
         out.println("Created " + output + ".");
-        out.println("Use `digdag upload <path.tar.gz> <project> <revision>` to upload it a server.");
+        out.println("Use `" + programName + " upload <path.tar.gz> <project> <revision>` to upload it a server.");
         out.println("");
         out.println("  Examples:");
-        out.println("    $ digdag upload " + output + " $(basename $(pwd)) -r $(date +%Y%m%d-%H%M%S)");
-        out.println("    $ digdag upload " + output + " $(git rev-parse --abbrev-ref HEAD) -r $(git rev-parse HEAD)");
+        out.println("    $ " + programName + " upload " + output + " $(basename $(pwd)) -r $(date +%Y%m%d-%H%M%S)");
+        out.println("    $ " + programName + " upload " + output + " $(git rev-parse --abbrev-ref HEAD) -r $(git rev-parse HEAD)");
         out.println("");
     }
 }

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Backfill.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Backfill.java
@@ -1,23 +1,20 @@
 package io.digdag.cli.client;
 
-import java.io.PrintStream;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
-
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParameterException;
 import com.google.common.base.Optional;
 import io.digdag.cli.SystemExitException;
 import io.digdag.cli.TimeUtil;
 import io.digdag.client.DigdagClient;
-import io.digdag.client.api.RestSessionAttempt;
-import io.digdag.client.api.RestSchedule;
+import io.digdag.client.api.LocalTimeOrInstant;
 import io.digdag.client.api.RestProject;
+import io.digdag.client.api.RestSchedule;
+import io.digdag.client.api.RestSessionAttempt;
 import io.digdag.client.api.RestWorkflowDefinition;
 import io.digdag.client.api.RestWorkflowSessionTime;
-import io.digdag.client.api.LocalTimeOrInstant;
-import io.digdag.core.Version;
+
+import java.util.List;
+import java.util.UUID;
 
 import static io.digdag.cli.SystemExitException.systemExit;
 
@@ -39,11 +36,6 @@ public class Backfill
     @Parameter(names = {"-d", "--dry-run"})
     boolean dryRun = false;
 
-    public Backfill(Version version, Map<String, String> env, PrintStream out, PrintStream err)
-    {
-        super(version, env, out, err);
-    }
-
     @Override
     public void mainWithClientException()
         throws Exception
@@ -61,7 +53,7 @@ public class Backfill
 
     public SystemExitException usage(String error)
     {
-        err.println("Usage: digdag backfill <project-name> <workflow-name>");
+        err.println("Usage: " + programName + " backfill <project-name> <workflow-name>");
         err.println("  Options:");
         err.println("    -f, --from 'yyyy-MM-dd[ HH:mm:ss]'  timestamp to start backfill from (required)");
         err.println("        --name NAME                  retry attempt name");
@@ -120,7 +112,7 @@ public class Backfill
         }
         else {
             err.println("Backfill session attempts started.");
-            err.println("Use `digdag sessions` to show the session attempts.");
+            err.println("Use `" + programName + " sessions` to show the session attempts.");
         }
     }
 

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Delete.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Delete.java
@@ -1,16 +1,13 @@
 package io.digdag.cli.client;
 
-import java.io.PrintStream;
-import java.io.InputStreamReader;
-import java.io.BufferedReader;
-import java.util.Map;
-
 import com.beust.jcommander.Parameter;
 import io.digdag.cli.SystemExitException;
 import io.digdag.cli.TimeUtil;
 import io.digdag.client.DigdagClient;
 import io.digdag.client.api.RestProject;
-import io.digdag.core.Version;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
 
 import static io.digdag.cli.SystemExitException.systemExit;
 
@@ -19,11 +16,6 @@ public class Delete
 {
     @Parameter(names = {"--force"})
     boolean force = false;
-
-    public Delete(Version version, Map<String, String> env, PrintStream out, PrintStream err)
-    {
-        super(version, env, out, err);
-    }
 
     @Override
     public void mainWithClientException()
@@ -37,7 +29,7 @@ public class Delete
 
     public SystemExitException usage(String error)
     {
-        err.println("Usage: digdag delete <project>");
+        err.println("Usage: " + programName + " delete <project>");
         err.println("  Options:");
         err.println("        --force                      skip y/N prompt");
         showCommonOptions();

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Kill.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Kill.java
@@ -2,21 +2,12 @@ package io.digdag.cli.client;
 
 import io.digdag.cli.SystemExitException;
 import io.digdag.client.DigdagClient;
-import io.digdag.core.Version;
-
-import java.io.PrintStream;
-import java.util.Map;
 
 import static io.digdag.cli.SystemExitException.systemExit;
 
 public class Kill
     extends ClientCommand
 {
-    public Kill(Version version, Map<String, String> env, PrintStream out, PrintStream err)
-    {
-        super(version, env, out, err);
-    }
-
     @Override
     public void mainWithClientException()
         throws Exception
@@ -29,7 +20,7 @@ public class Kill
 
     public SystemExitException usage(String error)
     {
-        err.println("Usage: digdag kill <attempt-id>");
+        err.println("Usage: " + programName + " kill <attempt-id>");
         err.println("  Options:");
         showCommonOptions();
         return systemExit(error);

--- a/digdag-cli/src/main/java/io/digdag/cli/client/ProjectUtil.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/ProjectUtil.java
@@ -6,7 +6,7 @@ import java.io.PrintStream;
 
 class ProjectUtil
 {
-    static void showUploadedProject(PrintStream out, RestProject proj)
+    static void showUploadedProject(PrintStream out, RestProject proj, String programName)
     {
         out.println("Uploaded:");
         out.println("  id: " + proj.getId());
@@ -16,6 +16,6 @@ class ProjectUtil
         out.println("  project created at: " + proj.getCreatedAt());
         out.println("  revision updated at: " + proj.getUpdatedAt());
         out.println("");
-        out.println("Use `digdag workflows` to show all workflows.");
+        out.println("Use `" + programName + " workflows` to show all workflows.");
     }
 }

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Push.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Push.java
@@ -1,18 +1,10 @@
 package io.digdag.cli.client;
 
-import java.io.PrintStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.Map;
-import java.util.HashMap;
-import java.time.Instant;
-
-import com.beust.jcommander.Parameter;
 import com.beust.jcommander.DynamicParameter;
+import com.beust.jcommander.Parameter;
+import com.google.common.base.Optional;
 import com.google.inject.Injector;
 import com.google.inject.Scopes;
-import com.google.common.base.Optional;
 import io.digdag.cli.StdErr;
 import io.digdag.cli.StdOut;
 import io.digdag.cli.SystemExitException;
@@ -23,8 +15,15 @@ import io.digdag.client.api.RestProject;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigFactory;
 import io.digdag.core.DigdagEmbed;
-import io.digdag.core.Version;
 import io.digdag.core.config.ConfigLoaderManager;
+
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
 
 import static io.digdag.cli.Arguments.loadParams;
 import static io.digdag.cli.SystemExitException.systemExit;
@@ -48,11 +47,6 @@ public class Push
     @Parameter(names = {"--schedule-from"})
     String scheduleFromString = null;
 
-    public Push(Version version, Map<String, String> env, PrintStream out, PrintStream err)
-    {
-        super(version, env, out, err);
-    }
-
     @Override
     public void mainWithClientException()
         throws Exception
@@ -65,7 +59,7 @@ public class Push
 
     public SystemExitException usage(String error)
     {
-        err.println("Usage: digdag push <project> -r <revision>");
+        err.println("Usage: " + programName + " push <project> -r <revision>");
         err.println("  Options:");
         err.println("        --project DIR                use this directory as the project directory (default: current directory)");
         err.println("    -r, --revision REVISION          specific revision name instead of auto-generated UUID");
@@ -122,6 +116,6 @@ public class Push
             revision = Upload.generateDefaultRevisionName();
         }
         RestProject proj = client.putProjectRevision(projName, revision, archivePath.toFile(), scheduleFrom);
-        showUploadedProject(out, proj);
+        showUploadedProject(out, proj, programName);
     }
 }

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Reschedule.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Reschedule.java
@@ -1,16 +1,13 @@
 package io.digdag.cli.client;
 
-import java.io.PrintStream;
-import java.time.Instant;
-import java.util.Map;
-
-import com.google.common.base.Optional;
 import com.beust.jcommander.Parameter;
+import com.google.common.base.Optional;
 import io.digdag.cli.SystemExitException;
 import io.digdag.cli.TimeUtil;
 import io.digdag.client.DigdagClient;
 import io.digdag.client.api.RestScheduleSummary;
-import io.digdag.core.Version;
+
+import java.time.Instant;
 
 import static io.digdag.cli.SystemExitException.systemExit;
 
@@ -28,11 +25,6 @@ public class Reschedule
 
     @Parameter(names = {"-d", "--dry-run"})
     boolean dryRun = false;
-
-    public Reschedule(Version version, Map<String, String> env, PrintStream out, PrintStream err)
-    {
-        super(version, env, out, err);
-    }
 
     @Override
     public void mainWithClientException()
@@ -54,7 +46,7 @@ public class Reschedule
 
     public SystemExitException usage(String error)
     {
-        err.println("Usage: digdag reschedule <schedule-id>");
+        err.println("Usage: " + programName + " reschedule <schedule-id>");
         err.println("  Options:");
         err.println("    -s, --skip N                     skips specified number of schedules from now");
         err.println("    -t, --skip-to 'yyyy-MM-dd HH:mm:ss Z'  skips schedules until the specified time (exclusive)");
@@ -98,7 +90,7 @@ public class Reschedule
             err.println("Schedule is not updated.");
         }
         else {
-            err.println("Use `digdag schedules` to show schedules.");
+            err.println("Use `" + programName + " schedules` to show schedules.");
         }
     }
 }

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Retry.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Retry.java
@@ -1,23 +1,21 @@
 package io.digdag.cli.client;
 
-import java.io.PrintStream;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.UUID;
-
-import com.google.common.base.Optional;
-import com.beust.jcommander.Parameter;
 import com.beust.jcommander.DynamicParameter;
+import com.beust.jcommander.Parameter;
+import com.google.common.base.Optional;
 import io.digdag.cli.SystemExitException;
 import io.digdag.cli.TimeUtil;
 import io.digdag.client.DigdagClient;
 import io.digdag.client.api.RestSessionAttempt;
-import io.digdag.client.api.RestWorkflowDefinition;
 import io.digdag.client.api.RestSessionAttemptRequest;
-import io.digdag.core.Version;
+import io.digdag.client.api.RestWorkflowDefinition;
 
-import static java.util.Locale.ENGLISH;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
 import static io.digdag.cli.SystemExitException.systemExit;
+import static java.util.Locale.ENGLISH;
 
 public class Retry
     extends ClientCommand
@@ -48,11 +46,6 @@ public class Retry
 
     @Parameter(names = {"--name"})
     String retryAttemptName = null;
-
-    public Retry(Version version, Map<String, String> env, PrintStream out, PrintStream err)
-    {
-        super(version, env, out, err);
-    }
 
     @Override
     public void mainWithClientException()
@@ -85,7 +78,7 @@ public class Retry
 
     public SystemExitException usage(String error)
     {
-        err.println("Usage: digdag retry <attempt-id>");
+        err.println("Usage: " + programName + " retry <attempt-id>");
         err.println("  Options:");
         err.println("        --name <name>                unique identifier of this retry attempt instead of auto-generated UUID");
         err.println("        --latest-revision            use the latest revision");
@@ -163,9 +156,9 @@ public class Retry
         ln("  created at: %s", TimeUtil.formatTime(newAttempt.getCreatedAt()));
         ln("");
 
-        err.printf("* Use `digdag session %d` to show session status.%n", newAttempt.getSessionId());
+        err.printf("* Use `" + programName + " session %d` to show session status.%n", newAttempt.getSessionId());
         err.println(String.format(ENGLISH,
-                "* Use `digdag task %d` and `digdag log %d` to show task status and logs.",
+                "* Use `" + programName + " task %d` and `" + programName + " log %d` to show task status and logs.",
                 newAttempt.getId(), newAttempt.getId()));
     }
 }

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Secrets.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Secrets.java
@@ -9,11 +9,8 @@ import io.digdag.cli.SystemExitException;
 import io.digdag.client.DigdagClient;
 import io.digdag.client.api.RestProject;
 import io.digdag.client.api.RestSecretList;
-import io.digdag.core.Version;
 
-import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -23,7 +20,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-import static com.sun.mail.imap.protocol.SearchSequence.isAscii;
 import static io.digdag.cli.SystemExitException.systemExit;
 import static io.digdag.client.DigdagClient.objectMapper;
 import static io.digdag.client.api.SecretValidation.isValidSecretKey;
@@ -41,14 +37,6 @@ public class Secrets
 
     @Parameter(names = {"--delete"}, variableArity = true)
     List<String> delete = new ArrayList<>();
-
-    private final InputStream in;
-
-    public Secrets(Version version, Map<String, String> env, PrintStream out, PrintStream err, InputStream in)
-    {
-        super(version, env, out, err);
-        this.in = in;
-    }
 
     @Override
     public void mainWithClientException()
@@ -240,7 +228,7 @@ public class Secrets
 
     public SystemExitException usage(String error)
     {
-        err.println("Usage: digdag secrets --project <project> [--set <key>=<value>] [--delete key]");
+        err.println("Usage: " + programName + " secrets --project <project> [--set <key>=<value>] [--delete key]");
         showCommonOptions();
         return systemExit(error);
     }

--- a/digdag-cli/src/main/java/io/digdag/cli/client/ShowAttempt.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/ShowAttempt.java
@@ -4,21 +4,12 @@ import io.digdag.cli.SystemExitException;
 import io.digdag.cli.TimeUtil;
 import io.digdag.client.DigdagClient;
 import io.digdag.client.api.RestSessionAttempt;
-import io.digdag.core.Version;
-
-import java.io.PrintStream;
-import java.util.Map;
 
 import static io.digdag.cli.SystemExitException.systemExit;
 
 public class ShowAttempt
     extends ClientCommand
 {
-    public ShowAttempt(Version version, Map<String, String> env, PrintStream out, PrintStream err)
-    {
-        super(version, env, out, err);
-    }
-
     @Override
     public void mainWithClientException()
             throws Exception
@@ -46,7 +37,7 @@ public class ShowAttempt
 
     public SystemExitException usage(String error)
     {
-        err.println("Usage: digdag attempt  <attempt-id>            show a single attempt");
+        err.println("Usage: " + programName + " attempt  <attempt-id>            show a single attempt");
         showCommonOptions();
         return systemExit(error);
     }

--- a/digdag-cli/src/main/java/io/digdag/cli/client/ShowAttempts.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/ShowAttempts.java
@@ -7,11 +7,8 @@ import io.digdag.cli.SystemExitException;
 import io.digdag.cli.TimeUtil;
 import io.digdag.client.DigdagClient;
 import io.digdag.client.api.RestSessionAttempt;
-import io.digdag.core.Version;
 
-import java.io.PrintStream;
 import java.util.List;
-import java.util.Map;
 
 import static io.digdag.cli.SystemExitException.systemExit;
 
@@ -20,11 +17,6 @@ public class ShowAttempts
 {
     @Parameter(names = {"-i", "--last-id"})
     Long lastId = null;
-
-    public ShowAttempts(Version version, Map<String, String> env, PrintStream out, PrintStream err)
-    {
-        super(version, env, out, err);
-    }
 
     @Override
     public void mainWithClientException()
@@ -49,8 +41,8 @@ public class ShowAttempts
 
     public SystemExitException usage(String error)
     {
-        err.println("Usage: digdag attempts                         show attempts for all sessions");
-        err.println("       digdag attempts <session-id>            show attempts for a session");
+        err.println("Usage: " + programName + " attempts                         show attempts for all sessions");
+        err.println("       " + programName + " attempts <session-id>            show attempts for a session");
         err.println("  Options:");
         err.println("    -i, --last-id ID                 shows more session attempts from this id");
         showCommonOptions();
@@ -76,7 +68,7 @@ public class ShowAttempts
         }
 
         if (attempts.isEmpty()) {
-            err.println("Use `digdag start` to start a session.");
+            err.println("Use `" + programName + " start` to start a session.");
         }
     }
 

--- a/digdag-cli/src/main/java/io/digdag/cli/client/ShowLog.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/ShowLog.java
@@ -1,19 +1,17 @@
 package io.digdag.cli.client;
 
-import java.io.PrintStream;
-import java.util.List;
-import java.io.IOException;
-import java.util.Map;
-
-import com.google.common.base.Optional;
 import com.beust.jcommander.Parameter;
+import com.google.common.base.Optional;
 import io.digdag.cli.SystemExitException;
 import io.digdag.client.DigdagClient;
 import io.digdag.client.api.RestLogFileHandle;
 import io.digdag.client.api.RestSessionAttempt;
 import io.digdag.client.api.RestTask;
-import io.digdag.core.Version;
 import io.digdag.core.log.LogLevel;
+
+import java.io.IOException;
+import java.util.List;
+
 import static io.digdag.cli.SystemExitException.systemExit;
 
 public class ShowLog
@@ -24,11 +22,6 @@ public class ShowLog
 
     @Parameter(names = {"-f", "--follow"})
     protected boolean follow = false;
-
-    public ShowLog(Version version, Map<String, String> env, PrintStream out, PrintStream err)
-    {
-        super(version, env, out, err);
-    }
 
     @Override
     public void mainWithClientException()
@@ -48,7 +41,7 @@ public class ShowLog
 
     public SystemExitException usage(String error)
     {
-        err.println("Usage: digdag log <attempt-id> [+task name prefix]");
+        err.println("Usage: " + programName + " log <attempt-id> [+task name prefix]");
         err.println("    -v, --verbose                    show debug logs");
         err.println("    -f, --follow                     show new logs until attempt or task finishes");
         err.println("  Options:");

--- a/digdag-cli/src/main/java/io/digdag/cli/client/ShowSchedule.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/ShowSchedule.java
@@ -1,25 +1,17 @@
 package io.digdag.cli.client;
 
-import java.io.PrintStream;
-import java.time.Instant;
-import java.util.Map;
-
 import io.digdag.cli.SystemExitException;
 import io.digdag.cli.TimeUtil;
 import io.digdag.client.DigdagClient;
 import io.digdag.client.api.RestSchedule;
-import io.digdag.core.Version;
+
+import java.time.Instant;
 
 import static io.digdag.cli.SystemExitException.systemExit;
 
 public class ShowSchedule
     extends ClientCommand
 {
-    public ShowSchedule(Version version, Map<String, String> env, PrintStream out, PrintStream err)
-    {
-        super(version, env, out, err);
-    }
-
     @Override
     public void mainWithClientException()
         throws Exception
@@ -35,7 +27,7 @@ public class ShowSchedule
 
     public SystemExitException usage(String error)
     {
-        err.println("Usage: digdag schedules");
+        err.println("Usage: " + programName + " schedules");
         err.println("  Options:");
         showCommonOptions();
         return systemExit(error);
@@ -59,6 +51,6 @@ public class ShowSchedule
             count++;
         }
         ln("%d entries.", count);
-        err.println("Use `digdag workflows [project-name] [workflow-name]` to show workflow details.");
+        err.println("Use `" + programName + " workflows [project-name] [workflow-name]` to show workflow details.");
     }
 }

--- a/digdag-cli/src/main/java/io/digdag/cli/client/ShowSession.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/ShowSession.java
@@ -8,11 +8,8 @@ import io.digdag.cli.TimeUtil;
 import io.digdag.client.DigdagClient;
 import io.digdag.client.api.RestProject;
 import io.digdag.client.api.RestSession;
-import io.digdag.core.Version;
 
-import java.io.PrintStream;
 import java.util.List;
-import java.util.Map;
 
 import static io.digdag.cli.SystemExitException.systemExit;
 
@@ -21,11 +18,6 @@ public class ShowSession
 {
     @Parameter(names = {"-i", "--last-id"})
     Long lastId = null;
-
-    public ShowSession(Version version, Map<String, String> env, PrintStream out, PrintStream err)
-    {
-        super(version, env, out, err);
-    }
 
     @Override
     public void mainWithClientException()
@@ -69,10 +61,10 @@ public class ShowSession
 
     public SystemExitException usage(String error)
     {
-        err.println("Usage: digdag sessions                         show sessions for all workflows");
-        err.println("       digdag sessions <project-name>          show sessions for all workflows in a project");
-        err.println("       digdag sessions <project-name> <name>   show sessions for a workflow");
-        err.println("       digdag session  <session-id>            show a single session");
+        err.println("Usage: " + programName + " sessions                         show sessions for all workflows");
+        err.println("       " + programName + " sessions <project-name>          show sessions for all workflows in a project");
+        err.println("       " + programName + " sessions <project-name> <name>   show sessions for a workflow");
+        err.println("       " + programName + " session  <session-id>            show a single session");
         err.println("  Options:");
         err.println("    -i, --last-id ID                 shows more session attempts from this id");
         showCommonOptions();
@@ -104,7 +96,7 @@ public class ShowSession
         }
 
         if (sessions.isEmpty()) {
-            err.println("Use `digdag start` to start a session.");
+            err.println("Use `" + programName + " start` to start a session.");
         }
     }
 

--- a/digdag-cli/src/main/java/io/digdag/cli/client/ShowTask.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/ShowTask.java
@@ -3,21 +3,12 @@ package io.digdag.cli.client;
 import io.digdag.cli.SystemExitException;
 import io.digdag.client.DigdagClient;
 import io.digdag.client.api.RestTask;
-import io.digdag.core.Version;
-
-import java.io.PrintStream;
-import java.util.Map;
 
 import static io.digdag.cli.SystemExitException.systemExit;
 
 public class ShowTask
     extends ClientCommand
 {
-    public ShowTask(Version version, Map<String, String> env, PrintStream out, PrintStream err)
-    {
-        super(version, env, out, err);
-    }
-
     @Override
     public void mainWithClientException()
         throws Exception
@@ -30,7 +21,7 @@ public class ShowTask
 
     public SystemExitException usage(String error)
     {
-        err.println("Usage: digdag tasks <attempt-id>");
+        err.println("Usage: " + programName + " tasks <attempt-id>");
         err.println("  Options:");
         showCommonOptions();
         return systemExit(error);

--- a/digdag-cli/src/main/java/io/digdag/cli/client/ShowWorkflow.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/ShowWorkflow.java
@@ -1,26 +1,19 @@
 package io.digdag.cli.client;
 
-import java.io.PrintStream;
-import java.util.List;
-import java.util.Map;
-
-import javax.ws.rs.NotFoundException;
 import io.digdag.cli.SystemExitException;
 import io.digdag.client.DigdagClient;
-import io.digdag.client.api.RestWorkflowDefinition;
 import io.digdag.client.api.RestProject;
-import io.digdag.core.Version;
+import io.digdag.client.api.RestWorkflowDefinition;
+
+import javax.ws.rs.NotFoundException;
+
+import java.util.List;
 
 import static io.digdag.cli.SystemExitException.systemExit;
 
 public class ShowWorkflow
     extends ClientCommand
 {
-    public ShowWorkflow(Version version, Map<String, String> env, PrintStream out, PrintStream err)
-    {
-        super(version, env, out, err);
-    }
-
     @Override
     public void mainWithClientException()
         throws Exception
@@ -42,7 +35,7 @@ public class ShowWorkflow
 
     public SystemExitException usage(String error)
     {
-        err.println("Usage: digdag workflows [project-name] [name]");
+        err.println("Usage: " + programName + " workflows [project-name] [name]");
         showCommonOptions();
         return systemExit(error);
     }
@@ -73,7 +66,7 @@ public class ShowWorkflow
             }
         }
         ln("");
-        err.println("Use `digdag workflows <project-name> <name>` to show details.");
+        err.println("Use `" + programName + " workflows <project-name> <name>` to show details.");
     }
 
     private void showWorkflowDetails(String projName, String defName)

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Upload.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Upload.java
@@ -1,16 +1,13 @@
 package io.digdag.cli.client;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.PrintStream;
-import java.util.Map;
-import java.util.UUID;
-
 import com.beust.jcommander.Parameter;
 import io.digdag.cli.SystemExitException;
 import io.digdag.client.DigdagClient;
 import io.digdag.client.api.RestProject;
-import io.digdag.core.Version;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
 
 import static io.digdag.cli.SystemExitException.systemExit;
 import static io.digdag.cli.client.ProjectUtil.showUploadedProject;
@@ -20,11 +17,6 @@ public class Upload
 {
     @Parameter(names = {"-r", "--revision"})
     String revision = null;
-
-    public Upload(Version version, Map<String, String> env, PrintStream out, PrintStream err)
-    {
-        super(version, env, out, err);
-    }
 
     @Override
     public void mainWithClientException()
@@ -38,7 +30,7 @@ public class Upload
 
     public SystemExitException usage(String error)
     {
-        err.println("Usage: digdag upload <path.tar.gz> <project>");
+        err.println("Usage: " + programName + " upload <path.tar.gz> <project>");
         err.println("  Options:");
         err.println("    -r, --revision REVISION          specific revision name instead of auto-generated UUID");
         //err.println("        --time-revision              use current time as the revision name");
@@ -54,7 +46,7 @@ public class Upload
             revision = generateDefaultRevisionName();
         }
         RestProject proj = client.putProjectRevision(projName, revision, new File(path));
-        showUploadedProject(out, proj);
+        showUploadedProject(out, proj, programName);
     }
 
     public static String generateDefaultRevisionName()

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Version.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Version.java
@@ -3,32 +3,26 @@ package io.digdag.cli.client;
 import io.digdag.cli.SystemExitException;
 import io.digdag.client.DigdagClient;
 
-import java.io.PrintStream;
 import java.util.Map;
 
 import static io.digdag.cli.SystemExitException.systemExit;
 
 public class Version extends ClientCommand
 {
-    public Version(io.digdag.core.Version version, Map<String, String> env, PrintStream out, PrintStream err)
-    {
-        super(version, env, out, err);
-    }
-
     @Override
     public void mainWithClientException()
             throws Exception
     {
         DigdagClient client = buildClient(false);
         Map<String, Object> remoteVersion = client.getVersion();
-        ln("Client version: " + localVersion);
+        ln("Client version: " + version);
         ln("Server version: " + remoteVersion.getOrDefault("version", ""));
     }
 
     @Override
     public SystemExitException usage(String error)
     {
-        err.println("Usage: digdag version");
+        err.println("Usage: " + programName + " version");
         err.println("  Options:");
         showCommonOptions();
         return systemExit(error);

--- a/digdag-cli/src/test/java/io/digdag/cli/client/ClientBuildingTest.java
+++ b/digdag-cli/src/test/java/io/digdag/cli/client/ClientBuildingTest.java
@@ -1,8 +1,15 @@
 package io.digdag.cli.client;
 
 import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.Properties;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.inject.Binder;
+import com.google.inject.Guice;
+import com.google.inject.Module;
+import io.digdag.cli.SystemExitException;
+import io.digdag.core.Environment;
 import org.junit.Test;
 
 import io.digdag.client.DigdagClient;
@@ -16,9 +23,7 @@ public class ClientBuildingTest
     private String buildEndpoint(String endpoint)
         throws Exception
     {
-        ShowWorkflow cmd = new ShowWorkflow(buildVersion(), ImmutableMap.of(), System.out, System.err);
-        cmd.endpoint = endpoint;
-        DigdagClient client = cmd.buildClient(false);
+        DigdagClient client = ClientCommand.buildClient(endpoint, ImmutableMap.of(), new Properties(), false, ImmutableMap.of());
         Field f = client.getClass().getDeclaredField("endpoint");
         f.setAccessible(true);
         return (String) f.get(client);

--- a/digdag-tests/src/test/java/acceptance/CustomProgramNameIT.java
+++ b/digdag-tests/src/test/java/acceptance/CustomProgramNameIT.java
@@ -1,0 +1,37 @@
+package acceptance;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import utils.CommandStatus;
+import utils.TestUtils;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class CustomProgramNameIT
+{
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        System.setProperty("io.digdag.cli.programName", "foo bar");
+    }
+
+    @After
+    public void tearDown()
+            throws Exception
+    {
+        System.clearProperty("io.digdag.cli.programName");
+    }
+
+    @Test
+    public void testCustomProgramName()
+            throws Exception
+    {
+        CommandStatus status = TestUtils.main("--help");
+        assertThat(status.errUtf8(), status.code(), is(0));
+        assertThat(status.errUtf8(), containsString("Usage: foo bar"));
+    }
+}


### PR DESCRIPTION
* Add `-Dio.digdag.cli.programName=<name>` system property for setting the name that the cli should use in help/usage text.

* Make it possible to specify `-c/--config` before the command on the command line. E.g. `digdag -c /custom/config workflows`.

* Wire the cli commands using Guice to eliminate a lot of boilerplate.