### PR TITLE
move project compilation to server

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/client/Archive.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Archive.java
@@ -86,14 +86,11 @@ public class Archive
         ConfigFactory cf = injector.getInstance(ConfigFactory.class);
         ConfigLoaderManager loader = injector.getInstance(ConfigLoaderManager.class);
 
-        // read parameters
-        Config overrideParams = loadParams(cf, loader, loadSystemProperties(), paramsFile, params);
-
         // load project
         Path projectPath = (projectDirName == null) ?
             Paths.get("").toAbsolutePath() :
             Paths.get(projectDirName).normalize().toAbsolutePath();
-        injector.getInstance(Archiver.class).createArchive(projectPath, Paths.get(output), overrideParams);
+        injector.getInstance(Archiver.class).createArchive(projectPath, Paths.get(output));
 
         out.println("Created " + output + ".");
         out.println("Use `" + programName + " upload <path.tar.gz> <project> <revision>` to upload it a server.");

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Archive.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Archive.java
@@ -50,7 +50,6 @@ public class Archive
         err.println("Usage: " + programName + " archive [options...]");
         err.println("  Options:");
         err.println("        --project DIR                use this directory as the project directory (default: current directory)");
-        err.println("    -f, --file PATH                  use this file to load a project (default: digdag.dig)");
         err.println("    -o, --output ARCHIVE.tar.gz      output path (default: digdag.archive.tar.gz)");
         Main.showCommonOptions(env, err);
         return systemExit(error);

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Archive.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Archive.java
@@ -31,12 +31,6 @@ public class Archive
     @Parameter(names = {"--project"})
     String projectDirName = null;
 
-    @DynamicParameter(names = {"-p", "--param"})
-    Map<String, String> params = new HashMap<>();
-
-    @Parameter(names = {"-P", "--params-file"})
-    String paramsFile = null;
-
     @Parameter(names = {"-o", "--output"})
     String output = "digdag.archive.tar.gz";
 
@@ -83,9 +77,6 @@ public class Archive
     private void archive(Injector injector)
             throws IOException
     {
-        ConfigFactory cf = injector.getInstance(ConfigFactory.class);
-        ConfigLoaderManager loader = injector.getInstance(ConfigLoaderManager.class);
-
         // load project
         Path projectPath = (projectDirName == null) ?
             Paths.get("").toAbsolutePath() :

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Archiver.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Archiver.java
@@ -65,8 +65,8 @@ class Archiver
                         try (InputStream in = Files.newInputStream(absPath)) {
                             ByteStreams.copy(in, tar);
                         }
-                        tar.closeArchiveEntry();
                     }
+                    tar.closeArchiveEntry();
                 }
             });
 

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Push.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Push.java
@@ -36,12 +36,6 @@ public class Push
     @Parameter(names = {"--project"})
     String projectDirName = null;
 
-    @DynamicParameter(names = {"-p", "--param"})
-    Map<String, String> params = new HashMap<>();
-
-    @Parameter(names = {"-P", "--params-file"})
-    String paramsFile = null;
-
     @Parameter(names = {"-r", "--revision"})
     String revision = null;
 
@@ -96,12 +90,6 @@ public class Push
                 .initialize()
                 .getInjector();
 
