### PR TITLE
[WIP] Allow ${...} syntax return objects and arrays

### DIFF
--- a/digdag-client/src/main/java/io/digdag/client/config/Config.java
+++ b/digdag-client/src/main/java/io/digdag/client/config/Config.java
@@ -22,7 +22,7 @@ import static java.util.Locale.ENGLISH;
 
 public class Config
 {
-    protected final ObjectMapper mapper;
+    protected ObjectMapper mapper;
     protected final ObjectNode object;
 
     Config(ObjectMapper mapper)

--- a/digdag-core/src/main/resources/io/digdag/core/agent/digdag.js
+++ b/digdag-core/src/main/resources/io/digdag/core/agent/digdag.js
@@ -1,9 +1,32 @@
+function scopedEvaluate(code, variables)
+{
+  var source = 'with(this){\n' + code + '}\n';
+
+  try {
+    var func = new Function(source);
+  } catch (e) {
+    e.source = source;
+    throw e;
+  }
+
+  if (typeof variables == "string") {
+    variables = JSON.parse(variables);
+  }
+  vs = func.call(variables);
+
+  return vs;
+}
+
+function jsonEvaluate(code, variables)
+{
+    return scopedEvaluate('return JSON.stringify((' + code + '))', variables);
+}
+
 // Code from Underscore.js
 function template(code, variables)
 {
   var matcher = RegExp([
-    (/\$(?!\$){%([\s\S]+?)%}/g).source,
-    (/\$(?!\$){([\s\S]+?)}/g).source
+    (/\${([\s\S]+?)}/g).source
   ].join('|') + '|$', 'g');
 
   var escapes = {
@@ -23,13 +46,11 @@ function template(code, variables)
 
   var index = 0;
   var source = "__p+='";
-  code.replace(matcher, function(match, statement, expression, offset) {
+  code.replace(matcher, function(match, expression, offset) {
     source += code.slice(index, offset).replace(/\$\$/g, "$").replace(escaper, escapeChar);
     index = offset + match.length;
 
-    if (statement) {
-      source += "';\n" + evaluate + "\n__p+='";
-    } else if (expression) {
+    if (expression) {
       source += "'+\n((__t=(" + expression + "))==null?'':(typeof __t==\"string\"?__t:JSON.stringify(__t)))+\n'";
     }
 
@@ -41,19 +62,5 @@ function template(code, variables)
     "print=function(){__p+=__j.call(arguments,'');};\n" +
     source + 'return __p;\n';
 
-  source = 'with(this){\n' + source + '}\n';
-
-  try {
-    var func = new Function(source);
-  } catch (e) {
-    e.source = source;
-    throw e;
-  }
-
-  if (typeof variables == "string") {
-    variables = JSON.parse(variables);
-  }
-  vs = func.call(variables);
-
-  return vs;
+  return scopedEvaluate(source, variables);
 }


### PR DESCRIPTION
Purpose of this PR is (was) implementing "Idea 3" of https://github.com/treasure-data/digdag/issues/25#issuecomment-203236773 to allow `key: ${foos}` syntax to put array (or objects) as a value of `key`.

However, I found a problem that `Config.get("key", String.class)` fails if value is an array or object.
 This means that following code fails:

```
_export:
  key:
    nested: v

+t:
  echo>: ${key}  # this is an object
```

But this works:

```
_export:
  key:
    nested: v

+t:
  echo>: foo${key}bar  # this is a string
```

I think this behavior is unexpected.

So, "Idea 4" could be better.
