### PR TITLE
Scrap backward compatibility of deprecated Operator.run() method

### DIFF
--- a/digdag-spi/src/main/java/io/digdag/spi/Operator.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/Operator.java
@@ -6,17 +6,7 @@ import java.util.List;
 
 public interface Operator
 {
-    // TODO: scrap backwards compatibility?
-    @Deprecated
-    default TaskResult run()
-    {
-        throw new UnsupportedOperationException();
-    }
-
-    default TaskResult run(TaskExecutionContext ctx)
-    {
-        return run();
-    }
+    TaskResult run(TaskExecutionContext ctx);
 
     /**
      * Get a list of secret selectors that describe the namespace(s) of secret keys that this


### PR DESCRIPTION
#276 already spoiled plugin backward compatibility