### PR TITLE
Update call> operator to read workflow files in a subdirectory

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/Arguments.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Arguments.java
@@ -47,7 +47,7 @@ public class Arguments
 
         // -P files
         if (paramsFile != null) {
-            overwriteParams.merge(loader.loadParameterizedFile(new File(paramsFile), cf.create()));
+            overwriteParams.merge(loader.loadParameterizedFile(new File(paramsFile)));
         }
 
         // -p options

--- a/digdag-cli/src/main/java/io/digdag/cli/Show.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Show.java
@@ -59,11 +59,10 @@ public class Show
     private void show(Injector injector, String workflowPath)
             throws Exception
     {
-        final ConfigFactory cf = injector.getInstance(ConfigFactory.class);
         final ConfigLoaderManager loader = injector.getInstance(ConfigLoaderManager.class);
         final WorkflowCompiler compiler = injector.getInstance(WorkflowCompiler.class);
 
-        List<WorkflowDefinition> workflowSources = loader.loadParameterizedFile(new File(workflowPath), cf.create()).convert(WorkflowDefinitionList.class).get();
+        List<WorkflowDefinition> workflowSources = loader.loadParameterizedFile(new File(workflowPath)).convert(WorkflowDefinitionList.class).get();
 
         List<Workflow> workflows = workflowSources
             .stream()

--- a/digdag-core/src/main/java/io/digdag/core/agent/CallOperatorFactory.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/CallOperatorFactory.java
@@ -1,8 +1,11 @@
 package io.digdag.core.agent;
 
+import java.io.IOException;
+import java.io.FileNotFoundException;
 import java.nio.file.Path;
 
 import com.google.inject.Inject;
+import com.google.common.base.Throwables;
 import io.digdag.spi.TaskExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,10 +13,13 @@ import io.digdag.spi.TaskRequest;
 import io.digdag.spi.TaskResult;
 import io.digdag.spi.Operator;
 import io.digdag.spi.OperatorFactory;
+import io.digdag.core.config.ConfigLoaderManager;
 import io.digdag.core.repository.ResourceNotFoundException;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigException;
 import io.digdag.client.config.ConfigFactory;
+import io.digdag.util.Workspace;
+import static io.digdag.core.archive.ProjectArchive.WORKFLOW_FILE_SUFFIX;
 
 public class CallOperatorFactory
         implements OperatorFactory
@@ -21,11 +27,13 @@ public class CallOperatorFactory
     private static Logger logger = LoggerFactory.getLogger(CallOperatorFactory.class);
 
     private final TaskCallbackApi callback;
+    private final ConfigLoaderManager configLoader;
 
     @Inject
-    public CallOperatorFactory(TaskCallbackApi callback)
+    public CallOperatorFactory(TaskCallbackApi callback, ConfigLoaderManager configLoader)
     {
         this.callback = callback;
+        this.configLoader = configLoader;
     }
 
     public String getType()
@@ -36,21 +44,19 @@ public class CallOperatorFactory
     @Override
     public Operator newTaskExecutor(Path workspacePath, TaskRequest request)
     {
-        return new CallOperator(callback, request);
+        return new CallOperator(workspacePath, request);
     }
 
-    private static class CallOperator
+    private class CallOperator
             implements Operator
     {
-        private final TaskCallbackApi callback;
+        private final Workspace workspace;
         private final TaskRequest request;
-        private ConfigFactory cf;
 
-        public CallOperator(TaskCallbackApi callback, TaskRequest request)
+        public CallOperator(Path workspacePath, TaskRequest request)
         {
-            this.callback = callback;
+            this.workspace = new Workspace(workspacePath);
             this.request = request;
-            this.cf = request.getConfig().getFactory();
         }
 
         @Override
@@ -59,18 +65,33 @@ public class CallOperatorFactory
             Config config = request.getConfig();
 
             String workflowName = config.get("_command", String.class);
-            int projectId = config.get("project_id", int.class);
             Config exportParams = config.getNestedOrGetEmpty("params");
 
             Config def;
-            try {
-                def = callback.getWorkflowDefinition(
-                        request.getSiteId(),
-                        projectId,
-                        workflowName);
+            if (workflowName.endsWith(WORKFLOW_FILE_SUFFIX)) {
+                Path path = workspace.getPath(workflowName);
+                try {
+                    def = configLoader.loadParameterizedFile(path.toFile());
+                }
+                catch (FileNotFoundException ex) {
+                    throw new ConfigException("File does not exist: " + workflowName);
+                }
+                catch (IOException ex) {
+                    throw Throwables.propagate(ex);
+                }
             }
-            catch (ResourceNotFoundException ex) {
-                throw new ConfigException(ex);
+            else {
+                int projectId = config.get("project_id", int.class);
+
+                try {
+                    def = callback.getWorkflowDefinition(
+                            request.getSiteId(),
+                            projectId,
+                            workflowName);
+                }
+                catch (ResourceNotFoundException ex) {
+                    throw new ConfigException(ex);
+                }
             }
 
             return TaskResult.defaultBuilder(request)

--- a/digdag-core/src/main/java/io/digdag/core/archive/ProjectArchiveLoader.java
+++ b/digdag-core/src/main/java/io/digdag/core/archive/ProjectArchiveLoader.java
@@ -77,7 +77,7 @@ public class ProjectArchiveLoader
         String workflowName = resourceNameToWorkflowName(resourceName);
 
         WorkflowFile workflowFile = WorkflowFile.fromConfig(workflowName,
-                configLoader.loadParameterizedFile(path.toFile(), overwriteParams));
+                configLoader.loadParameterizedFile(path.toFile()));
 
         int posSlash = workflowName.lastIndexOf('/');
         if (posSlash >= 0) {

--- a/digdag-core/src/main/java/io/digdag/core/config/ConfigLoaderManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/config/ConfigLoaderManager.java
@@ -19,10 +19,10 @@ public class ConfigLoaderManager
         this.yaml = yaml;
     }
 
-    public Config loadParameterizedFile(File path, Config params)
+    public Config loadParameterizedFile(File path)
         throws IOException
     {
         // TODO check suffix .dig, .yml or .yaml. otherwise throw exception
-        return yaml.loadParameterizedFile(path, params).toConfig(cf);
+        return yaml.loadParameterizedFile(path).toConfig(cf);
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/config/YamlConfigLoader.java
+++ b/digdag-core/src/main/java/io/digdag/core/config/YamlConfigLoader.java
@@ -62,13 +62,13 @@ public class YamlConfigLoader
         return ConfigElement.of(object);
     }
 
-    public ConfigElement loadParameterizedFile(File file, Config params)
+    public ConfigElement loadParameterizedFile(File file)
         throws IOException
     {
-        return ConfigElement.of(loadParameterizedInclude(file.toPath(), params));
+        return ConfigElement.of(loadParameterizedInclude(file.toPath()));
     }
 
-    ObjectNode loadParameterizedInclude(Path path, Config params)
+    ObjectNode loadParameterizedInclude(Path path)
         throws IOException
     {
         String content;
@@ -84,18 +84,16 @@ public class YamlConfigLoader
             throw new FileNotFoundException("Loading file named '/' is invalid");
         }
 
-        return new ParameterizeContext(includeDir, params).evalObjectRecursive(object);
+        return new ParameterizeContext(includeDir).evalObjectRecursive(object);
     }
 
     private class ParameterizeContext
     {
         private final Path includeDir;
-        private final Config params;
 
-        private ParameterizeContext(Path includeDir, Config params)
+        private ParameterizeContext(Path includeDir)
         {
             this.includeDir = includeDir.toAbsolutePath().normalize();
-            this.params = params;
         }
 
         private ObjectNode evalObjectRecursive(ObjectNode object)
@@ -172,7 +170,7 @@ public class YamlConfigLoader
                 throw new FileNotFoundException("File name must not include ..: " + name);
             }
 
-            return loadParameterizedInclude(path, params);
+            return loadParameterizedInclude(path);
         }
 
         private void mergeObject(ObjectNode dest, ObjectNode src)

--- a/digdag-core/src/test/java/io/digdag/core/config/YamlConfigLoaderTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/config/YamlConfigLoaderTest.java
@@ -34,6 +34,6 @@ public class YamlConfigLoaderTest
     {
         Path temp = Files.createTempFile("digdag-YamlConfigLoaderTest", ".yml");
         Files.write(temp, "{\"a\":1, \"a\":2}".getBytes(UTF_8));
-        loader.loadParameterizedFile(temp.toFile(), null);
+        loader.loadParameterizedFile(temp.toFile());
     }
 }