-        ConfigFactory cf = injector.getInstance(ConfigFactory.class);
-        ConfigLoaderManager loader = injector.getInstance(ConfigLoaderManager.class);
-
-        // read parameters
-        Config overrideParams = loadParams(cf, loader, loadSystemProperties(), paramsFile, params);
-
         // schedule_from will be server's current time if not set
         Optional<Instant> scheduleFrom;
         if (scheduleFromString == null) {
@@ -115,7 +103,7 @@ public class Push
         Path projectPath = (projectDirName == null) ?
             Paths.get("").toAbsolutePath() :
             Paths.get(projectDirName).normalize().toAbsolutePath();
-        injector.getInstance(Archiver.class).createArchive(projectPath, archivePath, overrideParams);
+        injector.getInstance(Archiver.class).createArchive(projectPath, archivePath);
 
         DigdagClient client = buildClient();
         if ("".equals(revision)) {

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Push.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Push.java
@@ -58,8 +58,6 @@ public class Push
         err.println("  Options:");
         err.println("        --project DIR                use this directory as the project directory (default: current directory)");
         err.println("    -r, --revision REVISION          specific revision name instead of auto-generated UUID");
-        err.println("    -p, --param KEY=VALUE            overwrites a parameter (use multiple times to set many parameters)");
-        err.println("    -P, --params-file PATH.yml       reads parameters from a YAML file");
         err.println("        --schedule-from \"yyyy-MM-dd HH:mm:ss Z\"  start schedules from this time instead of current time");
         showCommonOptions();
         return systemExit(error);

--- a/digdag-core/src/main/java/io/digdag/core/archive/ArchiveMetadata.java
+++ b/digdag-core/src/main/java/io/digdag/core/archive/ArchiveMetadata.java
@@ -13,8 +13,6 @@ import io.digdag.client.config.Config;
 @JsonDeserialize(as = ImmutableArchiveMetadata.class)
 public abstract class ArchiveMetadata
 {
-    public static final String FILE_NAME = ".digdag.dig";
-
     @JsonProperty("workflows")
     public abstract WorkflowDefinitionList getWorkflowList();
 

--- a/digdag-core/src/main/java/io/digdag/core/archive/ProjectArchive.java
+++ b/digdag-core/src/main/java/io/digdag/core/archive/ProjectArchive.java
@@ -60,7 +60,7 @@ public class ProjectArchive
     }
 
     // reused by ProjectArchiveLoader.load
-    static void listFiles(Path projectPath, PathConsumer consumer)
+    public static void listFiles(Path projectPath, PathConsumer consumer)
         throws IOException
     {
         listFilesRecursively(projectPath, projectPath, consumer, new HashSet<>());

--- a/digdag-core/src/main/java/io/digdag/core/archive/ProjectArchive.java
+++ b/digdag-core/src/main/java/io/digdag/core/archive/ProjectArchive.java
@@ -60,7 +60,7 @@ public class ProjectArchive
     }
 
     // reused by ProjectArchiveLoader.load
-    public static void listFiles(Path projectPath, PathConsumer consumer)
+    static void listFiles(Path projectPath, PathConsumer consumer)
         throws IOException
     {
         listFilesRecursively(projectPath, projectPath, consumer, new HashSet<>());

--- a/digdag-tests/src/test/java/acceptance/BackfillIT.java
+++ b/digdag-tests/src/test/java/acceptance/BackfillIT.java
@@ -1,5 +1,6 @@
 package acceptance;
 
+import com.google.common.io.Resources;
 import io.digdag.client.DigdagClient;
 import io.digdag.client.api.RestSession;
 import org.junit.Before;
@@ -17,6 +18,7 @@ import java.time.OffsetDateTime;
 import java.util.List;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
 import static utils.TestUtils.attemptSuccess;
 import static utils.TestUtils.expect;
 import static utils.TestUtils.copyResource;
@@ -114,14 +116,15 @@ public class BackfillIT
             assertThat(cmd.code(), is(0));
         }
 
-        copyResource("acceptance/backfill/backfill_sequential.dig", projectDir.resolve("backfill_sequential.dig"));
+        Files.write(projectDir.resolve("backfill_sequential.dig"), asList(Resources.toString(
+                Resources.getResource("acceptance/backfill/backfill_sequential.dig"), UTF_8)
+                .replace("${outdir}", outdir.toString())));
 
         // Push
         {
             CommandStatus cmd = main("push",
                     "-c", config.toString(),
                     "-e", server.endpoint(),
-                    "-p", "outdir="+outdir.toString(),
                     "--project", projectDir.toString(),
                     "backfill-test");
             assertThat(cmd.errUtf8(), cmd.code(), is(0));

--- a/digdag-tests/src/test/java/acceptance/RetryIT.java
+++ b/digdag-tests/src/test/java/acceptance/RetryIT.java
@@ -1,5 +1,6 @@
 package acceptance;
 
+import com.google.common.io.Resources;
 import io.digdag.client.DigdagClient;
 import io.digdag.client.api.Id;
 import io.digdag.client.api.RestSessionAttempt;
@@ -14,6 +15,8 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
 import static utils.TestUtils.copyResource;
 import static utils.TestUtils.getAttemptId;
 import static utils.TestUtils.main;
@@ -162,13 +165,15 @@ public class RetryIT
     private void pushRevision(String resourceName, String workflowName)
             throws IOException
     {
-        copyResource(resourceName, projectDir.resolve(workflowName + ".dig"));
+        Files.write(projectDir.resolve(workflowName + ".dig"), asList(Resources.toString(
+                Resources.getResource(resourceName), UTF_8)
+                .replace("${outdir}", root().toString())));
+
         CommandStatus pushStatus = main("push",
                 "retry",
                 "-c", config.toString(),
                 "--project", projectDir.toString(),
-                "-e", server.endpoint(),
-                "-p", "outdir=" + root());
+                "-e", server.endpoint());
         assertThat(pushStatus.errUtf8(), pushStatus.code(), is(0));
     }
 

--- a/digdag-tests/src/test/java/acceptance/ServerGracefulShutdownIT.java
+++ b/digdag-tests/src/test/java/acceptance/ServerGracefulShutdownIT.java
@@ -78,7 +78,7 @@ public class ServerGracefulShutdownIT
                     projectDir.toString());
             assertThat(initStatus.code(), is(0));
 
-            Files.write(projectDir.resolve("acceptance/server_graceful_shutdown/sleep.dig"), asList(Resources.toString(
+            Files.write(projectDir.resolve("sleep.dig"), asList(Resources.toString(
                     Resources.getResource("acceptance/server_graceful_shutdown/sleep.dig"), UTF_8)
                     .replace("${outdir}", root().toString())));
 

--- a/digdag-tests/src/test/java/acceptance/ServerGracefulShutdownIT.java
+++ b/digdag-tests/src/test/java/acceptance/ServerGracefulShutdownIT.java
@@ -1,5 +1,6 @@
 package acceptance;
 
+import com.google.common.io.Resources;
 import io.digdag.client.DigdagClient;
 import io.digdag.client.api.Id;
 import io.digdag.client.api.RestSessionAttempt;
@@ -21,6 +22,8 @@ import java.util.List;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.ServiceUnavailableException;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
 import static utils.TestUtils.copyResource;
 import static utils.TestUtils.getAttemptId;
 import static utils.TestUtils.main;
@@ -75,14 +78,15 @@ public class ServerGracefulShutdownIT
                     projectDir.toString());
             assertThat(initStatus.code(), is(0));
 
-            copyResource("acceptance/server_graceful_shutdown/sleep.dig", projectDir.resolve("sleep.dig"));
+            Files.write(projectDir.resolve("acceptance/server_graceful_shutdown/sleep.dig"), asList(Resources.toString(
+                    Resources.getResource("acceptance/server_graceful_shutdown/sleep.dig"), UTF_8)
+                    .replace("${outdir}", root().toString())));
 
             CommandStatus pushStatus = main("push",
                     "--project", projectDir.toString(),
                     "server_graceful_shutdown",
                     "-c", config.toString(),
-                    "-e", server.endpoint(),
-                    "-p", "outdir=" + root());
+                    "-e", server.endpoint());
             assertThat(pushStatus.errUtf8(), pushStatus.code(), is(0));
 
             CommandStatus startStatus = main("start",

--- a/digdag-tests/src/test/java/acceptance/ServerScheduleIT.java
+++ b/digdag-tests/src/test/java/acceptance/ServerScheduleIT.java
@@ -1,7 +1,7 @@
 package acceptance;
 
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Resources;
 import io.digdag.cli.TimeUtil;
 import io.digdag.client.DigdagClient;
 import io.digdag.client.api.Id;
@@ -31,6 +31,8 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -382,9 +384,11 @@ public class ServerScheduleIT
     {
         File outfile = folder.newFile();
         Files.createDirectories(projectDir);
-        addWorkflow(projectDir, "acceptance/schedule/skip_on_overtime.dig", "schedule.dig");
-        pushProject(server.endpoint(), projectDir, "schedule", ImmutableMap.of(
-                "outfile", outfile.toPath().toAbsolutePath().toString()));
+
+        Files.write(projectDir.resolve("schedule.dig"), asList(Resources.toString(
+                Resources.getResource("acceptance/schedule/skip_on_overtime.dig"), UTF_8)
+                .replace("${outfile}", outfile.toString())));
+        pushProject(server.endpoint(), projectDir, "schedule");
 
         TestUtils.expect(Duration.ofMinutes(1),
                 () -> Files.readAllLines(outfile.toPath()).size() >= 6);

--- a/digdag-tests/src/test/java/utils/TestUtils.java
+++ b/digdag-tests/src/test/java/utils/TestUtils.java
@@ -2,7 +2,6 @@ package utils;
 
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.DeleteObjectsRequest;
 import com.amazonaws.services.s3.model.ListObjectsRequest;
 import com.amazonaws.services.s3.model.ObjectListing;
@@ -409,11 +408,6 @@ public class TestUtils
 
     public static Id pushProject(String endpoint, Path project, String projectName)
     {
-        return pushProject(endpoint, project, projectName, ImmutableMap.of());
-    }
-
-    public static Id pushProject(String endpoint, Path project, String projectName, Map<String, String> params)
-    {
         List<String> command = new ArrayList<>();
         command.addAll(asList(
                 "push",
@@ -421,7 +415,6 @@ public class TestUtils
                 projectName,
                 "-c", "/dev/null",
                 "-e", endpoint));
-        params.forEach((k, v) -> command.addAll(asList("-p", k + "=" + v)));
         CommandStatus pushStatus = main(command);
         assertThat(pushStatus.errUtf8(), pushStatus.code(), is(0));
         Matcher matcher = PROJECT_ID_PATTERN.matcher(pushStatus.outUtf8());


### PR DESCRIPTION
Moving the project archive metadata compilation to the server makes it easier for the console to implement workflow editing.
