### PR TITLE
move secret scope precedence to provider

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/LocalSecretStoreManager.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/LocalSecretStoreManager.java
@@ -33,11 +33,11 @@ class LocalSecretStoreManager
     @Override
     public SecretStore getSecretStore(int siteId)
     {
-        return (context, key) -> {
+        return (projectId, scope, key) -> {
 
             // First attempt to find a matching secret in the backing stores
             for (SecretStore store : secretStores) {
-                Optional<String> secret = store.getSecret(context, key);
+                Optional<String> secret = store.getSecret(projectId, scope, key);
                 if (secret.isPresent()) {
                     return secret;
                 }

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Start.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Start.java
@@ -60,7 +60,7 @@ public class Start
             throw usage(null);
         }
         if (sessionString == null) {
-            throw usage("--session option is required");
+            sessionString = "now";
         }
         start(args.get(0), args.get(1));
     }
@@ -69,7 +69,7 @@ public class Start
     {
         err.println("Usage: " + programName + " start <project-name> <name>");
         err.println("  Options:");
-        err.println("        --session <hourly | daily | now | yyyy-MM-dd | \"yyyy-MM-dd HH:mm:ss\">  set session_time to this time (required)");
+        err.println("        --session <hourly | daily | now | yyyy-MM-dd | \"yyyy-MM-dd HH:mm:ss\">  set session_time to this time (default: now)");
         err.println("        --revision <name>            use a past revision");
         err.println("        --retry NAME                 set retry attempt name to a new session");
         err.println("    -d, --dry-run                    tries to start a session attempt but does nothing");
@@ -78,6 +78,7 @@ public class Start
         showCommonOptions();
         err.println("");
         err.println("  Examples:");
+        err.println("    $ " + programName + " start myproj workflow1                       # use the current timestamp as session_time");
         err.println("    $ " + programName + " start myproj workflow1 --session 2016-01-01  # use this day as session_time");
         err.println("    $ " + programName + " start myproj workflow1 --session hourly      # use current hour's 00:00");
         err.println("    $ " + programName + " start myproj workflow1 --session daily       # use current day's 00:00:00");

--- a/digdag-core/src/main/java/io/digdag/core/agent/DefaultSecretProvider.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/DefaultSecretProvider.java
@@ -12,6 +12,7 @@ import io.digdag.spi.SecretAccessContext;
 import io.digdag.spi.SecretAccessDeniedException;
 import io.digdag.spi.SecretAccessPolicy;
 import io.digdag.spi.SecretProvider;
+import io.digdag.spi.SecretScopes;
 import io.digdag.spi.SecretStore;
 
 import java.util.List;
@@ -99,6 +100,12 @@ class DefaultSecretProvider
 
     private Optional<String> fetchSecret(String key)
     {
-        return secretStore.getSecret(context, key);
+        Optional<String> projectSecret = secretStore.getSecret(context.projectId(), SecretScopes.PROJECT, key);
+
+        if (projectSecret.isPresent()) {
+            return projectSecret;
+        }
+
+        return secretStore.getSecret(context.projectId(), SecretScopes.PROJECT_DEFAULT, key);
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseMigrator.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseMigrator.java
@@ -823,6 +823,21 @@ public class DatabaseMigrator
         }
     };
 
+    private final Migration MigrateAddSecretsIndex = new Migration()
+    {
+        @Override
+        public String getVersion()
+        {
+            return "20160830123456";
+        }
+
+        @Override
+        public void migrate(Handle handle)
+        {
+            handle.update("create unique index secrets_on_site_id_and_project_id_and_scope_and_key on secrets (site_id, project_id, scope, key)");
+        }
+    };
+
     private final Migration[] migrations = {
         MigrateCreateTables,
         MigrateSessionsOnProjectIdIndexToDesc,
@@ -833,5 +848,6 @@ public class DatabaseMigrator
         MigrateAddSecretsTable,
         MigrateAddFinishedAtToSessionAttempts,
         MigrateQueueUniqueName,
+        MigrateAddSecretsIndex,
     };
 }

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSecretControlStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSecretControlStoreManager.java
@@ -10,15 +10,13 @@ import org.skife.jdbi.v2.DBI;
 public class DatabaseSecretControlStoreManager
         implements SecretControlStoreManager
 {
-    private final Config systemConfig;
     private final DatabaseConfig config;
     private final DBI dbi;
     private final SecretCrypto crypto;
 
     @Inject
-    public DatabaseSecretControlStoreManager(Config systemConfig, DatabaseConfig config, DBI dbi, SecretCrypto crypto)
+    public DatabaseSecretControlStoreManager(DatabaseConfig config, DBI dbi, SecretCrypto crypto)
     {
-        this.systemConfig = systemConfig;
         this.config = config;
         this.dbi = dbi;
         this.crypto = crypto;

--- a/digdag-core/src/test/java/io/digdag/core/database/DatabaseFactory.java
+++ b/digdag-core/src/test/java/io/digdag/core/database/DatabaseFactory.java
@@ -5,7 +5,6 @@ import com.google.common.base.Optional;
 import com.google.inject.Provider;
 import io.digdag.client.config.ConfigFactory;
 import io.digdag.core.agent.AgentId;
-import io.digdag.core.repository.ResourceConflictException;
 import io.digdag.core.workflow.TaskQueueDispatcher;
 import io.digdag.core.workflow.WorkflowCompiler;
 import io.digdag.core.workflow.WorkflowExecutor;
@@ -70,6 +69,16 @@ public class DatabaseFactory
                 objectMapper(),
                 configFactory.create(),
                 mock(Notifier.class));
+    }
+
+    public DatabaseSecretControlStoreManager getSecretControlStoreManager(String secret)
+    {
+        return new DatabaseSecretControlStoreManager(config, dbi, new AESGCMSecretCrypto(secret));
+    }
+
+    public DatabaseSecretStoreManager getSecretStoreManager(String secret)
+    {
+        return new DatabaseSecretStoreManager(config, dbi, new AESGCMSecretCrypto(secret));
     }
 
     public static class NullTaskQueueDispatcher

--- a/digdag-core/src/test/java/io/digdag/core/database/DatabaseSecretStoreTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/database/DatabaseSecretStoreTest.java
@@ -1,0 +1,126 @@
+package io.digdag.core.database;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Strings;
+import io.digdag.core.repository.Project;
+import io.digdag.core.repository.ProjectStore;
+import io.digdag.core.repository.StoredProject;
+import io.digdag.spi.SecretControlStore;
+import io.digdag.spi.SecretScopes;
+import io.digdag.spi.SecretStore;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Base64;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class DatabaseSecretStoreTest
+{
+    private static final String SECRET = Base64.getEncoder().encodeToString(
+            Strings.repeat(".", 16).getBytes(UTF_8));
+
+    private static final int SITE_ID = 17;
+
+    private static final String KEY1 = "foo1";
+    private static final String KEY2 = "foo2";
+    private static final String VALUE1 = "bar1";
+    private static final String VALUE2 = "bar2";
+    private static final String VALUE3 = "bar3";
+
+    private DatabaseFactory factory;
+    private StoredProject storedProject;
+    private DatabaseSecretControlStoreManager controlStoreManager;
+    private DatabaseSecretStoreManager storeManager;
+    private SecretControlStore secretControlStore;
+    private SecretStore secretStore;
+    private int projectId;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        factory = DatabaseTestingUtils.setupDatabase();
+        ProjectStore projectStore = factory.getProjectStoreManager().getProjectStore(SITE_ID);
+        Project project = Project.of("proj1");
+        storedProject = projectStore.putAndLockProject(project, (store, stored) -> stored);
+
+        controlStoreManager = factory.getSecretControlStoreManager(SECRET);
+        storeManager = factory.getSecretStoreManager(SECRET);
+        secretControlStore = controlStoreManager.getSecretControlStore(SITE_ID);
+        secretStore = storeManager.getSecretStore(SITE_ID);
+        projectId = storedProject.getId();
+    }
+
+    @Test
+    public void noSecret()
+            throws Exception
+    {
+        assertThat(secretControlStore.listProjectSecrets(projectId, SecretScopes.PROJECT), is(empty()));
+        assertThat(secretStore.getSecret(projectId, KEY1, SecretScopes.PROJECT), is(Optional.absent()));
+        secretControlStore.deleteProjectSecret(projectId, KEY1, SecretScopes.PROJECT);
+    }
+
+    @Test
+    public void singleSecret()
+            throws Exception
+    {
+        secretControlStore.setProjectSecret(projectId, SecretScopes.PROJECT, KEY1, VALUE1);
+        assertThat(secretStore.getSecret(projectId, SecretScopes.PROJECT, KEY1), is(Optional.of(VALUE1)));
+    }
+
+    @Test
+    public void multipleSecrets()
+            throws Exception
+    {
+        secretControlStore.setProjectSecret(projectId, SecretScopes.PROJECT, KEY1, VALUE1);
+        secretControlStore.setProjectSecret(projectId, SecretScopes.PROJECT, KEY2, VALUE2);
+        secretControlStore.setProjectSecret(projectId, SecretScopes.PROJECT_DEFAULT, KEY2, VALUE3);
+
+        assertThat(secretStore.getSecret(projectId, SecretScopes.PROJECT, KEY1), is(Optional.of(VALUE1)));
+        assertThat(secretStore.getSecret(projectId, SecretScopes.PROJECT, KEY2), is(Optional.of(VALUE2)));
+        assertThat(secretStore.getSecret(projectId, SecretScopes.PROJECT_DEFAULT, KEY2), is(Optional.of(VALUE3)));
+
+        // Delete with different scope should not delete the secret
+        secretControlStore.deleteProjectSecret(projectId, SecretScopes.PROJECT_DEFAULT, KEY1);
+        assertThat(secretStore.getSecret(projectId, SecretScopes.PROJECT, KEY1), is(Optional.of(VALUE1)));
+        assertThat(secretStore.getSecret(projectId, SecretScopes.PROJECT, KEY2), is(Optional.of(VALUE2)));
+        assertThat(secretStore.getSecret(projectId, SecretScopes.PROJECT_DEFAULT, KEY2), is(Optional.of(VALUE3)));
+
+        secretControlStore.deleteProjectSecret(projectId, SecretScopes.PROJECT, KEY1);
+        assertThat(secretStore.getSecret(projectId, SecretScopes.PROJECT, KEY1), is(Optional.absent()));
+        assertThat(secretStore.getSecret(projectId, SecretScopes.PROJECT, KEY2), is(Optional.of(VALUE2)));
+        assertThat(secretStore.getSecret(projectId, SecretScopes.PROJECT_DEFAULT, KEY2), is(Optional.of(VALUE3)));
+
+        secretControlStore.deleteProjectSecret(projectId, SecretScopes.PROJECT, KEY2);
+        assertThat(secretStore.getSecret(projectId, SecretScopes.PROJECT, KEY2), is(Optional.absent()));
+        assertThat(secretStore.getSecret(projectId, SecretScopes.PROJECT_DEFAULT, KEY2), is(Optional.of(VALUE3)));
+    }
+
+    @Test
+    public void getSecretWithScope()
+            throws Exception
+    {
+        String[] scopes = {
+                SecretScopes.PROJECT,
+                SecretScopes.PROJECT_DEFAULT,
+                "foobar"};
+
+        for (String setScope : scopes) {
+            secretControlStore.setProjectSecret(projectId, setScope, KEY1, VALUE1);
+            assertThat(secretStore.getSecret(projectId, setScope, KEY1), is(Optional.of(VALUE1)));
+
+            for (String getScope : scopes) {
+                if (getScope.equals(setScope)) {
+                    continue;
+                }
+                assertThat("set: " + setScope + ", get: " + getScope, secretStore.getSecret(projectId, getScope, KEY1), is(Optional.absent()));
+            }
+
+            secretControlStore.deleteProjectSecret(storedProject.getId(), setScope, KEY1);
+        }
+    }
+}

