### PR TITLE
Load system plugins from classpath

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/client/ClientCommand.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/ClientCommand.java
@@ -98,9 +98,6 @@ public abstract class ClientCommand
 
         PluginSet plugins = loadSystemPlugins(props);
 
-        // TODO: load this as a proper plugin
-        plugins = plugins.withPlugins(new TdDigdagClientConfigurationPlugin());
-
         List<DigdagClientConfigurator> clientConfigurators = plugins.withInjector(injector).getServiceProviders(DigdagClientConfigurator.class);
 
         if (endpoint == null) {

--- a/digdag-core/src/main/java/io/digdag/core/plugin/LocalPluginLoader.java
+++ b/digdag-core/src/main/java/io/digdag/core/plugin/LocalPluginLoader.java
@@ -1,0 +1,32 @@
+package io.digdag.core.plugin;
+
+import com.google.common.collect.ImmutableList;
+
+import io.digdag.spi.Plugin;
+
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.ServiceConfigurationError;
+
+public class LocalPluginLoader
+{
+    public LocalPluginLoader()
+    { }
+
+    public PluginSet load(ClassLoader classLoader)
+    {
+        try {
+            return new PluginSet(lookupPlugins(classLoader));
+        }
+        catch (ServiceConfigurationError ex) {
+            throw new RuntimeException("Failed to lookup io.digdag.spi.Plugin service from local class loader " + classLoader, ex);
+        }
+    }
+
+    static List<Plugin> lookupPlugins(ClassLoader classLoader)
+        throws ServiceConfigurationError
+    {
+        ServiceLoader<Plugin> serviceLoader = ServiceLoader.load(Plugin.class, classLoader);
+        return ImmutableList.copyOf(serviceLoader);
+    }
+}

--- a/digdag-core/src/main/java/io/digdag/core/plugin/PluginSet.java
+++ b/digdag-core/src/main/java/io/digdag/core/plugin/PluginSet.java
@@ -65,6 +65,11 @@ public class PluginSet
                 .toList());
     }
 
+    public PluginSet withPlugins(PluginSet another)
+    {
+        return withPlugins(another.plugins);
+    }
+
     public WithInjector withInjector(Injector injector)
     {
         return new WithInjector(injector);

--- a/digdag-core/src/main/java/io/digdag/core/plugin/RemotePluginLoader.java
+++ b/digdag-core/src/main/java/io/digdag/core/plugin/RemotePluginLoader.java
@@ -1,7 +1,6 @@
 package io.digdag.core.plugin;
 
 import java.util.List;
-import java.util.ServiceLoader;
 import java.util.stream.Collectors;
 import java.util.ServiceConfigurationError;
 import java.io.File;
@@ -38,6 +37,8 @@ import io.digdag.spi.Plugin;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static io.digdag.core.plugin.LocalPluginLoader.lookupPlugins;
 
 public class RemotePluginLoader
         implements PluginLoader
@@ -123,8 +124,7 @@ public class RemotePluginLoader
 
             ClassLoader pluginClassLoader = buildPluginClassLoader(artifactResults);
             try {
-                ServiceLoader<Plugin> serviceLoader = ServiceLoader.load(Plugin.class, pluginClassLoader);
-                List<Plugin> plugins = ImmutableList.copyOf(serviceLoader);
+                List<Plugin> plugins = lookupPlugins(pluginClassLoader);
                 if (plugins.isEmpty()) {
                     logger.warn("No plugins found from a dependency '" + dep + "'");
                 }

--- a/digdag-docs/src/internal.md
+++ b/digdag-docs/src/internal.md
@@ -118,13 +118,15 @@ Many of customization points in digdag are assuming Extension to override (e.g. 
 
 ### System plugins
 
-System plugins are plugins loaded when digdag starts. System plugins are loaded using an isolated class loader but they share the same Guice instance with digdag core. Thus system plugins can get any internal resources as long as an instance is available through `io.digdag.spi` interface.
+System plugins are plugins loaded when digdag starts. System plugins are used to customize global behavior of digdag. Adding a scheduler is one of the intended use cases (although this is not implemented yet).
 
-System plugins are used to customize global behavior of digdag. Adding a scheduler is one of intended use cases (although this is not implemented yet).
+If `io.digdag.spi.Plugin` implementations are available using Java's ServiceLoader mechanism in classpath, digdag uses them automatically.
+
+If plugin dependencies are written in config file, digdag downloads them from remote maven repositories, and loads `io.digdag.spi.Plugin` implementations using ServiceLoader. These plugins are loaded using isolated classloaders.
+
+Plugins share the same Guice instance with digdag core. Thus plugins can get any internal resources as long as an instance is available through `io.digdag.spi` interface which are shared even with isolated classloaders.
 
 A system plugin is instantiated once when digdag starts.
-
-Plugin loader can fetch files from remote maven repositories. Thus, plugins will be released as a jar file with a pom file on a maven repository.
 
 All dynamic plugins can be loaded as system plugins. But system plugins can't be loaded as dynamic plugins.
 

--- a/digdag-standards/src/main/resources/META-INF/services/io.digdag.spi.Plugin
+++ b/digdag-standards/src/main/resources/META-INF/services/io.digdag.spi.Plugin
@@ -1,0 +1,1 @@
+io.digdag.standards.td.TdDigdagClientConfigurationPlugin


### PR DESCRIPTION
If io.digdag.spi.Plugin are included in classpath when digdag-cli
starts, load them as system plugins. This is useful to customize digdag
using plugin mechanism. io.digdag.spi.Extension can do similar thing but
Extension is to override some built-in modules of digdag-core, while
io.digdag.spi.Plugin is used to add new module to exntension points.
They are used for different purposes.

This is a pull-req for #234.