### PR TITLE
[WIP] assign secret scopes to digdag and td config

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/LocalSecretStoreManager.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/LocalSecretStoreManager.java
@@ -4,6 +4,7 @@ import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import io.digdag.client.config.Config;
 import io.digdag.spi.SecretAccessContext;
+import io.digdag.spi.SecretScopes;
 import io.digdag.spi.SecretStore;
 import io.digdag.spi.SecretStoreManager;
 
@@ -44,6 +45,9 @@ class LocalSecretStoreManager
             }
 
             // Fall back to secrets from system config
+            if (!scope.equals(SecretScopes.PROJECT)) {
+                return Optional.absent();
+            }
             return Optional.fromNullable(secrets.get(key));
         };
     }

--- a/digdag-standards/src/main/java/io/digdag/standards/td/TdConfigSecretStore.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/td/TdConfigSecretStore.java
@@ -6,6 +6,7 @@ import com.google.inject.Inject;
 import com.treasuredata.client.ProxyConfig;
 import com.treasuredata.client.TDClientConfig;
 import io.digdag.spi.SecretAccessContext;
+import io.digdag.spi.SecretScopes;
 import io.digdag.spi.SecretStore;
 
 import javax.annotation.Nullable;
@@ -58,6 +59,9 @@ class TdConfigSecretStore
     @Override
     public Optional<String> getSecret(int projectId, String scope, String key)
     {
+        if (!scope.equals(SecretScopes.PROJECT_DEFAULT)) {
+            return Optional.absent();
+        }
         return Optional.fromNullable(secrets.get(key));
     }
 }

--- a/digdag-tests/src/test/java/acceptance/td/TdWaitIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/TdWaitIT.java
@@ -2,6 +2,7 @@ package acceptance.td;
 
 import com.google.common.collect.ImmutableMap;
 import com.treasuredata.client.TDClient;
+import com.treasuredata.client.model.TDDatabase;
 import io.digdag.client.DigdagClient;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
@@ -19,6 +20,7 @@ import utils.TestUtils;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.List;
 import java.util.UUID;
 
 import static acceptance.td.Secrets.TD_API_KEY;


### PR DESCRIPTION
- Assign PROJECT scope to digdag config
- Assign PROJECT_DEFAULT scope to td.conf

This ensures that e.g. td.apikey set in digdag config has higher priority than the apikey picked up from td.conf.
