### PR TITLE
Download command

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/Main.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Main.java
@@ -17,6 +17,7 @@ import io.digdag.cli.client.Archive;
 import io.digdag.cli.client.Backfill;
 import io.digdag.cli.client.Delete;
 import io.digdag.cli.client.DisableSchedule;
+import io.digdag.cli.client.Download;
 import io.digdag.cli.client.EnableSchedule;
 import io.digdag.cli.client.Kill;
 import io.digdag.cli.client.Push;
@@ -131,6 +132,7 @@ public class Main
         jc.addCommand("push", injector.getInstance(Push.class));
         jc.addCommand("archive", injector.getInstance(Archive.class));
         jc.addCommand("upload", injector.getInstance(Upload.class));
+        jc.addCommand("download", injector.getInstance(Download.class));
 
         jc.addCommand("workflow", injector.getInstance(ShowWorkflow.class), "workflows");
         jc.addCommand("start", injector.getInstance(Start.class));
@@ -303,6 +305,7 @@ public class Main
         err.println("");
         err.println("  Client-mode commands:");
         err.println("    push <project-name>                create and upload a new revision");
+        err.println("    download <project-name>            pull an uploaded revision");
         err.println("    start <project-name> <name>        start a new session attempt of a workflow");
         err.println("    retry <attempt-id>                 retry a session");
         err.println("    kill <attempt-id>                  kill a running session attempt");

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Download.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Download.java
@@ -1,0 +1,86 @@
+package io.digdag.cli.client;
+
+import com.beust.jcommander.Parameter;
+import io.digdag.cli.SystemExitException;
+import io.digdag.client.DigdagClient;
+import io.digdag.client.api.RestProject;
+import io.digdag.core.archive.ProjectArchives.ExtractListener;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.UUID;
+
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+
+import static io.digdag.core.archive.ProjectArchives.extractTarArchive;
+import static io.digdag.cli.SystemExitException.systemExit;
+import static io.digdag.cli.client.ProjectUtil.showUploadedProject;
+
+public class Download
+    extends ClientCommand
+{
+    @Parameter(names = {"-r", "--revision"})
+    String revision = null;
+
+    @Parameter(names = {"-o", "--output"})
+    String output = null;
+
+    @Override
+    public void mainWithClientException()
+        throws Exception
+    {
+        if (args.size() != 1) {
+            throw usage(null);
+        }
+        download(args.get(0));
+    }
+
+    public SystemExitException usage(String error)
+    {
+        err.println("Usage: " + programName + " download <project>");
+        err.println("  Options:");
+        err.println("    -r, --revision REVISION          specific revision name instead of the latest revision");
+        err.println("    -o, --output DIR                 extract files in this output directory (default: same with project name)");
+        showCommonOptions();
+        return systemExit(error);
+    }
+
+    private void download(String projName)
+        throws IOException, SystemExitException
+    {
+        DigdagClient client = buildClient();
+
+        RestProject project = client.getProject(projName);
+
+        if (revision == null) {
+            revision = project.getRevision();
+        }
+
+        if (output == null) {
+            output = projName;
+        }
+
+        final Path destDir = Paths.get(output);
+        Files.createDirectories(destDir);
+
+        extractTarArchive(destDir, client.getProjectArchive(project.getId(), revision), new ExtractListener() {
+            @Override
+            public void file(Path file)
+            {
+                ln("  %s", destDir.resolve(file));
+            }
+
+            @Override
+            public void symlink(Path file, String dest)
+            {
+                ln("  %s -> %s", destDir.resolve(file), dest);
+            }
+        });
+
+        ln("Extracted project '%s' revision '%s' to %s.", projName, revision, output);
+    }
+}

--- a/digdag-core/src/main/java/io/digdag/core/agent/ExtractArchiveWorkspaceManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/ExtractArchiveWorkspaceManager.java
@@ -1,30 +1,15 @@
 package io.digdag.core.agent;
 
-import java.util.Set;
-import java.util.HashSet;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.io.ByteArrayInputStream;
-import java.io.BufferedInputStream;
-import java.nio.channels.Channels;
-import java.nio.file.Path;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
-import java.nio.file.attribute.PosixFilePermission;
-import java.nio.file.attribute.PosixFilePermissions;
-import com.google.inject.Inject;
 import com.google.common.base.Optional;
