### PR TITLE
Add access to secrets to scripting operators

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/agent/DefaultTaskExecutionContext.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/DefaultTaskExecutionContext.java
@@ -1,16 +1,27 @@
 package io.digdag.core.agent;
 
+import io.digdag.spi.PrivilegedVariables;
 import io.digdag.spi.SecretProvider;
 import io.digdag.spi.TaskExecutionContext;
 
 class DefaultTaskExecutionContext
         implements TaskExecutionContext
 {
-    private SecretProvider secretProvider;
+    private final PrivilegedVariables privilegedVariables;
+    private final SecretProvider secretProvider;
 
-    DefaultTaskExecutionContext(SecretProvider secretProvider)
+    DefaultTaskExecutionContext(
+            PrivilegedVariables privilegedVariables,
+            SecretProvider secretProvider)
     {
+        this.privilegedVariables = privilegedVariables;
         this.secretProvider = secretProvider;
+    }
+
+    @Override
+    public PrivilegedVariables privilegedVariables()
+    {
+        return privilegedVariables;
     }
 
     @Override

--- a/digdag-core/src/main/java/io/digdag/core/agent/GrantedPrivilegedVariables.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/GrantedPrivilegedVariables.java
@@ -1,0 +1,114 @@
+package io.digdag.core.agent;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigException;
+import io.digdag.spi.PrivilegedVariables;
+import io.digdag.spi.SecretProvider;
+import io.digdag.spi.SecretScopes;
+import io.digdag.spi.SecretStore;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+public class GrantedPrivilegedVariables
+    implements PrivilegedVariables
+{
+    static SecretProvider privilegedSecretProvider(SecretStore secretStore, int projectId)
+    {
+        return (key) -> {
+            Optional<String> projectSecret = secretStore.getSecret(projectId, SecretScopes.PROJECT, key);
+
+            if (projectSecret.isPresent()) {
+                return projectSecret;
+            }
+
+            return secretStore.getSecret(projectId, SecretScopes.PROJECT_DEFAULT, key);
+        };
+    }
+
+    private static class SecretOnlyGrant
+    {
+        @JsonProperty
+        String secret;
+    }
+
+    public static GrantedPrivilegedVariables empty()
+    {
+        return new GrantedPrivilegedVariables(new LinkedHashMap<>());
+    }
+
+    public static GrantedPrivilegedVariables build(
+            Config grants,
+            Config params,
+            SecretProvider secretProvider)
+    {
+        Map<String, Supplier<String>> variables = new LinkedHashMap<>();
+        for (String key : grants.getKeys()) {
+            variables.put(key, buildAccessor(grants, key, params, secretProvider));
+        }
+        return new GrantedPrivilegedVariables(variables);
+    }
+
+    private static Supplier<String> buildAccessor(
+            Config grants, String key,
+            Config params,
+            SecretProvider secretProvider)
+    {
+        if (grants.get(key, JsonNode.class).isObject()) {
+            String secretOnlyKey = grants.getNested(key).convert(SecretOnlyGrant.class).secret;
+            return () -> secretProvider.getSecretOptional(secretOnlyKey).orNull();
+        }
+        else {
+            String secretSharedKey = grants.get(key, String.class);
+            return () -> {
+                Optional<String> secret = secretProvider.getSecretOptional(secretSharedKey);
+                if (secret.isPresent()) {
+                    return secret.get();
+                }
+
+                // TODO use ConfigKey class added at #336 to access nested key
+                List<String> configKey = ImmutableList.copyOf(secretSharedKey.split("\\."));
+                Config config = params;
+                for (String nestName : configKey.subList(0, configKey.size() - 1)) {
+					Optional<Config> nest = config.getOptionalNested(nestName);
+					if (!nest.isPresent()) {
+                        break;
+					}
+					config = nest.get();
+                }
+                return config.get(configKey.get(configKey.size() - 1), String.class);
+            };
+        }
+    }
+
+    private final Map<String, Supplier<String>> variables;
+
+    private GrantedPrivilegedVariables(
+            Map<String, Supplier<String>> variables)
+    {
+        this.variables = variables;
+    }
+
+    @Override
+    public Optional<String> getOptional(String key)
+    {
+        Supplier<String> var = variables.get(key);
+        if (var == null) {
+            return Optional.absent();
+        }
+        else {
+            return Optional.fromNullable(var.get());
+        }
+    }
+
+    @Override
+    public List<String> getKeys()
+    {
+        return ImmutableList.copyOf(variables.keySet());
+    }
+}

--- a/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
@@ -291,12 +291,6 @@ public class OperatorManager
 
         SecretStore secretStore = secretStoreManager.getSecretStore(mergedRequest.getSiteId());
 
-        PrivilegedVariables privilegedVariables = GrantedPrivilegedVariables.build(
-                // _env must be local config
-                mergedRequest.getLocalConfig().getNestedOrGetEmpty("_env"),
-                mergedRequest.getConfig(),
-                GrantedPrivilegedVariables.privilegedSecretProvider(secretStore, mergedRequest.getProjectId()));
-
         Config grants = mergedRequest.getConfig().getNestedOrGetEmpty("_secrets");
 
         SecretFilter operatorSecretFilter = SecretFilter.of(
@@ -313,6 +307,11 @@ public class OperatorManager
 
         DefaultSecretProvider secretProvider = new DefaultSecretProvider(
                 secretContext, secretAccessPolicy, grants, operatorSecretFilter, secretStore);
+
+        PrivilegedVariables privilegedVariables = GrantedPrivilegedVariables.build(
+                mergedRequest.getConfig().getNestedOrGetEmpty("_env"),
+                mergedRequest.getConfig(),
+                GrantedPrivilegedVariables.privilegedSecretProvider(secretContext, secretAccessPolicy, secretStore));
 
         TaskExecutionContext taskExecutionContext = new DefaultTaskExecutionContext(
                 privilegedVariables, secretProvider);

--- a/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
@@ -309,7 +309,7 @@ public class OperatorManager
                 secretContext, secretAccessPolicy, grants, operatorSecretFilter, secretStore);
 
         PrivilegedVariables privilegedVariables = GrantedPrivilegedVariables.build(
-                mergedRequest.getConfig().getNestedOrGetEmpty("_env"),
+                mergedRequest.getLocalConfig().getNestedOrGetEmpty("_env"),
                 mergedRequest.getConfig(),
                 GrantedPrivilegedVariables.privilegedSecretProvider(secretContext, secretAccessPolicy, secretStore));
 

--- a/digdag-core/src/test/java/io/digdag/core/agent/GrantedPrivilegedVariablesTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/agent/GrantedPrivilegedVariablesTest.java
@@ -1,0 +1,111 @@
+package io.digdag.core.agent;
+
+import com.google.common.base.Optional;
+
+import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigException;
+import io.digdag.spi.PrivilegedVariables;
+import io.digdag.spi.SecretNotFoundException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static io.digdag.client.config.ConfigUtils.newConfig;
+import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertNull;
+
+public class GrantedPrivilegedVariablesTest
+{
+    @Test
+    public void testExistance()
+    {
+        Config grants = newConfig()
+            .set("params_exists", "param1")
+            .set("params_not_exists", "param2")
+            .set("shared_secret_exists", "shared1")
+            .set("shared_secret_not_exists", "shared2")
+            .set("only_secret_exists", newConfig().set("secret", "only1"))
+            .set("only_secret_not_exists", newConfig().set("secret", "only2"));
+
+        Config params = newConfig()
+            .set("param1", "param1-value");
+
+        Config secrets = newConfig()
+            .set("shared1", "shared1-value")
+            .set("only1", "only1-value");
+
+        PrivilegedVariables vars = GrantedPrivilegedVariables.build(
+                grants, params, (key) -> secrets.getOptional(key, String.class));
+
+        assertThat(vars.getKeys(),
+                is(asList("params_exists", "params_not_exists", "shared_secret_exists", "shared_secret_not_exists", "only_secret_exists", "only_secret_not_exists")));
+
+        assertThat(vars.getOptional("params_exists"), is(Optional.of("param1-value")));
+        assertThat(vars.getOptional("params_not_exists"), is(Optional.absent()));
+        assertThat(vars.getOptional("shared_secret_exists"), is(Optional.of("shared1-value")));
+        assertThat(vars.getOptional("shared_secret_not_exists"), is(Optional.absent()));
+        assertThat(vars.getOptional("only_secret_exists"), is(Optional.of("only1-value")));
+        assertThat(vars.getOptional("only_secret_not_exists"), is(Optional.absent()));
+        assertThat(vars.getOptional("no_such_key"), is(Optional.absent()));
+
+        assertThat(vars.get("params_exists"), is("param1-value"));
+        assertException(() -> vars.get("params_not_exists"), ConfigException.class, "param2");
+        assertThat(vars.get("shared_secret_exists"), is("shared1-value"));
+        assertException(() -> vars.get("shared_secret_not_exists"), ConfigException.class, "shared2");
+        assertThat(vars.get("only_secret_exists"), is("only1-value"));
+        assertException(() -> vars.get("only_secret_not_exists"), SecretNotFoundException.class, "only2");
+        assertNull(vars.get("no_such_key"));
+    }
+
+    @Test
+    public void testNested()
+    {
+        Config grants = newConfig()
+            .set("exists", "nest.param1")
+            .set("key_not_exists", "nest.param2")
+            .set("nest_not_exists", "no.param3")
+            .set("secret_shared_exists", "nest.shared1")
+            .set("secret_only_exists", "nest.only1");
+
+        Config params = newConfig()
+            .set("nest", newConfig().set("param1", "param1-value"));
+
+        Config secrets = newConfig()
+            .set("nest.shared1", "shared1-value")
+            .set("nest.only1", "only1-value");
+
+        PrivilegedVariables vars = GrantedPrivilegedVariables.build(
+                grants, params, (key) -> secrets.getOptional(key, String.class));
+
+        assertThat(vars.getOptional("exists"), is(Optional.of("param1-value")));
+        assertThat(vars.getOptional("key_not_exists"), is(Optional.absent()));
+        assertThat(vars.getOptional("nest_not_exists"), is(Optional.absent()));
+        assertThat(vars.getOptional("secret_shared_exists"), is(Optional.of("shared1-value")));
+        assertThat(vars.getOptional("secret_only_exists"), is(Optional.of("only1-value")));
+
+        assertThat(vars.get("exists"), is("param1-value"));
+        assertException(() -> vars.get("key_not_exists"), ConfigException.class, "nest.param2");
+        assertException(() -> vars.get("nest_not_exists"), ConfigException.class, "no.param3");
+        assertThat(vars.get("secret_shared_exists"), is("shared1-value"));
+        assertThat(vars.get("secret_only_exists"), is("only1-value"));
+    }
+
+    private void assertException(Runnable func, Class<? extends Exception> expected, String message)
+    {
+        try {
+            func.run();
+            fail();
+        }
+        catch (Exception ex) {
+            assertThat(ex, instanceOf(expected));
+            assertThat(ex.getMessage(), containsString(message));
+        }
+    }
+}

--- a/digdag-spi/src/main/java/io/digdag/spi/PrivilegedVariables.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/PrivilegedVariables.java
@@ -1,7 +1,6 @@
 package io.digdag.spi;
 
 import com.google.common.base.Optional;
-import io.digdag.spi.SecretNotFoundException;
 import java.util.List;
 
 public interface PrivilegedVariables
@@ -18,12 +17,7 @@ public interface PrivilegedVariables
     //     and runtime parameters don't include key
     //     => throw ConfigException
 
-    default String get(String key)
-    {
-        return getOptional(key).or(() -> {
-            throw new SecretNotFoundException(key);
-        });
-    }
+    String get(String key);
 
     Optional<String> getOptional(String key);
 

--- a/digdag-spi/src/main/java/io/digdag/spi/PrivilegedVariables.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/PrivilegedVariables.java
@@ -1,0 +1,31 @@
+package io.digdag.spi;
+
+import com.google.common.base.Optional;
+import io.digdag.spi.SecretNotFoundException;
+import java.util.List;
+
+public interface PrivilegedVariables
+{
+    // PrivilegedVariables fetches variables lazily.
+    // Threfore, get(String key) may throw exceptions even if the key
+    // is included in the result of getKeys() as following:
+    //
+    // * key is granted for secret-only access
+    //   * secret store doesn't include key
+    //     => throw SecretNotFoundException
+    // * key is granted for secret-shared access
+    //   * secret store doesn't include key
+    //     and runtime parameters don't include key
+    //     => throw ConfigException
+
+    default String get(String key)
+    {
+        return getOptional(key).or(() -> {
+            throw new SecretNotFoundException(key);
+        });
+    }
+
+    Optional<String> getOptional(String key);
+
+    List<String> getKeys();
+}

--- a/digdag-spi/src/main/java/io/digdag/spi/TaskExecutionContext.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/TaskExecutionContext.java
@@ -2,5 +2,7 @@ package io.digdag.spi;
 
 public interface TaskExecutionContext
 {
+    PrivilegedVariables privilegedVariables();
+
     SecretProvider secrets();
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/ShOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/ShOperatorFactory.java
@@ -13,6 +13,7 @@ import io.digdag.spi.CommandExecutor;
 import io.digdag.spi.CommandLogger;
 import io.digdag.spi.Operator;
 import io.digdag.spi.OperatorFactory;
+import io.digdag.spi.PrivilegedVariables;
 import io.digdag.spi.TaskExecutionContext;
 import io.digdag.spi.TaskRequest;
 import io.digdag.spi.TaskResult;
@@ -57,12 +58,12 @@ public class ShOperatorFactory
     }
 
     @Override
-    public Operator newOperator(Path projectPath, TaskRequest request)
+    public ShOperator newOperator(Path projectPath, TaskRequest request)
     {
         return new ShOperator(projectPath, request);
     }
 
-    private class ShOperator
+    class ShOperator
             extends BaseOperator
     {
         public ShOperator(Path projectPath, TaskRequest request)
@@ -73,31 +74,7 @@ public class ShOperatorFactory
         @Override
         public List<String> secretSelectors()
         {
-            // Return the secret keys referred to in the env config
-            Set<String> selectors = new HashSet<>();
-            Config envConfig = this.request.getConfig().getNestedOrGetEmpty("_env");
-            for (String name : envConfig.getKeys()) {
-                if (!VALID_ENV_KEY.matcher(name).matches()) {
-                    throw new ConfigException("Invalid _env");
-                }
-                JsonNode value = envConfig.get(name, JsonNode.class);
-                switch(value.getNodeType()) {
-                    case OBJECT:
-                        ObjectNode ref = (ObjectNode) value;
-                        JsonNode secret = ref.get("secret");
-                        if (ref.size() != 1 || secret == null || !secret.isTextual()) {
-                            throw new ConfigException("Invalid _env");
-                        }
-                        String secretKey = secret.textValue();
-                        selectors.add(secretKey);
-                        break;
-                    case STRING:
-                        break;
-                    default:
-                        throw new ConfigException("Invalid _env");
-                }
-            }
-            return ImmutableList.copyOf(selectors);
+            return ImmutableList.of();
         }
 
         @Override
@@ -135,30 +112,7 @@ public class ShOperatorFactory
                 });
 
             // Set up process environment according to env config. This can also refer to secrets.
