### PR TITLE
Add /workflows REST API

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/client/ShowWorkflow.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/ShowWorkflow.java
@@ -53,16 +53,14 @@ public class ShowWorkflow
             }
         }
         else {
-            for (RestProject proj : client.getProjects()) {
-                try {
-                    List<RestWorkflowDefinition> defs = client.getWorkflowDefinitions(proj.getId());
-                    ln("  %s", proj.getName());
-                    for (RestWorkflowDefinition def : defs) {
-                        ln("    %s", def.getName());
-                    }
+            List<RestWorkflowDefinition> defs = client.getWorkflowDefinitions();
+            String lastProjName = null;
+            for (RestWorkflowDefinition def : defs) {
+                if (!def.getProject().getName().equals(lastProjName)) {
+                    ln("  %s", def.getProject().getName());
+                    lastProjName = def.getProject().getName();
                 }
-                catch (NotFoundException ex) {
-                }
+                ln("    %s", def.getName());
             }
         }
         ln("");

--- a/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
+++ b/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
@@ -277,6 +277,19 @@ public class DigdagClient implements AutoCloseable
                 .queryParam("last_id", lastId.orNull()));
     }
 
+    public List<RestWorkflowDefinition> getWorkflowDefinitions()
+    {
+        return doGet(new GenericType<List<RestWorkflowDefinition>>() { },
+                target("/api/workflows"));
+    }
+
+    public List<RestWorkflowDefinition> getWorkflowDefinitions(Optional<Long> lastId)
+    {
+        return doGet(new GenericType<List<RestWorkflowDefinition>>() { },
+                target("/api/workflows")
+                .queryParam("last_id", lastId.orNull()));
+    }
+
     public List<RestWorkflowDefinition> getWorkflowDefinitions(int projId)
     {
         return doGet(new GenericType<List<RestWorkflowDefinition>>() { },

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseMigrator.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseMigrator.java
@@ -27,7 +27,8 @@ public class DatabaseMigrator
 		new Migration_20160818043815_AddFinishedAtToSessionAttempts(),
 		new Migration_20160818220026_QueueUniqueName(),
 		new Migration_20160908175551_KeepSecretsUnique(),
-        new Migration_20160926123456_AddDisabledAtColumnToSchedules()
+        new Migration_20160926123456_AddDisabledAtColumnToSchedules(),
+        new Migration_20160928203753_AddWorkflowOrderIndex(),
 	})
     .sorted(Comparator.comparing(m -> m.getVersion()))
     .collect(Collectors.toList());

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
@@ -579,6 +579,7 @@ public class DatabaseProjectStoreManager
                         " where p.site_id = :siteId" +
                         " and p.deleted_at is null" +
                         " group by r.project_id" +
+                    " )) " +
                     " and wf.id > :lastId" +
                     " order by wf.id" +
                     " limit :limit" +

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
@@ -536,13 +536,12 @@ public class DatabaseProjectStoreManager
                 " join (" +
                     // list id of active (non-deleted) latest revisions in this site.
                     // this is not efficient but gave up optimization on h2.
-                    "select project_id, max(id) as revision_id from revisions" +
-                    " where project_id in (" +
-                        "select id from projects" +
-                        " where site_id = :siteId" +
-                        " and deleted_at is null" +
-                        ")" +
-                    " group by project_id" +
+                    "select r.project_id, max(r.id) as revision_id" +
+                    " from revisions r" +
+                    " join projects p on r.project_id = p.id" +
+                    " where p.site_id = :siteId" +
+                    " and p.deleted_at is null" +
+                    " group by r.project_id" +
                 ") a on wd.revision_id = a.revision_id" +
                 " join revisions rev on a.revision_id = rev.id" +
                 " join projects proj on a.project_id = proj.id" +
@@ -574,14 +573,12 @@ public class DatabaseProjectStoreManager
                     "select * from workflow_definitions wf" +
                     " where wf.revision_id = any(array(" +
                         // list id of active (non-deleted) latest revisions in this site