-import com.google.common.io.ByteStreams;
-import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
-import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
-import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import com.google.inject.Inject;
+import io.digdag.core.TempFileManager.TempDir;
+import io.digdag.core.TempFileManager;
+import io.digdag.core.archive.ProjectArchives;
+import io.digdag.spi.StorageObject;
+import io.digdag.spi.TaskRequest;
+import java.io.IOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import io.digdag.spi.TaskRequest;
-import io.digdag.spi.StorageObject;
-import io.digdag.core.TempFileManager;
-import io.digdag.core.TempFileManager.TempDir;
 
 public class ExtractArchiveWorkspaceManager
     implements WorkspaceManager
@@ -46,82 +31,10 @@ public class ExtractArchiveWorkspaceManager
         try (TempDir workspacePath = createNewWorkspace(request)) {
             Optional<StorageObject> in = archiveProvider.open();
             if (in.isPresent()) {
-                try (TarArchiveInputStream archive = new TarArchiveInputStream(new GzipCompressorInputStream(new BufferedInputStream(in.get().getContentInputStream())))) {
-                    extractArchive(workspacePath.get(), archive);
-                }
+                ProjectArchives.extractTarArchive(workspacePath.get(), in.get().getContentInputStream());
             }
             return func.run(workspacePath.get());
         }
-    }
-
-    private void extractArchive(Path destDir, TarArchiveInputStream archive)
-        throws IOException
-    {
-        String prefix = destDir.toAbsolutePath().normalize().toString();
-        TarArchiveEntry entry;
-        while (true) {
-            entry = archive.getNextTarEntry();
-            if (entry == null) {
-                break;
-            }
-            Path path = destDir.resolve(entry.getName()).normalize();
-            if (!path.toString().startsWith(prefix)) {
-                throw new RuntimeException("Archive includes an invalid entry: " + entry.getName());
-            }
-            if (entry.isDirectory()) {
-                Files.createDirectories(path);
-            }
-            else if (entry.isSymbolicLink()) {
-                Files.createDirectories(path.getParent());
-                String dest = entry.getLinkName();
-                Path destAbsPath = path.getParent().resolve(dest);
-                if (!destAbsPath.normalize().toString().startsWith(prefix)) {
-                    throw new RuntimeException("Archive includes an invalid symlink: " + entry.getName() + " -> " + dest);
-                }
-                Files.createSymbolicLink(path, Paths.get(dest));
-            }
-            else {
-                Files.createDirectories(path.getParent());
-                try (OutputStream out = Files.newOutputStream(path)) {
-                    ByteStreams.copy(archive, out);
-                }
-            }
-            Files.setPosixFilePermissions(path, getPosixFilePermissions(entry));
-        }
-    }
-
-    private Set<PosixFilePermission> getPosixFilePermissions(TarArchiveEntry entry)
-    {
-        int mode = entry.getMode();
-        Set<PosixFilePermission> perms = new HashSet<>();
-        if ((mode & 0400) != 0) {
-            perms.add(PosixFilePermission.OWNER_READ);
-        }
-        if ((mode & 0200) != 0) {
-            perms.add(PosixFilePermission.OWNER_WRITE);
-        }
-        if ((mode & 0100) != 0) {
-            perms.add(PosixFilePermission.OWNER_EXECUTE);
-        }
-        if ((mode & 0040) != 0) {
-            perms.add(PosixFilePermission.GROUP_READ);
-        }
-        if ((mode & 0020) != 0) {
-            perms.add(PosixFilePermission.GROUP_WRITE);
-        }
-        if ((mode & 0010) != 0) {
-            perms.add(PosixFilePermission.GROUP_EXECUTE);
-        }
-        if ((mode & 0004) != 0) {
-            perms.add(PosixFilePermission.OTHERS_READ);
-        }
-        if ((mode & 0002) != 0) {
-            perms.add(PosixFilePermission.OTHERS_WRITE);
-        }
-        if ((mode & 0001) != 0) {
-            perms.add(PosixFilePermission.OTHERS_EXECUTE);
-        }
-        return perms;
     }
 
     private TempDir createNewWorkspace(TaskRequest request)

