### PR TITLE
UI: sort log files by fileTime

### DIFF
--- a/digdag-ui/console.jsx
+++ b/digdag-ui/console.jsx
@@ -1273,7 +1273,8 @@ class AttemptLogsView extends React.Component {
   fetchLogs () {
     model().fetchAttemptLogFileHandles(this.props.attemptId).then(files => {
       if (!this.ignoreLastFetch) {
-        this.setState({files})
+        const sortedFiles = _.sortBy(files, 'fileTime');
+        this.setState({ files: sortedFiles });
       }
     })
   }


### PR DESCRIPTION
When there were more than one log files, the log wouldn't be arranged in order.