### PR TITLE
cli: windows: fix selfupdate

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/SelfUpdate.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/SelfUpdate.java
@@ -100,7 +100,7 @@ public class SelfUpdate
                         version, res.getStatus(), res.getStatusInfo(), res.readEntity(String.class)));
         }
 
-        Path path = Files.createTempFile("digdag-", ".jar");
+        Path path = Files.createTempFile("digdag-", ".bat");
         try (InputStream in = res.readEntity(InputStream.class)) {
             try (OutputStream out = Files.newOutputStream(path)) {
                 ByteStreams.copy(in, out);


### PR DESCRIPTION
On windows the file suffix must be `.bat`. Mac OS X and Linux do not care.