--- a/digdag-core/src/main/java/io/digdag/core/archive/ProjectArchives.java
+++ b/digdag-core/src/main/java/io/digdag/core/archive/ProjectArchives.java
@@ -1,0 +1,119 @@
+package io.digdag.core.archive;
+
+import com.google.common.io.ByteStreams;
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+
+public class ProjectArchives
+{
+    private ProjectArchives()
+    { }
+
+    public static interface ExtractListener
+    {
+        void file(Path file);
+
+        void symlink(Path file, String dest);
+    }
+
+    public static void extractTarArchive(Path destDir, InputStream in)
+        throws IOException
+    {
+        extractTarArchive(destDir, in, null);
+    }
+
+    public static void extractTarArchive(Path destDir, InputStream in, ExtractListener listener)
+        throws IOException
+    {
+        try (TarArchiveInputStream archive = new TarArchiveInputStream(new GzipCompressorInputStream(new BufferedInputStream(in, 16*1024)))) {
+            extractArchive(destDir.toAbsolutePath().normalize(), archive, listener);
+        }
+    }
+
+    private static void extractArchive(Path destDir, TarArchiveInputStream archive, ExtractListener listener)
+        throws IOException
+    {
+        String prefix = destDir.toString();
+        TarArchiveEntry entry;
+        while (true) {
+            entry = archive.getNextTarEntry();
+            if (entry == null) {
+                break;
+            }
+            Path path = destDir.resolve(entry.getName()).normalize();
+            if (!path.toString().startsWith(prefix)) {
+                throw new RuntimeException("Archive includes an invalid entry: " + entry.getName());
+            }
+            if (entry.isDirectory()) {
+                Files.createDirectories(path);
+            }
+            else if (entry.isSymbolicLink()) {
+                Files.createDirectories(path.getParent());
+                String dest = entry.getLinkName();
+                Path destAbsPath = path.getParent().resolve(dest).normalize();
+                if (!destAbsPath.normalize().toString().startsWith(prefix)) {
+                    throw new RuntimeException("Archive includes an invalid symlink: " + entry.getName() + " -> " + dest);
+                }
+                if (listener != null) {
+                    listener.symlink(destDir.relativize(path), dest);
+                }
+                Files.createSymbolicLink(path, Paths.get(dest));
+            }
+            else {
+                Files.createDirectories(path.getParent());
+                if (listener != null) {
+                    listener.file(destDir.relativize(path));
+                }
+                try (OutputStream out = Files.newOutputStream(path)) {
+                    ByteStreams.copy(archive, out);
+                }
+            }
+            Files.setPosixFilePermissions(path, getPosixFilePermissions(entry));
+        }
+    }
+
+    private static Set<PosixFilePermission> getPosixFilePermissions(TarArchiveEntry entry)
+    {
+        int mode = entry.getMode();
+        Set<PosixFilePermission> perms = new HashSet<>();
+        if ((mode & 0400) != 0) {
+            perms.add(PosixFilePermission.OWNER_READ);
+        }
+        if ((mode & 0200) != 0) {
+            perms.add(PosixFilePermission.OWNER_WRITE);
+        }
+        if ((mode & 0100) != 0) {
+            perms.add(PosixFilePermission.OWNER_EXECUTE);
+        }
+        if ((mode & 0040) != 0) {
+            perms.add(PosixFilePermission.GROUP_READ);
+        }
+        if ((mode & 0020) != 0) {
+            perms.add(PosixFilePermission.GROUP_WRITE);
+        }
+        if ((mode & 0010) != 0) {
+            perms.add(PosixFilePermission.GROUP_EXECUTE);
+        }
+        if ((mode & 0004) != 0) {
+            perms.add(PosixFilePermission.OTHERS_READ);
+        }
+        if ((mode & 0002) != 0) {
+            perms.add(PosixFilePermission.OTHERS_WRITE);
+        }
+        if ((mode & 0001) != 0) {
+            perms.add(PosixFilePermission.OTHERS_EXECUTE);
+        }
+        return perms;
+    }
+}