-            Config envConfig = this.request.getConfig().getNestedOrGetEmpty("_env");
-            for (String name : envConfig.getKeys()) {
-                if (!VALID_ENV_KEY.matcher(name).matches()) {
-                    throw new ConfigException("Invalid _env");
-                }
-                JsonNode value = envConfig.get(name, JsonNode.class);
-                switch(value.getNodeType()) {
-                    case OBJECT:
-                        ObjectNode ref = (ObjectNode) value;
-                        JsonNode secret = ref.get("secret");
-                        if (ref.size() != 1 || secret == null || !secret.isTextual()) {
-                            throw new ConfigException("Invalid _env");
-                        }
-                        String secretKey = secret.textValue();
-                        String secretValue = ctx.secrets().getSecret(secretKey);
-                        env.put(name, secretValue);
-                        break;
-                    case STRING:
-                        env.put(name, value.textValue());
-                        break;
-                    default:
-                        throw new ConfigException("Invalid _env");
-                }
-            }
+            collectEnvironmentVariables(env, ctx.privilegedVariables());
 
             // add workspace path to the end of $PATH so that bin/cmd works without ./ at the beginning
             String pathEnv = System.getenv("PATH");
@@ -194,6 +148,16 @@ public class ShOperatorFactory
             }
 
             return TaskResult.empty(request);
