### PR TITLE
Fix null value handling of config

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/agent/CheckedConfig.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/CheckedConfig.java
@@ -64,17 +64,17 @@ class CheckedConfig
     }
 
     @Override
-    protected JsonNode get(String key)
+    protected JsonNode getNode(String key)
     {
         this.usedKeys.add(key);
-        return super.get(key);
+        return super.getNode(key);
     }
 
     @Override
-    protected void set(String key, JsonNode value)
+    protected void setNode(String key, JsonNode value)
     {
         this.usedKeys.add(key);
-        super.set(key, value);
+        super.setNode(key, value);
     }
 
     // getKeys doesn't set usedKeys.setAllUsed(true) because operator plugins

--- a/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
@@ -230,7 +230,7 @@ public class OperatorManager
                 return;
             }
             type = operatorKey.get().substring(0, operatorKey.get().length() - 1);
-            Object command = config.get(operatorKey.get(), Object.class);
+            Object command = config.getOptional(operatorKey.get(), Object.class).orNull();
             config.set("_type", type);
             config.set("_command", command);
             logger.info("{}>: {}", type, Optional.fromNullable(command).or(""));
@@ -243,7 +243,7 @@ public class OperatorManager
 
         Config localConfig = config.getFactory().create();
         for (String localKey : request.getLocalConfig().getKeys()) {
-            localConfig.set(localKey, config.get(localKey, JsonNode.class).deepCopy());
+            localConfig.set(localKey, config.getOptional(localKey, JsonNode.class).transform(JsonNode::deepCopy).orNull());
         }
 
         // Track accessed keys using UsedKeysSet class


### PR DESCRIPTION
Operators assume that `config.get(...`) returns a non-null value but it
was returning null if the yaml file contains a null value. It causes
NullPointerException which is hard for users to debug.

For example, following workflow:

```
+test:
  sh>: echo ok
  shell: 
```

was failing with this message:

```
$ ./pkg/digdag-0.8.22-SNAPSHOT.jar run nv.dig  -a
2016-11-17 11:22:41 -0800: Digdag v0.8.22-SNAPSHOT
2016-11-17 11:22:43 -0800 [WARN] (main): Reusing the last session time 2016-11-17T00:00:00+00:00.
2016-11-17 11:22:43 -0800 [INFO] (main): Using session /Users/frsyuki/project/digdag/.digdag/status/20161117T000000+0000.
2016-11-17 11:22:43 -0800 [INFO] (main): Starting a new session project id=1 workflow name=nv session_time=2016-11-17T00:00:00+00:00
2016-11-17 11:22:43 -0800 [INFO] (0018@+nv+test): sh>: echo ok
2016-11-17 11:22:43 -0800 [ERROR] (0018@+nv+test): Task failed with unexpected error: null
java.lang.NullPointerException: null
        at io.digdag.standards.operator.ShOperatorFactory$ShOperator.runTask(ShOperatorFactory.java:110)
        at io.digdag.util.BaseOperator.run(BaseOperator.java:51)
        at io.digdag.core.agent.OperatorManager.callExecutor(OperatorManager.java:313)
        at io.digdag.cli.Run$OperatorManagerWithSkip.callExecutor(Run.java:678)
        at io.digdag.core.agent.OperatorManager.runWithWorkspace(OperatorManager.java:258)
        at io.digdag.core.agent.OperatorManager.lambda$runWithHeartbeat$2(OperatorManager.java:141)
        at io.digdag.core.agent.LocalWorkspaceManager.withExtractedArchive(LocalWorkspaceManager.java:25)
        at io.digdag.core.agent.OperatorManager.runWithHeartbeat(OperatorManager.java:139)
        at io.digdag.core.agent.OperatorManager.run(OperatorManager.java:123)
        at io.digdag.cli.Run$OperatorManagerWithSkip.run(Run.java:660)
        at io.digdag.core.agent.MultiThreadAgent.lambda$run$0(MultiThreadAgent.java:95)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)
2016-11-17 11:22:44 -0800 [INFO] (0018@+nv^failure-alert): type: notify
error:
  * +nv+test:
    java.lang.NullPointerException
```

This PR improves it to:

```
2016-11-17 11:21:48 -0800 [INFO] (0018@+nv+test): sh>: echo ok
2016-11-17 11:21:48 -0800 [ERROR] (0018@+nv+test): Configuration error at task +nv+test: Parameter 'shell' is required but null (config)
2016-11-17 11:21:48 -0800 [INFO] (0018@+nv^failure-alert): type: notify
error:
  * +nv+test:
    Parameter 'shell' is required but null
```