--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -686,7 +686,7 @@ Creates a project archive and upload it to the server. This command uploads work
     $ digdag push myproj -r "$(date +%Y-%m-%dT%H:%M:%S%z)"
     $ digdag push default -r "$(git show --pretty=format:'%T' | head -n 1)"
 
-:command:`---project DIR`
+:command:`--project DIR`
   Use this directory as the project directory (default: current directory).
 
   Example: --project workflow/
@@ -700,6 +700,32 @@ Creates a project archive and upload it to the server. This command uploads work
   Start schedules from this time. If this is not set, system time of the server is used. Parameter must include time zone offset. You can run ``date \"+%Y-%m-%d %H:%M:%S %z\"`` command to get current local time.
 
   Example: --schedule-from "2017-07-29 00:00:00 +0200"
+
+
+download
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: console
+
+    $ digdag download <project>
+
+Downloads a project archive and extract to a local directory.
+
+.. code-block:: console
+
+    $ digdag download myproj
+    $ digdag download myproj -o output
+    $ digdag download myproj -r rev20161106
+
+:command:`-o, --output DIR`
+  Extract contents to this directory (default: same with project name).
+
+  Example: -o output
+
+:command:`-r, --revision REVISION`
+  Download project archive of this revision (default: latest revision).
+
+  Example: -r f40172ebc58f58087b6132085982147efa9e81fb
 
 
 delete

--- a/digdag-tests/src/test/java/acceptance/DownloadIT.java
+++ b/digdag-tests/src/test/java/acceptance/DownloadIT.java
@@ -1,0 +1,91 @@
+package acceptance;
+
+import com.google.common.io.ByteStreams;
+import com.google.common.io.Resources;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import utils.CommandStatus;
+import utils.TemporaryDigdagServer;
+
+import static utils.TestUtils.copyResource;
+import static utils.TestUtils.main;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertThat;
+
+public class DownloadIT
+{
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Rule
+    public TemporaryDigdagServer server = TemporaryDigdagServer.of();
+
+    private Path projectDir;
+    private Path config;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        projectDir = folder.getRoot().toPath().resolve("foobar");
+        config = folder.newFile().toPath();
+    }
+
+    @Test
+    public void download()
+            throws Exception
+    {
+        // Create new project
+        CommandStatus initStatus = main("init",
+                "-c", config.toString(),
+                projectDir.toString());
+        assertThat(initStatus.code(), is(0));
+
+        Files.createDirectories(projectDir.resolve("files"));
+
+        copyResource("acceptance/basic.dig", projectDir.resolve("basic.dig"));
+        copyResource("acceptance/params.dig", projectDir.resolve("files").resolve("params.yml"));
+
+        // Push the project
+        CommandStatus pushStatus = main("push",
+                "--project", projectDir.toString(),
+                "download_proj",
+                "-c", config.toString(),
+                "-e", server.endpoint(),
+                "-r", "rev4711");
+        assertThat(pushStatus.errUtf8(), pushStatus.code(), is(0));
+
+        // Download the project
+        Path downloadDir = projectDir.resolve("extract");
+        CommandStatus downloadStatus = main("download",
+                "download_proj",
+                "-o", downloadDir.toString(),
+                "-c", config.toString(),
+                "-e", server.endpoint());
+        assertThat(downloadStatus.errUtf8(), downloadStatus.code(), is(0));
+
+        assertThat(Files.readAllBytes(downloadDir.resolve("basic.dig")), is(readResource("acceptance/basic.dig")));
+        assertThat(Files.readAllBytes(downloadDir.resolve("files").resolve("params.yml")), is(readResource("acceptance/params.dig")));
+
+        assertThat(downloadStatus.outUtf8(), containsString("rev4711"));
+    }
+
+    private byte[] readResource(String resource)
+        throws IOException
+    {
+        return Resources.asByteSource(Resources.getResource(resource)).read();
+    }
+}


### PR DESCRIPTION
`digdag download <project>` command lets users download a project archive to a local directory.
This is useful when we want to check the definition of workflows including query files and scripts as well as *.dig files themselves.