### PR TITLE
Add rename_tables option to td_ddl operator

### DIFF
--- a/digdag-docs/src/operators.rst
+++ b/digdag-docs/src/operators.rst
@@ -706,9 +706,12 @@ td_ddl>: Treasure Data operations
     +step2:
       td_ddl>:
       drop_tables: ["my_table_${session_date_compact}"]
-    +step2:
+    +step3:
       td_ddl>:
       empty_tables: ["my_table_${session_date_compact}"]
+    +step4:
+      td_ddl>:
+      rename_tables: [{from: "my_table_${session_date_compact}", to: "my_table"}]
 
 Secrets
 ~~~~~~~
@@ -733,6 +736,11 @@ Parameters
   Drop tables if exists.
 
   * :command:`drop_tables: [my_table1, my_table2]`
+
+:command:`rename_tables: [ARRAY OF {to:, from:}]`
+  Rename a table to another name (override the destination table if it already exists).
+
+  * :command:`rename_tables: [{from: my_table1, to: my_table2}]`
 
 :command:`create_databases: [ARRAY OF NAMES]`
   Create new databases if not exists.

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TDOperator.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TDOperator.java
@@ -177,6 +177,21 @@ public class TDOperator
         }
     }
 
+    public void ensureExistentTableRenamed(String existentTable, String toName)
+            throws TDClientException
+    {
+        try {
+            defaultRetryExecutor.run(() -> client.renameTable(database, existentTable, toName, true));
+        }
+        catch (RetryGiveupException ex) {
+            if (ex.getCause() instanceof TDClientHttpNotFoundException) {
+                // ignore
+                return;
+            }
+            throw Throwables.propagate(ex.getCause());
+        }
+    }
+
     public boolean tableExists(String table)
     {
         try {

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdDdlOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdDdlOperatorFactory.java
@@ -146,9 +146,7 @@ public class TdDdlOperatorFactory
                                 .retryUnless(TDOperator::isDeterministicClientException)
                                 .withRetryInterval(retryInterval)
                                 .withErrorMessage("Failed check existence of table %s.%s", database, from.getTable())
-                                .runOnce(boolean.class, s -> {
-                                    return op.withDatabase(database).tableExists(from.getTable());
-                                });
+                                .run(s -> op.withDatabase(database).tableExists(from.getTable()));
                         if (!exists) {
                             throw new ConfigException(String.format(ENGLISH,
                                         "Renaming table %s.%s doesn't exist", database, from.getTable()));

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdDdlOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdDdlOperatorFactory.java
@@ -145,7 +145,7 @@ public class TdDdlOperatorFactory
                         boolean exists = pollingRetryExecutor(state, "rename_check_retry")
                                 .retryUnless(TDOperator::isDeterministicClientException)
                                 .withRetryInterval(retryInterval)
-                                .withErrorMessage("Failed check existance of table %s.%s", database, from.getTable())
+                                .withErrorMessage("Failed check existence of table %s.%s", database, from.getTable())
                                 .runOnce(boolean.class, s -> {
                                     return op.withDatabase(database).tableExists(from.getTable());
                                 });

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdDdlOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdDdlOperatorFactory.java
@@ -1,8 +1,10 @@
 package io.digdag.standards.operator.td;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigException;
 import io.digdag.core.Environment;
 import io.digdag.spi.Operator;
 import io.digdag.spi.OperatorFactory;
@@ -14,6 +16,7 @@ import io.digdag.spi.TaskResult;
 import io.digdag.standards.operator.DurationInterval;
 import io.digdag.standards.operator.state.TaskState;
 import io.digdag.util.BaseOperator;
+import org.immutables.value.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -23,9 +26,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
-import static io.digdag.standards.operator.td.BaseTdJobOperator.configSelectorBuilder;
 import static com.google.common.collect.Iterables.concat;
 import static io.digdag.standards.operator.state.PollingRetryExecutor.pollingRetryExecutor;
+import static io.digdag.standards.operator.td.BaseTdJobOperator.configSelectorBuilder;
+import static java.util.Locale.ENGLISH;
 
 public class TdDdlOperatorFactory
         implements OperatorFactory
@@ -84,6 +88,8 @@ public class TdDdlOperatorFactory
             List<TableParam> createTableList = params.getListOrEmpty("create_tables", TableParam.class);
             List<TableParam> emptyTableList = params.getListOrEmpty("empty_tables", TableParam.class);
 
+            List<RenameTableConfig> renameTableList = params.getListOrEmpty("rename_tables", RenameTableConfig.class);
+
             List<Consumer<TDOperator>> operations = new ArrayList<>();
 
             for (String d : concat(dropDatabaseList, emptyDatabaseList)) {
@@ -110,8 +116,34 @@ public class TdDdlOperatorFactory
                     op.withDatabase(t.getDatabase().or(op.getDatabase())).ensureTableCreated(t.getTable());
                 });
             }
+            for (RenameTableConfig r : renameTableList) {
+                TableParam from = r.getFromTable();
+                String to = r.getToTable();
+                if (to.contains(".")) {
+                    throw new ConfigException("'to' option of rename_tables must not include database name");
+                }
+                operations.add(op -> {
+                    logger.info("Renaming TD table {}.{} -> {}", op.getDatabase(), from, to);
+                    op.withDatabase(from.getDatabase().or(op.getDatabase())).ensureExistentTableRenamed(from.getTable(), to);
+                });
+            }
 
             try (TDOperator op = TDOperator.fromConfig(env, params, context.getSecrets().getSecrets("td"))) {
+                // make sure that all "from" tables exist so that ignoring 404 Not Found in
+                // op.ensureExistentTableRenamed is valid.
+                boolean renameFromChecked = state.params().get("rename_from_checked", boolean.class, false);
+                if (!renameFromChecked && !renameTableList.isEmpty()) {
+                    for (RenameTableConfig r : renameTableList) {
+                        TableParam from = r.getFromTable();
+                        String database = from.getDatabase().or(op.getDatabase());
+                        if (!op.withDatabase(database).tableExists(from.getTable())) {
+                            throw new ConfigException(String.format(ENGLISH,
+                                        "Renaming table %s doesn't exist", database, r.getFromTable().getTable()));
+                        }
+                    }
+                    state.params().set("rename_from_checked", true);
+                }
+
                 int operation = state.params().get("operation", int.class, 0);
                 for (int i = operation; i < operations.size(); i++) {
                     state.params().set("operation", i);
@@ -124,11 +156,21 @@ public class TdDdlOperatorFactory
                             .withRetryInterval(retryInterval)
                             .withErrorMessage("DDL operation failed")
                             .runAction(s -> o.accept(op));
-
                 }
             }
 
             return TaskResult.empty(request);
         }