--- a/digdag-server/src/main/java/io/digdag/server/DefaultSecretAccessPolicy.java
+++ b/digdag-server/src/main/java/io/digdag/server/DefaultSecretAccessPolicy.java
@@ -99,5 +99,4 @@ public class DefaultSecretAccessPolicy
         }
         return policy;
     }
-
 }

--- a/digdag-spi/src/main/java/io/digdag/spi/SecretStore.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/SecretStore.java
@@ -4,5 +4,5 @@ import com.google.common.base.Optional;
 
 public interface SecretStore
 {
-    Optional<String> getSecret(SecretAccessContext context, String key);
+    Optional<String> getSecret(int projectId, String scope, String key);
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/td/TdConfigSecretStore.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/td/TdConfigSecretStore.java
@@ -56,7 +56,7 @@ class TdConfigSecretStore
     }
 
     @Override
-    public Optional<String> getSecret(SecretAccessContext context, String key)
+    public Optional<String> getSecret(int projectId, String scope, String key)
     {
         return Optional.fromNullable(secrets.get(key));
     }

--- a/digdag-tests/src/test/java/acceptance/InitPushStartIT.java
+++ b/digdag-tests/src/test/java/acceptance/InitPushStartIT.java
@@ -5,21 +5,21 @@ import io.digdag.client.DigdagClient;
 import io.digdag.client.api.RestProject;
 import io.digdag.client.api.RestSession;
 import io.digdag.client.api.RestSessionAttempt;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import utils.CommandStatus;
 import utils.TemporaryDigdagServer;
