### PR TITLE
[ui]: Accepts SHA from process.env

### DIFF
--- a/digdag-ui/webpack.production.config.js
+++ b/digdag-ui/webpack.production.config.js
@@ -5,7 +5,7 @@ var ManifestPlugin = require('./lib/ManifestPlugin')
 var getSHA1 = require('./lib/git-sha1')
 
 const timestamp = new Date().toISOString()
-const sha = getSHA1()
+const sha = process.env.SHA || getSHA1()
 
 module.exports = {
   devtool: 'source-map',


### PR DESCRIPTION
With this it should accept a third party SHA or use the repo one (useful for external config builds)