### PR TITLE
Added authentication skip if config is empty

### DIFF
--- a/digdag-ui/console.jsx
+++ b/digdag-ui/console.jsx
@@ -1345,6 +1345,12 @@ class LoginPage extends React.Component {
     });
   }
 
+  componentWillMount() {
+    if (!DIGDAG_CONFIG.auth.items.length) {
+      this.props.onSubmit({})
+    }
+  }
+
   onChange(key) {
     return (e) => {
       e.preventDefault();


### PR DESCRIPTION
This allows the client to skip the login screen if auth items is empty (which implies that the authentication data comes from cookies)