+        }
+    }
+
+    static void collectEnvironmentVariables(Map<String, String> env, PrivilegedVariables variables)
+    {
+        for (String name : variables.getKeys()) {
+            if (!VALID_ENV_KEY.matcher(name).matches()) {
+                throw new ConfigException("Invalid _env key name: " + name);
+            }
+            env.put(name, variables.get(name));
         }
     }
 

--- a/digdag-tests/src/test/java/acceptance/ShIT.java
+++ b/digdag-tests/src/test/java/acceptance/ShIT.java
@@ -1,0 +1,98 @@
+package acceptance;
+
+import com.google.common.collect.ImmutableList;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeThat;
+import static utils.TestUtils.copyResource;
+import static utils.TestUtils.main;
+import static org.hamcrest.Matchers.containsString;
+import utils.CommandStatus;
+
+public class ShIT
+{
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private Path projectDir;
+    private Path config;
+    private Path outfile;
+
+    @Before
+    public void setUp()
+        throws Exception
+    {
+        assumeThat(runEcho(), is(true));
+
+        projectDir = folder.getRoot().toPath().toAbsolutePath().normalize();
+        config = folder.newFile().toPath();
+        outfile = projectDir.resolve("outfile");
+    }
+
+    @Test
+    public void verifyEnvVars()
+            throws Exception
+    {
+        Files.write(config, ImmutableList.of(
+                    "secrets.my_secrets.d = secret-shared",
+                    "secrets.my_secrets.e = secret-only"
+                    ));
+
+        copyResource("acceptance/sh/env.dig", projectDir.resolve("workflow.dig"));
+
+        CommandStatus runStatus = main("run",
+                "-o", projectDir.toString(),
+                "--config", config.toString(),
+                "--project", projectDir.toString(),
+                "-p", "cmd=" + "command-line",
+                "-p", "outfile=" + outfile,
+                "workflow.dig");
+        assertThat(runStatus.errUtf8(), runStatus.code(), is(0));
+
+        assertThat(Files.readAllLines(outfile, UTF_8).get(0), is("exported 1 command-line secret-shared secret-only"));
+    }
+
+    @Test
+    public void verifySecretOnlyAccess()
+            throws Exception
+    {
+        copyResource("acceptance/sh/env_secret_only_reject.dig", projectDir.resolve("workflow.dig"));
+
+        CommandStatus runStatus = main("run",
+                "-o", projectDir.toString(),
+                "--config", config.toString(),
+                "--project", projectDir.toString(),
+                "workflow.dig");
+        assertThat(runStatus.errUtf8(), runStatus.code(), not(is(0)));
+
+        assertThat(runStatus.errUtf8(), containsString("Secret not found"));
+    }
+
+    private boolean runEcho()
+        throws Exception
+    {
+        ProcessBuilder pb = new ProcessBuilder("/bin/sh", "-c", "echo $var");
+        pb.environment().put("var", "unix");
+        try {
+            Process p = pb.start();
+            try (BufferedReader stdout = new BufferedReader(new InputStreamReader(p.getInputStream(), UTF_8))) {
+                return stdout.readLine().trim().equals("unix") && p.waitFor() == 0;
+            }
+        }
+        catch (IOException ex) {
+            return false;
+        }
+    }
+}

