### PR TITLE
Call operator supports files in subdirectory

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/agent/InProcessTaskCallbackApi.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/InProcessTaskCallbackApi.java
@@ -190,19 +190,4 @@ public class InProcessTaskCallbackApi
             return ex.getConflictedSession().getStateFlags();
         }
     }
-
-    @Override
-    public Config getWorkflowDefinition(
-            int siteId,
-            int projectId,
-            String workflowName)
-        throws ResourceNotFoundException
-    {
-        ProjectStore projectStore = pm.getProjectStore(siteId);
-
-        StoredProject proj = projectStore.getProjectById(projectId);
-        StoredWorkflowDefinitionWithProject def = projectStore.getLatestWorkflowDefinitionByName(proj.getId(), workflowName);
-
-        return def.getConfig();
-    }
 }

--- a/digdag-core/src/main/java/io/digdag/core/agent/TaskCallbackApi.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/TaskCallbackApi.java
@@ -43,10 +43,4 @@ public interface TaskCallbackApi
             Optional<String> retryAttemptName,
             Config overwriteParams)
         throws ResourceNotFoundException;
-
-    Config getWorkflowDefinition(
-            int siteId,
-            int projectId,
-            String workflowName)
-        throws ResourceNotFoundException;
 }

--- a/digdag-core/src/main/java/io/digdag/core/archive/ProjectArchiveLoader.java
+++ b/digdag-core/src/main/java/io/digdag/core/archive/ProjectArchiveLoader.java
@@ -84,9 +84,19 @@ public class ProjectArchiveLoader
             // workflow is in a subdirectory. set _workdir accordingly.
             String workdir = overwriteParams.getOptional("_workdir", String.class)  // overwriteParams has higher priority
                 .or(workflowName.substring(0, posSlash));
-            workflowFile.setWorkdir(workdir);
+            workflowFile.setBaseWorkdir(workdir);
         }
 
         return workflowFile;
+    }
+
+    public WorkflowFile loadWorkflowFileFromPath(Path projectPath, Path workflowPath,
+            Config overwriteParams)
+        throws IOException
+    {
+        String resourceName = ProjectArchive.realPathToResourceName(
+                projectPath.normalize().toAbsolutePath(),
+                workflowPath.normalize().toAbsolutePath());
+        return loadWorkflowFile(resourceName, workflowPath, overwriteParams);
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/archive/WorkflowFile.java
+++ b/digdag-core/src/main/java/io/digdag/core/archive/WorkflowFile.java
@@ -51,12 +51,12 @@ public class WorkflowFile
         check();
     }
 
-    public void setWorkdir(String value)
+    public void setBaseWorkdir(String base)
     {
-        topLevelExport.set("_workdir",
-                topLevelExport.getOptional("_workdir", String.class)
-                .transform(it -> it + "/" + value)
-                .or(value));
+        String workdir = topLevelExport.getOptional("_workdir", String.class)
+            .transform(it -> base + "/" + it)  // prepend base to _workdir
+            .or(base);
+        topLevelExport.set("_workdir", workdir);
     }
 
     protected void check()

--- a/digdag-docs/src/operators.rst
+++ b/digdag-docs/src/operators.rst
@@ -18,16 +18,17 @@ This operator embeds another workflow as a subtask.
     +step1:
       call>: another_workflow.dig
     +step2:
-      call>: sub/shared_workflow.dig
+      call>: common/shared_workflow.dig
 
 .. code-block:: yaml
 
     # another_workflow.dig
     +another:
-      sh>: tasks/another.sh
+      sh>: ../scripts/my_script.sh
 
 :command:`call>: FILE`
-  Path to a workflow definition file.
+  Path to a workflow definition file. File name must end with ``.dig``.
+  If called workflow is in a subdirectory, the workflow uses the subdirectory as the working directory. For example, a task has ``call>: common/called_workflow.dig``, using ``queries/data.sql`` file in the called workflow should be ``../queries/data.sql``.
 
   Example: another_workflow.dig
 

--- a/digdag-docs/src/operators.rst
+++ b/digdag-docs/src/operators.rst
@@ -16,18 +16,20 @@ This operator embeds another workflow as a subtask.
 
     # workflow1.dig
     +step1:
-      call>: another_workflow
+      call>: another_workflow.dig
+    +step2:
+      call>: sub/shared_workflow.dig
 
 .. code-block:: yaml
 
     # another_workflow.dig
-    +step2:
-      sh>: tasks/step2.sh
+    +another:
+      sh>: tasks/another.sh
 
-:command:`call>: NAME`
-  Name of a workflow.
+:command:`call>: FILE`
+  Path to a workflow definition file.
 
-  Example: another_workflow
+  Example: another_workflow.dig
 
 require>: Depends on another workflow
 ----------------------------------

