### PR TITLE
load td.conf

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/Run.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Run.java
@@ -10,6 +10,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.inject.Inject;
 import com.google.inject.Injector;
 import com.google.inject.Scopes;
+import com.google.inject.multibindings.Multibinder;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigException;
 import io.digdag.client.config.ConfigFactory;
@@ -51,6 +52,7 @@ import io.digdag.core.workflow.WorkflowTaskList;
 import io.digdag.spi.ScheduleTime;
 import io.digdag.spi.Scheduler;
 import io.digdag.spi.SecretAccessPolicy;
+import io.digdag.spi.SecretStore;
 import io.digdag.spi.SecretStoreManager;
 import io.digdag.spi.TaskRequest;
 import io.digdag.spi.TaskResult;
@@ -220,6 +222,7 @@ public class Run
                 .setSystemPlugins(loadSystemPlugins(systemProps))
                 .addModules(binder -> {
                     binder.bind(SecretAccessPolicy.class).to(LocalSecretAccessPolicy.class).in(Scopes.SINGLETON);
+                    Multibinder.newSetBinder(binder, SecretStore.class);
                     binder.bind(SecretStoreManager.class).to(LocalSecretStoreManager.class).in(Scopes.SINGLETON);
                     binder.bind(ResumeStateManager.class).in(Scopes.SINGLETON);
                     binder.bind(YamlMapper.class).in(Scopes.SINGLETON);  // used by ResumeStateManager

--- a/digdag-cli/src/main/java/io/digdag/cli/client/ClientCommand.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/ClientCommand.java
@@ -98,9 +98,6 @@ public abstract class ClientCommand
 
         PluginSet plugins = loadSystemPlugins(props);
 
-        // TODO: load this as a proper plugin
-        plugins = plugins.withPlugins(new TdDigdagClientConfigurationPlugin());
-
         List<DigdagClientConfigurator> clientConfigurators = plugins.withInjector(injector).getServiceProviders(DigdagClientConfigurator.class);
 
         if (endpoint == null) {

--- a/digdag-cli/src/test/java/io/digdag/cli/client/ClientBuildingTest.java
+++ b/digdag-cli/src/test/java/io/digdag/cli/client/ClientBuildingTest.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Field;
 import java.util.Map;
 import java.util.Properties;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Binder;
 import com.google.inject.Guice;
@@ -23,7 +24,7 @@ public class ClientBuildingTest
     private String buildEndpoint(String endpoint)
         throws Exception
     {
-        DigdagClient client = ClientCommand.buildClient(endpoint, ImmutableMap.of(), new Properties(), false, ImmutableMap.of());
+        DigdagClient client = ClientCommand.buildClient(endpoint, ImmutableMap.of(), new Properties(), false, ImmutableMap.of(), ImmutableList.of());
         Field f = client.getClass().getDeclaredField("endpoint");
         f.setAccessible(true);
         return (String) f.get(client);

--- a/digdag-core/src/main/java/io/digdag/core/plugin/LocalPluginLoader.java
+++ b/digdag-core/src/main/java/io/digdag/core/plugin/LocalPluginLoader.java
@@ -1,0 +1,32 @@
+package io.digdag.core.plugin;
+
+import com.google.common.collect.ImmutableList;
+
+import io.digdag.spi.Plugin;
+
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.ServiceConfigurationError;
+
+public class LocalPluginLoader
+{
+    public LocalPluginLoader()
+    { }
+
+    public PluginSet load(ClassLoader classLoader)
+    {
+        try {
+            return new PluginSet(lookupPlugins(classLoader));
+        }
+        catch (ServiceConfigurationError ex) {
+            throw new RuntimeException("Failed to lookup io.digdag.spi.Plugin service from local class loader " + classLoader, ex);
+        }
+    }
+
+    static List<Plugin> lookupPlugins(ClassLoader classLoader)
+        throws ServiceConfigurationError
+    {
+        ServiceLoader<Plugin> serviceLoader = ServiceLoader.load(Plugin.class, classLoader);
+        return ImmutableList.copyOf(serviceLoader);
+    }
+}

--- a/digdag-core/src/main/java/io/digdag/core/plugin/PluginSet.java
+++ b/digdag-core/src/main/java/io/digdag/core/plugin/PluginSet.java
@@ -65,6 +65,11 @@ public class PluginSet
                 .toList());
     }
 
+    public PluginSet withPlugins(PluginSet another)
+    {
+        return withPlugins(another.plugins);
+    }
+
     public WithInjector withInjector(Injector injector)
     {
         return new WithInjector(injector);

--- a/digdag-core/src/main/java/io/digdag/core/plugin/RemotePluginLoader.java
+++ b/digdag-core/src/main/java/io/digdag/core/plugin/RemotePluginLoader.java
@@ -1,7 +1,6 @@
 package io.digdag.core.plugin;
 
 import java.util.List;
-import java.util.ServiceLoader;
 import java.util.stream.Collectors;
 import java.util.ServiceConfigurationError;
 import java.io.File;
@@ -38,6 +37,8 @@ import io.digdag.spi.Plugin;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static io.digdag.core.plugin.LocalPluginLoader.lookupPlugins;
 
 public class RemotePluginLoader
         implements PluginLoader
@@ -123,8 +124,7 @@ public class RemotePluginLoader
 
             ClassLoader pluginClassLoader = buildPluginClassLoader(artifactResults);
             try {
-                ServiceLoader<Plugin> serviceLoader = ServiceLoader.load(Plugin.class, pluginClassLoader);
-                List<Plugin> plugins = ImmutableList.copyOf(serviceLoader);
+                List<Plugin> plugins = lookupPlugins(pluginClassLoader);
                 if (plugins.isEmpty()) {
                     logger.warn("No plugins found from a dependency '" + dep + "'");
                 }

--- a/digdag-docs/src/internal.md
+++ b/digdag-docs/src/internal.md
@@ -118,13 +118,15 @@ Many of customization points in digdag are assuming Extension to override (e.g. 
 
 ### System plugins
 
-System plugins are plugins loaded when digdag starts. System plugins are loaded using an isolated class loader but they share the same Guice instance with digdag core. Thus system plugins can get any internal resources as long as an instance is available through `io.digdag.spi` interface.
+System plugins are plugins loaded when digdag starts. System plugins are used to customize global behavior of digdag. Adding a scheduler is one of the intended use cases (although this is not implemented yet).
 
-System plugins are used to customize global behavior of digdag. Adding a scheduler is one of intended use cases (although this is not implemented yet).
+If `io.digdag.spi.Plugin` implementations are available using Java's ServiceLoader mechanism in classpath, digdag uses them automatically.
+
+If plugin dependencies are written in config file, digdag downloads them from remote maven repositories, and loads `io.digdag.spi.Plugin` implementations using ServiceLoader. These plugins are loaded using isolated classloaders.
+
+Plugins share the same Guice instance with digdag core. Thus plugins can get any internal resources as long as an instance is available through `io.digdag.spi` interface which are shared even with isolated classloaders.
 
 A system plugin is instantiated once when digdag starts.
-
-Plugin loader can fetch files from remote maven repositories. Thus, plugins will be released as a jar file with a pom file on a maven repository.
 
 All dynamic plugins can be loaded as system plugins. But system plugins can't be loaded as dynamic plugins.
 

--- a/digdag-spi/src/main/java/io/digdag/spi/DigdagClientConfigurator.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/DigdagClientConfigurator.java
@@ -1,0 +1,11 @@
+package io.digdag.spi;
+
+import io.digdag.client.DigdagClient;
+
+public interface DigdagClientConfigurator
+{
+    /**
+     * Decorate and/or transform a {@link DigdagClient.Builder} with some configuration. May return the passed in builder instance or another instance entirely.
+     */
+    DigdagClient.Builder configureClient(DigdagClient.Builder builder);
+}

--- a/digdag-spi/src/main/java/io/digdag/spi/Plugin.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/Plugin.java
@@ -1,8 +1,11 @@
 package io.digdag.spi;
 
-import java.util.List;
+import com.google.inject.Binder;
 
 public interface Plugin
 {
     <T> Class<? extends T> getServiceProvider(Class<T> type);
+
+    default <T> void configureBinder(Class<T> type, Binder binder) {
+    }
 }

--- a/digdag-standards/build.gradle
+++ b/digdag-standards/build.gradle
@@ -28,4 +28,7 @@ dependencies {
     // https://bugs.eclipse.org/bugs/show_bug.cgi?id=475546
     // https://github.com/eclipse/jetty.project/issues/416
     compile 'org.eclipse.jetty:jetty-client:9.3.11.v20160721'
+
+    // XXX (dano): This is just here so we can disable TDClientConfing spam in TdDigdagClientConfigurationPlugin
+    compile 'ch.qos.logback:logback-classic:1.1.5'
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/StandardsExtension.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/StandardsExtension.java
@@ -7,6 +7,7 @@ import io.digdag.spi.Extension;
 import io.digdag.standards.operator.OperatorModule;
 import io.digdag.standards.scheduler.SchedulerModule;
 import io.digdag.standards.command.CommandExecutorModule;
+import io.digdag.standards.td.TdConfigurationModule;
 
 public class StandardsExtension
         implements Extension
@@ -17,7 +18,8 @@ public class StandardsExtension
         return ImmutableList.of(
                 new SchedulerModule(),
                 new CommandExecutorModule(),
-                new OperatorModule()
+                new OperatorModule(),
+                new TdConfigurationModule()
                 );
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/td/TdClientConfigProvider.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/td/TdClientConfigProvider.java
@@ -1,0 +1,83 @@
+package io.digdag.standards.td;
+
+import ch.qos.logback.classic.Level;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import com.treasuredata.client.AbstractTDClientBuilder;
+import com.treasuredata.client.TDClientConfig;
+import io.digdag.core.Environment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
+
+public class TdClientConfigProvider
+        implements Provider<TDClientConfig>
+{
+    private final Map<String, String> env;
+
+    @Inject
+    public TdClientConfigProvider(@Environment Map<String, String> env)
+    {
+        this.env = env;
+    }
+
+    @Override
+    public TDClientConfig get()
+    {
+        ConfigLoader configLoader = new ConfigLoader();
+
+        // XXX (dano): silence spam in TDClientConfig
+        Logger logger = LoggerFactory.getLogger(TDClientConfig.class);
+        if (logger instanceof ch.qos.logback.classic.Logger) {
+            ((ch.qos.logback.classic.Logger) logger).setLevel(Level.WARN);
+        }
+
+        Path tdConf = configPath(env);
+        if (Files.exists(tdConf)) {
+            configLoader.setProperties(TDClientConfig.readTDConf(tdConf.toFile()));
+        }
+
+        return configLoader.buildConfig();
+    }
+
+    private static Path configPath(Map<String, String> env)
+    {
+        String path;
+        path = env.get("TREASURE_DATA_CONFIG_PATH");
+        if (path != null) {
+            return Paths.get(path);
+        }
+        path = env.get("TD_CONFIG_PATH");
+        if (path != null) {
+            return Paths.get(path);
+        }
+        return Paths.get(System.getProperty("user.home"), ".td", "td.conf");
+    }
+
+    // XXX (dano): Awful hack...
+    static class ConfigLoader
+            extends AbstractTDClientBuilder<Void, ConfigLoader>
+    {
+
+        ConfigLoader()
+        {
+            super(false);
+        }
+
+        @Override
+        protected ConfigLoader self()
+        {
+            return this;
+        }
+
+        @Override
+        public Void build()
+        {
+            throw new UnsupportedOperationException();
+        }
+    }
+}

--- a/digdag-standards/src/main/java/io/digdag/standards/td/TdClientConfigProvider.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/td/TdClientConfigProvider.java
@@ -28,6 +28,11 @@ public class TdClientConfigProvider
     @Override
     public TDClientConfig get()
     {
+        Path tdConf = configPath(env);
+        if (!Files.exists(tdConf)) {
+            return null;
+        }
+
         ConfigLoader configLoader = new ConfigLoader();
 
         // XXX (dano): silence spam in TDClientConfig
@@ -36,10 +41,7 @@ public class TdClientConfigProvider
             ((ch.qos.logback.classic.Logger) logger).setLevel(Level.WARN);
         }
 
-        Path tdConf = configPath(env);
-        if (Files.exists(tdConf)) {
-            configLoader.setProperties(TDClientConfig.readTDConf(tdConf.toFile()));
-        }
+        configLoader.setProperties(TDClientConfig.readTDConf(tdConf.toFile()));
 
         return configLoader.buildConfig();
     }

--- a/digdag-standards/src/main/java/io/digdag/standards/td/TdConfigSecretStore.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/td/TdConfigSecretStore.java
@@ -8,6 +8,8 @@ import com.treasuredata.client.TDClientConfig;
 import io.digdag.spi.SecretAccessContext;
 import io.digdag.spi.SecretStore;
 
+import javax.annotation.Nullable;
+
 import java.util.Map;
 
 class TdConfigSecretStore
@@ -15,8 +17,17 @@ class TdConfigSecretStore
 {
     private final Map<String, String> secrets;
 
+    private final boolean enabled = Boolean.parseBoolean(System.getProperty("io.digdag.standards.td.secrets.enabled", "true"));
+
     @Inject
-    public TdConfigSecretStore(TDClientConfig clientConfig)
+    public TdConfigSecretStore(@Nullable TDClientConfig clientConfig)
+    {
+        this.secrets = (!enabled || clientConfig == null)
+                ? ImmutableMap.of()
+                : secrets(clientConfig);
+    }
+
+    private static ImmutableMap<String, String> secrets(TDClientConfig clientConfig)
     {
         ImmutableMap.Builder<String, String> secrets = ImmutableMap.builder();
 
@@ -41,7 +52,7 @@ class TdConfigSecretStore
             }
         }
 
-        this.secrets = secrets.build();
+        return secrets.build();
     }
 
     @Override

--- a/digdag-standards/src/main/java/io/digdag/standards/td/TdConfigSecretStore.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/td/TdConfigSecretStore.java
@@ -1,0 +1,52 @@
+package io.digdag.standards.td;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import com.treasuredata.client.ProxyConfig;
+import com.treasuredata.client.TDClientConfig;
+import io.digdag.spi.SecretAccessContext;
+import io.digdag.spi.SecretStore;
+
+import java.util.Map;
+
+class TdConfigSecretStore
+        implements SecretStore
+{
+    private final Map<String, String> secrets;
+
+    @Inject
+    public TdConfigSecretStore(TDClientConfig clientConfig)
+    {
+        ImmutableMap.Builder<String, String> secrets = ImmutableMap.builder();
+
+        secrets.put("td.endpoint", clientConfig.endpoint);
+        if (clientConfig.apiKey.isPresent()) {
+            secrets.put("td.apikey", clientConfig.apiKey.get());
+        }
+        secrets.put("td.use_ssl", String.valueOf(clientConfig.useSSL));
+
+        secrets.put("td.proxy.enabled", String.valueOf(clientConfig.proxy.isPresent()));
+        if (clientConfig.proxy.isPresent()) {
+            ProxyConfig proxy = clientConfig.proxy.get();
+            secrets.put("td.proxy.host", proxy.getHost());
+            secrets.put("td.proxy.port", String.valueOf(proxy.getPort()));
+            Optional<String> user = proxy.getUser();
+            if (user.isPresent()) {
+                secrets.put("td.proxy.user", user.get());
+            }
+            Optional<String> password = proxy.getPassword();
+            if (password.isPresent()) {
+                secrets.put("td.proxy.password", password.get());
+            }
+        }
+
+        this.secrets = secrets.build();
+    }
+
+    @Override
+    public Optional<String> getSecret(SecretAccessContext context, String key)
+    {
+        return Optional.fromNullable(secrets.get(key));
+    }
+}

--- a/digdag-standards/src/main/java/io/digdag/standards/td/TdConfigurationModule.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/td/TdConfigurationModule.java
@@ -1,0 +1,17 @@
+package io.digdag.standards.td;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.name.Names;
+import com.treasuredata.client.TDClientConfig;
+import io.digdag.spi.SecretStore;
+
+public class TdConfigurationModule implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(TDClientConfig.class).toProvider(TdClientConfigProvider.class);
+        binder.bind(SecretStore.class).annotatedWith(Names.named("td")).to(TdConfigSecretStore.class).asEagerSingleton();
+    }
+}

--- a/digdag-standards/src/main/java/io/digdag/standards/td/TdConfigurationModule.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/td/TdConfigurationModule.java
@@ -2,16 +2,17 @@ package io.digdag.standards.td;
 
 import com.google.inject.Binder;
 import com.google.inject.Module;
-import com.google.inject.name.Names;
+import com.google.inject.multibindings.Multibinder;
 import com.treasuredata.client.TDClientConfig;
 import io.digdag.spi.SecretStore;
 
-public class TdConfigurationModule implements Module
+public class TdConfigurationModule
+        implements Module
 {
     @Override
     public void configure(Binder binder)
     {
         binder.bind(TDClientConfig.class).toProvider(TdClientConfigProvider.class);
-        binder.bind(SecretStore.class).annotatedWith(Names.named("td")).to(TdConfigSecretStore.class).asEagerSingleton();
+        Multibinder.newSetBinder(binder, SecretStore.class).addBinding().to(TdConfigSecretStore.class).asEagerSingleton();
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/td/TdDigdagClientConfigurationPlugin.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/td/TdDigdagClientConfigurationPlugin.java
@@ -1,0 +1,27 @@
+package io.digdag.standards.td;
+
+import com.google.inject.Binder;
+import com.treasuredata.client.TDClientConfig;
+import io.digdag.spi.DigdagClientConfigurator;
+import io.digdag.spi.Plugin;
+
+public class TdDigdagClientConfigurationPlugin
+        implements Plugin
+{
+    @Override
+    public <T> Class<? extends T> getServiceProvider(Class<T> type)
+    {
+        if (type == DigdagClientConfigurator.class) {
+            return TdDigdagClientConfigurator.class.asSubclass(type);
+        }
+        else {
+            return null;
+        }
+    }
+
+    @Override
+    public <T> void configureBinder(Class<T> type, Binder binder)
+    {
+        binder.bind(TDClientConfig.class).toProvider(TdClientConfigProvider.class).asEagerSingleton();
+    }
+}

--- a/digdag-standards/src/main/java/io/digdag/standards/td/TdDigdagClientConfigurator.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/td/TdDigdagClientConfigurator.java
@@ -1,0 +1,39 @@
+package io.digdag.standards.td;
+
+import com.google.inject.Inject;
+import com.treasuredata.client.TDClientConfig;
+import io.digdag.client.DigdagClient;
+import io.digdag.spi.DigdagClientConfigurator;
+
+public class TdDigdagClientConfigurator
+        implements DigdagClientConfigurator
+{
+    private final boolean enabled = Boolean.parseBoolean(System.getProperty("io.digdag.standards.td.client-configurator-enabled", "false"));
+
+    private final TDClientConfig clientConfig;
+
+    @Inject
+    public TdDigdagClientConfigurator(TDClientConfig clientConfig)
+    {
+        this.clientConfig = clientConfig;
+    }
+
+    @Override
+    public DigdagClient.Builder configureClient(DigdagClient.Builder builder)
+    {
+        if (!enabled) {
+            return builder;
+        }
+
+        builder = DigdagClient.builder();
+        builder.host("api-workflow.treasuredata.com");
+        builder.ssl(true);
+
+        if (clientConfig.apiKey.isPresent()) {
+            // TODO: support other authorization value forms as well
+            builder.header("Authorization", "TD1 " + clientConfig.apiKey.get());
+        }
+
+        return builder;
+    }
+}

--- a/digdag-standards/src/main/java/io/digdag/standards/td/TdDigdagClientConfigurator.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/td/TdDigdagClientConfigurator.java
@@ -5,15 +5,22 @@ import com.treasuredata.client.TDClientConfig;
 import io.digdag.client.DigdagClient;
 import io.digdag.spi.DigdagClientConfigurator;
 
+import javax.annotation.Nullable;
+
+import java.net.URI;
+
 public class TdDigdagClientConfigurator
         implements DigdagClientConfigurator
 {
-    private final boolean enabled = Boolean.parseBoolean(System.getProperty("io.digdag.standards.td.client-configurator-enabled", "false"));
+    private static final String DEFAULT_ENDPOINT = "https://api-workflow.treasuredata.com:443";
+
+    private final boolean enabled = Boolean.parseBoolean(System.getProperty("io.digdag.standards.td.client-configurator.enabled", "false"));
+    private final String endpoint = System.getProperty("io.digdag.standards.td.client-configurator.endpoint", DEFAULT_ENDPOINT);
 
     private final TDClientConfig clientConfig;
 
     @Inject
-    public TdDigdagClientConfigurator(TDClientConfig clientConfig)
+    public TdDigdagClientConfigurator(@Nullable TDClientConfig clientConfig)
     {
         this.clientConfig = clientConfig;
     }
@@ -21,13 +28,15 @@ public class TdDigdagClientConfigurator
     @Override
     public DigdagClient.Builder configureClient(DigdagClient.Builder builder)
     {
-        if (!enabled) {
+        if (!enabled || clientConfig == null) {
             return builder;
         }
 
-        builder = DigdagClient.builder();
-        builder.host("api-workflow.treasuredata.com");
-        builder.ssl(true);
+        URI uri = URI.create(endpoint);
+
+        builder.host(uri.getHost());
+        builder.port((uri.getPort() != -1) ? uri.getPort() : defaultPort(uri.getScheme()));
+        builder.ssl("https".equals(uri.getScheme()));
 
         if (clientConfig.apiKey.isPresent()) {
             // TODO: support other authorization value forms as well
@@ -35,5 +44,16 @@ public class TdDigdagClientConfigurator
         }
 
         return builder;
+    }
+
+    private int defaultPort(String scheme)
+    {
+        switch (scheme) {
+            case "http":
+                return 80;
+            case "https":
+                return 443;
+        }
+        throw new IllegalArgumentException("Unknown scheme: " + scheme);
     }
 }

--- a/digdag-standards/src/main/resources/META-INF/services/io.digdag.spi.Plugin
+++ b/digdag-standards/src/main/resources/META-INF/services/io.digdag.spi.Plugin
@@ -1,0 +1,1 @@
+io.digdag.standards.td.TdDigdagClientConfigurationPlugin

--- a/digdag-tests/src/test/java/acceptance/td/TdConfIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/TdConfIT.java
@@ -32,6 +32,7 @@ import static io.netty.handler.codec.http.HttpHeaders.Names.AUTHORIZATION;
 import static io.netty.handler.codec.http.HttpResponseStatus.OK;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.not;
@@ -59,6 +60,7 @@ public class TdConfIT
         assumeThat(TD_API_KEY, not(isEmptyOrNullString()));
         tdConf = folder.newFolder().toPath().resolve("td.conf");
         digdagConf = folder.newFolder().toPath().resolve("digdag");
+        Files.write(digdagConf, emptyList());
     }
 
     @Before

--- a/digdag-tests/src/test/java/acceptance/td/TdConfIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/TdConfIT.java
@@ -1,0 +1,182 @@
+package acceptance.td;
+
+import com.google.common.collect.ImmutableMap;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.littleshoot.proxy.HttpFilters;
+import org.littleshoot.proxy.HttpFiltersAdapter;
+import org.littleshoot.proxy.HttpFiltersSourceAdapter;
+import org.littleshoot.proxy.HttpProxyServer;
+import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static acceptance.td.Secrets.TD_API_KEY;
+import static io.netty.handler.codec.http.HttpHeaders.Names.AUTHORIZATION;
+import static io.netty.handler.codec.http.HttpResponseStatus.OK;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeThat;
+import static utils.TestUtils.main;
+
+public class TdConfIT
+{
+    private static final String MOCK_TD_API_KEY = "4711/badf00d";
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private Path tdConf;
+
+    private HttpProxyServer proxyServer;
+    private List<FullHttpRequest> requests = Collections.synchronizedList(new ArrayList<>());
+    private Path digdagConf;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        assumeThat(TD_API_KEY, not(isEmptyOrNullString()));
+        tdConf = folder.newFolder().toPath().resolve("td.conf");
+        digdagConf = folder.newFolder().toPath().resolve("digdag");
+    }
+
+    @Before
+    public void setupProxy()
+    {
+        proxyServer = DefaultHttpProxyServer
+                .bootstrap()
+                .withPort(0)
+                .withFiltersSource(new HttpFiltersSourceAdapter()
+                {
+                    @Override
+                    public int getMaximumRequestBufferSizeInBytes()
+                    {
+                        return 1024 * 1024;
+                    }
+
+                    @Override
+                    public HttpFilters filterRequest(HttpRequest httpRequest, ChannelHandlerContext channelHandlerContext)
+                    {
+                        return new HttpFiltersAdapter(httpRequest)
+                        {
+                            @Override
+                            public HttpResponse clientToProxyRequest(HttpObject httpObject)
+                            {
+                                assert httpObject instanceof FullHttpRequest;
+                                FullHttpRequest req = ((FullHttpRequest) httpObject).copy();
+                                requests.add(req);
+
+                                if (req.getMethod() == HttpMethod.GET &&
+                                        req.getUri().equals("http://foo.baz.bar:80/api/projects")) {
+                                    return new DefaultFullHttpResponse(req.getProtocolVersion(), OK,
+                                            Unpooled.wrappedBuffer("[]".getBytes(UTF_8)));
+                                }
+                                return null;
+                            }
+                        };
+                    }
+                }).start();
+    }
+
+    @After
+    public void stopProxy()
+            throws Exception
+    {
+        if (proxyServer != null) {
+            proxyServer.stop();
+            proxyServer = null;
+        }
+    }
+
+    @Before
+    public void enableClientConfiguration()
+            throws Exception
+    {
+        System.setProperty("io.digdag.standards.td.client-configurator.enabled", "true");
+        System.setProperty("io.digdag.standards.td.client-configurator.endpoint", "http://foo.baz.bar");
+    }
+
+    @After
+    public void disableClientConfiguration()
+            throws Exception
+    {
+        System.clearProperty("io.digdag.standards.td.client-configurator.enabled");
+        System.clearProperty("io.digdag.standards.td.client-configurator.endpoint");
+    }
+
+    @Test
+    public void verifyCliConfiguresDigdagClientUsingTdConf()
+            throws Exception
+    {
+        Files.write(tdConf, asList(
+                "[account]",
+                "  user = foo@bar.com",
+                "  apikey = " + MOCK_TD_API_KEY
+        ));
+
+        String proxyUrl = "http://" + proxyServer.getListenAddress().getHostString() + ":" + proxyServer.getListenAddress().getPort();
+        Map<String, String> env = ImmutableMap.of(
+                "http_proxy", proxyUrl,
+                "TD_CONFIG_PATH", tdConf.toString()
+        );
+
+        main(env, "workflows",
+                "-c", digdagConf.toString(),
+                "--disable-version-check");
+
+        assertThat(requests.isEmpty(), is(false));
+        for (FullHttpRequest request : requests) {
+            assertThat(request.getUri(), is("http://foo.baz.bar:80/api/projects"));
+            assertThat(request.headers().get(AUTHORIZATION), is("TD1 " + MOCK_TD_API_KEY));
+        }
+    }
+
+    @Test
+    public void verifyCliIgnoresMissingTdConf()
+            throws Exception
+    {
+        assertThat(Files.notExists(tdConf), is(true));
+
+        String proxyUrl = "http://" + proxyServer.getListenAddress().getHostString() + ":" + proxyServer.getListenAddress().getPort();
+        Map<String, String> env = ImmutableMap.of(
+                "http_proxy", proxyUrl,
+                "TD_CONFIG_PATH", tdConf.toString()
+        );
+
+        Files.write(digdagConf, asList(
+                "client.http.endpoint = http://baz.quux:80",
+                "client.http.headers.authorization = FOO " + MOCK_TD_API_KEY
+        ));
+
+        main(env, "workflows",
+                "-c", digdagConf.toString(),
+                "--disable-version-check");
+
+        assertThat(requests.isEmpty(), is(false));
+        for (FullHttpRequest request : requests) {
+            assertThat(request.getUri(), is("http://baz.quux:80/api/projects"));
+            assertThat(request.headers().get(AUTHORIZATION), is("FOO " + MOCK_TD_API_KEY));
+        }
+    }
+}


### PR DESCRIPTION
* Add digdag client configuration plugin interface and an implementation that loads apikey from `~/.td/td.conf` and sets endpoint etc. This is disabled by default and can be enabled via `-Dio.digdag.standards.td.client-configurator-enabled=true`.

* Make the local secret store manager load secrets from a set of backing secret stores and add a secret store implementation that provides secrets td client configuration secrets from `~/.td/td.conf`

* Allow plugins to configure their injector, similar to a guice module.