### PR TITLE
Move /schedules?project_id=&workflow= to /projects/id to be consistent with #46

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/client/Backfill.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Backfill.java
@@ -119,7 +119,7 @@ public class Backfill
     private static RestSchedule findScheduleByWorkflowName(DigdagClient client,
             String projName, String workflowName)
     {
-        for (RestSchedule sched : client.getSchedules()) {
+        for (RestSchedule sched : client.getSchedules(Optional.absent())) {  // TODO use pagination (last_id) to get all schedules
             if (projName.equals(sched.getProject().getName()) &&
                     workflowName.equals(sched.getWorkflow().getName())) {
                 return sched;

--- a/digdag-cli/src/main/java/io/digdag/cli/client/ShowSchedule.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/ShowSchedule.java
@@ -1,5 +1,7 @@
 package io.digdag.cli.client;
 
+import com.google.common.base.Optional;
+
 import io.digdag.cli.SystemExitException;
 import io.digdag.cli.TimeUtil;
 import io.digdag.client.DigdagClient;
@@ -41,7 +43,7 @@ public class ShowSchedule
         DigdagClient client = buildClient();
         ln("Schedules:");
         int count = 0;
-        for (RestSchedule sched : client.getSchedules()) {
+        for (RestSchedule sched : client.getSchedules(Optional.absent())) {  // TODO use pagination (last_id) to get all schedules
             ln("  id: %d", sched.getId());
             ln("  project: %s", sched.getProject().getName());
             ln("  workflow: %s", sched.getWorkflow().getName());

--- a/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
+++ b/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
@@ -398,21 +398,32 @@ public class DigdagClient implements AutoCloseable
                 target("/api/schedules"));
     }
 
-    public List<RestSchedule> getSchedules(int projectId)
+    public List<RestSchedule> getSchedules(Optional<Integer> lastId)
     {
-        return getSchedules(projectId, Optional.absent());
+        return doGet(new GenericType<List<RestSchedule>>() { },
+                target("/api/schedules")
+                .queryParam("last_id", lastId.orNull()));
     }
 
-    public List<RestSchedule> getSchedules(int projectId, String workflowName) {
-        return getSchedules(projectId, Optional.of(workflowName));
+    public List<RestSchedule> getSchedules(int projectId, Optional<Integer> lastId)
+    {
+        return getSchedules(projectId, Optional.absent(), lastId);
     }
 
-    public List<RestSchedule> getSchedules(int projectId, Optional<String> workflowName)
+    public List<RestSchedule> getSchedules(int projectId, String workflowName)
+    {
+        return getSchedules(projectId, Optional.of(workflowName), Optional.absent());
+    }
+
+    public List<RestSchedule> getSchedules(int projectId, Optional<String> workflowName, Optional<Integer> lastId)
     {
         WebTarget target = target("/api/schedules")
                 .queryParam("project_id", projectId);
         if (workflowName.isPresent()) {
             target = target.queryParam("workflow", workflowName.get());
+        }
+        else {
+            target = target.queryParam("last_id", lastId.orNull());
         }
         return doGet(new GenericType<List<RestSchedule>>() {}, target);
     }

--- a/digdag-tests/src/test/java/acceptance/ServerScheduleIT.java
+++ b/digdag-tests/src/test/java/acceptance/ServerScheduleIT.java
@@ -127,7 +127,7 @@ public class ServerScheduleIT
         assertThat(scheds.size(), is(1));
         RestSchedule sched = scheds.get(0);
 
-        List<RestSchedule> projectSchedules = client.getSchedules(projectId);
+        List<RestSchedule> projectSchedules = client.getSchedules(projectId, Optional.absent());
         assertThat(projectSchedules, is(scheds));
 
         List<RestSchedule> workflowSchedules = client.getSchedules(projectId, "schedule");

--- a/digdag-tests/src/test/java/acceptance/ServerScheduleIT.java
+++ b/digdag-tests/src/test/java/acceptance/ServerScheduleIT.java
@@ -4,9 +4,11 @@ import com.google.common.base.Optional;
 import io.digdag.client.DigdagClient;
 import io.digdag.client.api.RestSchedule;
 import io.digdag.client.api.RestScheduleSummary;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import utils.CommandStatus;
 import utils.TemporaryDigdagServer;
@@ -18,8 +20,12 @@ import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.util.List;
 
+import javax.ws.rs.NotFoundException;
+
 import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertThat;
 import static utils.TestUtils.addWorkflow;
 import static utils.TestUtils.copyResource;
@@ -33,6 +39,9 @@ public class ServerScheduleIT
 
     @Rule
     public TemporaryDigdagServer server = TemporaryDigdagServer.of();
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
 
     private Path config;
     private Path projectDir;
@@ -49,6 +58,13 @@ public class ServerScheduleIT
                 .host(server.host())
                 .port(server.port())
                 .build();
+    }
+
+    @After
+    public void shutdown()
+            throws Exception
+    {
+        client.close();
     }
 
     @Test
@@ -130,8 +146,8 @@ public class ServerScheduleIT
         List<RestSchedule> projectSchedules = client.getSchedules(projectId, Optional.absent());
         assertThat(projectSchedules, is(scheds));
 
-        List<RestSchedule> workflowSchedules = client.getSchedules(projectId, "schedule");
-        assertThat(workflowSchedules, is(scheds));
+        RestSchedule workflowSchedule = client.getSchedule(projectId, "schedule");
+        assertThat(workflowSchedule, is(sched));
 
         assertThat(sched.getProject().getName(), is("foobar"));
         assertThat(sched.getNextRunTime(), is(Instant.parse("2291-02-09T00:09:00Z")));  // updated to hourly
@@ -193,5 +209,55 @@ public class ServerScheduleIT
         assertThat(schedulesAfterPush.size(), is(1));
         assertThat(schedulesAfterPush.get(0).getId(), is(sched.getId()));
         assertThat(schedulesAfterPush.get(0).getDisabledAt(), is(disabled.getDisabledAt()));
+    }
+
+    @Test
+    public void deleteProjectAndLookupByProjectId()
+            throws Exception
+    {
+        Files.createDirectories(projectDir);
+        addWorkflow(projectDir, "acceptance/schedule/daily10.dig", "schedule.dig");
+        int projectId = pushProject(server.endpoint(), projectDir);
+
+        // Delete project
+        client.deleteProject(projectId);
+
+        // Schedules are not available
+        assertThat(client.getSchedules().size(), is(0));
+
+        exception.expectMessage(containsString("HTTP 404 Not Found"));
+        exception.expect(NotFoundException.class);
+        client.getSchedules(projectId, Optional.absent());
+    }
+
+    @Test
+    public void deleteProjectAndLookByName()
+            throws Exception
+    {
+        Files.createDirectories(projectDir);
+        addWorkflow(projectDir, "acceptance/schedule/daily10.dig", "schedule.dig");
+        int projectId = pushProject(server.endpoint(), projectDir);
+
+        // Delete project
+        client.deleteProject(projectId);
+
+        // Schedules are not available
+        exception.expectMessage(containsString("HTTP 404 Not Found"));
+        exception.expect(NotFoundException.class);
+        client.getSchedule(projectId, "schedule");
+    }
+
+    @Test
+    public void getScheduleByInvalidName()
+            throws Exception
+    {
+        Files.createDirectories(projectDir);
+        addWorkflow(projectDir, "acceptance/schedule/daily10.dig", "schedule.dig");
+        int projectId = pushProject(server.endpoint(), projectDir);
+
+        exception.expectMessage(containsString("schedule not found in the latest revision"));
+        exception.expectMessage(not(containsString("HTTP 404 Not Found")));
+        exception.expect(NotFoundException.class);
+        client.getSchedule(projectId, "hieizanenryakuzi");
     }
 }


### PR DESCRIPTION
#46 added plural REST API with ?name= parameter.

> If a resource exist, these new REST API return an array with one element in it. If a resource doesn't exist, it returns an empty array (not 404 Not Found). With this way, client can tell that a project doesn't exist when GET /api/projects/{id}/workflows?name=<name>[&revision=name] returns 404 Not Found because it returns an empty array if a project exists but workflow doesn't exist.

This is PR to #309.