### PR TITLE
add started_at field to task api endpoint

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/client/ShowTask.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/ShowTask.java
@@ -1,6 +1,7 @@
 package io.digdag.cli.client;
 
 import io.digdag.cli.SystemExitException;
+import io.digdag.cli.TimeUtil;
 import io.digdag.client.DigdagClient;
 import io.digdag.client.api.Id;
 import io.digdag.client.api.RestTask;
@@ -38,6 +39,8 @@ public class ShowTask
             ln("   id: %s", task.getId());
             ln("   name: %s", task.getFullName());
             ln("   state: %s", task.getState());
+            ln("   started: %s", task.getStartedAt().transform(TimeUtil::formatTime).or(""));
+            ln("   updated: %s", TimeUtil.formatTime(task.getUpdatedAt()));
             ln("   config: %s", task.getConfig());
             ln("   parent: %s", task.getParentId().orNull());
             ln("   upstreams: %s", task.getUpstreams());

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
@@ -1939,6 +1939,7 @@ public class DatabaseSessionStoreManager
                 .upstreams(getLongIdList(r, "upstream_ids"))
                 .updatedAt(getTimestampInstant(r, "updated_at"))
                 .retryAt(getOptionalTimestampInstant(r, "retry_at"))
+                .startedAt(getOptionalTimestampInstant(r, "started_at"))
                 .stateParams(cfm.fromResultSetOrEmpty(r, "state_params"))
                 .retryCount(r.getInt("retry_count"))
                 .attemptId(r.getLong("attempt_id"))


### PR DESCRIPTION
Expose the task start time in the `/api/attempts/{id}/tasks` endpoint so that task execution timings can be shown by the cli and visualized by the UI.