--- a/digdag-tests/src/test/java/acceptance/CallIT.java
+++ b/digdag-tests/src/test/java/acceptance/CallIT.java
@@ -1,0 +1,135 @@
+package acceptance;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import utils.CommandStatus;
+import utils.TemporaryDigdagServer;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+
+import static utils.TestUtils.copyResource;
+import static utils.TestUtils.getAttemptId;
+import static utils.TestUtils.expect;
+import static utils.TestUtils.main;
+import static utils.TestUtils.attemptSuccess;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class CallIT
+{
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Rule
+    public TemporaryDigdagServer server = TemporaryDigdagServer.of();
+
+    private Path config;
+    private Path projectDir;
+
+    private Path root()
+    {
+        return folder.getRoot().toPath().toAbsolutePath();
+    }
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        projectDir = folder.getRoot().toPath().resolve("foobar");
+        config = folder.newFile().toPath();
+    }
+
+    private void initCallProject()
+            throws Exception
+    {
+        // Create new project
+        CommandStatus initStatus = main("init",
+                "-c", config.toString(),
+                projectDir.toString());
+        assertThat(initStatus.errUtf8(), initStatus.code(), is(0));
+
+        copyResource("acceptance/call/parent.dig", projectDir.resolve("parent.dig"));
+        copyResource("acceptance/call/child.dig", projectDir.resolve("child.dig"));
+        Files.createDirectories(projectDir.resolve("sub").resolve("subsub"));
+        copyResource("acceptance/call/child.dig", projectDir.resolve("sub").resolve("child.dig"));
+        copyResource("acceptance/call/child.dig", projectDir.resolve("sub").resolve("subsub").resolve("child.dig"));
+    }
+
+    @Test
+    public void callSubdirLocal()
+            throws Exception
+    {
+        initCallProject();
+
+        // Run the workflow
+        {
+            CommandStatus startStatus = main("run",
+                    "-c", config.toString(),
+                    "--project", projectDir.toString(),
+                    "parent.dig",
+                    "-p", "outdir=" + root());
+            assertThat(startStatus.errUtf8(), startStatus.code(), is(0));
+        }
+
+        // Verify that the file created by the child workflow is there
+        assertThat(Files.exists(root().resolve("call_by_name.out")), is(true));
+        assertThat(Files.exists(root().resolve("call_by_file.out")), is(true));
+        assertThat(Files.exists(root().resolve("call_sub.out")), is(true));
+        assertThat(Files.exists(root().resolve("call_subsub.out")), is(true));
+
+        // Verify pwd of the scripts
+        Path base = Paths.get(new String(Files.readAllBytes(root().resolve("call_by_name.out")), UTF_8).trim());
+        assertThat(Paths.get(new String(Files.readAllBytes(root().resolve("call_sub.out")), UTF_8).trim()), is(base.resolve("sub")));
+        assertThat(Paths.get(new String(Files.readAllBytes(root().resolve("call_subsub.out")), UTF_8).trim()), is(base.resolve("sub").resolve("subsub")));
+    }
+
+    @Test
+    public void callSubdirServer()
+            throws Exception
+    {
+        initCallProject();
+
+        // Push the project
+        CommandStatus pushStatus = main("push",
+                "--project", projectDir.toString(),
+                "call",
+                "-c", config.toString(),
+                "-e", server.endpoint(),
+                "-p", "outdir=" + root());
+        assertThat(pushStatus.errUtf8(), pushStatus.code(), is(0));
+
+        // Start the workflow
+        long attemptId;
+        {
+            CommandStatus startStatus = main("start",
+                    "-c", config.toString(),
+                    "-e", server.endpoint(),
+                    "call", "parent",
+                    "--session", "now");
+            assertThat(startStatus.code(), is(0));
+            attemptId = getAttemptId(startStatus);
+        }
+
+        // Wait for the attempt to complete
+        expect(Duration.ofMinutes(5), attemptSuccess(server.endpoint(), attemptId));
+
+        // Verify that the file created by the child workflow is there
+        assertThat(Files.exists(root().resolve("call_by_name.out")), is(true));
+        assertThat(Files.exists(root().resolve("call_by_file.out")), is(true));
+        assertThat(Files.exists(root().resolve("call_sub.out")), is(true));
+        assertThat(Files.exists(root().resolve("call_subsub.out")), is(true));
+
+        // Verify pwd of the scripts
+        Path subPath = Paths.get(new String(Files.readAllBytes(root().resolve("call_sub.out")), UTF_8).trim());
+        Path subsubPath = Paths.get(new String(Files.readAllBytes(root().resolve("call_subsub.out")), UTF_8).trim());
+        assertThat(subPath.getFileName(), is(Paths.get("sub")));
+        assertThat(subsubPath.getFileName(), is(Paths.get("subsub")));
+        assertThat(subsubPath.getParent().getFileName(), is(Paths.get("sub")));
+    }
+}

--- a/digdag-tests/src/test/resources/acceptance/call/child.dig
+++ b/digdag-tests/src/test/resources/acceptance/call/child.dig
@@ -1,0 +1,2 @@
++hello:
+  sh>: pwd > ${outdir}/${name}.out

--- a/digdag-tests/src/test/resources/acceptance/call/parent.dig
+++ b/digdag-tests/src/test/resources/acceptance/call/parent.dig
@@ -1,0 +1,24 @@
++call_by_name:
+  _export:
+    name: call_by_name
+  +call:
+    call>: child
+
++call_by_file:
+  _export:
+    name: call_by_file
+  +call:
+    call>: child.dig
+
++call_sub:
+  _export:
+    name: call_sub
+  +call:
+    call>: sub/child.dig
+
++call_subsub:
+  _export:
+    name: call_subsub
+  +call:
+    call>: sub/subsub/child.dig
+


### PR DESCRIPTION
Dividing a large workflow definition into multiple files is helpful to
organize a complex workflow definition. call> is more straightforward
(and less hacky) compared to !include in terms of syntax.

This changes `call>` operator to be able to load workflow files from
any *.dig files in the project archive including files in subdirectories.

When `call>` calls a workflow in a subdirectory, the called workflow uses
the subdirectory as the working directory. This is a significant difference from
`!include`.

