### PR TITLE
Reimplement user-defined secret access api to operators

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/agent/SecretAccessFilteredException.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/SecretAccessFilteredException.java
@@ -1,0 +1,12 @@
+package io.digdag.core.agent;
+
+import io.digdag.spi.SecretAccessDeniedException;
+
+class SecretAccessFilteredException
+        extends SecretAccessDeniedException
+{
+    public SecretAccessFilteredException(String key, String message)
+    {
+        super(key, message);
+    }
+}

--- a/digdag-core/src/test/java/io/digdag/core/agent/OperatorSecretFilterTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/agent/OperatorSecretFilterTest.java
@@ -1,0 +1,161 @@
+package io.digdag.core.agent;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableSet;
+import com.google.inject.Inject;
+import com.google.inject.Scopes;
+import com.google.inject.multibindings.Multibinder;
+import io.digdag.client.config.Config;
+import io.digdag.core.DigdagEmbed;
+import io.digdag.spi.Operator;
+import io.digdag.spi.OperatorContext;
+import io.digdag.spi.OperatorFactory;
+import io.digdag.spi.SecretAccessList;
+import io.digdag.spi.SecretStore;
+import io.digdag.spi.SecretStoreManager;
+import io.digdag.spi.TaskRequest;
+import io.digdag.spi.TaskResult;
+import java.nio.file.Paths;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import static io.digdag.client.config.ConfigUtils.newConfig;
+import static io.digdag.core.workflow.OperatorTestingUtils.newTaskRequest;
+import static io.digdag.core.workflow.WorkflowTestingUtils.setupEmbed;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class OperatorSecretFilterTest
+{
+    static class SecretAccessOperatorFactory
+            implements OperatorFactory
+    {
+        @Inject
+        public SecretAccessOperatorFactory()
+        { }
+
+        @Override
+        public String getType()
+        {
+            return "secret_access";
+        }
+
+        @Override
+        public SecretAccessList getSecretAccessList()
+        {
+            return () -> ImmutableSet.of("statically_declared_key");
+        }
+
+        @Override
+        public Operator newOperator(OperatorContext context)
+        {
+            return new SecretAccessOperator(context);
+        }
+    }
+
+    static class SecretAccessOperator
+            implements Operator
+    {
+        private final OperatorContext context;
+
+        public SecretAccessOperator(OperatorContext context)
+        {
+            this.context = context;
+        }
+
+        @Override
+        public boolean testUserSecretAccess(String key)
+        {
+            return key.equals("user_key");
+        }
+
+        @Override
+        public TaskResult run()
+        {
+            String get = context.getTaskRequest().getConfig().get("get", String.class);
+            String got = context.getSecrets().getSecret(get);
+            return TaskResult.defaultBuilder(context.getTaskRequest())
+                .storeParams(newConfig().set("got", got))
+                .build();
+        }
+    }
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    private DigdagEmbed embed;
+    private OperatorManager operatorManager;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        this.embed = setupEmbed((bootstrap) -> bootstrap.addModules((binder) -> {
+                    Multibinder.newSetBinder(binder, OperatorFactory.class)
+                        .addBinding().to(SecretAccessOperatorFactory.class).in(Scopes.SINGLETON);
+                })
+                .overrideModulesWith((binder) -> {
+                    SecretStore secrets = (projectId, scope, key) -> Optional.of(key + ".value");
+                    binder.bind(SecretStoreManager.class).toInstance(siteId -> secrets);
+                })
+            );
+        this.operatorManager = embed.getInjector().getInstance(OperatorManager.class);
+    }
+
+    @After
+    public void shutdown()
+            throws Exception
+    {
+        embed.close();
+    }
+
+    @Test
+    public void verifyPredeclaredAccessAllowed()
+    {
+        Config config = newConfig().set("get", "statically_declared_key");
+        Config stored = run("secret_access", config);
+        assertThat(stored.get("got", String.class), is("statically_declared_key.value"));
+    }
+
+    @Test
+    public void verifyNonPredeclaredAccessRejected()
+    {
+        exception.expect(SecretAccessFilteredException.class);
+        exception.expectMessage(containsString("kkk"));
+
+        Config config = newConfig().set("get", "kkk");
+        run("secret_access", config);
+    }
+
+    @Test
+    public void verifyUserGrantedAccessAllowed()
+    {
+        Config config = newConfig().set("get", "user_key").set("_secret", newConfig().set("user_key", true));
+        Config stored = run("secret_access", config);
+        assertThat(stored.get("got", String.class), is("user_key.value"));
+    }
+
+    @Test
+    public void verifyUserGrantedButOperatorFilteredAccessRejected()
+    {
+        exception.expect(SecretAccessFilteredException.class);
+        exception.expectMessage(containsString("kkk"));
+
+        Config config = newConfig().set("get", "kkk").set("_secret", newConfig().set("kkk", true));
+        run("secret_access", config);
+    }
+
+    private Config run(String operatorType, Config config)
+    {
+        TaskResult result = operatorManager.callExecutor(
+                Paths.get(""),
+                operatorType,
+                newTaskRequest().withConfig(config));
+        return result.getStoreParams();
+    }
+}

