### PR TITLE
use msgpack 0.8.11

### DIFF
--- a/digdag-standards/build.gradle
+++ b/digdag-standards/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 
     // td
     compile 'com.treasuredata.client:td-client:0.7.26'
-    compile 'org.msgpack:msgpack-core:0.8.2'
+    compile 'org.msgpack:msgpack-core:0.8.11'
     compile 'org.yaml:snakeyaml:1.17'
 
     // postgresql


### PR DESCRIPTION
We have seen issues with reading numbers producing incorrect values when downloading job results from td api using msgpack 0.8.2.