--- a/digdag-docs/src/operators.rst
+++ b/digdag-docs/src/operators.rst
@@ -16,18 +16,20 @@ This operator embeds another workflow as a subtask.
 
     # workflow1.dig
     +step1:
-      call>: another_workflow
+      call>: another_workflow.dig
+    +step2:
+      call>: sub/shared_workflow.dig
 
 .. code-block:: yaml
 
     # another_workflow.dig
-    +step2:
-      sh>: tasks/step2.sh
+    +another:
+      sh>: tasks/another.sh
 
-:command:`call>: NAME`
-  Name of a workflow.
+:command:`call>: FILE`
+  Path to a workflow definition file.
 
-  Example: another_workflow
+  Example: another_workflow.dig
 
 require>: Depends on another workflow
 ----------------------------------

--- a/digdag-tests/src/test/java/acceptance/CallIT.java
+++ b/digdag-tests/src/test/java/acceptance/CallIT.java
@@ -1,0 +1,90 @@
+package acceptance;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import utils.CommandStatus;
+import utils.TemporaryDigdagServer;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+
+import static utils.TestUtils.copyResource;
+import static utils.TestUtils.getAttemptId;
+import static utils.TestUtils.expect;
+import static utils.TestUtils.main;
+import static utils.TestUtils.attemptSuccess;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class CallIT
+{
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Rule
+    public TemporaryDigdagServer server = TemporaryDigdagServer.of();
+
+    private Path config;
+    private Path projectDir;
+
+    private Path root()
+    {
+        return folder.getRoot().toPath().toAbsolutePath();
+    }
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        projectDir = folder.getRoot().toPath().resolve("foobar");
+        config = folder.newFile().toPath();
+    }
+
+    @Test
+    public void testCall()
+            throws Exception
+    {
+        // Create new project
+        CommandStatus initStatus = main("init",
+                "-c", config.toString(),
+                projectDir.toString());
+        assertThat(initStatus.errUtf8(), initStatus.code(), is(0));
+
+        copyResource("acceptance/call/parent.dig", projectDir.resolve("parent.dig"));
+        copyResource("acceptance/call/child.dig", projectDir.resolve("child.dig"));
+        Files.createDirectories(projectDir.resolve("sub"));
+        copyResource("acceptance/call/child.dig", projectDir.resolve("sub").resolve("child.dig"));
+
+        // Push the project
+        CommandStatus pushStatus = main("push",
+                "--project", projectDir.toString(),
+                "call",
+                "-c", config.toString(),
+                "-e", server.endpoint(),
+                "-p", "outdir=" + root());
+        assertThat(pushStatus.errUtf8(), pushStatus.code(), is(0));
+
+        // Start the workflow
+        long attemptId;
+        {
+            CommandStatus startStatus = main("start",
+                    "-c", config.toString(),
+                    "-e", server.endpoint(),
+                    "call", "parent",
+                    "--session", "now");
+            assertThat(startStatus.code(), is(0));
+            attemptId = getAttemptId(startStatus);
+        }
+
+        // Wait for the attempt to complete
+        expect(Duration.ofMinutes(5), attemptSuccess(server.endpoint(), attemptId));
+
+        // Verify that the file created by the child workflow is there
+        assertThat(Files.exists(root().resolve("call_by_name.out")), is(true));
+        assertThat(Files.exists(root().resolve("call_by_file.out")), is(true));
+        assertThat(Files.exists(root().resolve("call_sub.out")), is(true));
+    }
+}

