### PR TITLE
secrets: allow access by default for local server

### DIFF
--- a/digdag-server/src/main/java/io/digdag/server/DefaultSecretAccessPolicy.java
+++ b/digdag-server/src/main/java/io/digdag/server/DefaultSecretAccessPolicy.java
@@ -29,17 +29,47 @@ public class DefaultSecretAccessPolicy
     private static final Logger logger = LoggerFactory.getLogger(DefaultSecretAccessPolicy.class);
 
     private final ServerSecretAccessPolicy policy;
+    private final Boolean enabled;
 
     @Inject
     public DefaultSecretAccessPolicy(Config systemConfig, ObjectMapper mapper)
             throws IOException
     {
-        this.policy = loadPolicy(systemConfig, mapper);
+        ServerSecretAccessPolicy.Builder builder;
+        Optional<String> policyFilename = systemConfig.getOptional("digdag.secret-access-policy-file", String.class);
+        if (policyFilename.isPresent()) {
+            this.enabled = true;
+            builder = ServerSecretAccessPolicy.builder().from(readPolicy(mapper, Paths.get(policyFilename.get())));
+        }
+        else {
+            this.enabled = systemConfig.get("secret-access-policy.enabled", Boolean.class, false);
+            builder = ServerSecretAccessPolicy.builder();
+        }
+
+        Pattern pattern = Pattern.compile("^secret-access-policy\\.operators\\.(\\w+)\\.secrets$");
+
+        for (String key : systemConfig.getKeys()) {
+            Matcher m = pattern.matcher(key);
+            if (m.find()) {
+                String operatorType = m.group(1);
+                String value = systemConfig.get(key, String.class);
+                List<SecretSelector> selectors = mapper.readValue(value, new TypeReference<List<SecretSelector>>() {});
+                builder.putOperators(operatorType, OperatorSecretAccessPolicy.of(selectors));
+            }
+        }
+
+        this.policy = builder.build();
+
+        logger.info("loaded secret access policy: {} (enabled: {})", policy, enabled);
     }
 
     @Override
     public boolean isSecretAccessible(SecretAccessContext context, String key)
     {
+        if (!enabled) {
+            return true;
+        }
+
         if (policy == null) {
             return false;
         }
@@ -58,45 +88,18 @@ public class DefaultSecretAccessPolicy
         return false;
     }
 
-    private static ServerSecretAccessPolicy loadPolicy(Config systemConfig, ObjectMapper mapper)
-            throws IOException
-    {
-        ServerSecretAccessPolicy.Builder builder;
-        Optional<String> policyFilename = systemConfig.getOptional("digdag.secret-access-policy-file", String.class);
-        if (policyFilename.isPresent()) {
-            builder = ServerSecretAccessPolicy.builder().from(readPolicy(mapper, Paths.get(policyFilename.get())));
-        }
-        else {
-            builder = ServerSecretAccessPolicy.builder();
-        }
-
-        Pattern pattern = Pattern.compile("^secret-access-policy\\.operators\\.(\\w+)\\.secrets$");
-
-        for (String key : systemConfig.getKeys()) {
-            Matcher m = pattern.matcher(key);
-            if (m.find()) {
-                String operatorType = m.group(1);
-                String value = systemConfig.get(key, String.class);
-                List<SecretSelector> selectors = mapper.readValue(value, new TypeReference<List<SecretSelector>>() {});
-                builder.putOperators(operatorType, OperatorSecretAccessPolicy.of(selectors));
-            }
-        }
-
-        ServerSecretAccessPolicy policy = builder.build();
-
-        logger.info("loaded secret access policy: {}", policy);
-
-        return policy;
-    }
-
     private static ServerSecretAccessPolicy readPolicy(ObjectMapper mapper, Path path)
             throws IOException
     {
-        ServerSecretAccessPolicy policy;
         try (InputStream in = Files.newInputStream(path)) {
-            YAMLParser parser = new YAMLFactory().createParser(in);
-            policy = mapper.readValue(parser, ServerSecretAccessPolicy.class);
+            return readPolicy(mapper, in);
         }
-        return policy;
+    }
+
+    private static ServerSecretAccessPolicy readPolicy(ObjectMapper mapper, InputStream in)
+            throws IOException
+    {
+        YAMLParser parser = new YAMLFactory().createParser(in);
+        return mapper.readValue(parser, ServerSecretAccessPolicy.class);
     }
 }

--- a/digdag-tests/src/test/java/acceptance/td/Secrets.java
+++ b/digdag-tests/src/test/java/acceptance/td/Secrets.java
@@ -20,6 +20,7 @@ public class Secrets
     {
         return ImmutableList.of(
                 "digdag.secret-encryption-key = " + ENCRYPTION_KEY,
+                "secret-access-policy.enabled = true",
                 "secret-access-policy.operators.td.secrets = [\"td.*\"]",
                 "secret-access-policy.operators.td_ddl.secrets = [\"td.*\"]",
                 "secret-access-policy.operators.td_for_each.secrets = [\"td.*\"]",

--- a/digdag-tests/src/test/java/acceptance/td/TdIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/TdIT.java
@@ -47,6 +47,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+import static acceptance.td.Secrets.ENCRYPTION_KEY;
 import static acceptance.td.Secrets.TD_API_KEY;
 import static io.netty.handler.codec.http.HttpHeaders.Names.CONNECTION;
 import static io.netty.handler.codec.http.HttpHeaders.Values.CLOSE;
@@ -250,6 +251,35 @@ public class TdIT
         expect(Duration.ofMinutes(5), attemptSuccess(server.endpoint(), attemptId));
 
         assertThat(requests.stream().filter(req -> req.getUri().contains("/v3/job/issue")).count(), is(greaterThan(0L)));
+    }
+
+    @Test
+    public void testRunQueryOnServerWithoutSecretAccessPolicy()
+            throws Exception
+    {
+        TemporaryDigdagServer server = TemporaryDigdagServer.builder()
+                .configuration("digdag.secret-encryption-key = " + ENCRYPTION_KEY)
+                .build();
+
+        server.start();
+
+        copyResource("acceptance/td/td/td.dig", projectDir.resolve("workflow.dig"));
+        copyResource("acceptance/td/td/query.sql", projectDir.resolve("query.sql"));
+
+        int projectId = TestUtils.pushProject(server.endpoint(), projectDir);
+
+        DigdagClient digdagClient = DigdagClient.builder()
+                .host(server.host())
+                .port(server.port())
+                .build();
+
+        digdagClient.setProjectSecret(projectId, "td.apikey", TD_API_KEY);
+
+        long attemptId = pushAndStart(server.endpoint(), projectDir, "workflow", ImmutableMap.of(
+                "outfile", outfile.toString(),
+                "td.use_ssl", "false"));
+
+        expect(Duration.ofMinutes(5), attemptSuccess(server.endpoint(), attemptId));
     }
 
     @Test


### PR DESCRIPTION
Do not require users running a local digdag server to create a secret access policy. Allow all secret accesses by default in local server mode.