### PR TITLE
Return 404 Not Found when http method name is unknown

### DIFF
--- a/digdag-guice-rs/src/main/java/io/digdag/guice/rs/GuiceRsServletContainerInitializer.java
+++ b/digdag-guice-rs/src/main/java/io/digdag/guice/rs/GuiceRsServletContainerInitializer.java
@@ -2,6 +2,7 @@ package io.digdag.guice.rs;
 
 import java.util.Map;
 import java.util.Set;
+import java.io.IOException;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.google.inject.Module;
@@ -13,8 +14,12 @@ import javax.servlet.ServletContainerInitializer;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
+import javax.servlet.ServletException;
 import javax.servlet.ServletRegistration;
 import javax.servlet.annotation.HandlesTypes;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 @HandlesTypes(GuiceRsBootstrap.class)
 public class GuiceRsServletContainerInitializer
@@ -63,6 +68,20 @@ public class GuiceRsServletContainerInitializer
             .stream()
             .map(binding -> binding.getProvider().get())
             .forEach(initializer -> initializer.register(injector, context));
+
+        // return 404 Not Found if all URL patterns don't match
+        context.addServlet("default", new DefaultServlet())
+            .addMapping("/");
+    }
+
+    private static class DefaultServlet extends HttpServlet
+    {
+        @Override
+        protected void service(HttpServletRequest request, HttpServletResponse response)
+                throws ServletException, IOException
+        {
+            response.sendError(HttpServletResponse.SC_NOT_FOUND);
+        }
     }
 
     private static class CloseableInjectorDestroyListener

--- a/digdag-tests/src/test/java/acceptance/ServerErrorStatusCodeIT.java
+++ b/digdag-tests/src/test/java/acceptance/ServerErrorStatusCodeIT.java
@@ -1,0 +1,103 @@
+package acceptance;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.ImmutableList;
+
+import java.util.Arrays;
+import java.util.List;
+
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import utils.TemporaryDigdagServer;
+
+import static org.junit.Assert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+public class ServerErrorStatusCodeIT
+{
+    private List<String> READ_METHODS = Arrays.asList(
+            "GET", "OPTIONS", "HEAD"
+    );
+
+    private List<String> WRITE_METHODS = Arrays.asList(
+            "POST", "PUT", "DELETE"
+    );
+
+    private List<String> UNKNOWN_METHODS = Arrays.asList(
+            "TRACE", "LOCK", "INVALID_METHOD_NAME"
+    );
+
+    @Rule
+    public TemporaryDigdagServer server = TemporaryDigdagServer.of();
+
+    private OkHttpClient client;
+
+    @Before
+    public void setUp()
+    {
+        client = new OkHttpClient();
+    }
+
+    @Test
+    public void verify404NotFoundOnUnmatchingApplicationResource()
+            throws Exception
+    {
+        for (String httpMethod : Iterables.concat(READ_METHODS, WRITE_METHODS, UNKNOWN_METHODS)) {
+            Response response = client.newCall(new Request.Builder()
+                    .url(server.endpoint() + "/api/no_such_api")
+                    .method(httpMethod,
+                        WRITE_METHODS.contains(httpMethod) ?
+                            RequestBody.create(MediaType.parse("text/plain"), "") : null)
+                    .build()).execute();
+            assertThat(httpMethod, response.code(), is(404));
+        }
+    }
+
+    @Test
+    public void verify404NotFoundOnUnmatchingServlet()
+            throws Exception
+    {
+        for (String httpMethod : Iterables.concat(READ_METHODS, WRITE_METHODS, UNKNOWN_METHODS)) {
+            Response response = client.newCall(new Request.Builder()
+                    .url(server.endpoint() + "/no_such_api")
+                    .method(httpMethod,
+                        WRITE_METHODS.contains(httpMethod) ?
+                            RequestBody.create(MediaType.parse("text/plain"), "") : null)
+                    .build()).execute();
+            assertThat(httpMethod, response.code(), is(404));
+        }
+    }
+
+    @Test
+    public void verify405MethodNotAllowedOnUnknownMethods()
+            throws Exception
+    {
+        for (String httpMethod : UNKNOWN_METHODS) {
+            Response response = client.newCall(new Request.Builder()
+                    .url(server.endpoint() + "/api/version")
+                    .method(httpMethod, null)
+                    .build()).execute();
+            assertThat(httpMethod, response.code(), is(405));
+        }
+    }
+
+    @Test
+    public void verify405MethodNotAllowedOnUnsupportedMethods()
+            throws Exception
+    {
+        for (String httpMethod : WRITE_METHODS) {
+            Response response = client.newCall(new Request.Builder()
+                    .url(server.endpoint() + "/api/version")
+                    .method(httpMethod, RequestBody.create(MediaType.parse("text/plain"), ""))
+                    .build()).execute();
+            assertThat(httpMethod, response.code(), is(405));
+        }
+    }
+}


### PR DESCRIPTION
Before:

* Path is under /api (handled by RESTeasy's HttpServlet30Dispatcher)

  * If a method for the path is NOT available: 404 Not Found

  * If a method for the path is available:

    * if `@GET`, etc. annotation is same with the requested method: 200 OK

    * otherwise: 405 Method Not Allowed

* Path is not under /api

  * Resource is always unavailable (no servlets are mapped to this path)

  * If method is either of GET, HEAD, POST, PUT, DELETE, OPTIONS, or
    TRACE: 404 Not Found
    (handled by Undertow's DefaultServlet which extends
     javax.servlet.http.HttpServlet)

  * otherwise: 501 Not Implemented

This change maps a new servlet to /api that returns 404 Not Found for
any requesting methods so that behavior becomes consistent with paths
under /api.

javax.servlet.http.HttpServlet was returning 501 Not Implemented: http://www.docjar.com/html/api/javax/servlet/http/HttpServlet.java.html