### PR TITLE
td operators should not retry on invalid table name

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TDOperator.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TDOperator.java
@@ -392,7 +392,20 @@ public class TDOperator
                 case HttpStatus.REQUEST_TIMEOUT_408:
                     return false;
                 default:
+                    // return true if 4xx
                     return statusCode >= 400 && statusCode < 500;
+            }
+        }
+        else if (ex instanceof TDClientException) {
+            // failed before sending HTTP request or receiving HTTP response
+            TDClientException.ErrorType errorType = ((TDClientException) ex).getErrorType();
+            switch (errorType) {
+                case INVALID_CONFIGURATION:  // failed to read td.conf, failed to pares integer in properties set to TDClientBuilder, etc.
+                case INVALID_INPUT:          // early table name validation fails, failed to format request body in json, etc.
+                    return true;
+                default:
+                    // other cases such as PROXY_AUTHENTICATION_FAILURE, SSL_ERROR, REQUEST_TIMEOUT, INTERRUPTED, etc.
+                    break;  // pass-through
             }
         }
         return false;

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/td/TDOperatorTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/td/TDOperatorTest.java
@@ -345,6 +345,26 @@ public class TDOperatorTest
     }
 
     @Test
+    public void verifyNoRetryInvalidTableName()
+            throws Exception
+    {
+        TDOperator operator = new TDOperator(client, "foobar");
+
+        String jobStateKey = "fooJob";
+
+        Config state = configFactory.create();
+
+        // Create domain key
+        runJobIteration(operator, state, jobStateKey, pollInterval, retryInterval, jobStarter);
+
+        // Start job: Fail with TDClientException with TDClientException.ErrorType.INVALID_INPUT
+        when(jobStarter.startJob(any(TDOperator.class), anyString()))
+                .thenThrow(new TDClientException(TDClientException.ErrorType.INVALID_INPUT, "Table name must follow this pattern ^([a-z0-9_]+)$: InsertIntoHere"));
+        exception.expect(TDClientException.class);
+        operator.runJob(TaskState.of(state), jobStateKey, pollInterval, retryInterval, jobStarter);
+    }
+
+    @Test
     public void testRunJobMigrateState()
             throws Exception
     {


### PR DESCRIPTION
TDClient throws TDClientException (not TDClientHttpException) when
problem happens before sending request or during receiving requests.
This includes deterministic exceptions such as invalid table name
because TDClient validates table names before sending it to the server
(at least with v0.7.26).