### PR TITLE
build image: use system TS instead of commit TS

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,10 +1,11 @@
-GIT_SHOW = $(shell git log -n 1 --pretty=format:%ad-%H --date format-local:%Y%m%dT%H%M%S)
+GIT_SHOW = $(shell git log -n 1 --pretty=format:%H)
+TS = $(shell date -u +%Y%m%dT%H%M%S)
 GIT_STATUS = $(shell git status --porcelain --ignore-submodules=dirty 2> /dev/null | tail -n 1)
 
 ifeq ($(strip $(GIT_STATUS)),)
-	IMAGE_TAG = $(GIT_SHOW)
+	IMAGE_TAG = $(TS)-$(GIT_SHOW)
 else
-	IMAGE_TAG = $(GIT_SHOW)-dirty
+	IMAGE_TAG = $(TS)-$(GIT_SHOW)-dirty
 endif
 
 IMAGE_NAMESPACE = digdag


### PR DESCRIPTION
The build image build install the _latest_ version of several dependencies. Hence the actual contents depend on the actual time of the build more than the time of the commit. So differentiate on both commit hash and build timestamp.