-                        "select max(id) from revisions" +
-                        " where project_id = any(array(" +
-                            "select id from projects" +
-                            " where site_id = :siteId" +
-                            " and deleted_at is null" +
-                            "))" +
-                        " group by project_id" +
-                        "))" +
+                        "select max(r.id)" +
+                        " from revisions r" +
+                        " join projects p on r.project_id = p.id" +
+                        " where p.site_id = :siteId" +
+                        " and p.deleted_at is null" +
+                        " group by r.project_id" +
                     " and wf.id > :lastId" +
                     " order by wf.id" +
                     " limit :limit" +

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
@@ -282,6 +282,13 @@ public class DatabaseProjectStoreManager
         }
 
         @Override
+        public List<StoredWorkflowDefinitionWithProject> getLatestActiveWorkflowDefinitions(int pageSize, Optional<Long> lastId)
+            throws ResourceNotFoundException
+        {
+            return autoCommit((handle, dao) -> dao.getLatestActiveWorkflowDefinitions(siteId, pageSize, lastId.or(0L)));
+        }
+
+        @Override
         public List<StoredWorkflowDefinition> getWorkflowDefinitions(int revId, int pageSize, Optional<Long> lastId)
         {
             return autoCommit((handle, dao) -> dao.getWorkflowDefinitions(siteId, revId, pageSize, lastId.or(0L)));
@@ -520,6 +527,30 @@ public class DatabaseProjectStoreManager
                 " key (site_id, name)" +
                 " values (:siteId, :name, coalesce((select created_at from projects where site_id = :siteId and name = :name), now()))")
         void upsertAndLockProject(@Bind("siteId") int siteId, @Bind("name") String name);
+
+        @Override
+        @SqlQuery("select wd.*, wc.config, wc.timezone," +
+                " proj.id as proj_id, proj.name as proj_name, proj.deleted_name as proj_deleted_name, proj.deleted_at as proj_deleted_at, proj.site_id, proj.created_at as proj_created_at," +
+                " rev.name as rev_name, rev.default_params as rev_default_params" +
+                " from workflow_definitions wd" +
+                " join (" +
+                    // list id of active (non-deleted) latest revisions in this site.
+                    // this is not efficient but gave up optimization on h2.
+                    "select project_id, max(id) as revision_id from revisions" +
+                    " where project_id in (" +
+                        "select id from projects" +
+                        " where site_id = :siteId" +
+                        " and deleted_at is null" +
+                        ")" +
+                    " group by project_id" +
+                ") a on wd.revision_id = a.revision_id" +
+                " join revisions rev on a.revision_id = rev.id" +
+                " join projects proj on a.project_id = proj.id" +
+                " join workflow_configs wc on wc.id = wd.config_id" +
+                " where wd.id > :lastId" +
+                " order by wd.id" +
+                " limit :limit")
+        List<StoredWorkflowDefinitionWithProject> getLatestActiveWorkflowDefinitions(@Bind("siteId") int siteId, @Bind("limit") int limit, @Bind("lastId") long lastId);
     }
 
     public interface PgDao
@@ -533,6 +564,33 @@ public class DatabaseProjectStoreManager
                 // this query includes "set created_at = projects.created_at" because "do nothing"
                 // doesn't lock the row
         StoredProject upsertAndLockProject(@Bind("siteId") int siteId, @Bind("name") String name);
+
+        @Override
+        @SqlQuery("select wd.*, wc.config, wc.timezone," +
+                " proj.id as proj_id, proj.name as proj_name, proj.deleted_name as proj_deleted_name, proj.deleted_at as proj_deleted_at, proj.site_id, proj.created_at as proj_created_at," +
+                " rev.name as rev_name, rev.default_params as rev_default_params" +
+                " from (" +
+                    // order by id and limit before join
+                    "select * from workflow_definitions wf" +
+                    " where wf.revision_id = any(array(" +
+                        // list id of active (non-deleted) latest revisions in this site
+                        "select max(id) from revisions" +
+                        " where project_id = any(array(" +
+                            "select id from projects" +
+                            " where site_id = :siteId" +
+                            " and deleted_at is null" +
+                            "))" +
+                        " group by project_id" +
+                        "))" +
+                    " and wf.id > :lastId" +
+                    " order by wf.id" +
+                    " limit :limit" +
+                ") wd" +
+                " join revisions rev on rev.id = wd.revision_id" +
+                " join projects proj on proj.id = rev.project_id" +
+                " join workflow_configs wc on wc.id = wd.config_id" +
+                " order by wd.id")
+        List<StoredWorkflowDefinitionWithProject> getLatestActiveWorkflowDefinitions(@Bind("siteId") int siteId, @Bind("limit") int limit, @Bind("lastId") long lastId);
     }
 
     public interface Dao
