### PR TITLE
Report uncaught errors through JMX 

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/ErrorReporter.java
+++ b/digdag-core/src/main/java/io/digdag/core/ErrorReporter.java
@@ -1,0 +1,16 @@
+package io.digdag.core;
+
+public interface ErrorReporter
+{
+    void reportUncaughtError(Throwable error);
+
+    static ErrorReporter empty()
+    {
+        return new ErrorReporter()
+        {
+            @Override
+            public void reportUncaughtError(Throwable error)
+            { }
+        };
+    }
+}

--- a/digdag-core/src/main/java/io/digdag/core/agent/LocalAgentManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/LocalAgentManager.java
@@ -3,7 +3,6 @@ package io.digdag.core.agent;
 import java.util.function.Supplier;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
-import javax.annotation.Nullable;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import com.google.inject.Inject;
@@ -20,9 +19,8 @@ public class LocalAgentManager
     private volatile Thread thread;
     private volatile MultiThreadAgent agent;
 
-    @Nullable
     @Inject(optional = true)
-    private ErrorReporter errorReporter = null;
+    private ErrorReporter errorReporter = ErrorReporter.empty();
 
     @Inject
     public LocalAgentManager(

--- a/digdag-core/src/main/java/io/digdag/core/agent/LocalAgentManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/LocalAgentManager.java
@@ -3,12 +3,14 @@ package io.digdag.core.agent;
 import java.util.function.Supplier;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ExecutorService;
+import javax.annotation.Nullable;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import com.google.inject.Inject;
 import com.google.common.base.Optional;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.digdag.core.BackgroundExecutor;
+import io.digdag.core.ErrorReporter;
 import io.digdag.core.queue.TaskQueueServerManager;
 
 public class LocalAgentManager
@@ -18,6 +20,10 @@ public class LocalAgentManager
     private volatile Thread thread;
     private volatile MultiThreadAgent agent;
 
+    @Nullable
+    @Inject(optional = true)
+    private ErrorReporter errorReporter = null;
+
     @Inject
     public LocalAgentManager(
             AgentConfig config,
@@ -26,7 +32,7 @@ public class LocalAgentManager
             OperatorManager operatorManager)
     {
         if (config.getEnabled()) {
-            this.agentFactory = () -> new MultiThreadAgent(config, agentId, taskServer, operatorManager);
+            this.agentFactory = () -> new MultiThreadAgent(config, agentId, taskServer, operatorManager, errorReporter);
         }
         else {
             this.agentFactory = null;

--- a/digdag-core/src/main/java/io/digdag/core/agent/MultiThreadAgent.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/MultiThreadAgent.java
@@ -9,6 +9,7 @@ import java.time.Duration;
 import com.google.common.base.Optional;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.digdag.spi.TaskRequest;
+import io.digdag.core.ErrorReporter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,17 +22,21 @@ public class MultiThreadAgent
     private final AgentId agentId;
     private final TaskServerApi taskServer;
     private final OperatorManager runner;
+    private final ErrorReporter errorReporter;
     private final ThreadPoolExecutor executor;
     private final Object newTaskLock = new Object();
     private volatile boolean stop = false;
 
-    public MultiThreadAgent(AgentConfig config, AgentId agentId,
-            TaskServerApi taskServer, OperatorManager runner)
+    public MultiThreadAgent(
+            AgentConfig config, AgentId agentId,
+            TaskServerApi taskServer, OperatorManager runner,
+            ErrorReporter errorReporter)
     {
         this.agentId = agentId;
         this.config = config;
         this.taskServer = taskServer;
         this.runner = runner;
+        this.errorReporter = errorReporter;
         ThreadFactory threadFactory = new ThreadFactoryBuilder()
             .setDaemon(false)  // make them non-daemon threads so that shutting down agent doesn't kill operator execution
             .setNameFormat("task-thread-%d")
@@ -91,6 +96,7 @@ public class MultiThreadAgent
                                 }
                                 catch (Throwable t) {
                                     logger.error("Uncaught exception. Task queue will detect this failure and this task will be retried later.", t);
+                                    errorReporter.reportUncaughtError(t);
                                 }
                             });
                         }
