### PR TITLE
Optimize WorkflowExecutor.propagateAllBlockedToReady

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
@@ -319,6 +319,25 @@ public class DatabaseSessionStoreManager
     }
 
     @Override
+    public List<Long> findDirectParentsOfBlockedTasks(long lastId)
+    {
+        return autoCommit((handle, dao) ->
+                handle.createQuery(
+                    "select distinct parent_id" +
+                    " from tasks" +
+                    " where parent_id > :lastId" +
+                    " and state = " + TaskStateCode.BLOCKED_CODE +
+                    " order by parent_id" +
+                    " limit :limit"
+                    )
+                .bind("lastId", lastId)
+                .bind("limit", 100)
+                .mapTo(Long.class)
+                .list()
+            );
+    }
+
+    @Override
     public boolean requestCancelAttempt(long attemptId)
     {
         return transaction((handle, dao, ts) -> {

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
@@ -291,7 +291,7 @@ public class DatabaseSessionStoreManager
     }
 
     @Override
-    public List<TaskStateSummary> findTasksByState(TaskStateCode state, long lastId)
+    public List<Long> findTasksByState(TaskStateCode state, long lastId)
     {
         return autoCommit((handle, dao) -> dao.findTasksByState(state.get(), lastId, 100));
     }
@@ -1492,14 +1492,14 @@ public class DatabaseSessionStoreManager
                 " limit :limit")
         List<TaskStateSummary> findRecentlyChangedTasks(@Bind("updatedSince") Instant updatedSince, @Bind("lastId") long lastId, @Bind("limit") int limit);
 
-        @SqlQuery("select id, attempt_id, parent_id, state, updated_at" +
+        @SqlQuery("select id" +
                 " from tasks" +
                 " where state = :state" +
                 " and id > :lastId" +
                 " order by id asc" +
                 //" order by updated_at asc, id asc" +
                 " limit :limit")
-        List<TaskStateSummary> findTasksByState(@Bind("state") short state, @Bind("lastId") long lastId, @Bind("limit") int limit);
+        List<Long> findTasksByState(@Bind("state") short state, @Bind("lastId") long lastId, @Bind("limit") int limit);
 
         @SqlQuery("select id from tasks" +
                 " where id = :id" +

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20151204221156_CreateTables.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20151204221156_CreateTables.java
@@ -161,7 +161,6 @@ public class Migration_20151204221156_CreateTables
         handle.update("create index tasks_on_attempt_id on tasks (attempt_id, id)");
         handle.update("create index tasks_on_parent_id_and_state on tasks (parent_id, state)");
         if (context.isPostgres()) {
-            // for findDirectParentsOfBlockedTasks at propagateBlockedChildrenToReady
             // for findTasksByState(PLANNED) at propagateAllPlannedToDone
             // for findTasksByState(READY) through findAllReadyTaskIds() at enqueueReadyTasks
             handle.update("create index tasks_on_state_and_id on tasks (state, id) where state = 0 or state = 1 or state = 5");

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20151204221156_CreateTables.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20151204221156_CreateTables.java
@@ -161,7 +161,7 @@ public class Migration_20151204221156_CreateTables
         handle.update("create index tasks_on_attempt_id on tasks (attempt_id, id)");
         handle.update("create index tasks_on_parent_id_and_state on tasks (parent_id, state)");
         if (context.isPostgres()) {
-            // for findTasksByState(BLOCKED) at propagateAllBlockedToReady
+            // for findDirectParentsOfBlockedTasks at propagateBlockedChildrenToReady
             // for findTasksByState(PLANNED) at propagateAllPlannedToDone
             // for findTasksByState(READY) through findAllReadyTaskIds() at enqueueReadyTasks
             handle.update("create index tasks_on_state_and_id on tasks (state, id) where state = 0 or state = 1 or state = 5");

--- a/digdag-core/src/main/java/io/digdag/core/session/SessionStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/session/SessionStoreManager.java
@@ -42,7 +42,7 @@ public interface SessionStoreManager
     List<TaskStateSummary> findRecentlyChangedTasks(Instant updatedSince, long lastId);
 
     // for WorkflowExecutorManager.propagateAllPlannedToDone
-    List<TaskStateSummary> findTasksByState(TaskStateCode state, long lastId);
+    List<Long> findTasksByState(TaskStateCode state, long lastId);
 
     // for WorkflowExecutorManager.propagateSessionArchive
     List<TaskAttemptSummary> findRootTasksByStates(TaskStateCode[] states, long lastId);

--- a/digdag-core/src/main/java/io/digdag/core/session/SessionStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/session/SessionStoreManager.java
@@ -47,6 +47,8 @@ public interface SessionStoreManager
     // for WorkflowExecutorManager.propagateSessionArchive
     List<TaskAttemptSummary> findRootTasksByStates(TaskStateCode[] states, long lastId);
 
+    List<Long> findDirectParentsOfBlockedTasks(long lastId);
+
     boolean requestCancelAttempt(long attemptId);
 
     int trySetRetryWaitingToReady();

--- a/digdag-core/src/main/java/io/digdag/core/session/SessionStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/session/SessionStoreManager.java
@@ -41,12 +41,13 @@ public interface SessionStoreManager
     // for WorkflowExecutorManager.IncrementalStatusPropagator.propagateStatus
     List<TaskStateSummary> findRecentlyChangedTasks(Instant updatedSince, long lastId);
 
-    // for WorkflowExecutorManager.propagateAllBlockedToReady
+    // for WorkflowExecutorManager.propagateAllPlannedToDone
     List<TaskStateSummary> findTasksByState(TaskStateCode state, long lastId);
 
     // for WorkflowExecutorManager.propagateSessionArchive
     List<TaskAttemptSummary> findRootTasksByStates(TaskStateCode[] states, long lastId);
 
+    // for WorkflowExecutorManager.propagateBlockedChildrenToReady
     List<Long> findDirectParentsOfBlockedTasks(long lastId);
 
     boolean requestCancelAttempt(long attemptId);

--- a/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java
+++ b/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java
@@ -473,20 +473,20 @@ public class WorkflowExecutor
         boolean anyChanged = false;
         long lastTaskId = 0;
         while (true) {
-            List<TaskStateSummary> tasks = sm.findTasksByState(TaskStateCode.PLANNED, lastTaskId);
-            if (tasks.isEmpty()) {
+            List<Long> taskIds = sm.findTasksByState(TaskStateCode.PLANNED, lastTaskId);
+            if (taskIds.isEmpty()) {
                 break;
             }
             anyChanged =
-                tasks
+                taskIds
                 .stream()
-                .map(summary -> {
-                    return sm.lockTaskIfExists(summary.getId(), (store, storedTask) ->
+                .map(taskId -> {
+                    return sm.lockTaskIfExists(taskId, (store, storedTask) ->
                         setDoneFromDoneChildren(new TaskControl(store, storedTask))
                     ).or(false);
                 })
                 .reduce(anyChanged, (a, b) -> a || b);
-            lastTaskId = tasks.get(tasks.size() - 1).getId();
+            lastTaskId = taskIds.get(taskIds.size() - 1);
         }
         return anyChanged;
     }


### PR DESCRIPTION
This method takes very long time if number of BLOCKED tasks
increased because it has a loop in it. Because the loop blocks
shutdown process, server returns 503 Service Unavailable to
clients for long time.

This method was fetching all BLOCKED tasks and get their parent_id.
If this method uses SQL to get the parent_id list directly, number of
the loop and data transfer from database to the server become several
times smaller.

```
=> select count(*) from (select id, parent_id, state from tasks where state = 0) orig;
  count
---------
 5278779
(1 row)

Time: 2877.191 ms
```

```
=> select count(*) from (select distinct parent_id from tasks where state = 0) optimized;
 count
--------
 135461
(1 row)

Time: 3972.704 ms
```

Query plan:

```
=> explain analyze select distinct parent_id from tasks where parent_id > 12345 and state = 0 order by parent_id limit 100;
                                                                            QUERY PLAN
-------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.43..356.94 rows=100 width=8) (actual time=0.039..3.068 rows=100 loops=1)
   ->  Unique  (cost=0.43..240934.82 rows=67581 width=8) (actual time=0.037..2.779 rows=100 loops=1)
         ->  Index Only Scan using tasks_on_parent_id_and_state on tasks  (cost=0.43..227809.86 rows=5249982 width=8) (actual time=0.033..1.553 rows=1088 loops=1)
               Index Cond: ((parent_id > 12345) AND (state = 0))
               Heap Fetches: 1023
 Planning time: 0.102 ms
 Execution time: 3.184 ms
(7 rows)
```

This query is scalable against number of tasks because query plan doesn't include SORT node.