### PR TITLE
Nested transaction must not open a new connection to avoid deadlock

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/database/BasicDatabaseStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/BasicDatabaseStoreManager.java
@@ -251,6 +251,7 @@ public abstract class BasicDatabaseStoreManager <D>
                 throw Throwables.propagate(innerException);
             }
             catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
                 throw Throwables.propagate(ex);
             }
         }
@@ -301,6 +302,7 @@ public abstract class BasicDatabaseStoreManager <D>
                 throw Throwables.propagate(innerException);
             }
             catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
                 throw Throwables.propagate(ex);
             }
         }
@@ -353,6 +355,7 @@ public abstract class BasicDatabaseStoreManager <D>
                 throw Throwables.propagate(innerException);
             }
             catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
                 throw Throwables.propagate(ex);
             }
         }
@@ -420,6 +423,7 @@ public abstract class BasicDatabaseStoreManager <D>
             throw Throwables.propagate(innerException);
         }
         catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
             throw Throwables.propagate(ex);
         }
     }
@@ -472,6 +476,7 @@ public abstract class BasicDatabaseStoreManager <D>
                 throw Throwables.propagate(innerException);
             }
             catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
                 throw Throwables.propagate(ex);
             }
         }
@@ -498,6 +503,7 @@ public abstract class BasicDatabaseStoreManager <D>
                 throw Throwables.propagate(innerException);
             }
             catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
                 throw Throwables.propagate(ex);
             }
         }
@@ -525,6 +531,7 @@ public abstract class BasicDatabaseStoreManager <D>
                 throw Throwables.propagate(innerException);
             }
             catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
                 throw Throwables.propagate(ex);
             }
         }

--- a/digdag-core/src/main/java/io/digdag/core/database/BasicDatabaseStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/BasicDatabaseStoreManager.java
@@ -22,7 +22,6 @@ import io.digdag.core.repository.ResourceNotFoundException;
 import io.digdag.core.repository.ResourceConflictException;
 import io.digdag.util.RetryExecutor;
 import io.digdag.util.RetryExecutor.RetryGiveupException;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 public abstract class BasicDatabaseStoreManager <D>
 {
@@ -227,7 +226,6 @@ public abstract class BasicDatabaseStoreManager <D>
         }
     }
 
