### PR TITLE
include usage of 'moment' to the default example

### DIFF
--- a/digdag-cli/src/main/resources/digdag/cli/init_examples/echo/workflow.dig
+++ b/digdag-cli/src/main/resources/digdag/cli/init_examples/echo/workflow.dig
@@ -4,7 +4,7 @@ timezone: UTC
   echo>: start ${session_time}
 
 +disp_current_date:
-  echo>: ${new Date().toUTCString()}
+  echo>: ${moment(session_time).utc().format('YYYY-MM-DD HH:mm:ss Z')}
 
 +repeat:
   for_each>:


### PR DESCRIPTION
that is added since #314.