### PR TITLE
Add attempts.index to avoid confusion between session id and attempt id

### DIFF
--- a/digdag-client/src/main/java/io/digdag/client/api/RestSessionAttempt.java
+++ b/digdag-client/src/main/java/io/digdag/client/api/RestSessionAttempt.java
@@ -14,6 +14,8 @@ public interface RestSessionAttempt
 {
     Id getId();
 
+    int getIndex();
+
     IdAndName getProject();
 
     //Optional<String> getRevision();

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseMigrator.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseMigrator.java
@@ -33,6 +33,8 @@ public class DatabaseMigrator
         new Migration_20161028112233_AddStateFlagsAndCreatedAtIndexToSessionAttempts(),
         new Migration_20161110112233_AddStartedAtColumnAndIndexToTasks(),
         new Migration_20161209001857_CreateDelayedSessionAttempts(),
+        new Migration_20170116082921_AddAttemptIndexColumn1(),
+        new Migration_20170116090744_AddAttemptIndexColumn2(),
     })
     .sorted(Comparator.comparing(m -> m.getVersion()))
     .collect(Collectors.toList());

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
@@ -1508,7 +1508,7 @@ public class DatabaseSessionStoreManager
         @SqlQuery("select now() as date")
         Instant now();
 
-        @SqlQuery("select s.*, sa.site_id, sa.attempt_name, sa.workflow_definition_id, sa.state_flags, sa.timezone, sa.params, sa.created_at, sa.finished_at" +
+        @SqlQuery("select s.*, sa.site_id, sa.attempt_name, sa.workflow_definition_id, sa.state_flags, sa.timezone, sa.params, sa.created_at, sa.finished_at, sa.index" +
                 " from sessions s" +
                 " join session_attempts sa on sa.id = s.last_attempt_id" +
                 " where s.project_id in (select id from projects where site_id = :siteId)" +
@@ -1517,14 +1517,14 @@ public class DatabaseSessionStoreManager
                 " limit :limit")
         List<StoredSessionWithLastAttempt> getSessions(@Bind("siteId") int siteId, @Bind("limit") int limit, @Bind("lastId") long lastId);
 
-        @SqlQuery("select s.*, sa.site_id, sa.attempt_name, sa.workflow_definition_id, sa.state_flags, sa.timezone, sa.params, sa.created_at, sa.finished_at" +
+        @SqlQuery("select s.*, sa.site_id, sa.attempt_name, sa.workflow_definition_id, sa.state_flags, sa.timezone, sa.params, sa.created_at, sa.finished_at, sa.index" +
                 " from sessions s" +
                 " join session_attempts sa on sa.id = s.last_attempt_id" +
                 " where s.id = :id" +
                 " and sa.site_id = :siteId")
         StoredSessionWithLastAttempt getSession(@Bind("siteId") int siteId, @Bind("id") long id);
 
-        @SqlQuery("select s.*, sa.site_id, sa.attempt_name, sa.workflow_definition_id, sa.state_flags, sa.timezone, sa.params, sa.created_at, sa.finished_at" +
+        @SqlQuery("select s.*, sa.site_id, sa.attempt_name, sa.workflow_definition_id, sa.state_flags, sa.timezone, sa.params, sa.created_at, sa.finished_at, sa.index" +
                 " from sessions s" +
                 " join session_attempts sa on sa.id = s.last_attempt_id" +
                 " where s.project_id = :projId" +
@@ -1534,7 +1534,7 @@ public class DatabaseSessionStoreManager
                 " limit :limit")
         List<StoredSessionWithLastAttempt> getSessionsOfProject(@Bind("siteId") int siteId, @Bind("projId") int projId, @Bind("limit") int limit, @Bind("lastId") long lastId);
 
-        @SqlQuery("select s.*, sa.site_id, sa.attempt_name, sa.workflow_definition_id, sa.state_flags, sa.timezone, sa.params, sa.created_at, sa.finished_at" +
+        @SqlQuery("select s.*, sa.site_id, sa.attempt_name, sa.workflow_definition_id, sa.state_flags, sa.timezone, sa.params, sa.created_at, sa.finished_at, sa.index" +
                 " from sessions s" +
                 " join session_attempts sa on sa.id = s.last_attempt_id" +
                 " where s.project_id = :projId" +
@@ -1661,7 +1661,8 @@ public class DatabaseSessionStoreManager
                     " where id = :id" +
                     " and site_id = :siteId" +
                 ")" +
-                " and s.last_attempt_id is not null")
+                " and s.last_attempt_id is not null" +
+                " order by index")
         List<StoredSessionAttemptWithSession> getOtherAttempts(@Bind("siteId") int siteId, @Bind("id") long id);
 
         @SqlQuery("select * from session_attempts sa" +
@@ -1710,8 +1711,10 @@ public class DatabaseSessionStoreManager
                 " limit 1")
         Long getLastExecutedSessionTime(@Bind("projectId") int projectId, @Bind("workflowName") String workflowName, @Bind("beforeThisSessionTime") long beforeThisSessionTime);
 
-        @SqlUpdate("insert into session_attempts (session_id, site_id, project_id, attempt_name, workflow_definition_id, state_flags, timezone, params, created_at)" +
-                " values (:sessionId, :siteId, :projectId, :attemptName, :workflowDefinitionId, :stateFlags, :timezone, :params, now())")
+        @SqlUpdate("insert into session_attempts (session_id, site_id, project_id, attempt_name, workflow_definition_id, state_flags, timezone, params, created_at, index)" +
+                " values (:sessionId, :siteId, :projectId, :attemptName, :workflowDefinitionId, :stateFlags, :timezone, :params, now(), " +
+                    "(select coalesce(max(index), 0) + 1 from session_attempts where session_id = :sessionId)" +
+                ")")
         @GetGeneratedKeys
         long insertAttempt(@Bind("siteId") int siteId, @Bind("projectId") int projectId, @Bind("sessionId") long sessionId, @Bind("attemptName") String attemptName, @Bind("workflowDefinitionId") Long workflowDefinitionId, @Bind("stateFlags") int stateFlags, @Bind("timezone") String timezone, @Bind("params") Config params);
 
@@ -1740,7 +1743,7 @@ public class DatabaseSessionStoreManager
         @SqlQuery("select id from tasks where state = :state limit :limit")
         List<Long> findAllTaskIdsByState(@Bind("state") short state, @Bind("limit") int limit);
 
-        @SqlQuery("select id, session_id, state_flags from session_attempts where id = :attemptId for update")
+        @SqlQuery("select id, session_id, state_flags, index from session_attempts where id = :attemptId for update")
         SessionAttemptSummary lockAttempt(@Bind("attemptId") long attemptId);
 
         @SqlUpdate("insert into tasks (attempt_id, parent_id, task_type, state, state_flags, updated_at)" +
@@ -1976,6 +1979,7 @@ public class DatabaseSessionStoreManager
             return ImmutableStoredSessionAttempt.builder()
                 .id(r.getLong("id"))
                 .sessionId(r.getLong("session_id"))
+                .index(r.getInt("index"))  // this may return 0 (which means index was null) until Migration_20161207220744_AddAttemptIndexColumn2 is applied
                 .retryAttemptName(DEFAULT_ATTEMPT_NAME.equals(attemptName) ? Optional.absent() : Optional.of(attemptName))
                 .workflowDefinitionId(getOptionalLong(r, "workflow_definition_id"))
                 .stateFlags(AttemptStateFlags.of(r.getInt("state_flags")))
@@ -2005,6 +2009,7 @@ public class DatabaseSessionStoreManager
             return ImmutableStoredSessionAttemptWithSession.builder()
                 .id(r.getLong("id"))
                 .sessionId(r.getLong("session_id"))
+                .index(r.getInt("index"))
                 .retryAttemptName(DEFAULT_ATTEMPT_NAME.equals(attemptName) ? Optional.absent() : Optional.of(attemptName))
                 .workflowDefinitionId(getOptionalLong(r, "workflow_definition_id"))
                 .stateFlags(AttemptStateFlags.of(r.getInt("state_flags")))
@@ -2045,6 +2050,7 @@ public class DatabaseSessionStoreManager
                     .lastAttemptId(r.getLong("last_attempt_id"))
                     .lastAttempt(ImmutableStoredSessionAttempt.builder()
                             .id(r.getLong("last_attempt_id"))
+                            .index(r.getInt("index"))
                             .retryAttemptName(DEFAULT_ATTEMPT_NAME.equals(attemptName) ? Optional.absent() : Optional.of(attemptName))
                             .workflowDefinitionId(getOptionalLong(r, "workflow_definition_id"))
                             .sessionId(r.getLong("id"))
@@ -2073,6 +2079,7 @@ public class DatabaseSessionStoreManager
                 .id(r.getLong("id"))
                 .sessionId(r.getLong("session_id"))
                 .stateFlags(AttemptStateFlags.of(r.getInt("state_flags")))
+                .index(r.getInt("index"))  // this may return 0 (which means index was null) until Migration_20161207220744_AddAttemptIndexColumn2 is applied
                 .build();
         }
     }

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration.java
@@ -6,7 +6,7 @@ import org.skife.jdbi.v2.Handle;
 
 public interface Migration
 {
-    static Pattern MIGRATION_NAME_PATTERN = Pattern.compile("Migration_([0-9]{14})_([A-Za-z]+)");
+    static Pattern MIGRATION_NAME_PATTERN = Pattern.compile("Migration_([0-9]{14})_([A-Za-z0-9]+)");
 
     default String getVersion()
     {

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20170116082921_AddAttemptIndexColumn1.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20170116082921_AddAttemptIndexColumn1.java
@@ -1,0 +1,15 @@
+package io.digdag.core.database.migrate;
+
+import java.util.List;
+import org.skife.jdbi.v2.Handle;
+
+public class Migration_20161207212921_AddAttemptIndexColumn1
+        implements Migration
+{
+    @Override
+    public void migrate(Handle handle, MigrationContext context)
+    {
+        handle.update("alter table session_attempts" +
+                " add column index int");
+    }
+}

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20170116082921_AddAttemptIndexColumn1.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20170116082921_AddAttemptIndexColumn1.java
@@ -3,7 +3,7 @@ package io.digdag.core.database.migrate;
 import java.util.List;
 import org.skife.jdbi.v2.Handle;
 
-public class Migration_20161207212921_AddAttemptIndexColumn1
+public class Migration_20170116082921_AddAttemptIndexColumn1
         implements Migration
 {
     @Override

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20170116090744_AddAttemptIndexColumn2.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20170116090744_AddAttemptIndexColumn2.java
@@ -1,0 +1,57 @@
+package io.digdag.core.database.migrate;
+
+import java.util.List;
+import org.skife.jdbi.v2.Handle;
+
+public class Migration_20161207220744_AddAttemptIndexColumn2
+        implements Migration
+{
+    @Override
+    public void migrate(Handle handle, MigrationContext context)
+    {
+        if (context.isPostgres()) {
+            handle.update(
+                    "update session_attempts set index = seq.index " +
+                    "from (" +
+                        "select id, rank() over (partition by session_id order by id) as index from session_attempts" +
+                    ") seq " +
+                    "where session_attempts.id = seq.id");
+        }
+        else {
+            List<IdAndSessionId> list =
+                handle.createQuery("select id, session_id from session_attempts order by session_id, id")
+                .map((index, r, ctx) -> new IdAndSessionId(r.getLong("id"), r.getLong("sessionId")))
+                .list();
+            long lastSessionId = 0L;
+            long lastIndex = 0;
+            for (IdAndSessionId s : list) {
+                if (lastSessionId != s.sessionId) {
+                    lastSessionId = s.sessionId;
+                    lastIndex = 0;
+                }
+                lastIndex++;
+                handle.createStatement("update session_attempts where id = :id set index = :index")
+                    .bind("id", s.id)
+                    .bind("index", lastIndex)
+                    .execute();
+            }
+        }
+
+        handle.update("alter table session_attempts" +
+                " alter column index set not null");
+
+        handle.update("create unique index session_attempts_on_session_id_and_index on session_attempts (session_id, index desc)");
+    }
+
+    private static class IdAndSessionId
+    {
+        long id;
+        long sessionId;
+
+        IdAndSessionId(long id, long sessionId)
+        {
+            this.id = id;
+            this.sessionId = sessionId;
+        }
+    }
+}

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20170116090744_AddAttemptIndexColumn2.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20170116090744_AddAttemptIndexColumn2.java
@@ -3,7 +3,7 @@ package io.digdag.core.database.migrate;
 import java.util.List;
 import org.skife.jdbi.v2.Handle;
 
-public class Migration_20161207220744_AddAttemptIndexColumn2
+public class Migration_20170116090744_AddAttemptIndexColumn2
         implements Migration
 {
     @Override

--- a/digdag-core/src/main/java/io/digdag/core/session/SessionAttemptSummary.java
+++ b/digdag-core/src/main/java/io/digdag/core/session/SessionAttemptSummary.java
@@ -15,6 +15,8 @@ public abstract class SessionAttemptSummary
 
     public abstract long getSessionId();
 
+    public abstract int getIndex();
+
     public abstract AttemptStateFlags getStateFlags();
 }
 

--- a/digdag-core/src/main/java/io/digdag/core/session/StoredSessionAttempt.java
+++ b/digdag-core/src/main/java/io/digdag/core/session/StoredSessionAttempt.java
@@ -16,11 +16,14 @@ public abstract class StoredSessionAttempt
 
     public abstract long getSessionId();
 
+    public abstract int getIndex();
+
     public abstract Instant getCreatedAt();
 
     public abstract Optional<Instant> getFinishedAt();
 
-    public static StoredSessionAttempt copyOf(StoredSessionAttempt o) {
+    public static StoredSessionAttempt copyOf(StoredSessionAttempt o)
+    {
         return ImmutableStoredSessionAttempt.builder().from(o).build();
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/session/StoredSessionAttemptWithSession.java
+++ b/digdag-core/src/main/java/io/digdag/core/session/StoredSessionAttemptWithSession.java
@@ -35,6 +35,7 @@ public abstract class StoredSessionAttemptWithSession
             .params(attempt.getParams())
             .stateFlags(attempt.getStateFlags())
             .sessionId(attempt.getSessionId())
+            .index(attempt.getIndex())
             .createdAt(attempt.getCreatedAt())
             .siteId(siteId)
             .sessionUuid(sessionUuid)

--- a/digdag-core/src/test/java/io/digdag/core/database/DatabaseSessionStoreManagerTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/database/DatabaseSessionStoreManagerTest.java
@@ -399,6 +399,10 @@ public class DatabaseSessionStoreManagerTest
                 is(store.getAttemptsOfSession(session2.getId(), 100, Optional.of(rawAttempt3.getId()))));
         assertEmpty(anotherSite.getAttemptsOfSession(session2.getId(), 100, Optional.absent()));
 
+        assertThat(attempt1.getIndex(), is(1));
+        assertThat(attempt2.getIndex(), is(1));
+        assertThat(attempt3.getIndex(), is(2));
+
         ////
         // public getters
         //

--- a/digdag-server/src/main/java/io/digdag/server/rs/RestModels.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/RestModels.java
@@ -282,6 +282,7 @@ public final class RestModels
     {
         return RestSessionAttempt.builder()
             .id(id(attempt.getId()))
+            .index(attempt.getIndex())
             .project(IdAndName.of(id(session.getProjectId()), projectName))
             .workflow(NameOptionalId.of(session.getWorkflowName(), attempt.getWorkflowDefinitionId().transform(w -> id(w))))
             .sessionId(id(attempt.getSessionId()))


### PR DESCRIPTION
Attempts have similar number with sessions but they're different. Using
attempt id and session id on clients (digdag-cli and digdag-ui) is
confusing. The idea here is to assign a sequence number to attempts in a
session (like #1, #2, ...) so that clients can implement better
interface to identify an attempt (like 2981#1, 2981#2, ...).