-    @SuppressFBWarnings("RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE")
     public <T> T transaction(TransactionAction<T, D> action)
     {
         Handle nested = currentTransaction.get();

--- a/digdag-core/src/main/java/io/digdag/core/database/BasicDatabaseStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/BasicDatabaseStoreManager.java
@@ -439,7 +439,7 @@ public abstract class BasicDatabaseStoreManager <D>
         // 5. PostgreSQL silently translate COMMIT to ROLLBACK without errors. The thread
         //    assumes that the transaction is committed but actually everything is rolled back.
         //
-        // To avoid this issue, the thread needs to send a dummy SELECT statement after step 4.
+        // To avoid this issue, the thread needs to send a dummy SELECT statement before step 4.
         // PostgreSQL makes the statement failed ("ERROR:  25P02: current transaction is aborted,
         // commands ignored until end of transaction block").
         //

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
@@ -176,7 +176,7 @@ public class DatabaseProjectStoreManager
         public <T> T putAndLockProject(Project project, ProjectLockAction<T> func)
                 throws ResourceConflictException
         {
-            return transactionWithRetry((handle, dao, ts) -> {
+            return transactionWithLocalRetry((handle, dao, ts) -> {
                 int projId;
 
                 if (!ts.isRetried()) {

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
@@ -176,7 +176,7 @@ public class DatabaseProjectStoreManager
         public <T> T putAndLockProject(Project project, ProjectLockAction<T> func)
                 throws ResourceConflictException
         {
-            return transaction((handle, dao, ts) -> {
+            return transactionWithRetry((handle, dao, ts) -> {
                 int projId;
 
                 if (!ts.isRetried()) {
@@ -204,14 +204,14 @@ public class DatabaseProjectStoreManager
                 }
 
                 return func.call(new DatabaseProjectControlStore(handle, siteId), proj);
-            }, ResourceConflictException.class);
+            }, ResourceConflictException.class, RuntimeException.class);
         }
 
         @Override
         public <T> T deleteProject(int projId, ProjectObsoleteAction<T> func)
             throws ResourceNotFoundException
         {
-            return transaction((handle, dao, ts) -> {
+            return transaction((handle, dao) -> {
                 StoredProject proj = requiredResource(
                         dao.getProjectByIdWithLockForDelete(siteId, projId),
                         "project id=%d", projId);

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseScheduleStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseScheduleStoreManager.java
@@ -56,7 +56,7 @@ public class DatabaseScheduleStoreManager
     @Override
     public void lockReadySchedules(Instant currentTime, ScheduleAction func)
     {
-        List<RuntimeException> exceptions = transaction((handle, dao, ts) -> {
+        List<RuntimeException> exceptions = transaction((handle, dao) -> {
             return dao.lockReadySchedules(currentTime.getEpochSecond(), 10)  // TODO 10 should be configurable?
                 .stream()
                 .map(schedId -> {
@@ -86,7 +86,7 @@ public class DatabaseScheduleStoreManager
     public <T> T lockScheduleById(int schedId, ScheduleLockAction<T> func)
         throws ResourceNotFoundException, ResourceConflictException
     {
-        return this.<T, ResourceNotFoundException, ResourceConflictException>transaction((handle, dao, ts) -> {
+        return this.<T, ResourceNotFoundException, ResourceConflictException>transaction((handle, dao) -> {
             // JOIN + FOR UPDATE doesn't work with H2 database. So here locks it first then get columns.
             if (dao.lockScheduleById(schedId) == 0) {
                 throw new ResourceNotFoundException("schedule id="+schedId);

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSecretControlStore.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSecretControlStore.java
@@ -29,7 +29,7 @@ class DatabaseSecretControlStore
         String encrypted = crypto.encryptSecret(value);
         String engine = crypto.getName();
 
-        transaction((handle, dao, ts) -> {
+        transaction((handle, dao) -> {
             dao.deleteProjectSecret(siteId, projectId, scope, key);
             dao.insertProjectSecret(siteId, projectId, scope, key, engine, encrypted);
             return null;
@@ -39,7 +39,7 @@ class DatabaseSecretControlStore
     @Override
     public void deleteProjectSecret(int projectId, String scope, String key)
     {
-        transaction((handle, dao, ts) -> {
+        transaction((handle, dao) -> {
             dao.deleteProjectSecret(siteId, projectId, scope, key);
             return null;
         });
@@ -48,7 +48,7 @@ class DatabaseSecretControlStore
     @Override
     public List<String> listProjectSecrets(int projectId, String scope)
     {
-        return transaction((handle, dao, ts) -> dao.listProjectSecrets(siteId, projectId, scope));
+        return transaction((handle, dao) -> dao.listProjectSecrets(siteId, projectId, scope));
     }
 
     interface Dao

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
@@ -929,7 +929,7 @@ public class DatabaseSessionStoreManager
         public <T> T putAndLockSession(Session session, SessionLockAction<T> func)
             throws ResourceConflictException, ResourceNotFoundException
         {
-            return DatabaseSessionStoreManager.this.<T, ResourceConflictException, ResourceNotFoundException>transactionWithRetry((handle, dao, ts) -> {
+            return DatabaseSessionStoreManager.this.<T, ResourceConflictException, ResourceNotFoundException>transactionWithLocalRetry((handle, dao, ts) -> {
                 long sesId;
 
                 switch (databaseType) {

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseTaskQueueServer.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseTaskQueueServer.java
@@ -164,7 +164,7 @@ public class DatabaseTaskQueueServer
             @Nullable byte[] data)
         throws ResourceConflictException
     {
-        long id = transaction((handle, dao, ts) -> {
+        long id = transaction((handle, dao) -> {
             long queuedTaskId = catchConflict(() ->
                 dao.insertQueuedTask(siteId, queueId, uniqueName, data),
                 "lock of task name=%s in site id = %d and queue id=%d", uniqueName, siteId, queueId);
@@ -217,7 +217,7 @@ public class DatabaseTaskQueueServer
     private void deleteTask0(int siteId, long taskLockId, String agentId)
         throws TaskNotFoundException, TaskConflictException
     {
-        this.<Boolean, TaskNotFoundException, TaskConflictException>transaction((handle, dao, ts) -> {
+        this.<Boolean, TaskNotFoundException, TaskConflictException>transaction((handle, dao) -> {
             int count;
 
             count = dao.deleteQueuedTask(siteId, taskLockId);
@@ -243,7 +243,7 @@ public class DatabaseTaskQueueServer
 
     private boolean forceDeleteTask0(long taskLockId)
     {
-        return this.transaction((handle, dao, ts) -> {
+        return this.transaction((handle, dao) -> {
             int taskCount = dao.forceDeleteQueuedTask(taskLockId);
             int lockCount = dao.forceDeleteQueuedTaskLock(taskLockId);
             return taskCount > 0 || lockCount > 0;
@@ -340,7 +340,7 @@ public class DatabaseTaskQueueServer
 
         try {
             if (isEmbededDatabase()) {
-                return transaction((handle, dao, ts) -> {
+                return transaction((handle, dao) -> {
                     List<Long> taskLockIds = handle.createQuery(
                             "select id " +
                             "from queued_task_locks " +

--- a/digdag-core/src/test/java/io/digdag/core/workflow/WorkflowExecutorParallelStressTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/WorkflowExecutorParallelStressTest.java
@@ -1,0 +1,76 @@
+package io.digdag.core.workflow;
+
+import io.digdag.client.config.Config;
+import io.digdag.core.LocalSite;
+import io.digdag.core.DigdagEmbed;
+import io.digdag.core.session.StoredSessionAttemptWithSession;
+import io.digdag.core.repository.ResourceConflictException;
+import io.digdag.core.repository.ResourceNotFoundException;
+import io.digdag.core.workflow.WorkflowTestingUtils;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import java.util.concurrent.Future;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import static io.digdag.core.workflow.WorkflowTestingUtils.setupEmbed;
+import static io.digdag.core.workflow.WorkflowTestingUtils.loadYamlResource;
+
+public class WorkflowExecutorParallelStressTest
+{
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private DigdagEmbed embed;
+    private LocalSite localSite;
+
+    @Before
+    public void setUp()
+        throws Exception
+    {
+        this.embed = setupEmbed();
+        this.localSite = embed.getInjector().getInstance(LocalSite.class);
+    }
+
+    @After
+    public void destroy()
+        throws Exception
+    {
+        embed.close();
+    }
+
+    @Test
+    public void parallelExecutionLoopShouldNotThrowError()
+        throws Exception
+    {
+        StoredSessionAttemptWithSession attempt = submitWorkflow("parallel_stress", loadYamlResource("/io/digdag/core/workflow/parallel_stress.dig"));
+
+        ExecutorService threads = Executors.newCachedThreadPool();
+        ImmutableList.Builder<Future> futures = ImmutableList.builder();
+
+        for (int i = 0; i < 1; i++) {
+            futures.add(threads.submit(() -> {
+                try {
+                    localSite.runUntilDone(attempt.getId());
+                }
+                catch (Exception ex) {
+                    throw Throwables.propagate(ex);
+                }
+            }));
+        }
+
+        for (Future f : futures.build()) {
+            f.get();
+        }
+    }
+
+    private StoredSessionAttemptWithSession submitWorkflow(String workflowName, Config config)
+        throws ResourceNotFoundException, ResourceConflictException
+    {
+        return WorkflowTestingUtils.submitWorkflow(localSite, folder.getRoot().toPath(), workflowName, config);
+    }
+}

--- a/digdag-core/src/test/java/io/digdag/core/workflow/WorkflowExecutorParallelStressTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/WorkflowExecutorParallelStressTest.java
@@ -52,7 +52,7 @@ public class WorkflowExecutorParallelStressTest
         ExecutorService threads = Executors.newCachedThreadPool();
         ImmutableList.Builder<Future> futures = ImmutableList.builder();
 
-        for (int i = 0; i < 1; i++) {
+        for (int i = 0; i < 10; i++) {
             futures.add(threads.submit(() -> {
                 try {
                     localSite.runUntilDone(attempt.getId());

--- a/digdag-core/src/test/resources/io/digdag/core/workflow/parallel_stress.dig
+++ b/digdag-core/src/test/resources/io/digdag/core/workflow/parallel_stress.dig
@@ -1,9 +1,9 @@
 +parallel_generate:
-  loop>: 8
+  loop>: 10
   _parallel: true
   _do:
     +parallel_run:
-      loop>: 5
+      loop>: 10
       _parallel: true
       _do:
         noop>:


### PR DESCRIPTION
Deadlock happens in following scenario:

* Thread1 starts a transaction and locks a row (such as lockTaskIfExists).
* Thread2 opens a connection and tries to lock the same row. This is
  blocked because thread1 already locks the row.
* Thread1 tries to open another connection in the transaction. This
  could be blocked for ever by Thread2 if number of opened connection
  reached maximumPoolSize when thread2 opened a connection.

`WorkflowExecutor.getTaskRequest` behaves like thread1 (`sm.getAttemptWithSessionById` in `lockTaskIfExists`).
`WorkflowExecutor.enqueueTask` also behaves like thread1 (`DatabaseTaskQueueServer.enqueue` in `lockTaskIfExists`).

WorkflowExecutorParallelStressTest reproduces this issue. It reproduces as a timeout error (`Connection is not available, request timed out after 30000ms`)
This issue doesn't happen h2 database because digdag doesn't use connection pool with h2.