+    }
+
+    @Value.Immutable
+    @Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+    interface RenameTableConfig
+    {
+        @JsonProperty("from")
+        TableParam getFromTable();
+
+        @JsonProperty("to")
+        String getToTable();
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdDdlOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdDdlOperatorFactory.java
@@ -120,7 +120,8 @@ public class TdDdlOperatorFactory
                 TableParam from = r.getFromTable();
                 String to = r.getToTable();
                 if (to.contains(".")) {
-                    throw new ConfigException("'to' option of rename_tables must not include database name");
+                    // renaming a table across databases is not supported by the td's rest api itself
+                    throw new ConfigException("'to' option of rename_tables can't include database name");
                 }
                 operations.add(op -> {
                     logger.info("Renaming TD table {}.{} -> {}", op.getDatabase(), from, to);
@@ -138,7 +139,7 @@ public class TdDdlOperatorFactory
                         String database = from.getDatabase().or(op.getDatabase());
                         if (!op.withDatabase(database).tableExists(from.getTable())) {
                             throw new ConfigException(String.format(ENGLISH,
-                                        "Renaming table %s doesn't exist", database, r.getFromTable().getTable()));
+                                        "Renaming table %s.%s doesn't exist", database, from.getTable()));
                         }
                     }
                     state.params().set("rename_from_checked", true);

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdDdlOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdDdlOperatorFactory.java
@@ -1,6 +1,7 @@
 package io.digdag.standards.operator.td;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import io.digdag.client.config.Config;
