### PR TITLE
UI: fetch log file by attemptId and file.fileName when file.direct is not exist

### DIFF
--- a/digdag-ui/console.jsx
+++ b/digdag-ui/console.jsx
@@ -1189,6 +1189,7 @@ class LogFileView extends React.Component {
   ignoreLastFetch:boolean;
 
   props:{
+    attemptId: number;
     file: LogFileHandle;
   };
 
@@ -1212,7 +1213,7 @@ class LogFileView extends React.Component {
   }
 
   fetchFile () {
-    model().fetchLogFile(this.props.file).then(data => {
+    model().fetchLogFile(this.props.attemptId, this.props.file).then(data => {
       if (!this.ignoreLastFetch) {
         this.setState({data})
       }
@@ -1265,7 +1266,7 @@ class AttemptLogsView extends React.Component {
       return <pre />
     }
     return this.state.files.map(file => {
-      return <LogFileView key={file.fileName} file={file} />
+      return <LogFileView key={file.fileName} file={file} attemptId={this.props.attemptId}/>
     })
   }
 

--- a/digdag-ui/model.js
+++ b/digdag-ui/model.js
@@ -252,12 +252,11 @@ export class Model {
     return this.get(`logs/${attemptId}/files?task=${encodeURIComponent(taskName)}`)
   }
 
-  fetchLogFile (file: LogFileHandle) {
+  fetchLogFile (attemptId: number, file: LogFileHandle) {
     if (!file.direct) {
-      return new Promise((resolve, reject) => {
-        reject(`Cannot fetch non-direct log file: ${file.fileName}`)
-      })
+      file.direct = this.config.url + `logs/${attemptId}/files/${file.fileName}`
     }
+
     return fetch(file.direct).then(response => {
       if (!response.ok) {
         throw new Error(response.statusText)

--- a/digdag-ui/model.js
+++ b/digdag-ui/model.js
@@ -254,15 +254,9 @@ export class Model {
 
   fetchLogFile (attemptId: number, file: LogFileHandle) {
     if (!file.direct) {
-      file.direct = this.config.url + `logs/${attemptId}/files/${file.fileName}`
+      return this.fetchArrayBuffer(`${this.config.url}logs/${attemptId}/files/${file.fileName}`)
     }
-
-    return fetch(file.direct).then(response => {
-      if (!response.ok) {
-        throw new Error(response.statusText)
-      }
-      return response.arrayBuffer()
-    })
+    return this.fetchArrayBuffer(file.direct)
   }
 
   fetchProjectArchiveLatest (projectId: number): Promise<ProjectArchive> {
@@ -380,6 +374,15 @@ export class Model {
         throw new Error(response.statusText)
       }
       return response.json()
+    })
+  }
+
+  fetchArrayBuffer (url: string) {
+    return fetch(url).then(response => {
+      if (!response.ok) {
+        throw new Error(response.statusText)
+      }
+      return response.arrayBuffer()
     })
   }
 


### PR DESCRIPTION
The 'digdag-ui' only fetched log file when file.direct was exist.
When file.direct is not exist, the return value will be `Cannot fetch non-direct log file: ${file.fileName}`.
However, the implementation in 'digdag-cli' will fetch log by attemptId and file.fileName when there is no file.direct. (see line 556 to 580 https://github.com/treasure-data/digdag/blob/7eba3480841f0c6a272bf44de6acb201187c51b3/digdag-client/src/main/java/io/digdag/client/DigdagClient.java)
I added one more parameter(attemptId) to LogFileView and generated a new file.direct by attemptId and file.fileName when file.direct is not exist.