### PR TITLE
Fixed build for dev env

### DIFF
--- a/digdag-ui/lib/html-template.js
+++ b/digdag-ui/lib/html-template.js
@@ -1,5 +1,6 @@
 module.exports = function htmlTemplate ({ htmlWebpackPlugin }) {
   const { files, options: { build, data } } = htmlWebpackPlugin
+  const configPath = build ? '' : '/config'
   return `
     <!DOCTYPE html>
     <html lang='en'>
@@ -10,7 +11,7 @@ module.exports = function htmlTemplate ({ htmlWebpackPlugin }) {
     </head>
     <body>
       <div id='app'></div>
-      <script src='/config.js' type='text/javascript'></script>
+      <script src='${configPath}/config.js' type='text/javascript'></script>
       <script src='${files.chunks.bootstrap.entry}'></script>
       <script src='${files.chunks.app.entry}'></script>
       ${[...files.css].map((css) => `

--- a/digdag-ui/webpack.make.js
+++ b/digdag-ui/webpack.make.js
@@ -92,7 +92,7 @@ module.exports = function buildWebpackConfig ({ build = false }) {
       historyApiFallback: {
         index: OUTPUT_PATH
       },
-      contentBase: BUILD_PATH,
+      contentBase: build ? BUILD_PATH : './',
       port: 9000,
       quiet: false,
       stats: {


### PR DESCRIPTION
Previously would result in a blank page, because content was served from `/` instead of `./` and config.js was loaded from wrong path