@@ -174,6 +175,7 @@ public class TdDdlOperatorFactory
 
     @Value.Immutable
     @Value.Style(visibility = Value.Style.ImplementationVisibility.PACKAGE)
+    @JsonDeserialize(as = ImmutableRenameTableConfig.class)
     interface RenameTableConfig
     {
         @JsonProperty("from")

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdDdlOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdDdlOperatorFactory.java
@@ -147,7 +147,7 @@ public class TdDdlOperatorFactory
                                 .withRetryInterval(retryInterval)
                                 .withErrorMessage("Failed check existance of table %s.%s", database, from.getTable())
                                 .runOnce(boolean.class, s -> {
-                                    return !op.withDatabase(database).tableExists(from.getTable());
+                                    return op.withDatabase(database).tableExists(from.getTable());
                                 });
                         if (!exists) {
                             throw new ConfigException(String.format(ENGLISH,

--- a/digdag-tests/src/test/java/acceptance/td/TdDdlIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/TdDdlIT.java
@@ -50,6 +50,7 @@ import static java.nio.file.StandardOpenOption.APPEND;
 import static java.util.Arrays.asList;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
@@ -304,8 +305,9 @@ public class TdDdlIT
             throws IOException
     {
         addWorkflow(projectDir, "acceptance/td/td_ddl/rename_not_exists.dig");
-        CommandStatus runStatus = runWorkflow("rename_not_exists");
-        assertThat(runStatus.errUtf8(), runStatus.code(), not(0));
+        CommandStatus runStatus = runWorkflow("rename_not_exists", "database=" + database);
+        assertThat(runStatus.errUtf8(), runStatus.code(), is(not(0)));
+        assertThat(runStatus.errUtf8(), containsString("Renaming table " + database + ".rename_table_from doesn't exist"));
     }
 
     private CommandStatus runWorkflow(String workflow, String... params)

--- a/digdag-tests/src/test/java/acceptance/td/TdDdlIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/TdDdlIT.java
@@ -310,6 +310,16 @@ public class TdDdlIT
         assertThat(runStatus.errUtf8(), containsString("Renaming table " + database + ".rename_table_from doesn't exist"));
     }
 
+    @Test
+    public void testDdlFailIfSomeRenameFromNotExists()
+            throws IOException
+    {
+        addWorkflow(projectDir, "acceptance/td/td_ddl/rename_partial_exists.dig");
+        CommandStatus runStatus = runWorkflow("rename_partial_exists", "database=" + database);
+        assertThat(runStatus.errUtf8(), runStatus.code(), is(not(0)));
+        assertThat(runStatus.errUtf8(), containsString("Renaming table " + database + ".rename_table_from_2 doesn't exist"));
+    }
+
     private CommandStatus runWorkflow(String workflow, String... params)
     {
         List<String> args = new ArrayList<>();

--- a/digdag-tests/src/test/java/acceptance/td/TdDdlIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/TdDdlIT.java
@@ -252,7 +252,7 @@ public class TdDdlIT
         assertThat(databases, not(hasItem(dropDb2)));
 
         List<String> tables = client.listTables(database).stream().map(TDTable::getName).collect(toList());
-        assertThat(tables, containsInAnyOrder("create_table_1", "create_table_2", "empty_table_1", "empty_table_2"));
+        assertThat(tables, containsInAnyOrder("create_table_1", "create_table_2", "empty_table_1", "empty_table_2", "rename_table_1_to", "rename_table_2_to"));
     }
 
     private void runDdlWorkflow()
@@ -269,6 +269,15 @@ public class TdDdlIT
                 "empty_db_2=" + emptyDb2);
         assertThat(runStatus.errUtf8(), runStatus.code(), is(0));
         assertThat(Files.exists(outfile), is(true));
+    }
+
+    @Test
+    public void testDdlFailIfRenameFromNotExists()
+            throws IOException
+    {
+        addWorkflow(projectDir, "acceptance/td/td_ddl/rename_not_exists.dig");
+        CommandStatus runStatus = runWorkflow("rename_not_exists");
+        assertThat(runStatus.errUtf8(), runStatus.code(), not(0));
     }
 
     private CommandStatus runWorkflow(String workflow, String... params)

--- a/digdag-tests/src/test/resources/acceptance/td/td_ddl/rename_not_exists.dig
+++ b/digdag-tests/src/test/resources/acceptance/td/td_ddl/rename_not_exists.dig
@@ -1,0 +1,10 @@
+timezone: UTC
+
++rename:
+  td_ddl>:
+  drop_tables: ["rename_table_from"]
+
++rename:
+  td_ddl>:
+  rename_tables: [{from: "rename_table_from", to: "rename_table_to"}]
+

--- a/digdag-tests/src/test/resources/acceptance/td/td_ddl/rename_not_exists.dig
+++ b/digdag-tests/src/test/resources/acceptance/td/td_ddl/rename_not_exists.dig
@@ -1,6 +1,6 @@
 timezone: UTC
 
-+rename:
++drop:
   td_ddl>:
   drop_tables: ["rename_table_from"]
 

--- a/digdag-tests/src/test/resources/acceptance/td/td_ddl/rename_partial_exists.dig
+++ b/digdag-tests/src/test/resources/acceptance/td/td_ddl/rename_partial_exists.dig
@@ -1,0 +1,16 @@
+timezone: UTC
+
++drop:
+  td_ddl>:
+  drop_tables: ["rename_table_from_1", "rename_table_from_2"]
+
++create:
+  td_ddl>:
+  create_tables: ["rename_table_from_1"]
+
++rename:
+  td_ddl>:
+  rename_tables:
+    - {from: "rename_table_from_1", to: "rename_table_to_1"}
+    - {from: "rename_table_from_2", to: "rename_table_to_2"}
+

--- a/digdag-tests/src/test/resources/acceptance/td/td_ddl/td_ddl.dig
+++ b/digdag-tests/src/test/resources/acceptance/td/td_ddl/td_ddl.dig
@@ -2,7 +2,7 @@ timezone: UTC
 
 +prep:
   td_ddl>:
-  create_tables: ["drop_table_1", "drop_table_2"]
+  create_tables: ["drop_table_1", "drop_table_2", "rename_table_1_from", "rename_table_2_from", "rename_table_2_to"]
   create_databases: ["${drop_db_1}", "${drop_db_2}"]
 
 +ddl:
@@ -13,6 +13,7 @@ timezone: UTC
   create_databases: ["${create_db_1}", "${create_db_2}"]
   drop_databases: ["${drop_db_1}", "${drop_db_2}"]
   empty_databases: ["${empty_db_1}", "${empty_db_2}"]
+  rename_tables: [{from: "rename_table_1_from", to: "rename_table_1_to"}, {from: "rename_table_2_from", to: "rename_table_2_to"}]
 
 +post:
   sh>: touch ${outfile}


### PR DESCRIPTION
Syntax:

```
td_ddl>:
rename_tables: [{from: t1, to: t2}, {from: a1, to: a2}]
```

How it works:

1. make sure that all `from` tables exist.
2. repeat renameTable REST API call with overwrite=true option until it succeeds or 404 Not Found happens.
3. ignore 404 Not Found errors. This should be valid because step 1. confirmed that all tables exist. If 404 happens, it means that an operation is duplicated in somewhere (operator, client, load balancer, server, etc.).