--- a/digdag-core/src/test/java/io/digdag/core/workflow/OperatorTestingUtils.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/OperatorTestingUtils.java
@@ -65,6 +65,7 @@ public class OperatorTestingUtils
             .siteId(1)
             .projectId(2)
             .workflowName("wf")
+            .revision(Optional.of("rev"))
             .taskId(3)
             .attemptId(4)
             .sessionId(5)

--- a/digdag-core/src/test/java/io/digdag/core/workflow/WorkflowTestingUtils.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/WorkflowTestingUtils.java
@@ -39,6 +39,7 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Function;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static io.digdag.core.database.DatabaseTestingUtils.cleanDatabase;
@@ -50,7 +51,12 @@ public class WorkflowTestingUtils
 
     public static DigdagEmbed setupEmbed()
     {
-        DigdagEmbed embed = new DigdagEmbed.Bootstrap()
+        return setupEmbed(bootstrap -> bootstrap);
+    }
+
+    public static DigdagEmbed setupEmbed(Function<DigdagEmbed.Bootstrap, DigdagEmbed.Bootstrap> customizer)
+    {
+        DigdagEmbed.Bootstrap bootstrap = new DigdagEmbed.Bootstrap()
             .withExtensionLoader(false)
             .addModules((binder) -> {
                 binder.bind(CommandExecutor.class).to(SimpleCommandExecutor.class).in(Scopes.SINGLETON);
@@ -71,7 +77,8 @@ public class WorkflowTestingUtils
             .overrideModulesWith((binder) -> {
                 binder.bind(DatabaseConfig.class).toInstance(getEnvironmentDatabaseConfig());
             })
-            .initializeWithoutShutdownHook();
+            ;
+        DigdagEmbed embed = customizer.apply(bootstrap).initializeWithoutShutdownHook();
         cleanDatabase(embed);
         return embed;
     }

--- a/digdag-spi/src/main/java/io/digdag/spi/Operator.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/Operator.java
@@ -7,4 +7,16 @@ import java.util.List;
 public interface Operator
 {
     TaskResult run();
+
+    /**
+     * Return false if operator doesn't need the given secret key granted explicitly by users.
+     *
+     * This method allows operator implementations to reject use of secrets which are explicitly
+     * granted by _secret directive when the operator knows the key is actually unnecessary.
+     * Operators should override this method to avoid unintentional use of secrets.
+     */
+    default boolean testUserSecretAccess(String key)
+    {
+        return true;
+    }
 }

--- a/digdag-spi/src/main/java/io/digdag/spi/OperatorFactory.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/OperatorFactory.java
@@ -9,9 +9,16 @@ public interface OperatorFactory
     String getType();
 
     /**
-     * Get a list of secret secret keys that this intends to access.
+     * Get a list of secret secret keys that this operator intends to access.
+     *
      * An attempt to access a secret using a key not covered by
      * one of these keys will result in a {@link SecretAccessDeniedException}.
+     *
+     * If this operator wants to use secret keys given by configuration parameters
+     * (e.g. secrets.getSecrets(config.get("secret", String.class))), the keys won't be (can't be)
+     * included here. Instead, users must grant the access explicitly using _secret directive.
+     * Operators should test the access to the key by overriding
+     * {@link Operator#testUserSecretAccess(String)} method.
      */
     default SecretAccessList getSecretAccessList()
     {

--- a/digdag-spi/src/main/java/io/digdag/spi/SecretAccessDeniedException.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/SecretAccessDeniedException.java
@@ -5,9 +5,9 @@ public class SecretAccessDeniedException
 {
     private String key;
 
-    public SecretAccessDeniedException(String key)
+    public SecretAccessDeniedException(String key, String message)
     {
-        super("Access denied for key: '" + key + "'");
+        super(message);
         this.key = key;
     }
 


### PR DESCRIPTION
The first secret API design included a use case where operators use secret keys given by users in workflow definition (e.g.: `config: {spark.td.apikey: {secret: td.apikey}}}` but #344 removed it.
This PR re-adds to the API to the operator API. Use case:

* Operators must declare list of accessing secret keys in OperatorFactory.getSecretAccessList.
* But users can explicitly grant access to secrets using `_secret` directive when users give name of the secrets as a configuration parameter. Operators can get these secrets even when getSecretAccessList doesn't include them.
* Operators still have a chance to reject it by implementing Operator.testUserSecretAccess(key) method. This is useful when operators give SecretProvider to an external library and operators want to avoid the library's unexpected use of secrets.
