### PR TITLE
Do not use td.apikey and pg.password params

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/operator/pg/PgConnectionConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/pg/PgConnectionConfig.java
@@ -24,7 +24,7 @@ public abstract class PgConnectionConfig
                 .host(secrets.getSecretOptional("host").or(() -> params.get("host", String.class)))
                 .port(secrets.getSecretOptional("port").transform(Integer::parseInt).or(() -> params.get("port", int.class, 5432)))
                 .user(secrets.getSecretOptional("user").or(() -> params.get("user", String.class)))
-                .password(secrets.getSecretOptional("password").or(params.getOptional("password", String.class)))
+                .password(secrets.getSecretOptional("password"))
                 .database(secrets.getSecretOptional("database").or(() -> params.get("database", String.class)))
                 .ssl(secrets.getSecretOptional("ssl").transform(Boolean::parseBoolean).or(() -> params.get("ssl", boolean.class, false)))
                 .connectTimeout(secrets.getSecretOptional("connect_timeout").transform(DurationParam::parse).or(() ->

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TDClientFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TDClientFactory.java
@@ -37,15 +37,18 @@ class TDClientFactory
             }
         }
 
-        String apikey = secrets.getSecretOptional("apikey").or(() -> params.get("apikey", String.class)).trim();
-        if (apikey.isEmpty()) {
-            throw new ConfigException("Parameter 'apikey' is empty");
+        Optional<String> apikey = secrets.getSecretOptional("apikey").transform(String::trim);
+        if (!apikey.isPresent()) {
+            throw new ConfigException("The 'td.apikey' secret is missing");
+        }
+        if (apikey.get().isEmpty()) {
+            throw new ConfigException("The 'td.apikey' secret is empty");
         }
         
         return builder
                 .setEndpoint(secrets.getSecretOptional("endpoint").or(() -> params.get("endpoint", String.class, "api.treasuredata.com")))
                 .setUseSSL(useSSL)
-                .setApiKey(apikey)
+                .setApiKey(apikey.get())
                 .setRetryLimit(0)  // disable td-client's retry mechanism
                 ;
     }

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/pg/PgConnectionConfigTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/pg/PgConnectionConfigTest.java
@@ -55,7 +55,7 @@ public class PgConnectionConfigTest
         );
 
         this.connConfigWithCustomValue = PgConnectionConfig.configure(
-                key -> Optional.absent(), jdbcOpTestHelper.createConfig(customConfigValues)
+                key -> key.equals("password") ? Optional.of("password1") : Optional.absent(), jdbcOpTestHelper.createConfig(customConfigValues)
         );
 
         this.connConfigWithCustomValueFromSecrets = PgConnectionConfig.configure(

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/td/TDClientFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/td/TDClientFactoryTest.java
@@ -20,7 +20,7 @@ import static org.junit.Assert.assertThat;
 
 public class TDClientFactoryTest
 {
-    private static final SecretProvider EMPTY_SECRETS = key -> Optional.absent();
+    private static final SecretProvider SECRETS = key -> Optional.fromNullable(ImmutableMap.of("apikey", "foobar").get(key));
 
     private final ObjectMapper mapper = new ObjectMapper()
             .registerModule(new GuavaModule())
@@ -46,7 +46,7 @@ public class TDClientFactoryTest
                                 .set("use_ssl", true));
 
         TDClientBuilder builder = TDClientFactory.clientBuilderFromConfig(
-                ImmutableMap.of(), config, key -> Optional.fromNullable(ImmutableMap.of("apikey", "foobar").get(key)));
+                ImmutableMap.of(), config, SECRETS);
         TDClientConfig clientConfig = builder.buildConfig();
 
         assertThat(clientConfig.proxy.get().getUser(), is(Optional.of("me")));