@@ -629,6 +687,8 @@ public class DatabaseProjectStoreManager
                 " and proj.site_id = :siteId" +
                 " limit 1")
         StoredWorkflowDefinitionWithProject getLatestWorkflowDefinitionByName(@Bind("siteId") int siteId, @Bind("projId") int projId, @Bind("name") String name);
+
+        List<StoredWorkflowDefinitionWithProject> getLatestActiveWorkflowDefinitions(int siteId, int limit, long lastId);
 
         // getWorkflowDetailsById is same with getWorkflowDetailsByIdInternal
         // excepting site_id check

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20160928203753_AddWorkflowOrderIndex.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20160928203753_AddWorkflowOrderIndex.java
@@ -8,7 +8,13 @@ public class Migration_20160928203753_AddWorkflowOrderIndex
     @Override
     public void migrate(Handle handle, MigrationContext context)
     {
-        // DatabaseProjectStoreManager.PgDao.getLatestActiveWorkflowDefinitions uses this index.
-        handle.update("create index workflow_definitions_on_revision_id_and_id on workflow_definitions (revision_id, id);");
+        // DatabaseProjectStoreManager.PgDao.getLatestActiveWorkflowDefinitions uses these indexes.
+        handle.update("create index workflow_definitions_on_revision_id_and_id on workflow_definitions (revision_id, id)");
+        if (context.isPostgres()) {
+            handle.update("create index projects_on_site_id_and_id on projects (site_id, id) where deleted_at is null");
+        }
+        else {
+            handle.update("create index projects_on_site_id_and_id on projects (site_id, id)");
+        }
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20160928203753_AddWorkflowOrderIndex.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20160928203753_AddWorkflowOrderIndex.java
@@ -1,0 +1,14 @@
+package io.digdag.core.database.migrate;
+
+import org.skife.jdbi.v2.Handle;
+
+public class Migration_20160928203753_AddWorkflowOrderIndex
+        implements Migration
+{
+    @Override
+    public void migrate(Handle handle, MigrationContext context)
+    {
+        // DatabaseProjectStoreManager.PgDao.getLatestActiveWorkflowDefinitions uses this index.
+        handle.update("create index workflow_definitions_on_revision_id_and_id on workflow_definitions (revision_id, id);");
+    }
+}

--- a/digdag-core/src/main/java/io/digdag/core/repository/ProjectStore.java
+++ b/digdag-core/src/main/java/io/digdag/core/repository/ProjectStore.java
@@ -62,5 +62,8 @@ public interface ProjectStore
     StoredWorkflowDefinitionWithProject getLatestWorkflowDefinitionByName(int projId, String name)
         throws ResourceNotFoundException;
 
+    List<StoredWorkflowDefinitionWithProject> getLatestActiveWorkflowDefinitions(int pageSize, Optional<Long> lastId)
+        throws ResourceNotFoundException;
+
     TimeZoneMap getWorkflowTimeZonesByIdList(List<Long> defIdList);
 }

--- a/digdag-server/src/main/java/io/digdag/server/rs/WorkflowResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/WorkflowResource.java
@@ -48,6 +48,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 public class WorkflowResource
     extends AuthenticatedResource
 {
+    // GET  /api/workflows                                   # list workflows of the latest revisions of active projects
     // GET  /api/workflows/{id}                              # get a workflow
     // GET  /api/workflows/{id}/truncated_session_time       # truncate a time based on timzeone of this workflow
     //
@@ -92,6 +93,20 @@ public class WorkflowResource
         }
         StoredWorkflowDefinition def = rs.getWorkflowDefinitionByName(rev.getId(), wfName);
         return RestModels.workflowDefinition(proj, rev, def);
