### PR TITLE
Retry workflow executor loop on unexpected error

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/agent/LocalAgentManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/LocalAgentManager.java
@@ -15,8 +15,8 @@ public class LocalAgentManager
         implements BackgroundExecutor
 {
     private final Supplier<MultiThreadAgent> agentFactory;
-    private Thread thread;
-    private MultiThreadAgent agent;
+    private volatile Thread thread;
+    private volatile MultiThreadAgent agent;
 
     @Inject
     public LocalAgentManager(

--- a/digdag-core/src/main/java/io/digdag/core/agent/MultiThreadAgent.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/MultiThreadAgent.java
@@ -102,7 +102,14 @@ public class MultiThreadAgent
                 }
             }
             catch (Throwable t) {
-                logger.error("Uncaught exception. Ignoring.", t);
+                logger.error("Uncaught exception during acquiring tasks from a server. Ignoring. Agent thread will be retried.", t);
+                try {
+                    // sleep before retrying
+                    Thread.sleep(1000);
+                }
+                catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                }
             }
         }
     }

--- a/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
@@ -312,7 +312,7 @@ public class OperatorManager
             }
         }
         catch (Throwable t) {
-            logger.error("An uncaught exception is ignored. Heartbeat thread will be retried.", t);
+            logger.error("Uncaught exception during sending task heartbeats to a server. Ignoring. Heartbeat thread will be retried.", t);
         }
     }
 

--- a/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java
+++ b/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java
@@ -342,6 +342,18 @@ public class WorkflowExecutor
         }
     }
 
+    public void noticeRunWhileConditionChange()
+    {
+        propagatorLock.lock();
+        try {
+            // don't set propagatorNotice but break wait at runWhile
+            propagatorCondition.signalAll();
+        }
+        finally {
+            propagatorLock.unlock();
+        }
+    }
+
     public void run()
             throws InterruptedException
     {
@@ -377,7 +389,7 @@ public class WorkflowExecutor
     private static final int INITIAL_INTERVAL = 100;
     private static final int MAX_INTERVAL = 5000;
 
-    private void runWhile(BooleanSupplier cond)
+    public void runWhile(BooleanSupplier cond)
             throws InterruptedException
     {
         try (TaskQueuer queuer = new TaskQueuer()) {

--- a/digdag-server/src/main/java/io/digdag/server/WorkflowExecutorLoop.java
+++ b/digdag-server/src/main/java/io/digdag/server/WorkflowExecutorLoop.java
@@ -1,0 +1,113 @@
+package io.digdag.server;
+
+import com.google.inject.Inject;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import io.digdag.core.BackgroundExecutor;
+import io.digdag.core.workflow.WorkflowExecutor;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.function.Supplier;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+
+public class WorkflowExecutorLoop
+        implements BackgroundExecutor
+{
+    private static final Logger logger = LoggerFactory.getLogger(WorkflowExecutorLoop.class);
+
+    private final Supplier<Thread> threadFactory;
+    private final WorkflowExecutor workflowExecutor;
+
+    private volatile Thread thread = null;
+    private volatile boolean stop = false;
+
+    @Inject
+    public WorkflowExecutorLoop(
+            ServerConfig serverConfig,
+            WorkflowExecutor workflowExecutor)
+    {
+        if (serverConfig.getExecutorEnabled()) {
+            this.threadFactory = () -> new ThreadFactoryBuilder()
+                .setDaemon(true)
+                .setNameFormat("workflow-executor-%d")
+                .build()
+                .newThread(this::run);
+        }
+        else {
+            this.threadFactory = null;
+        }
+        this.workflowExecutor = workflowExecutor;
+    }
+
+    private void run()
+    {
+        while (!stop) {
+            try {
+                workflowExecutor.runWhile(() -> !stop);
+            }
+            catch (Throwable t) {
+                logger.error("Uncaught error during executing workflow state machine. Ignoring. Loop will be retried.", t);
+                try {
+                    // sleep before retrying
+                    Thread.sleep(1000);
+                }
+                catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+        }
+    }
+
+    @PostConstruct
+    public synchronized void start()
+    {
+        if (threadFactory != null && thread == null) {
+            Thread thread = threadFactory.get();
+            thread.start();
+            this.thread = thread;
+        }
+    }
+
+    @PreDestroy
+    public synchronized void shutdown()
+        throws InterruptedException
+    {
+        startShutdown();
+
+        if (thread != null) {
+            thread.join(100);
+            if (thread.isAlive()) {
+                logger.info("Waiting for completion of workflow executor loop...");
+                do {
+                    workflowExecutor.noticeRunWhileConditionChange();
+                    thread.join(1000);
+                } while (thread.isAlive());
+            }
+            thread = null;
+        }
+    }
+
+    @Override
+    public void eagerShutdown()
+            throws InterruptedException
+    {
+        startShutdown();
+    }
+
+    private void startShutdown()
+    {
+        if (stop == false) {
+            stop = true;
+            logger.info("Shutting down workflow executor loop");
+
+            // noticeRunWhileConditionChange is not 100% accurate because
+            // WorkflowExecutor doesn't lock stop flag before check. But
+            // it will be repeated at shutdown() method later
+            workflowExecutor.noticeRunWhileConditionChange();
+        }
+    }
+}

--- a/digdag-server/src/main/java/io/digdag/server/WorkflowExecutorLoop.java
+++ b/digdag-server/src/main/java/io/digdag/server/WorkflowExecutorLoop.java
@@ -100,7 +100,7 @@ public class WorkflowExecutorLoop
 
     private void startShutdown()
     {
-        if (stop == false) {
+        if (!stop) {
             stop = true;
             logger.info("Shutting down workflow executor loop");
 

--- a/digdag-tests/src/test/java/acceptance/ServerGracefulShutdownIT.java
+++ b/digdag-tests/src/test/java/acceptance/ServerGracefulShutdownIT.java
@@ -168,5 +168,6 @@ public class ServerGracefulShutdownIT
 
         assertThat(server.outUtf8(), containsString("Shutting down HTTP worker threads"));
         assertThat(server.outUtf8(), containsString("Shutting down system"));
+        assertThat(server.outUtf8(), containsString("Shutdown completed"));
     }
 }


### PR DESCRIPTION
Thread created at `ServerBootstrap.initialize` was calling
`control.destroy` when WorkflowExecutor throws an unexpected exception.
But this is bad because `DeploymentManager.undeploy` is called and thus
HTTP handlers will start returning errors (`500 Internal Server Error`)
to all requests with `Deployment digdag-server.war has stopped` error
logs until the server restarts.

This changes the behavior to not undeploy DeploymentManager. Instead,
workflow executor loop is retried for ever.