### PR TITLE
Added job link to tasks table

### DIFF
--- a/digdag-ui/console.jsx
+++ b/digdag-ui/console.jsx
@@ -55,6 +55,7 @@ type AuthItem = {
 
 type ConsoleConfig = {
   url: string;
+  jobUrl: (id:string) => string;
   navbar: ?{
     brand: ?string;
     logo: ?string;
@@ -815,12 +816,23 @@ function formatTaskState(state) {
   }
 }
 
+const JobLink = ({ params }:{params: Object}) => {
+  console.log(params)
+  const jobId = params.td && params.td.last_job_id
+  const link = DIGDAG_CONFIG.jobUrl(jobId)
+  if (!jobId) {
+    return null
+  }
+  return <a href={link} target="_blank">{jobId}</a>
+}
+
 const TaskListView = (props:{tasks: Array<Task>}) =>
   <div className="table-responsive">
     <table className="table table-striped table-hover table-condensed">
       <thead>
       <tr>
         <th>ID</th>
+        <th>Job</th>
         <th>Name</th>
         <th>Parent ID</th>
         <th>Updated</th>
@@ -835,6 +847,7 @@ const TaskListView = (props:{tasks: Array<Task>}) =>
         props.tasks.map(task =>
           <tr key={task.id}>
             <td>{task.id}</td>
+            <td><JobLink params={task.storeParams}/></td>
             <td>{task.fullName}</td>
             <td>{task.parentId}</td>
             <td>{formatTimestamp(task.updatedAt)}</td>

--- a/digdag-ui/console.jsx
+++ b/digdag-ui/console.jsx
@@ -816,9 +816,10 @@ function formatTaskState(state) {
   }
 }
 
-const JobLink = ({ params }:{params: Object}) => {
-  console.log(params)
-  const jobId = params.td && params.td.last_job_id
+const JobLink = ({storeParams, stateParams}:{storeParams: Object, stateParams: Object}) => {
+  const paramsJobId = storeParams.td && storeParams.td.last_job_id
+  const stateJobId = stateParams.job && stateParams.job.jobId
+  const jobId = paramsJobId || stateJobId
   const link = DIGDAG_CONFIG.jobUrl(jobId)
   if (!jobId) {
     return null
@@ -847,7 +848,7 @@ const TaskListView = (props:{tasks: Array<Task>}) =>
         props.tasks.map(task =>
           <tr key={task.id}>
             <td>{task.id}</td>
-            <td><JobLink params={task.storeParams}/></td>
+            <td><JobLink storeParams={task.storeParams} stateParams={task.stateParams}/></td>
             <td>{task.fullName}</td>
             <td>{task.parentId}</td>
             <td>{formatTimestamp(task.updatedAt)}</td>

--- a/digdag-ui/public/config.js
+++ b/digdag-ui/public/config.js
@@ -1,5 +1,6 @@
 var DIGDAG_CONFIG = {
   url: 'http://localhost:65432/api/',
+  jobUrl: (jobId) => ``,
   navbar: {
     logo: '/logo.png',
     brand: 'Digdag',


### PR DESCRIPTION
This adds a job link to the tasks table (for now only td jobs id from storeParams are considered linkable)