--- a/digdag-tests/src/test/resources/acceptance/secrets/echo_secret.dig
+++ b/digdag-tests/src/test/resources/acceptance/secrets/echo_secret.dig
@@ -1,7 +1,4 @@
 +echo:
-  _secrets:
-    key1: true
   _env:
-    FOO:
-      secret: key1
+    FOO: {secret: key1}
   sh>: echo $FOO > ${OUTFILE}

--- a/digdag-tests/src/test/resources/acceptance/secrets/echo_secret_parameterized.dig
+++ b/digdag-tests/src/test/resources/acceptance/secrets/echo_secret_parameterized.dig
@@ -1,7 +1,4 @@
 +echo:
-  _secrets:
-    some_secret: ${secret_key}
   _env:
-    VALUE:
-      secret: some_secret
+    VALUE: ${secret_key}
   sh>: echo $VALUE > ${OUTFILE}

--- a/digdag-tests/src/test/resources/acceptance/sh/env.dig
+++ b/digdag-tests/src/test/resources/acceptance/sh/env.dig
@@ -1,0 +1,14 @@
+_export:
+  my_params:
+    a: exported
+    b: 1
+
++run:
+  sh>: echo $VAR_A $VAR_B $VAR_C $VAR_D $VAR_E > $outfile
+  _env:
+    VAR_A: my_params.a
+    VAR_B: my_params.b
+    VAR_C: cmd
+    VAR_D: my_secrets.d
+    VAR_E: {secret: my_secrets.e}
+