+    }
+
+    @GET
+    @Path("/api/workflows")
+    public List<RestWorkflowDefinition> getWorkflowDefinitions(
+            @QueryParam("last_id") Long lastId)
+        throws ResourceNotFoundException
+    {
+        List<StoredWorkflowDefinitionWithProject> defs =
+            rm.getProjectStore(getSiteId())
+            .getLatestActiveWorkflowDefinitions(100, Optional.fromNullable(lastId));
+        return defs.stream()
+            .map(def -> RestModels.workflowDefinition(def))
+            .collect(Collectors.toList());
     }
 
     @GET

--- a/digdag-tests/src/test/java/acceptance/td/TdConfIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/TdConfIT.java
@@ -149,7 +149,7 @@ public class TdConfIT
 
         assertThat(requests.isEmpty(), is(false));
         for (FullHttpRequest request : requests) {
-            assertThat(request.getUri(), is("http://foo.baz.bar:80/api/projects"));
+            assertThat(request.getUri(), is("http://foo.baz.bar:80/api/workflows"));
             assertThat(request.headers().get(AUTHORIZATION), is("TD1 " + MOCK_TD_API_KEY));
         }
     }
@@ -177,7 +177,7 @@ public class TdConfIT
 
         assertThat(requests.isEmpty(), is(false));
         for (FullHttpRequest request : requests) {
-            assertThat(request.getUri(), is("http://baz.quux:80/api/projects"));
+            assertThat(request.getUri(), is("http://baz.quux:80/api/workflows"));
             assertThat(request.headers().get(AUTHORIZATION), is("FOO " + MOCK_TD_API_KEY));
         }
     }


### PR DESCRIPTION
This improves latency of typical operations including `digdag workflows`
command.

New indexes are for PostgreSQL so that it can run the query without Sort or HashAggregate nodes as following. Query execution time doesn't increase depending number of old deleted projects or old revisions.

```
=> explain select wd.*, wc.config, wc.timezone, proj.id as proj_id, proj.name as proj_name, proj.deleted_name as proj_deleted_name, proj.deleted_at as proj_deleted_at, proj.site_id, proj.created_at as proj_created_at, rev.name as rev_name, rev.default_params as rev_default_params from (select * from workflow_definitions wf where wf.revision_id = any(array(select max(r.id) from revisions r join projects p on r.project_id = p.id where p.site_id = 1 and p.deleted_at is null group by r.project_id)) and wf.id > 10 order by wf.id limit 10) wd join revisions rev on rev.id = wd.revision_id join projects proj on proj.id = rev.project_id join workflow_configs wc on wc.id = wd.config_id order by wd.id;
                                                                 QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------------------
 Nested Loop  (cost=8.70..34.10 rows=9 width=368)
   ->  Nested Loop  (cost=8.56..25.82 rows=9 width=213)
         ->  Nested Loop  (cost=8.42..23.87 rows=10 width=129)
               ->  Limit  (cost=8.28..14.55 rows=10 width=26)
                     InitPlan 1 (returns $1)
                       ->  GroupAggregate  (cost=0.28..8.13 rows=7 width=8)
                             Group Key: r.project_id
                             ->  Nested Loop  (cost=0.28..8.03 rows=7 width=8)
                                   ->  Index Scan using projects_on_site_id_and_id on projects p  (cost=0.14..3.15 rows=1 width=4)
                                         Index Cond: (site_id = 1)
                                   ->  Index Only Scan using revisions_on_project_id_and_id on revisions r  (cost=0.14..4.80 rows=7 width=8)
                                         Index Cond: (project_id = p.id)
                     ->  Index Scan using workflow_definitions_pkey on workflow_definitions wf  (cost=0.14..12.68 rows=20 width=26)
                           Index Cond: (id > 10)
                           Filter: (revision_id = ANY ($1))
               ->  Index Scan using revisions_pkey on revisions rev  (cost=0.14..0.91 rows=1 width=107)
                     Index Cond: (id = wf.revision_id)
         ->  Index Scan using projects_pkey on projects proj  (cost=0.14..0.18 rows=1 width=88)
               Index Cond: (id = rev.project_id)
   ->  Index Scan using workflow_configs_pkey on workflow_configs wc  (cost=0.14..0.91 rows=1 width=159)
         Index Cond: (id = wf.config_id)
```
