### PR TITLE
Add read permission after selfupdate

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/SelfUpdate.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/SelfUpdate.java
@@ -107,6 +107,7 @@ public class SelfUpdate
             }
         }
         path.toFile().setExecutable(true, false);
+        path.toFile().setReadable(true, false);
 
         out.println("Verifying...");
         verify(path, version);


### PR DESCRIPTION
Reported-by pilot
[Qiita](http://qiita.com/pilot/items/287af34c47c087a78705) (Japanese text)

Current selfupdate write to file with permission `rwx--x--x`
The command can't execute on Linux if the user isn't the owner.

I tested on CentOS 6/7

```
# id
uid=0(root) gid=0(root) groups=0(root) context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
# umask
0022
# ls -l `which digdag`
-rwxr-xr-x. 1 root root 24144190 Oct  8 10:13 /usr/local/bin/digdag
# digdag --version
0.8.17
# digdag selfupdate
2016-10-25 10:25:33 +0900: Digdag v0.8.17
Checking the latest version...
Upgrading to 0.8.17...
Verifying...
Upgraded to 0.8.17
# ls -l `which digdag`
-rwx--x--x. 1 root root 24144190 Oct 25 10:25 /usr/local/bin/digdag
# su - vagrant
$ digdag --version
bash: /usr/local/bin/digdag: Permission denied
$ sudo chmod 755 `which digdag`
$ digdag --version
0.8.17
```