### PR TITLE
Add appveyor.yml to enable AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+version: "{branch} {build}"
+
+build:
+  verbosity: detailed
+
+build_script:
+  - gradlew.bat cleanTest test --info --no-daemon
+
+cache:
+  - C:\Users\appveyor\.gradle
+
+environment:
+  matrix:
+  - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+  - JAVA_HOME: C:\Program Files (x86)\Java\jdk1.8.0
+
+test: off


### PR DESCRIPTION
Enables AppVeyor to run CI on Windows.
AppVeyor's free environments for OSS provides very limited resource. So here runs unit tests only.
Fixes #244.