### PR TITLE
Fix race condition around SessionAttemptControl.archiveTasks

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
@@ -70,6 +70,41 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+/**
+ * Store session state on a database.
+ *
+ * Lock relations:
+ *
+ * Attempt initialization:
+ *   // insert the root task of an attempt
+ *   insertRootTask:
+ *     locked session
+ *
+ *   // used by dynamic task generation
+ *   addResumingTasks:
+ *     locked root task
+ *
+ * Attempt execution:
+ *   // generating regular dynamic tasks and monitor tasks
+ *   addSubtask:
+ *     locked parent task
+ *
+ *   // generating dynamic tasks that are resumed by previous attempt
+ *   addResumedSubtask:
+ *     locked parent task
+ *
+ *   // reinserting tasks for group-retry
+ *   copyInitialTasksForRetry:
+ *     locked parent task
+ *     and parent task is ready
+ *
+ * Attempt cleanup:
+ *   // SessionAttemptControlStore.archiveTasks
+ *   aggregateAndInsertTaskArchive, deleteAllTasksOfAttempt, setDoneToAttemptState:
+ *     locked attempt
+ *     and attempt is done yet
+ *
+ */
 public class DatabaseSessionStoreManager
         extends BasicDatabaseStoreManager<DatabaseSessionStoreManager.Dao>
         implements SessionStoreManager

--- a/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java
+++ b/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java
@@ -621,7 +621,7 @@ public class WorkflowExecutor
                 .map(task -> {
                     return sm.lockAttemptIfExists(task.getAttemptId(), (store, summary) -> {
                         if (summary.getStateFlags().isDone()) {
-                            // already archived. This means that another thread archvied
+                            // already archived. This means that another thread archived
                             // this attempt after findRootTasksByStates call.
                             return false;
                         }

--- a/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java
+++ b/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java
@@ -620,9 +620,16 @@ public class WorkflowExecutor
                 .stream()
                 .map(task -> {
                     return sm.lockAttemptIfExists(task.getAttemptId(), (store, summary) -> {
-                        SessionAttemptControl control = new SessionAttemptControl(store, task.getAttemptId());
-                        control.archiveTasks(archiveMapper, task.getState() == TaskStateCode.SUCCESS);
-                        return true;
+                        if (summary.getStateFlags().isDone()) {
+                            // already archived. This means that another thread archvied
+                            // this attempt after findRootTasksByStates call.
+                            return false;
+                        }
+                        else {
+                            SessionAttemptControl control = new SessionAttemptControl(store, task.getAttemptId());
+                            control.archiveTasks(archiveMapper, task.getState() == TaskStateCode.SUCCESS);
+                            return true;
+                        }
                     }).or(false);
                 })
                 .reduce(anyChanged, (a, b) -> a || b);


### PR DESCRIPTION
`WorkflowExecutor.propagateSessionArchive` lists up finished root tasks
using one transaction. Then, use another transaction to archive the
attempts of the root tasks. This is intentional to avoid long lock
because archiving tasks is expected to take long time especially if the
attempt has many tasks.

However, because they use two transactions, another thread may archive
an attempt between the two transactions. Therefore, the later
transaction needs to re-check state of the attempt before actually
archiving it.

Without this fix, a thread may try to archive an empty attempt because the other thread archives (=deletes) all tasks. And because task_archives table has unique index on attempt id, the transaction fails with `duplicate key value violates unique constraint "task_archives_pkey"` message. So, this problem doesn't cause inconsistent data.
