### PR TITLE
separate user & system smtp config

### DIFF
--- a/digdag-tests/src/test/java/acceptance/ErrorServerMailIT.java
+++ b/digdag-tests/src/test/java/acceptance/ErrorServerMailIT.java
@@ -16,10 +16,10 @@ import utils.TestUtils;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
-import static utils.TestUtils.copyResource;
-import static utils.TestUtils.main;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static utils.TestUtils.copyResource;
+import static utils.TestUtils.main;
 import static utils.TestUtils.startMailServer;
 
 public class ErrorServerMailIT
@@ -29,8 +29,10 @@ public class ErrorServerMailIT
     private static final String LOCAL_SESSION_TIME = "2016-01-02 03:04:05";
     private static final String SESSION_TIME_ISO = "2016-01-02T03:04:05+00:00";
     private static final String HOSTNAME = "127.0.0.1";
+    private static final String SMTP_USER = "mail-user";
+    private static final String SMTP_PASS = "mail-pass";
 
-    private final Wiser mailServer = startMailServer(HOSTNAME);
+    private final Wiser mailServer = startMailServer(HOSTNAME, SMTP_USER, SMTP_PASS);
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
@@ -41,8 +43,8 @@ public class ErrorServerMailIT
                     "config.mail.host=" + HOSTNAME,
                     "config.mail.port=" + mailServer.getServer().getPort(),
                     "config.mail.from=" + SENDER,
-                    "config.mail.username=mail-user",
-                    "config.mail.password=mail-pass",
+                    "config.mail.username=" + SMTP_USER,
+                    "config.mail.password=" + SMTP_PASS,
                     "config.mail.tls=false"
             )
             .build();

--- a/digdag-tests/src/test/java/acceptance/LocalModeMailIT.java
+++ b/digdag-tests/src/test/java/acceptance/LocalModeMailIT.java
@@ -26,8 +26,10 @@ public class LocalModeMailIT
     private static final String LOCAL_SESSION_TIME = "2016-01-02 03:04:05";
     private static final String SESSION_TIME_ISO = "2016-01-02T03:04:05+00:00";
     private static final String HOSTNAME = "127.0.0.1";
+    private static final String SMTP_USER = "mail-user";
+    private static final String SMTP_PASS = "mail-pass";
 
-    private final Wiser mailServer = startMailServer(HOSTNAME);
+    private final Wiser mailServer = startMailServer(HOSTNAME, SMTP_USER, SMTP_PASS);
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
@@ -53,8 +55,8 @@ public class LocalModeMailIT
                 "params.mail.host=" + HOSTNAME,
                 "params.mail.port=" + mailServer.getServer().getPort(),
                 "params.mail.from=" + SENDER,
-                "params.mail.username=mail-user",
-                "params.mail.password=mail-pass",
+                "params.mail.username=" + SMTP_USER,
+                "secrets.mail.password=" + SMTP_PASS,
                 "params.mail.tls=false"
         ));
         Path configFile = configDir.resolve("config");

--- a/digdag-tests/src/test/java/acceptance/MailNotificationIT.java
+++ b/digdag-tests/src/test/java/acceptance/MailNotificationIT.java
@@ -5,6 +5,10 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.subethamail.smtp.AuthenticationHandler;
 import org.subethamail.wiser.Wiser;
 import org.subethamail.wiser.WiserMessage;
 import utils.CommandStatus;
@@ -15,6 +19,7 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
 
+import static org.mockito.Mockito.when;
 import static utils.TestUtils.attemptSuccess;
 import static utils.TestUtils.copyResource;
 import static utils.TestUtils.expect;
@@ -32,8 +37,10 @@ public class MailNotificationIT
     private static final String HOSTNAME = "127.0.0.1";
     private static final String SENDER = "digdag@foo.bar";
     private static final String RECEIVER = "alert@foo.bar";
+    private static final String SMTP_USER = "mail-user";
+    private static final String SMTP_PASS = "mail-pass";
 
-    private final Wiser mailServer = startMailServer(HOSTNAME);
+    private Wiser mailServer = startMailServer(HOSTNAME, SMTP_USER, SMTP_PASS);
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
@@ -46,8 +53,8 @@ public class MailNotificationIT
                     "notification.mail.from = " + SENDER,
                     "notification.mail.host= " + HOSTNAME,
                     "notification.mail.port=" + mailServer.getServer().getPort(),
-                    "notification.mail.username=mail-user",
-                    "notification.mail.password=mail-pass",
+                    "notification.mail.username=" + SMTP_USER,
+                    "notification.mail.password=" + SMTP_PASS,
                     "notification.mail.tls=false")
             .build();
 

--- a/digdag-tests/src/test/java/acceptance/td/Secrets.java
+++ b/digdag-tests/src/test/java/acceptance/td/Secrets.java
@@ -1,8 +1,8 @@
 package acceptance.td;
 
-import com.amazonaws.util.Base64;
 import com.google.common.collect.ImmutableList;
 
+import java.util.Base64;
 import java.util.Collection;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -14,7 +14,7 @@ public class Secrets
         ThreadLocalRandom.current().nextBytes(ENCRYPTION_KEY_BYTES);
     }
 
-    static final String ENCRYPTION_KEY = Base64.encodeAsString(ENCRYPTION_KEY_BYTES);
+    static final String ENCRYPTION_KEY = Base64.getEncoder().encodeToString(ENCRYPTION_KEY_BYTES);
 
     static Collection<String> secretsServerConfiguration()
     {

--- a/digdag-tests/src/test/java/utils/TemporaryDigdagServer.java
+++ b/digdag-tests/src/test/java/utils/TemporaryDigdagServer.java
@@ -13,7 +13,6 @@ import io.digdag.core.database.DataSourceProvider;
 import io.digdag.core.database.DatabaseConfig;
 import io.digdag.core.database.RemoteDatabaseConfig;
 import io.digdag.server.ServerRuntimeInfo;
-import org.junit.rules.RuleChain;
 import org.junit.rules.TemporaryFolder;
 import org.junit.rules.TestRule;
 import org.junit.runner.Description;
@@ -43,7 +42,7 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.LocalTime;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -54,9 +53,8 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadLocalRandom;
 
-import static utils.TestUtils.configFactory;
-import static utils.TestUtils.main;
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
@@ -735,6 +733,14 @@ public class TemporaryDigdagServer
         {
             properties.setProperty(key, value);
             return this;
+        }
+
+        public Builder withRandomSecretEncryptionKey()
+        {
+            byte[] key = new byte[128 / 8];
+            ThreadLocalRandom.current().nextBytes(key);
+            String keyBase64 = Base64.getEncoder().encodeToString(key);
+            return configuration("digdag.secret-encryption-key = " + keyBase64);
         }
 
         public TemporaryDigdagServer build()


### PR DESCRIPTION
The main purpose of this PR is to not send our system user/password to a user-controlled smtp host if the user specifies one.