### PR TITLE
Remove unnecessary UPDATE call when leaf tasks successfully finished

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
@@ -848,7 +848,7 @@ public class DatabaseSessionStoreManager
             return n > 0;
         }
 
-        public boolean setDoneStateShortCircuit(long taskId, TaskStateCode beforeState, TaskStateCode afterState, Config error)
+        public boolean setErrorStateShortCircuit(long taskId, TaskStateCode beforeState, TaskStateCode afterState, Config error)
         {
             long n = dao.setDoneState(taskId, beforeState.get(), afterState.get());
             if (n > 0) {
@@ -859,6 +859,20 @@ public class DatabaseSessionStoreManager
         }
 
         public boolean setPlannedStateSuccessful(long taskId, TaskStateCode beforeState, TaskStateCode afterState, TaskResult result)
+        {
+            long n = dao.setState(taskId, beforeState.get(), afterState.get());
+            if (n > 0) {
+                dao.setSuccessfulReport(taskId,
+                        result.getSubtaskConfig(),
+                        result.getExportParams(),
+                        result.getStoreParams(),
+                        cf.create());  // TODO create a class for stored report
+                return true;
+            }
+            return false;
+        }
+
+        public boolean setSuccessStateShortCircuit(long taskId, TaskStateCode beforeState, TaskStateCode afterState, TaskResult result)
         {
             long n = dao.setState(taskId, beforeState.get(), afterState.get());
             if (n > 0) {

--- a/digdag-core/src/main/java/io/digdag/core/session/TaskControlStore.java
+++ b/digdag-core/src/main/java/io/digdag/core/session/TaskControlStore.java
@@ -40,8 +40,11 @@ public interface TaskControlStore
 
     boolean setDoneState(long taskId, TaskStateCode beforeState, TaskStateCode afterState);
 
-    // planned to error
-    boolean setDoneStateShortCircuit(long taskId, TaskStateCode beforeState, TaskStateCode afterState, Config error);
+    // running to success
+    boolean setSuccessStateShortCircuit(long taskId, TaskStateCode beforeState, TaskStateCode afterState, TaskResult result);
+
+    // running to error
+    boolean setErrorStateShortCircuit(long taskId, TaskStateCode beforeState, TaskStateCode afterState, Config error);
 
     // planned to success
     boolean setPlannedStateSuccessful(long taskId, TaskStateCode beforeState, TaskStateCode afterState, TaskResult result);

--- a/digdag-core/src/main/java/io/digdag/core/workflow/TaskControl.java
+++ b/digdag-core/src/main/java/io/digdag/core/workflow/TaskControl.java
@@ -277,9 +277,10 @@ public class TaskControl
         return false;
     }
 
+    // setRunningToPlannedWithDelayedError + setPlannedToError
     public boolean setRunningToShortCircuitError(Config error)
     {
-        if (store.setDoneStateShortCircuit(getId(), TaskStateCode.RUNNING, TaskStateCode.ERROR, error)) {
+        if (store.setErrorStateShortCircuit(getId(), TaskStateCode.RUNNING, TaskStateCode.ERROR, error)) {
             state = TaskStateCode.ERROR;
             return true;
         }
@@ -343,6 +344,16 @@ public class TaskControl
         }
         return false;
         // transitionToPlanned
+    }
+
+    // setRunningToPlannedSuccessful + setPlannedToSuccess
+    public boolean setRunningToShortCircuitSuccess(TaskResult result)
+    {
+        if (store.setSuccessStateShortCircuit(getId(), TaskStateCode.RUNNING, TaskStateCode.SUCCESS, result)) {
+            state = TaskStateCode.SUCCESS;
+            return true;
+        }
+        return false;
     }
 
     // to planned with error

--- a/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java
+++ b/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java
@@ -98,7 +98,7 @@ import static java.util.Locale.ENGLISH;
  *       : ERROR with error
  *
  *   taskSucceeded:
- *     lockedTask.setRunningToPlannedSuccessful:
+ *     (if subtasks or check task exist) lockedTask.setRunningToPlannedSuccessful:
  *       : PLANNED
  *     lockedTask.setRunningToShortCircuitSuccess:
  *       : SUCCESS


### PR DESCRIPTION
taskSucceeded callback uses setRunningToPlannedSuccessful to change task
state to PLANNED without flags (flags are set only when state is in
PLANNED). setDoneFromDoneChildren changes task state to SUCCESS if the
task is in PLANNED state and there're no flags if there're no children.
This means that taskSucceeded callback can set SUCCESS state immediately
if it doesn't add children.