--- a/digdag-tests/src/test/resources/acceptance/call/child.dig
+++ b/digdag-tests/src/test/resources/acceptance/call/child.dig
@@ -1,0 +1,2 @@
++hello:
+  sh>: touch ${outdir}/${name}.out

--- a/digdag-tests/src/test/resources/acceptance/call/parent.dig
+++ b/digdag-tests/src/test/resources/acceptance/call/parent.dig
@@ -1,0 +1,18 @@
++call_by_name:
+  _export:
+    name: call_by_name
+  +call:
+    call>: child
+
++call_by_file:
+  _export:
+    name: call_by_file
+  +call:
+    call>: child.dig
+
++call_sub:
+  _export:
+    name: call_sub
+  +call:
+    call>: sub/child.dig
+


### PR DESCRIPTION
Dividing a large workflow definition into multiple files is helpful to
organize a complex workflow definition. `call>` is more straightforward
(and less hacky) compared to `!include` in terms of syntax.

This changes `call>` operator to be able to load workflow definition from a file so that it can call workflows in a subdirectory. *.dig files in subdirectories won't be recognized as workflows.

This change includes removal of `params` argument from
`ConfigLoaderManager.loadParameterizedFile` method. `params` argument was necessary when it was using jinja2 to preprocess a file. It's unnecessary any more since digdag evaluates parameters when a workflow runs.
