### PR TITLE
download command to download to temp file

### DIFF
--- a/digdag-client/build.gradle
+++ b/digdag-client/build.gradle
@@ -19,4 +19,7 @@ dependencies {
 
     compile  'org.immutables:value:2.0.21'
     compile  'org.immutables:builder:2.0.21'
+
+    testCompile 'com.squareup.okhttp3:okhttp:3.4.1'
+    testCompile 'com.squareup.okhttp3:mockwebserver:3.4.1'
 }

--- a/digdag-client/build.gradle
+++ b/digdag-client/build.gradle
@@ -7,6 +7,8 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-databind:${project.ext.jacksonVersion}"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-guava:${project.ext.jacksonVersion}"
 
+    compile "com.github.rholder:guava-retrying:2.0.0"
+
     compile 'org.jboss.resteasy:resteasy-client:3.0.13.Final'
     compile 'org.apache.commons:commons-compress:1.10'
     compile 'io.jsonwebtoken:jjwt:0.6.0'

--- a/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
+++ b/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
@@ -12,7 +12,6 @@ import com.github.rholder.retry.Retryer;
 import com.github.rholder.retry.RetryerBuilder;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Predicates;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
@@ -47,7 +46,6 @@ import io.digdag.client.api.SessionTimeTruncate;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigFactory;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
-import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
 
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.WebApplicationException;
@@ -70,7 +68,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -591,7 +588,7 @@ public class DigdagClient implements AutoCloseable
             Invocation request = client.target(UriBuilder.fromUri(handle.getDirect().get().getUrl()))
                     .request()
                     .buildGet();
-            return getLogFile(request);
+            return invokeWithRetry(request).readEntity(InputStream.class);
         }
         else {
             return getLogFile(attemptId, handle.getFileName());
@@ -607,12 +604,13 @@ public class DigdagClient implements AutoCloseable
                 .headers(this.headers.get())
                 .buildGet();
 
-        return getLogFile(request);
+        return invokeWithRetry(request)
+                .readEntity(InputStream.class);
     }
 
-    private InputStream getLogFile(Invocation request)
+    private Response invokeWithRetry(Invocation request)
     {
-        Retryer<InputStream> retryer = RetryerBuilder.<InputStream>newBuilder()
+        Retryer<Response> retryer = RetryerBuilder.<Response>newBuilder()
                 .retryIfException(not(DigdagClient::isDeterministicError))
                 .withWaitStrategy(exponentialWait())
                 .withStopStrategy(stopAfterAttempt(10))
@@ -625,7 +623,7 @@ public class DigdagClient implements AutoCloseable
                     res.close();
                     return handleErrorStatus(res);
                 }