@@ -103,6 +109,7 @@ public class MultiThreadAgent
             }
             catch (Throwable t) {
                 logger.error("Uncaught exception during acquiring tasks from a server. Ignoring. Agent thread will be retried.", t);
+                errorReporter.reportUncaughtError(t);
                 try {
                     // sleep before retrying
                     Thread.sleep(1000);

--- a/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
@@ -9,6 +9,7 @@ import io.digdag.core.log.LogLevel;
 import io.digdag.core.log.TaskContextLogging;
 import io.digdag.core.log.TaskLogger;
 import io.digdag.core.workflow.WorkflowCompiler;
+import io.digdag.core.ErrorReporter;
 import io.digdag.spi.Operator;
 import io.digdag.spi.OperatorFactory;
 import io.digdag.spi.SecretAccessContext;
@@ -59,6 +60,9 @@ public class OperatorManager
 
     private final ScheduledExecutorService heartbeatScheduler;
     private final ConcurrentHashMap<Long, TaskRequest> runningTaskMap = new ConcurrentHashMap<>();  // {taskId => TaskRequest}
+
+    @Inject(optional = true)
+    private ErrorReporter errorReporter = ErrorReporter.empty();
 
     @Inject
     public OperatorManager(AgentConfig agentConfig, AgentId agentId,
@@ -313,6 +317,7 @@ public class OperatorManager
         }
         catch (Throwable t) {
             logger.error("Uncaught exception during sending task heartbeats to a server. Ignoring. Heartbeat thread will be retried.", t);
+            errorReporter.reportUncaughtError(t);
         }
     }
 

--- a/digdag-core/src/main/java/io/digdag/core/database/DataSourceProvider.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DataSourceProvider.java
@@ -54,7 +54,7 @@ public class DataSourceProvider
         // that such behavior using DB_CLOSE_DELAY=-1 option, there're no methods to close the
         // database explicitly. Only way to close is to not disable shutdown hook of H2 database
         // (DB_CLOSE_ON_EXIT=TRUE). But this also causes unexpected behavior when PreDestroy is
-        // triggered at shutdown hook. Therefore, here needs to rely on injector to take care of
+        // triggered in a shutdown hook. Therefore, here needs to rely on injector to take care of
         // dependencies so that the database is closed after calling all other PreDestroy methods
         // that depend on this DataSourceProvider.
         // To solve this issue, here holds one Connection until PreDestroy.

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseTaskQueueServer.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseTaskQueueServer.java
@@ -17,6 +17,7 @@ import com.google.common.collect.*;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.digdag.core.ErrorReporter;
 import io.digdag.core.queue.QueueSettingStore;
 import io.digdag.core.queue.QueueSettingStoreManager;
 import io.digdag.core.queue.StoredQueueSetting;
@@ -52,6 +53,9 @@ public class DatabaseTaskQueueServer
     private final int expireLockInterval;
     private final LocalLockMap localLockMap = new LocalLockMap();
     private final ScheduledExecutorService expireExecutor;
+
+    @Inject(optional = true)
+    private ErrorReporter errorReporter = ErrorReporter.empty();
 
     @Inject
     public DatabaseTaskQueueServer(DBI dbi, DatabaseConfig config, DatabaseTaskQueueConfig queueConfig, ObjectMapper taskObjectMapper)
@@ -435,6 +439,7 @@ public class DatabaseTaskQueueServer
         }
         catch (Throwable t) {
             logger.error("An uncaught exception is ignored. This lock expiration thread will be restarted.", t);
+            errorReporter.reportUncaughtError(t);
         }
     }
 

--- a/digdag-core/src/main/java/io/digdag/core/schedule/ScheduleExecutor.java
+++ b/digdag-core/src/main/java/io/digdag/core/schedule/ScheduleExecutor.java
@@ -42,7 +42,7 @@ public class ScheduleExecutor
     private final ScheduleStoreManager sm;
     private final SchedulerManager srm;
     private final ScheduleHandler handler;
