### PR TITLE
Caching is failing on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,12 +34,15 @@ before_install:
     docker run \
     -w /digdag \
     -v `pwd`/:/digdag \
-    -v ~/.gradle:/root/.gradle \
+    -v $HOME/.gradle:/root/.gradle \
     digdag-build \
     ./gradlew testClasses
   - ci/validate.sh
 
 install: true
+
+before_cache:
+  - sudo chown `id -u`:`id -g` -R $HOME/docker $HOME/.gradle $HOME/.m2  # make them cachable
 
 script:
   - ci/run_test.sh


### PR DESCRIPTION
```
$ store build cache
...
FAILED: tar -Pzcf /home/travis/.casher/push.tgz /home/travis/docker
/home/travis/.gradle /home/travis/.m2
tar: /home/travis/.gradle/daemon/3.0: Cannot open: Permission denied
tar: Exiting with failure status due to previous errors
```