### PR TITLE
UI: add retry with latest revision button

### DIFF
--- a/digdag-ui/console.jsx
+++ b/digdag-ui/console.jsx
@@ -955,6 +955,14 @@ const SessionView = withRouter(
         .then(() => router.push('/sessions'))
     }
 
+    retrySessionWithLatestRevision () {
+      const { session, router } = this.props
+      this.setState({ loading: true })
+      model()
+        .retrySessionWithLatestRevision(session, uuid.v4())
+        .then(() => router.push('/sessions'))
+    }
+
     render () {
       const { loading } = this.state
       const { session } = this.props
@@ -971,6 +979,15 @@ const SessionView = withRouter(
                 onClick={this.retrySession.bind(this)}
               >
                 RETRY
+              </button>
+            }
+            {canRetry &&
+              <button
+                className='btn btn-success pull-right'
+                disabled={loading}
+                onClick={this.retrySessionWithLatestRevision.bind(this)}
+              >
+                RETRY_LATEST
               </button>
             }
           </h2>

--- a/digdag-ui/model.js
+++ b/digdag-ui/model.js
@@ -308,6 +308,19 @@ export class Model {
     })
   }
 
+  retrySessionWithLatestRevision (session: Session, sessionUUID: string) {
+    const { lastAttempt, project, workflow } = session
+    const model = this
+    return this.fetchProjectWorkflow (project.id, workflow.name).then(function(result){
+      return model.put('attempts', {
+        workflowId: result.id,
+        params: lastAttempt && lastAttempt.params,
+        sessionTime: session.sessionTime,
+        retryAttemptName: sessionUUID
+      })
+    })  
+  }
+
   fetchProjectWorkflowSchedule (projectId: number, workflowName: string): Promise<*> {
     return this.get(`projects/${projectId}/schedules?workflow=${workflowName}`)
   }


### PR DESCRIPTION
The retry button is great now, but sometimes user will make mistake on his workflow and need to retry his workflow with latest revision not just the origin revision.
I refered to retry implementation in "digdag-cli" (https://github.com/treasure-data/digdag/blob/2f88fe1d2dcb1fc66e430094c162f2dd89ccc2b3/digdag-cli/src/main/java/io/digdag/cli/client/Retry.java).
It used two api calls to implement "retry with latest revision": the first was to get the latest workflow id by project id and workflow name and replace the failed job's workflow id to call a new attempt request.
Therefore, I implemented "retrySessionWithLatestRevision" function by copying the "retrySession" function and replacing the workflow id with latest workflow id, same as the logic in "digdag-cli"