@@ -58,10 +58,8 @@ public class TDClientFactoryTest
     public void testProxyConfigFromEnv()
     {
         Map<String, String> env = ImmutableMap.of("http_proxy", "https://me:%27(%23%25@example.com:9119");
-        Config config = newConfig()
-                .set("apikey", "foobar");
 
-        TDClientBuilder builder = TDClientFactory.clientBuilderFromConfig(env, config, EMPTY_SECRETS);
+        TDClientBuilder builder = TDClientFactory.clientBuilderFromConfig(env, newConfig(), SECRETS);
         TDClientConfig clientConfig = builder.buildConfig();
 
         assertThat(clientConfig.proxy.get().getUser(), is(Optional.of("me")));

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/td/TDOperatorTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/td/TDOperatorTest.java
@@ -32,10 +32,7 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class TDOperatorTest
 {
-    // TODO: update these tests to use secrets
-
     private static final ImmutableMap<String, String> EMPTY_ENV = ImmutableMap.of();
-    private static final SecretProvider EMPTY_SECRETS = key -> Optional.absent();
 
     @Rule public final ExpectedException exception = ExpectedException.none();
 
@@ -58,11 +55,13 @@ public class TDOperatorTest
             throws Exception
     {
         Config config = newConfig()
-                .set("database", "")
-                .set("apikey", "foobar");
+                .set("database", "");
+
+        SecretProvider secrets = key -> Optional.fromNullable(
+                ImmutableMap.of("apikey", "foobar").get(key));
 
         exception.expect(ConfigException.class);
-        TDOperator.fromConfig(EMPTY_ENV, config, EMPTY_SECRETS);
+        TDOperator.fromConfig(EMPTY_ENV, config, secrets);
     }
 
     @Test
@@ -70,11 +69,13 @@ public class TDOperatorTest
             throws Exception
     {
         Config config = newConfig()
-                .set("database", " \t\n")
-                .set("apikey", "foobar");
+                .set("database", " \t\n");
+
+        SecretProvider secrets = key -> Optional.fromNullable(
+                ImmutableMap.of("apikey", "foobar").get(key));
 
         exception.expect(ConfigException.class);
-        TDOperator.fromConfig(EMPTY_ENV, config, EMPTY_SECRETS);
+        TDOperator.fromConfig(EMPTY_ENV, config, secrets);
     }
 
     @Test
@@ -82,11 +83,13 @@ public class TDOperatorTest
             throws Exception
     {
         Config config = newConfig()
-                .set("database", "foobar")
-                .set("apikey", "");
+                .set("database", "foobar");
+
+        SecretProvider secrets = key -> Optional.fromNullable(
+                ImmutableMap.of("apikey", "").get(key));
 
         exception.expect(ConfigException.class);
-        TDOperator.fromConfig(EMPTY_ENV, config, EMPTY_SECRETS);
+        TDOperator.fromConfig(EMPTY_ENV, config, secrets);
     }
 
     @Test
@@ -94,11 +97,13 @@ public class TDOperatorTest
             throws Exception
     {
         Config config = newConfig()
-                .set("database", "foobar")
-                .set("apikey", " \n\t");
+                .set("database", "foobar");
+
+        SecretProvider secrets = key -> Optional.fromNullable(
+                ImmutableMap.of("apikey", " \n\t").get(key));
 
         exception.expect(ConfigException.class);
-        TDOperator.fromConfig(EMPTY_ENV, config, EMPTY_SECRETS);
+        TDOperator.fromConfig(EMPTY_ENV, config, secrets);
     }
 
     @Test
@@ -106,9 +111,10 @@ public class TDOperatorTest
             throws Exception
     {
         Config config = newConfig()
-                .set("database", "foobar")
-                .set("apikey", "quux");
-        TDOperator.fromConfig(EMPTY_ENV, config, EMPTY_SECRETS);
+                .set("database", "foobar");
+        SecretProvider secrets = key -> Optional.fromNullable(
+                ImmutableMap.of("apikey", "quux").get(key));
+        TDOperator.fromConfig(EMPTY_ENV, config, secrets);
     }
 
     @Test


### PR DESCRIPTION
Require td.apikey and pg.password to be secrets.