-                return res.readEntity(InputStream.class);
+                return res;
             });
         }
         catch (ExecutionException | RetryException e) {
@@ -819,16 +817,16 @@ public class DigdagClient implements AutoCloseable
 
     private <T> T doGet(GenericType<T> type, WebTarget target)
     {
-        return target.request("application/json")
+        return invokeWithRetry(target.request("application/json")
             .headers(headers.get())
-            .get(type);
+            .buildGet()).readEntity(type);
     }
 
     private <T> T doGet(Class<T> type, WebTarget target)
     {
-        return target.request("application/json")
+        return invokeWithRetry(target.request("application/json")
             .headers(headers.get())
-            .get(type);
+            .buildGet()).readEntity(type);
     }
 
     private <T> T doPut(Class<T> type, String contentType, Object body, WebTarget target)

--- a/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
+++ b/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
@@ -7,9 +7,14 @@ import com.fasterxml.jackson.databind.InjectableValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
 import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import com.github.rholder.retry.RetryException;
+import com.github.rholder.retry.Retryer;
+import com.github.rholder.retry.RetryerBuilder;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Predicates;
 import com.google.common.base.Strings;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import io.digdag.client.api.Id;
 import io.digdag.client.api.JacksonTimeModule;
@@ -42,11 +47,13 @@ import io.digdag.client.api.SessionTimeTruncate;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigFactory;
 import org.jboss.resteasy.client.jaxrs.ResteasyClientBuilder;
+import org.jboss.resteasy.client.jaxrs.internal.ClientInvocation;
 
 import javax.ws.rs.NotFoundException;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Entity;
+import javax.ws.rs.client.Invocation;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MultivaluedHashMap;
@@ -62,13 +69,23 @@ import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static com.github.rholder.retry.StopStrategies.stopAfterAttempt;
+import static com.github.rholder.retry.WaitStrategies.exponentialWait;
+import static com.google.common.base.Predicates.not;
 import static java.util.Locale.ENGLISH;
+import static javax.ws.rs.core.Response.Status.Family.SUCCESSFUL;
+import static org.jboss.resteasy.client.jaxrs.internal.ClientInvocation.handleErrorStatus;
 
 public class DigdagClient implements AutoCloseable
 {
+    private static final int TOO_MANY_REQUESTS_429 = 429;
+    private static final int REQUEST_TIMEOUT_408 = 408;
+
     public static class Builder
     {
         private String host = null;
@@ -571,11 +588,10 @@ public class DigdagClient implements AutoCloseable
     public InputStream getLogFile(Id attemptId, RestLogFileHandle handle)
     {
         if (handle.getDirect().isPresent()) {
-            Response res = client.target(UriBuilder.fromUri(handle.getDirect().get().getUrl()))
+            Invocation request = client.target(UriBuilder.fromUri(handle.getDirect().get().getUrl()))
                     .request()
-                    .get();
-            // TODO check status code
-            return res.readEntity(InputStream.class);
+                    .buildGet();
+            return getLogFile(request);
         }
         else {
             return getLogFile(attemptId, handle.getFileName());
@@ -584,14 +600,62 @@ public class DigdagClient implements AutoCloseable
 
     public InputStream getLogFile(Id attemptId, String fileName)
     {
-        Response res = target("/api/logs/{id}/files/{fileName}")
-            .resolveTemplate("id", attemptId)
-            .resolveTemplate("fileName", fileName)
-            .request()
-            .headers(headers.get())
-            .get();
-        // TODO check status code
-        return res.readEntity(InputStream.class);
+        Invocation request = target("/api/logs/{id}/files/{fileName}")
+                .resolveTemplate("id", attemptId)
+                .resolveTemplate("fileName", fileName)
+                .request()
+                .headers(this.headers.get())
+                .buildGet();
+
+        return getLogFile(request);
+    }
+
+    private InputStream getLogFile(Invocation request)
+    {
+        Retryer<InputStream> retryer = RetryerBuilder.<InputStream>newBuilder()
+                .retryIfException(not(DigdagClient::isDeterministicError))
+                .withWaitStrategy(exponentialWait())
+                .withStopStrategy(stopAfterAttempt(10))
+                .build();
+
+        try {
+            return retryer.call(() -> {
+                Response res = request.invoke();
+                if (res.getStatusInfo().getFamily() != SUCCESSFUL) {
+                    res.close();
+                    return handleErrorStatus(res);
+                }
+                return res.readEntity(InputStream.class);
+            });
+        }
+        catch (ExecutionException | RetryException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
+    private static boolean isDeterministicError(Throwable ex)
+    {
+        return ex instanceof WebApplicationException &&
+                isDeterministicError(((WebApplicationException) ex).getResponse());
+    }
+
+    private static boolean isDeterministicError(Response res)
+    {
+        return isDeterministicError(res.getStatus());
+    }
+
+    private static boolean isDeterministicError(int status)
+    {
+        if (status >= 400 && status < 500) {
+            switch (status) {
+                case TOO_MANY_REQUESTS_429:
+                case REQUEST_TIMEOUT_408:
+                    return false;
+                default:
+                    return true;
+            }
+        }
+        return false;
     }
 
     public RestSessionAttempt startSessionAttempt(RestSessionAttemptRequest request)
@@ -710,7 +774,7 @@ public class DigdagClient implements AutoCloseable
                 .request()
                 .headers(headers.get())
                 .put(Entity.entity(RestSetSecretRequest.of(value), "application/json"));
-        if (response.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL) {
+        if (response.getStatusInfo().getFamily() != SUCCESSFUL) {
             throw new WebApplicationException("Failed to set project secret: " + response.getStatusInfo());
         }
     }
@@ -728,7 +792,7 @@ public class DigdagClient implements AutoCloseable
                 .headers(headers.get())
                 .delete();
 
-        if (response.getStatusInfo().getFamily() != Response.Status.Family.SUCCESSFUL) {
+        if (response.getStatusInfo().getFamily() != SUCCESSFUL) {
             throw new WebApplicationException("Failed to delete project secret: " + response.getStatusInfo());
         }
     }

--- a/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
+++ b/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
@@ -70,6 +70,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 import static com.github.rholder.retry.StopStrategies.stopAfterAttempt;
 import static com.github.rholder.retry.WaitStrategies.exponentialWait;
@@ -627,7 +628,8 @@ public class DigdagClient implements AutoCloseable
             });
         }
         catch (ExecutionException | RetryException e) {
-            throw Throwables.propagate(e);
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            throw Throwables.propagate(cause);
         }
     }
 

--- a/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
+++ b/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
@@ -424,14 +424,14 @@ public class DigdagClient implements AutoCloseable
     // TODO getArchive with streaming
     public InputStream getProjectArchive(Id projId, String revision)
     {
-        Response res = target("/api/projects/{id}/archive")
+        Invocation request = target("/api/projects/{id}/archive")
             .resolveTemplate("id", projId)
             .queryParam("revision", revision)
             .request()
             .headers(headers.get())
-            .get();
-        // TODO check status code
-        return res.readEntity(InputStream.class);
+            .buildGet();
+        return invokeWithRetry(request)
+            .readEntity(InputStream.class);
     }
 
     public RestScheduleCollection getSchedules()

--- a/digdag-client/src/test/java/io/digdag/client/DigdagClientTest.java
+++ b/digdag-client/src/test/java/io/digdag/client/DigdagClientTest.java
@@ -3,6 +3,7 @@ package io.digdag.client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.CharStreams;
+import io.digdag.client.api.Id;
 import io.digdag.client.api.RestDirectDownloadHandle;
 import io.digdag.client.api.RestLogFileHandle;
 import okhttp3.internal.tls.SslClient;
@@ -90,7 +91,7 @@ public class DigdagClientTest
                 .setBody(objectMapper.writeValueAsString(expectedLogFileHandles))
                 .setHeader(CONTENT_TYPE, APPLICATION_JSON));
 
-        List<RestLogFileHandle> receivedLogFileHandles = client.getLogFileHandlesOfAttempt(17);
+        List<RestLogFileHandle> receivedLogFileHandles = client.getLogFileHandlesOfAttempt(Id.of("17")).getFiles();
 
         assertThat(receivedLogFileHandles, is(expectedLogFileHandles));
 
@@ -126,7 +127,7 @@ public class DigdagClientTest
                 .setBody(objectMapper.writeValueAsString(expectedLogFileHandles))
                 .setHeader(CONTENT_TYPE, APPLICATION_JSON));
 
-        List<RestLogFileHandle> receivedLogFileHandles = client.getLogFileHandlesOfTask(17, "test-task");
+        List<RestLogFileHandle> receivedLogFileHandles = client.getLogFileHandlesOfTask(Id.of("17"), "test-task").getFiles();
 
         assertThat(receivedLogFileHandles, is(expectedLogFileHandles));
 
@@ -139,7 +140,7 @@ public class DigdagClientTest
     public void getLogFileDirect()
             throws Exception
     {
-        int attemptId = 17;
+        Id attemptId = Id.of("17");
         String logFileContents = "foo\nbar";
         String logFilePath = "/logs/test-task-1.log";
         String logFileUrl = "https://" + mockWebServer.getHostName() + ":" + mockWebServer.getPort() + logFilePath;
@@ -183,7 +184,7 @@ public class DigdagClientTest
                 .setBody(logFileContents)
                 .setHeader(CONTENT_TYPE, TEXT_PLAIN));
 
-        InputStream logFileStream = client.getLogFile(17, RestLogFileHandle.builder()
+        InputStream logFileStream = client.getLogFile(Id.of("17"), RestLogFileHandle.builder()
                 .agentId("test-agent")
                 .fileName(logFileName)
                 .fileSize(4711)
@@ -209,7 +210,7 @@ public class DigdagClientTest
         mockWebServer.setDispatcher(dispatcher);
 
         try {
-            client.getLogFile(17, RestLogFileHandle.builder()
+            client.getLogFile(Id.of("17"), RestLogFileHandle.builder()
                     .agentId("test-agent")
                     .fileName("test-task-1.log")
                     .fileSize(4711)

--- a/digdag-client/src/test/java/io/digdag/client/DigdagClientTest.java
+++ b/digdag-client/src/test/java/io/digdag/client/DigdagClientTest.java
@@ -1,0 +1,196 @@
+package io.digdag.client;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.CharStreams;
+import io.digdag.client.api.RestDirectDownloadHandle;
+import io.digdag.client.api.RestLogFileHandle;
+import okhttp3.internal.tls.SslClient;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.time.Instant;
+import java.util.List;
+
+import static java.time.temporal.ChronoUnit.SECONDS;
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
+import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class DigdagClientTest
+{
+    private MockWebServer mockWebServer;
+    private DigdagClient client;
+    private ObjectMapper objectMapper;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        mockWebServer = new MockWebServer();
+        mockWebServer.useHttps(SslClient.localhost().socketFactory, false);
+        mockWebServer.start();
+
+        client = DigdagClient.builder()
+                .disableCertValidation(true)
+                .ssl(true)
+                .host(mockWebServer.getHostName())
+                .port(mockWebServer.getPort())
+                .build();
+
+        objectMapper = DigdagClient.objectMapper();
+    }
+
+    @After
+    public void tearDown()
+            throws Exception
+    {
+        if (mockWebServer != null) {
+            mockWebServer.shutdown();
+        }
+    }
+
+    @Test
+    public void getLogFileHandlesOfAttempt()
+            throws Exception
+    {
+        List<RestLogFileHandle> expectedLogFileHandles = ImmutableList.of(
+                RestLogFileHandle.builder()
+                        .agentId("test-agent")
+                        .fileName("test-task-1.log")
+                        .fileSize(4711)
+                        .fileTime(Instant.now().truncatedTo(SECONDS))
+                        .taskName("test-task-1")
+                        .build(),
+                RestLogFileHandle.builder()
+                        .agentId("test-agent")
+                        .fileName("test-task-2.log")
+                        .fileSize(4712)
+                        .fileTime(Instant.now().truncatedTo(SECONDS))
+                        .taskName("test-task-2")
+                        .build()
+        );
+
+        mockWebServer.enqueue(new MockResponse().setResponseCode(500));
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(objectMapper.writeValueAsString(expectedLogFileHandles))
+                .setHeader(CONTENT_TYPE, APPLICATION_JSON));
+
+        List<RestLogFileHandle> receivedLogFileHandles = client.getLogFileHandlesOfAttempt(17);
+
+        assertThat(receivedLogFileHandles, is(expectedLogFileHandles));
+
+        assertThat(mockWebServer.getRequestCount(), is(2));
+        assertThat(mockWebServer.takeRequest().getPath(), is("/api/logs/17/files"));
+        assertThat(mockWebServer.takeRequest().getPath(), is("/api/logs/17/files"));
+    }
+
+    @Test
+    public void getLogFileHandlesOfTask()
+            throws Exception
+    {
+        List<RestLogFileHandle> expectedLogFileHandles = ImmutableList.of(
+                RestLogFileHandle.builder()
+                        .agentId("test-agent")
+                        .fileName("test-task-1.log")
+                        .fileSize(4711)
+                        .fileTime(Instant.now().truncatedTo(SECONDS))
+                        .taskName("test-task-1")
+                        .build(),
+                RestLogFileHandle.builder()
+                        .agentId("test-agent")
+                        .fileName("test-task-2.log")
+                        .fileSize(4712)
+                        .fileTime(Instant.now().truncatedTo(SECONDS))
+                        .taskName("test-task-2")
+                        .build()
+        );
+
+        mockWebServer.enqueue(new MockResponse().setResponseCode(500));
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(objectMapper.writeValueAsString(expectedLogFileHandles))
+                .setHeader(CONTENT_TYPE, APPLICATION_JSON));
+
+        List<RestLogFileHandle> receivedLogFileHandles = client.getLogFileHandlesOfTask(17, "test-task");
+
+        assertThat(receivedLogFileHandles, is(expectedLogFileHandles));
+
+        assertThat(mockWebServer.getRequestCount(), is(2));
+        assertThat(mockWebServer.takeRequest().getPath(), is("/api/logs/17/files?task=test-task"));
+        assertThat(mockWebServer.takeRequest().getPath(), is("/api/logs/17/files?task=test-task"));
+    }
+
+    @Test
+    public void getLogFileDirect()
+            throws Exception
+    {
+        int attemptId = 17;
+        String logFileContents = "foo\nbar";
+        String logFilePath = "/logs/test-task-1.log";
+        String logFileUrl = "https://" + mockWebServer.getHostName() + ":" + mockWebServer.getPort() + logFilePath;
+
+        mockWebServer.enqueue(new MockResponse().setResponseCode(500));
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(logFileContents)
+                .setHeader(CONTENT_TYPE, TEXT_PLAIN));
+
+        InputStream logFileStream = client.getLogFile(attemptId, RestLogFileHandle.builder()
+                .direct(RestDirectDownloadHandle.of(logFileUrl))
+                .agentId("test-agent")
+                .fileName("test-task-1.log")
+                .fileSize(4711)
+                .fileTime(Instant.now().truncatedTo(SECONDS))
+                .taskName("test-task-1")
+                .build());
+
+        String receivedLogFileContents = CharStreams.toString(new InputStreamReader(logFileStream));
+
+        assertThat(receivedLogFileContents, is(logFileContents));
+
+        assertThat(mockWebServer.getRequestCount(), is(2));
+        assertThat(mockWebServer.takeRequest().getPath(), is(logFilePath));
+        assertThat(mockWebServer.takeRequest().getPath(), is(logFilePath));
+    }
+
+    @Test
+    public void getLogFile()
+            throws Exception
+    {
+        int attemptId = 17;
+        String logFileContents = "foo\nbar";
+        String logFileName = "test-task-1.log";
+        String logFilePath = "/api/logs/" + attemptId + "/files/" + logFileName;
+
+        mockWebServer.enqueue(new MockResponse().setResponseCode(500));
+
+        mockWebServer.enqueue(new MockResponse()
+                .setBody(logFileContents)
+                .setHeader(CONTENT_TYPE, TEXT_PLAIN));
+
+        InputStream logFileStream = client.getLogFile(17, RestLogFileHandle.builder()
+                .agentId("test-agent")
+                .fileName(logFileName)
+                .fileSize(4711)
+                .fileTime(Instant.now().truncatedTo(SECONDS))
+                .taskName("test-task-1")
+                .build());
+
+        String receivedLogFileContents = CharStreams.toString(new InputStreamReader(logFileStream));
+
+        assertThat(receivedLogFileContents, is(logFileContents));
+
+        assertThat(mockWebServer.getRequestCount(), is(2));
+        assertThat(mockWebServer.takeRequest().getPath(), is(logFilePath));
+        assertThat(mockWebServer.takeRequest().getPath(), is(logFilePath));
+    }
+}

--- a/digdag-client/src/test/java/io/digdag/client/DigdagClientTest.java
+++ b/digdag-client/src/test/java/io/digdag/client/DigdagClientTest.java
@@ -1,27 +1,24 @@
 package io.digdag.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.common.collect.ImmutableList;
 import com.google.common.io.CharStreams;
 import io.digdag.client.api.Id;
 import io.digdag.client.api.RestDirectDownloadHandle;
 import io.digdag.client.api.RestLogFileHandle;
+import io.digdag.client.api.RestLogFileHandleCollection;
 import okhttp3.internal.tls.SslClient;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import okhttp3.mockwebserver.QueueDispatcher;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import javax.ws.rs.InternalServerErrorException;
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.time.Instant;
-import java.util.List;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
@@ -68,22 +65,23 @@ public class DigdagClientTest
     public void getLogFileHandlesOfAttempt()
             throws Exception
     {
-        List<RestLogFileHandle> expectedLogFileHandles = ImmutableList.of(
-                RestLogFileHandle.builder()
-                        .agentId("test-agent")
-                        .fileName("test-task-1.log")
-                        .fileSize(4711)
-                        .fileTime(Instant.now().truncatedTo(SECONDS))
-                        .taskName("test-task-1")
-                        .build(),
-                RestLogFileHandle.builder()
-                        .agentId("test-agent")
-                        .fileName("test-task-2.log")
-                        .fileSize(4712)
-                        .fileTime(Instant.now().truncatedTo(SECONDS))
-                        .taskName("test-task-2")
-                        .build()
-        );
+        RestLogFileHandleCollection expectedLogFileHandles = RestLogFileHandleCollection.builder()
+                .addFiles(
+                        RestLogFileHandle.builder()
+                                .agentId("test-agent")
+                                .fileName("test-task-1.log")
+                                .fileSize(4711)
+                                .fileTime(Instant.now().truncatedTo(SECONDS))
+                                .taskName("test-task-1")
+                                .build(),
+                        RestLogFileHandle.builder()
+                                .agentId("test-agent")
+                                .fileName("test-task-2.log")
+                                .fileSize(4712)
+                                .fileTime(Instant.now().truncatedTo(SECONDS))
+                                .taskName("test-task-2")
+                                .build()
+                ).build();
 
         mockWebServer.enqueue(new MockResponse().setResponseCode(500));
 
@@ -91,7 +89,7 @@ public class DigdagClientTest
                 .setBody(objectMapper.writeValueAsString(expectedLogFileHandles))
                 .setHeader(CONTENT_TYPE, APPLICATION_JSON));
 
-        List<RestLogFileHandle> receivedLogFileHandles = client.getLogFileHandlesOfAttempt(Id.of("17")).getFiles();
+        RestLogFileHandleCollection receivedLogFileHandles = client.getLogFileHandlesOfAttempt(Id.of("17"));
 
         assertThat(receivedLogFileHandles, is(expectedLogFileHandles));
 
@@ -104,22 +102,23 @@ public class DigdagClientTest
     public void getLogFileHandlesOfTask()
             throws Exception
     {
-        List<RestLogFileHandle> expectedLogFileHandles = ImmutableList.of(
-                RestLogFileHandle.builder()
-                        .agentId("test-agent")
-                        .fileName("test-task-1.log")
-                        .fileSize(4711)
-                        .fileTime(Instant.now().truncatedTo(SECONDS))
-                        .taskName("test-task-1")
-                        .build(),
-                RestLogFileHandle.builder()
-                        .agentId("test-agent")
-                        .fileName("test-task-2.log")
-                        .fileSize(4712)
-                        .fileTime(Instant.now().truncatedTo(SECONDS))
-                        .taskName("test-task-2")
-                        .build()
-        );
+        RestLogFileHandleCollection expectedLogFileHandles = RestLogFileHandleCollection.builder()
+                .addFiles(
+                        RestLogFileHandle.builder()
+                                .agentId("test-agent")
+                                .fileName("test-task-1.log")
+                                .fileSize(4711)
+                                .fileTime(Instant.now().truncatedTo(SECONDS))
+                                .taskName("test-task-1")
+                                .build(),
+                        RestLogFileHandle.builder()
+                                .agentId("test-agent")
+                                .fileName("test-task-2.log")
+                                .fileSize(4712)
+                                .fileTime(Instant.now().truncatedTo(SECONDS))
+                                .taskName("test-task-2")
+                                .build()
+                ).build();
 
         mockWebServer.enqueue(new MockResponse().setResponseCode(500));
 
@@ -127,7 +126,7 @@ public class DigdagClientTest
                 .setBody(objectMapper.writeValueAsString(expectedLogFileHandles))
                 .setHeader(CONTENT_TYPE, APPLICATION_JSON));
 
-        List<RestLogFileHandle> receivedLogFileHandles = client.getLogFileHandlesOfTask(Id.of("17"), "test-task").getFiles();
+        RestLogFileHandleCollection receivedLogFileHandles = client.getLogFileHandlesOfTask(Id.of("17"), "test-task");
 
         assertThat(receivedLogFileHandles, is(expectedLogFileHandles));
 

--- a/digdag-standards/build.gradle
+++ b/digdag-standards/build.gradle
@@ -26,20 +26,21 @@ dependencies {
     compile 'com.amazonaws:aws-java-sdk-s3:1.10.65'
 
     // bigquery
-    compile 'com.google.apis:google-api-services-bigquery:v2-rev325-1.22.0'
+    compile ('com.google.apis:google-api-services-bigquery:v2-rev325-1.22.0') { exclude group: 'com.google.guava', module: 'guava-jdk5' }
 
     // gcs
-    compile 'com.google.apis:google-api-services-storage:v1-rev88-1.22.0'
+    compile ('com.google.apis:google-api-services-storage:v1-rev88-1.22.0') { exclude group: 'com.google.guava', module: 'guava-jdk5' }
 
     // dependency conflict resolution
     compile 'joda-time:joda-time:2.9.4'
-    compile 'com.google.auth:google-auth-library-credentials:0.4.0'
-    compile 'com.google.auth:google-auth-library-oauth2-http:0.4.0'
-    compile 'com.google.http-client:google-http-client:1.22.0'
-    compile 'com.google.http-client:google-http-client-jackson2:1.22.0'
-    compile 'com.google.oauth-client:google-oauth-client:1.22.0'
+
+    compile ('com.google.auth:google-auth-library-credentials:0.4.0') { exclude group: 'com.google.guava', module: 'guava-jdk5' }
+    compile ('com.google.auth:google-auth-library-oauth2-http:0.4.0') { exclude group: 'com.google.guava', module: 'guava-jdk5' }
+    compile ('com.google.http-client:google-http-client:1.22.0') { exclude group: 'com.google.guava', module: 'guava-jdk5' }
+    compile ('com.google.http-client:google-http-client-jackson2:1.22.0') { exclude group: 'com.google.guava', module: 'guava-jdk5' }
+    compile ('com.google.oauth-client:google-oauth-client:1.22.0') { exclude group: 'com.google.guava', module: 'guava-jdk5' }
+
     compile 'com.google.code.findbugs:jsr305:3.0.1'
-    compile 'com.google.guava:guava-jdk5:17.0'
 
     // Newer version of jetty-client with some important bugfixes.
     // jetty-client is used by td-client-java, and ideally we would bump the version there but

--- a/digdag-tests/src/test/java/acceptance/DownloadIT.java
+++ b/digdag-tests/src/test/java/acceptance/DownloadIT.java
@@ -22,6 +22,7 @@ import utils.TemporaryDigdagServer;
 import static utils.TestUtils.copyResource;
 import static utils.TestUtils.main;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertThat;
 
@@ -48,25 +49,7 @@ public class DownloadIT
     public void download()
             throws Exception
     {
-        // Create new project
-        CommandStatus initStatus = main("init",
-                "-c", config.toString(),
-                projectDir.toString());
-        assertThat(initStatus.code(), is(0));
-
-        Files.createDirectories(projectDir.resolve("files"));
-
-        copyResource("acceptance/basic.dig", projectDir.resolve("basic.dig"));
-        copyResource("acceptance/params.dig", projectDir.resolve("files").resolve("params.yml"));
-
-        // Push the project
-        CommandStatus pushStatus = main("push",
-                "--project", projectDir.toString(),
-                "download_proj",
-                "-c", config.toString(),
-                "-e", server.endpoint(),
-                "-r", "rev4711");
-        assertThat(pushStatus.errUtf8(), pushStatus.code(), is(0));
+        pushProject("download_proj", "rev4711");
 
         // Download the project
         Path downloadDir = projectDir.resolve("extract");
@@ -81,6 +64,62 @@ public class DownloadIT
         assertThat(Files.readAllBytes(downloadDir.resolve("files").resolve("params.yml")), is(readResource("acceptance/params.dig")));
 
         assertThat(downloadStatus.outUtf8(), containsString("rev4711"));
+    }
+
+    @Test
+    public void projectNotFound()
+            throws Exception
+    {
+        Path downloadDir = projectDir.resolve("extract");
+        CommandStatus downloadStatus = main("download",
+                "download_proj",
+                "-o", downloadDir.toString(),
+                "-c", config.toString(),
+                "-e", server.endpoint());
+        assertThat(downloadStatus.errUtf8(), downloadStatus.code(), not(0));
+        assertThat(downloadStatus.errUtf8(), containsString("project not found: download_proj"));
+    }
+
+    @Test
+    public void revisionNotFound()
+            throws Exception
+    {
+        pushProject("download_proj", "rev4711");
+
+        // Download the project with -r option
+        Path downloadDir = projectDir.resolve("extract");
+        CommandStatus downloadStatus = main("download",
+                "download_proj",
+                "-o", downloadDir.toString(),
+                "-r", "no_such_revision",
+                "-c", config.toString(),
+                "-e", server.endpoint());
+        assertThat(downloadStatus.errUtf8(), downloadStatus.code(), not(0));
+        assertThat(downloadStatus.errUtf8(), containsString("Project archive of revision 'no_such_revision' does not exist."));
+    }
+
+    private void pushProject(String projectName, String revisionName)
+            throws Exception
+    {
+        // Create new project
+        CommandStatus initStatus = main("init",
+                "-c", config.toString(),
+                projectDir.toString());
+        assertThat(initStatus.code(), is(0));
+
+        Files.createDirectories(projectDir.resolve("files"));
+
+        copyResource("acceptance/basic.dig", projectDir.resolve("basic.dig"));
+        copyResource("acceptance/params.dig", projectDir.resolve("files").resolve("params.yml"));
+
+        // Push the project
+        CommandStatus pushStatus = main("push",
+                "--project", projectDir.toString(),
+                projectName,
+                "-c", config.toString(),
+                "-e", server.endpoint(),
+                "-r", revisionName);
+        assertThat(pushStatus.errUtf8(), pushStatus.code(), is(0));
     }
 
     private byte[] readResource(String resource)


### PR DESCRIPTION
I found that some tests on Travis CI failing with following message

```
acceptance.DownloadIT > download FAILED
    java.lang.AssertionError: 2016-12-12 10:03:54 +0000: Digdag v0.8.23-SNAPSHOT
    error: Attempted read on closed stream. (io)

    Expected: is <0>
         but: was <1>
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
        at org.junit.Assert.assertThat(Assert.java:956)
        at acceptance.DownloadIT.download(DownloadIT.java:78)
```

They succeed when I restart it. Example: https://api.travis-ci.org/jobs/183174886/log.txt?deansi=true

One of the possible causes is that HTTP server disconnects the TCP session because of socket timeout when client's extracting process is too slow.
This PR changes the `download` command so that client downloads the archive to a temp file as fast as possible so that following extracting doesn't keep the socket idling.

This assumes #373 to be merged.