+import utils.TestUtils;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 
-import static utils.TestUtils.copyResource;
-import static utils.TestUtils.getAttemptId;
-import static utils.TestUtils.getSessionId;
-import static utils.TestUtils.main;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.contains;
@@ -28,6 +28,10 @@ import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThan;
 import static org.junit.Assert.assertThat;
+import static utils.TestUtils.copyResource;
+import static utils.TestUtils.getAttemptId;
+import static utils.TestUtils.getSessionId;
+import static utils.TestUtils.main;
 
 public class InitPushStartIT
 {
@@ -309,5 +313,22 @@ public class InitPushStartIT
         assertThat(startStatus.errUtf8(), startStatus.code(), is(1));
         assertThat(startStatus.errUtf8(), containsString("A session for the requested session_time already exists (session_id=" + sessionId + ", attempt_id=" + attemptId + ", session_time=2016-01-01T00:00Z)"));
         assertThat(startStatus.errUtf8(), containsString("hint: use `digdag retry " + attemptId + " --latest-revision` command to run the session again for the same session_time"));
+    }
+
+    @Test
+    public void startWithDefaultSessionTime()
+            throws Exception
+    {
+
+        Files.createDirectories(projectDir);
+        copyResource("acceptance/basic.dig", projectDir.resolve("basic.dig"));
+        long attemptId = TestUtils.pushAndStart(server.endpoint(), projectDir, "basic");
+
+        long now = Instant.now().getEpochSecond();
+
+        RestSessionAttempt sessionAttempt = client.getSessionAttempt(attemptId);
+        assertThat((double) sessionAttempt.getSessionTime().toInstant().getEpochSecond(), Matchers.closeTo(now, 30));
+
+        TestUtils.expect(Duration.ofSeconds(300), TestUtils.attemptSuccess(server.endpoint(), attemptId));
     }
 }

--- a/digdag-tests/src/test/java/utils/TestUtils.java
+++ b/digdag-tests/src/test/java/utils/TestUtils.java
@@ -343,8 +343,7 @@ public class TestUtils
         List<String> startCommand = new ArrayList<>(asList("start",
                 "-c", "/dev/null",
                 "-e", endpoint,
-                projectName, workflow,
-                "--session", "now"));
+                projectName, workflow));
 
         params.forEach((k, v) -> startCommand.addAll(asList("-p", k + "=" + v)));
 


### PR DESCRIPTION
As the SecretProvider is the interface that is used to fetch secrets in a workflow scope, it makes more sense to make the precedence decision there and simplify SecretStore.

Also:

* Add secrets table index (with unique constraint)
* Add database secret store test