-    private final SessionStoreManager sessionStoreManager;  // used for validation at backfill
+    private final SessionStoreManager sessionStoreManager;  // used for validation in backfill method
     private ScheduledExecutorService executor;
 
     @Inject(optional = true)

--- a/digdag-core/src/main/java/io/digdag/core/schedule/ScheduleExecutor.java
+++ b/digdag-core/src/main/java/io/digdag/core/schedule/ScheduleExecutor.java
@@ -14,6 +14,7 @@ import com.google.inject.Inject;
 import com.google.common.base.*;
 import com.google.common.collect.ImmutableList;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.digdag.core.ErrorReporter;
 import io.digdag.spi.ScheduleTime;
 import io.digdag.spi.Scheduler;
 import io.digdag.core.BackgroundExecutor;
@@ -43,6 +44,9 @@ public class ScheduleExecutor
     private final ScheduleHandler handler;
     private final SessionStoreManager sessionStoreManager;  // used for validation at backfill
     private ScheduledExecutorService executor;
+
+    @Inject(optional = true)
+    private ErrorReporter errorReporter = ErrorReporter.empty();
 
     @Inject
     public ScheduleExecutor(
@@ -100,6 +104,7 @@ public class ScheduleExecutor
         }
         catch (Throwable t) {
             logger.error("An uncaught exception is ignored. Scheduling will be retried.", t);
+            errorReporter.reportUncaughtError(t);
         }
     }
 

--- a/digdag-core/src/main/java/io/digdag/core/session/SessionMonitorExecutor.java
+++ b/digdag-core/src/main/java/io/digdag/core/session/SessionMonitorExecutor.java
@@ -13,6 +13,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import io.digdag.core.BackgroundExecutor;
+import io.digdag.core.ErrorReporter;
 import io.digdag.core.workflow.TaskControl;
 import io.digdag.core.workflow.Tasks;
 import io.digdag.core.workflow.WorkflowExecutor;
@@ -28,6 +29,9 @@ public class SessionMonitorExecutor
     private final SessionStoreManager sm;
     private final WorkflowExecutor exec;
     private ScheduledExecutorService executor;
+
+    @Inject(optional = true)
+    private ErrorReporter errorReporter = ErrorReporter.empty();
 
     @Inject
     public SessionMonitorExecutor(
@@ -82,6 +86,7 @@ public class SessionMonitorExecutor
         }
         catch (Throwable t) {
             logger.error("An uncaught exception is ignored. This session monitor scheduling will be retried.", t);
+            errorReporter.reportUncaughtError(t);
         }
     }
 

