### PR TITLE
(typeof null === 'object') is true

### DIFF
--- a/digdag-ui/console.jsx
+++ b/digdag-ui/console.jsx
@@ -857,7 +857,7 @@ function resolveTaskFile (taskType:string, command:string, task:Object, projectA
 }
 
 function enumerateTaskFiles (node:Object, files:Array<TaskFile>, projectArchive:ProjectArchive) {
-  if (typeof node === 'object') {
+  if (node && typeof node === 'object') {
     let {taskType, command} = task(node)
     const taskFile = resolveTaskFile(taskType, command, node, projectArchive)
     if (taskFile) {


### PR DESCRIPTION
`node == null` is causing unexpected exception at `node['_type']` in `function task`.