--- a/digdag-tests/src/test/resources/acceptance/sh/env_secret_only_reject.dig
+++ b/digdag-tests/src/test/resources/acceptance/sh/env_secret_only_reject.dig
@@ -1,0 +1,7 @@
+_export:
+  my_params:
+    a
++run:
+  sh>: echo $VAR_A
+  _env:
+    VAR_A: {secret: my_params.a}


### PR DESCRIPTION
Users can grant access to secret parameters to scripting operators (sh>, py>, rb>) by explicitly using new `_env` directive. Secrets are set as environment variables.

Operators access to the variables through `PrivilegedVariables` interface. Operators don't need to declare access to the secrets in `Operator.secretSelectors()` method because PrivilegedVariables are supposed to be privileged that are granted by the config explicitly as like `_secrets` directive. This also means that operators can access to secrets only when the operator statically declare them in advance (*), or workflow config explicitly allows them dynamically.

(\* to achieve this, another pull-request is necessary that moves Operator.secretSelectors method to OperatorFactory: #344).

`_env` must be local config at this moment. Setting `_env` in `_export` or store params don't take effect. This is because I'm expecting update of security model of `_env` in the future and it shouldn't break working workflow definitions. The update is about this security concern: 

```
+my_task:
  untrusted_3rd_party_plugin>: do something
```

When this `untrusted_3rd_party_plugin` runs, it can generate following tasks without any permission from users:

```
+my_task^sub+generated_by_untrusted_plugin_get:
  _env:
    IT: {secret: my.secure.data}
  sh>: echo "$IT" > tmp.txt

# same thing happens with previous _secret + _env model
+my_task^sub+generated_by_untrusted_plugin_get:
  _secret:
    my.secure.data: true
  _env:
    IT: {secret: my.secure.data}
  sh>: echo "$IT" > tmp.txt

+my_task^sub+generated_by_untrusted_plugin_use:
  untrusted_3rd_party_plugin>: use tmp.txt
```

This issue happens when `sh>` operator is trusted (trusted by secret access policy) even if `untrusted_3rd_party_plugin` has no permission to access secrets. Currently, this concern is out of this PR's focus excepting that `_env` must be in local config to be prepared for future changes. Future changes may be something that restricts access to secrets from generated subtasks by the permissions of the generating task. This idea may also need some changes to the plugin system so that users (not system administrators) can grant access to secrets per operator in a workflow.