--- a/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java
+++ b/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java
@@ -346,7 +346,7 @@ public class WorkflowExecutor
     {
         propagatorLock.lock();
         try {
-            // don't set propagatorNotice but break wait at runWhile
+            // don't set propagatorNotice but break wait in runWhile
             propagatorCondition.signalAll();
         }
         finally {
@@ -957,7 +957,7 @@ public class WorkflowExecutor
 
             // remove conditional subtasks that may cause JavaScript evaluation error if they include reference to a nested field such as
             // this_will_be_set_at_this_task.this_is_null.this_access_causes_error.
-            // _do is another conditional subtsaks but they are kept remained and removed later at ConfigEvalEngine because
+            // _do is another conditional subtsaks but they are kept remained here and removed later in ConfigEvalEngine because
             // operator factory needs _do while _check and _error are used only by WorkflowExecutor.
             Config localConfig = task.getConfig().getLocal().deepCopy();
             params.remove("_check");

--- a/digdag-server/src/main/java/io/digdag/server/JmxErrorReporter.java
+++ b/digdag-server/src/main/java/io/digdag/server/JmxErrorReporter.java
@@ -1,0 +1,28 @@
+package io.digdag.server;
+
+import com.google.inject.Inject;
+import org.weakref.jmx.Managed;
+import io.digdag.core.ErrorReporter;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class JmxErrorReporter
+    implements ErrorReporter
+{
+    private final AtomicInteger uncaughtErrorCount = new AtomicInteger(0);
+
+    @Inject
+    public JmxErrorReporter()
+    { }
+
+    @Override
+    public void reportUncaughtError(Throwable error)
+    {
+        uncaughtErrorCount.incrementAndGet();
+    }
+
+    @Managed
+    public int getUncaughtErrorCount()
+    {
+        return uncaughtErrorCount.get();
+    }
+}

--- a/digdag-server/src/main/java/io/digdag/server/JmxModule.java
+++ b/digdag-server/src/main/java/io/digdag/server/JmxModule.java
@@ -14,6 +14,7 @@ import com.google.inject.spi.TypeListener;
 import com.google.inject.matcher.AbstractMatcher;
 
 import io.digdag.client.config.ConfigElement;
+import io.digdag.core.ErrorReporter;
 
 import java.lang.management.ManagementFactory;
 import java.lang.reflect.Field;
@@ -28,6 +29,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.weakref.jmx.guice.MBeanModule;
 
+import static org.weakref.jmx.guice.ExportBinder.newExporter;
+
 public class JmxModule
     implements Module
 {
@@ -39,6 +42,8 @@ public class JmxModule
         new MBeanModule().configure(binder);
         binder.bind(MBeanServer.class).toInstance(ManagementFactory.getPlatformMBeanServer());
         binder.bind(JmxAgent.class).asEagerSingleton();
+        binder.bind(ErrorReporter.class).to(JmxErrorReporter.class).in(Scopes.SINGLETON);
+        newExporter(binder).export(ErrorReporter.class).withGeneratedName();
     }
 
     private static class JmxAgent

--- a/digdag-server/src/main/java/io/digdag/server/WorkflowExecutorLoop.java
+++ b/digdag-server/src/main/java/io/digdag/server/WorkflowExecutorLoop.java
@@ -4,6 +4,7 @@ import com.google.inject.Inject;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import io.digdag.core.BackgroundExecutor;
+import io.digdag.core.ErrorReporter;
 import io.digdag.core.workflow.WorkflowExecutor;
 
 import org.slf4j.Logger;
@@ -24,6 +25,9 @@ public class WorkflowExecutorLoop
 
     private volatile Thread thread = null;
     private volatile boolean stop = false;
+
+    @Inject(optional = true)
+    private ErrorReporter errorReporter = ErrorReporter.empty();
 
     @Inject
     public WorkflowExecutorLoop(
@@ -51,6 +55,7 @@ public class WorkflowExecutorLoop
             }
             catch (Throwable t) {
                 logger.error("Uncaught error during executing workflow state machine. Ignoring. Loop will be retried.", t);
+                errorReporter.reportUncaughtError(t);
                 try {
                     // sleep before retrying
                     Thread.sleep(1000);

--- a/digdag-server/src/main/java/io/digdag/server/WorkflowExecutorLoop.java
+++ b/digdag-server/src/main/java/io/digdag/server/WorkflowExecutorLoop.java
@@ -111,7 +111,7 @@ public class WorkflowExecutorLoop
 
             // noticeRunWhileConditionChange is not 100% accurate because
             // WorkflowExecutor doesn't lock stop flag before check. But
-            // it will be repeated at shutdown() method later
+            // it will be repeated in shutdown() method later
             workflowExecutor.noticeRunWhileConditionChange();
         }
     }

--- a/digdag-tests/src/test/java/acceptance/ServerJmxIT.java
+++ b/digdag-tests/src/test/java/acceptance/ServerJmxIT.java
@@ -1,11 +1,21 @@
 package acceptance;
 
+import com.google.common.base.Throwables;
+
 import org.junit.Rule;
 import org.junit.Test;
+import io.digdag.core.database.DataSourceProvider;
 import utils.TemporaryDigdagServer;
 
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.time.Duration;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import java.sql.Connection;
+import java.sql.Statement;
+
 import javax.management.remote.JMXServiceURL;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXConnectorFactory;
@@ -15,6 +25,9 @@ import javax.management.ObjectName;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeThat;
+
+import static utils.TestUtils.expect;
 
 public class ServerJmxIT
 {
@@ -27,16 +40,27 @@ public class ServerJmxIT
                     "server.jmx.port=0")
             .build();
 
-    @Test
-    public void scheduleStartTime()
-            throws Exception
+    private static JMXConnector connectJmx(TemporaryDigdagServer server)
+        throws IOException
     {
         Matcher matcher = JMX_PORT_PATTERN.matcher(server.outUtf8());
         assertThat(matcher.find(), is(true));
         int port = Integer.parseInt(matcher.group(1));
 
-        JMXServiceURL url = new JMXServiceURL("service:jmx:rmi:///jndi/rmi://:" + port + "/jmxrmi");
-        try (JMXConnector con = JMXConnectorFactory.connect(url, null)) {
+        try {
+            JMXServiceURL url = new JMXServiceURL("service:jmx:rmi:///jndi/rmi://:" + port + "/jmxrmi");
+            return JMXConnectorFactory.connect(url, null);
+        }
+        catch (MalformedURLException ex) {
+            throw Throwables.propagate(ex);
+        }
+    }
+
+    @Test
+    public void verifyJmx()
+            throws Exception
+    {
+        try (JMXConnector con = connectJmx(server)) {
             MBeanServerConnection beans = con.getMBeanServerConnection();
 
             Object uptime = beans.getAttribute(ObjectName.getInstance("java.lang", "type", "Runtime"), "Uptime");
@@ -44,6 +68,32 @@ public class ServerJmxIT
 
             Object enqueueCount = beans.getAttribute(ObjectName.getInstance("io.digdag.core.workflow", "name", "TaskQueueDispatcher"), "EnqueueCount");
             assertThat(enqueueCount, is(0L));
+        }
+    }
+
+    @Test
+    public void verifyUncaughtErrorCount()
+            throws Exception
+    {
+        assumeThat(server.isRemoteDatabase(), is(true));
+
+        try (JMXConnector con = connectJmx(server)) {
+            MBeanServerConnection beans = con.getMBeanServerConnection();
+
+            Object uncaughtErrorCount = beans.getAttribute(ObjectName.getInstance("io.digdag.core", "name", "ErrorReporter"), "UncaughtErrorCount");
+            assertThat(uncaughtErrorCount, is(0));
+
+            // oops, tasks table is broken!?
+            try (DataSourceProvider dsp = new DataSourceProvider(server.getRemoteTestDatabaseConfig())) {
+                Statement stmt = dsp.get().getConnection().createStatement();
+                stmt.execute("drop table tasks cascade");
+            }
+
+            // should increment uncaught exception count
+            expect(Duration.ofMinutes(5), () -> {
+                int count = (int) beans.getAttribute(ObjectName.getInstance("io.digdag.core", "name", "ErrorReporter"), "UncaughtErrorCount");
+                return count > 0;
+            });
         }
     }
 }

--- a/digdag-tests/src/test/java/utils/TemporaryDigdagServer.java
+++ b/digdag-tests/src/test/java/utils/TemporaryDigdagServer.java
@@ -552,6 +552,16 @@ public class TemporaryDigdagServer
         temporaryFolder.delete();
     }
 
+    public boolean isRemoteDatabase()
+    {
+        return testDatabaseConfig != null && testDatabaseConfig.getRemoteDatabaseConfig().isPresent();
+    }
+
+    public DatabaseConfig getRemoteTestDatabaseConfig()
+    {
+        return testDatabaseConfig;
+    }
+
     public boolean hasUnixProcess()
     {
         return serverProcess != null && isUnixProcess(serverProcess);


### PR DESCRIPTION
Background executor threads try to recover from uncaught errors as much
as possible. However, because those errors are unexpected, system
administrators should be notified. This change introduces new
ErrorReporter interface so that administrators can customize the behavior
when uncaught errors are thrown. Default implementation reports counts
using JMX.

#257 is an example that should be notified.

This change assumes #257. Changes since #257 is https://github.com/treasure-data/digdag/compare/retry-workflow-executor-loop...report-unexpected-errors

