### PR TITLE
Update TaskExecutionException API and avoid error with empty message

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
@@ -387,13 +387,16 @@ public class OperatorManager
                 sb.append("\n> ");
             }
             sb.append(message);
-            sb.append(" (");
-            sb.append(ex.getClass().getSimpleName()
-                        .replaceFirst("(?:Exception|Error)$", "")
-                        .replaceAll("([A-Z]+)([A-Z][a-z])", "$1 $2")
-                        .replaceAll("([a-z])([A-Z])", "$1 $2")
-                        .toLowerCase());
-            sb.append(")");
+            if (!(ex instanceof TaskExecutionException)) {
+                // skip TaskExecutionException because it's expected to have well-formatted message
+                sb.append(" (");
+                sb.append(ex.getClass().getSimpleName()
+                            .replaceFirst("(?:Exception|Error)$", "")
+                            .replaceAll("([A-Z]+)([A-Z][a-z])", "$1 $2")
+                            .replaceAll("([a-z])([A-Z])", "$1 $2")
+                            .toLowerCase());
+                sb.append(")");
+            }
         }
         if (ex.getCause() != null) {
             collectExceptionMessage(sb, ex.getCause(), used);

--- a/digdag-core/src/main/java/io/digdag/core/agent/RequireOperatorFactory.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/RequireOperatorFactory.java
@@ -90,8 +90,7 @@ public class RequireOperatorFactory
                 throw new ConfigException(ex);
             }
             catch (ResourceLimitExceededException ex) {
-                throw new TaskExecutionException(ex,
-                        TaskExecutionException.buildExceptionErrorConfig(ex));
+                throw new TaskExecutionException(ex);
             }
         }
     }

--- a/digdag-core/src/test/java/io/digdag/core/agent/OperatorManagerExceptionTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/agent/OperatorManagerExceptionTest.java
@@ -1,0 +1,160 @@
+package io.digdag.core.agent;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import com.google.inject.Inject;
+import com.google.inject.Scopes;
+import com.google.inject.multibindings.Multibinder;
+import io.digdag.client.config.Config;
+import io.digdag.core.DigdagEmbed;
+import io.digdag.spi.Operator;
+import io.digdag.spi.OperatorContext;
+import io.digdag.spi.OperatorFactory;
+import io.digdag.spi.SecretAccessList;
+import io.digdag.spi.SecretStore;
+import io.digdag.spi.SecretStoreManager;
+import io.digdag.spi.TaskRequest;
+import io.digdag.spi.TaskResult;
+import java.nio.file.Paths;
+import io.digdag.spi.TaskExecutionException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import io.digdag.client.config.ConfigUtils;
+
+import static io.digdag.client.config.ConfigUtils.newConfig;
+import static io.digdag.core.workflow.OperatorTestingUtils.newTaskRequest;
+import static io.digdag.core.workflow.WorkflowTestingUtils.setupEmbed;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class OperatorManagerExceptionTest
+{
+    static class CustomErrorOperatorFactory
+            implements OperatorFactory
+    {
+        @Inject
+        public CustomErrorOperatorFactory()
+        { }
+
+        @Override
+        public String getType()
+        {
+            return "custom_error";
+        }
+
+        @Override
+        public Operator newOperator(OperatorContext context)
+        {
+            return new CustomErrorOperator(context);
+        }
+    }
+
+    static class CustomErrorOperator
+            implements Operator
+    {
+        private final OperatorContext context;
+
+        public CustomErrorOperator(OperatorContext context)
+        {
+            this.context = context;
+        }
+
+        @Override
+        public TaskResult run()
+        {
+            throw EXCEPTIONS.get(context.getTaskRequest().getConfig().get("_command", String.class));
+        }
+    }
+
+    private static class CustomRuntimeException extends RuntimeException
+    {
+        CustomRuntimeException(String message)
+        {
+            super(message);
+        }
+
+        CustomRuntimeException(String message, Throwable cause)
+        {
+            super(message, cause);
+        }
+    }
+
+    private final static Map<String, RuntimeException> EXCEPTIONS = ImmutableMap.<String, RuntimeException>builder()
+        .put("runtime", new RuntimeException("foobar"))
+        .put("custom", new CustomRuntimeException("foobar"))
+        .put("custom_nested", new CustomRuntimeException(null, new RuntimeException("nested")))
+        .put("wrapped_runtime", new TaskExecutionException(new RuntimeException("foobar")))
+        .put("wrapped_custom", new TaskExecutionException(new CustomRuntimeException("foobar")))
+        .put("wrapped_null_message", new TaskExecutionException(new CustomRuntimeException(null, new RuntimeException("cause"))))
+        .put("wrapped_custom_message", new TaskExecutionException("custom!!", new RuntimeException("foo")))
+        .build();
+
+    private DigdagEmbed embed;
+    private OperatorManager operatorManager;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        this.embed = setupEmbed((bootstrap) -> bootstrap.addModules((binder) -> {
+                    Multibinder.newSetBinder(binder, OperatorFactory.class)
+                        .addBinding().to(CustomErrorOperatorFactory.class).in(Scopes.SINGLETON);
+                })
+            );
+        this.operatorManager = embed.getInjector().getInstance(OperatorManager.class);
+    }
+
+    @After
+    public void shutdown()
+            throws Exception
+    {
+        embed.close();
+    }
+
+    @Test
+    public void verifyException()
+    {
+        expectRuntimeException("runtime", RuntimeException.class, "foobar (runtime)");
+        expectRuntimeException("custom", CustomRuntimeException.class, "foobar (custom runtime)");
+        expectRuntimeException("custom_nested", CustomRuntimeException.class, "CustomRuntimeException (custom runtime)\n> nested (runtime)");
+        expectExecutionException("wrapped_runtime", "foobar (runtime)");
+        expectExecutionException("wrapped_custom", "foobar (custom runtime)");
+        expectExecutionException("wrapped_null_message", "cause (custom runtime)");
+        expectExecutionException("wrapped_custom_message", "custom!!");
+    }
+
+    private void expectExecutionException(String name, String expectedMessage)
+    {
+        Config config = newConfig().set("_command", name);
+        try {
+            operatorManager.callExecutor(Paths.get(""), "custom_error", newTaskRequest().withConfig(config));
+            fail("expected TaskExecutionException");
+        }
+        catch (RuntimeException ex) {
+            assertThat(ex, instanceOf(TaskExecutionException.class));
+            Config error = ((TaskExecutionException) ex).getError(ConfigUtils.configFactory).or(newConfig());
+            assertThat(error.get("message", String.class, null), is(expectedMessage));
+        }
+    }
+
+    private void expectRuntimeException(String name, Class<?> expectedClass, String expectedMessage)
+    {
+        Config config = newConfig().set("_command", name);
+        try {
+            operatorManager.callExecutor(Paths.get(""), "custom_error", newTaskRequest().withConfig(config));
+            fail("expected RuntimeException");
+        }
+        catch (RuntimeException ex) {
+            assertThat((Object) ex.getClass(), is((Object) expectedClass));
+            assertThat(OperatorManager.formatExceptionMessage(ex), is(expectedMessage));
+        }
+    }
+}

--- a/digdag-plugin-utils/src/main/java/io/digdag/util/BaseOperator.java
+++ b/digdag-plugin-utils/src/main/java/io/digdag/util/BaseOperator.java
@@ -11,7 +11,6 @@ import io.digdag.spi.OperatorContext;
 import io.digdag.spi.TaskExecutionException;
 import io.digdag.spi.TaskRequest;
 import io.digdag.spi.TaskResult;
-import static io.digdag.spi.TaskExecutionException.buildExceptionErrorConfig;
 
 public abstract class BaseOperator
         implements Operator
@@ -52,8 +51,7 @@ public abstract class BaseOperator
 
             boolean doRetry = retry.evaluate();
             if (doRetry) {
-                throw new TaskExecutionException(ex,
-                        buildExceptionErrorConfig(ex),
+                throw TaskExecutionException.ofNextPollingWithCause(ex,
                         retry.getNextRetryInterval(),
                         ConfigElement.copyOf(retry.getNextRetryStateParams()));
             }

--- a/digdag-spi/src/main/java/io/digdag/spi/TaskExecutionException.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/TaskExecutionException.java
@@ -160,6 +160,15 @@ public class TaskExecutionException
         this.stateParams = Optional.absent();
     }
 
+    @Deprecated
+    public TaskExecutionException(Throwable cause, ConfigElement error)
+    {
+        super(formatExceptionMessage(cause), cause);
+        this.error = Optional.of(error);
+        this.retryInterval = Optional.absent();
+        this.stateParams = Optional.absent();
+    }
+
     public Optional<Config> getError(ConfigFactory cf)
     {
         return error.transform(it -> it.toConfig(cf));

--- a/digdag-spi/src/main/java/io/digdag/spi/TaskExecutionException.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/TaskExecutionException.java
@@ -9,13 +9,37 @@ import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigFactory;
 import io.digdag.client.config.ConfigElement;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+import static java.util.Locale.ENGLISH;
+
+/**
+ * An exception thrown when an expected exception happens.
+ *
+ * <p>
+ * When an error happens in an operator, it should be wrapped with TaskExecutionException if
+ * the cause is expected so that Digdag shows a message for users without verbose stacktrace.
+ * The other exception classes are regarded as unexpected and Digdag shows stacktrace for operator
+ * developers.
+ * </p>
+ *
+ * <p>
+ * TaskExecutionException is also used to let Digdag retry the task later. Use ofNextPolling
+ * (if task retries for simple polling) or ofNextPollingWithCause (if task retries to recover
+ * from an error) method to retry.
+ * </p>
+ */
 public class TaskExecutionException
         extends RuntimeException
 {
     public static ConfigElement buildExceptionErrorConfig(Throwable ex)
     {
+        return buildExceptionErrorConfig(formatExceptionMessage(ex), ex);
+    }
+
+    public static ConfigElement buildExceptionErrorConfig(String message, Throwable ex)
+    {
         Map<String, String> map = ImmutableMap.of(
-                "message", ex.toString(),
+                "message", message,
                 "stacktrace",
                 Arrays.asList(ex.getStackTrace())
                 .stream()
@@ -24,9 +48,41 @@ public class TaskExecutionException
         return ConfigElement.ofMap(map);
     }
 
+    private static String formatExceptionMessage(Throwable ex)
+    {
+        return firstNonEmptyMessage(ex)
+            .transform(message -> {
+                return String.format(ENGLISH, "%s (%s)", message,
+                        ex.getClass().getSimpleName()
+                        .replaceFirst("(?:Exception|Error)$", "")
+                        .replaceAll("([A-Z]+)([A-Z][a-z])", "$1 $2")
+                        .replaceAll("([a-z])([A-Z])", "$1 $2")
+                        .toLowerCase());
+            })
+            .or(() -> ex.toString());
+    }
+
+    private static Optional<String> firstNonEmptyMessage(Throwable ex)
+    {
+        String message = ex.getMessage();
+        if (!isNullOrEmpty(message)) {
+            return Optional.of(message);
+        }
+        Throwable cause = ex.getCause();
+        if (cause == null) {
+            return Optional.absent();
+        }
+        return firstNonEmptyMessage(cause);
+    }
+
     public static TaskExecutionException ofNextPolling(int interval, ConfigElement nextStateParams)
     {
         return new TaskExecutionException(interval, nextStateParams);
+    }
+
+    public static TaskExecutionException ofNextPollingWithCause(Throwable cause, int interval, ConfigElement nextStateParams)
+    {
+        return new TaskExecutionException(cause, buildExceptionErrorConfig(cause), interval, nextStateParams);
     }
 
     private TaskExecutionException(int retryInterval, ConfigElement stateParams)
@@ -37,40 +93,71 @@ public class TaskExecutionException
         this.stateParams = Optional.of(stateParams);
     }
 
+    private TaskExecutionException(Throwable cause, ConfigElement error, int retryInterval, ConfigElement stateParams)
+    {
+        super(cause);
+        this.error = Optional.of(error);
+        this.retryInterval = Optional.of(retryInterval);
+        this.stateParams = Optional.of(stateParams);
+    }
+
     private final Optional<ConfigElement> error;
     private final Optional<Integer> retryInterval;
     private final Optional<ConfigElement> stateParams;
 
-    public TaskExecutionException(Throwable cause, ConfigElement error)
+    /**
+     * Wrap an expected exception to make the task failed.
+     */
+    public TaskExecutionException(Throwable cause)
     {
-        super(cause);
-        this.error = Optional.of(error);
+        this(formatExceptionMessage(cause), cause);
+    }
+
+    /**
+     * Wrap an expected exception with a custom well-formatted message to make the task failed.
+     */
+    public TaskExecutionException(String customMessage, Throwable cause)
+    {
+        super(customMessage, cause);
+        this.error = Optional.of(buildExceptionErrorConfig(customMessage, cause));
         this.retryInterval = Optional.absent();
         this.stateParams = Optional.absent();
     }
 
+    /**
+     * Build an expected exception with a simple message to make the task failed.
+     */
+    public TaskExecutionException(String message)
+    {
+        this(message, ImmutableMap.of());
+    }
+
+    /**
+     * Build an expected exception with a simple message and properties to make the task failed.
+     */
+    public TaskExecutionException(String message, Map<String, String> errorProperties)
+    {
+        super(message);
+        this.error = Optional.of(buildPropertiesErrorConfig(message, errorProperties));
+        this.retryInterval = Optional.absent();
+        this.stateParams = Optional.absent();
+    }
+
+    private static ConfigElement buildPropertiesErrorConfig(String message, Map<String, String> errorProperties)
+    {
+        ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
+        builder.putAll(errorProperties);
+        builder.put("message", message);
+        return ConfigElement.ofMap(builder.build());
+    }
+
+    @Deprecated
     public TaskExecutionException(String message, ConfigElement error)
     {
         super(message);
         this.error = Optional.of(error);
         this.retryInterval = Optional.absent();
         this.stateParams = Optional.absent();
-    }
-
-    public TaskExecutionException(Throwable cause, ConfigElement error, int retryInterval, ConfigElement stateParams)
-    {
-        super(cause);
-        this.error = Optional.of(error);
-        this.retryInterval = Optional.of(retryInterval);
-        this.stateParams = Optional.of(stateParams);
-    }
-
-    public TaskExecutionException(String message, ConfigElement error, int retryInterval, ConfigElement stateParams)
-    {
-        super(message);
-        this.error = Optional.of(error);
-        this.retryInterval = Optional.of(retryInterval);
-        this.stateParams = Optional.of(stateParams);
     }
 
     public Optional<Config> getError(ConfigFactory cf)

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/FailOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/FailOperatorFactory.java
@@ -49,7 +49,7 @@ public class FailOperatorFactory
             Config errorParams = params.getFactory().create();
             errorParams.set("message", message);
 
-            throw new TaskExecutionException(message, ConfigElement.copyOf(errorParams));
+            throw new TaskExecutionException(message);
         }
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/HttpOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/HttpOperatorFactory.java
@@ -279,7 +279,7 @@ public class HttpOperatorFactory
                         return new RuntimeException("Failed HTTP request: " + requestStatus(req, res, uriIsSecret));
                     default:
                         // 4xx: The request is invalid for this resource. Fail hard without retrying.
-                        return new TaskExecutionException("HTTP 4XX Client Error: " + requestStatus(req, res, uriIsSecret), ConfigElement.empty());
+                        return new TaskExecutionException("HTTP 4XX Client Error: " + requestStatus(req, res, uriIsSecret));
                 }
             }
             else if (res.getStatus() >= 500 && res.getStatus() < 600) {
@@ -301,7 +301,7 @@ public class HttpOperatorFactory
             }
             else {
                 // No, so fail hard.
-                return new TaskExecutionException(message, ConfigElement.empty());
+                return new TaskExecutionException(message);
             }
         }
 
@@ -366,7 +366,7 @@ public class HttpOperatorFactory
             if (storeContent) {
                 String content = response.getContentAsString();
                 if (content.length() > maxStoredResponseContentSize) {
-                    throw new TaskExecutionException("Response content too large: " + content.length() + " > " + maxStoredResponseContentSize, ConfigElement.empty());
+                    throw new TaskExecutionException("Response content too large: " + content.length() + " > " + maxStoredResponseContentSize);
                 }
                 http.set("last_content", content);
                 builder.addResetStoreParams(ConfigKey.of("http", "last_content"));
@@ -397,7 +397,7 @@ public class HttpOperatorFactory
                 httpClient.start();
             }
             catch (Exception e) {
-                throw new TaskExecutionException(e, TaskExecutionException.buildExceptionErrorConfig(e));
+                throw new TaskExecutionException(e);
             }
             return httpClient;
         }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/MailOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/MailOperatorFactory.java
@@ -178,7 +178,7 @@ public class MailOperatorFactory
                 Transport.send(msg);
             }
             catch (MessagingException | IOException ex) {
-                throw new TaskExecutionException(ex, TaskExecutionException.buildExceptionErrorConfig(ex));
+                throw new TaskExecutionException(ex);
             }
 
             return TaskResult.empty(request);
@@ -214,7 +214,7 @@ public class MailOperatorFactory
                     .orNull();
 
             if (smtpConfig == null) {
-                throw new TaskExecutionException("Missing SMTP configuration", ConfigElement.empty());
+                throw new TaskExecutionException("Missing SMTP configuration");
             }
 
             Properties props = new Properties();

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/NotifyOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/NotifyOperatorFactory.java
@@ -76,7 +76,8 @@ public class NotifyOperatorFactory
                 notifier.sendNotification(notification);
             }
             catch (NotificationException e) {
-                throw new TaskExecutionException(e, ConfigElement.copyOf(params));
+                // notification failed
+                throw new TaskExecutionException(e);
             }
 
             return TaskResult.empty(request);

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/aws/EmrOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/aws/EmrOperatorFactory.java
@@ -395,7 +395,7 @@ public class EmrOperatorFactory
                                             details != null ? details : "{}");
                                 }
 
-                                throw new TaskExecutionException("EMR job failed", ConfigElement.empty());
+                                throw new TaskExecutionException("EMR job failed");
 
                             case "COMPLETED":
                                 logger.info("EMR steps done");
@@ -519,7 +519,7 @@ public class EmrOperatorFactory
                     if (createOnly) {
                         // TODO: log more information about the errors
                         // TODO: inspect state change reason to figure out whether it was the boot that failed or e.g. steps submitted by another agent
-                        throw new TaskExecutionException("EMR boot failed: " + cluster.id(), ConfigElement.empty());
+                        throw new TaskExecutionException("EMR boot failed: " + cluster.id());
                     }
                     return Optional.of(clusterState);
 

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/aws/EmrOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/aws/EmrOperatorFactory.java
@@ -782,7 +782,7 @@ public class EmrOperatorFactory
                     configurationJson = workspace.templateFile(templateEngine, node.asText(), UTF_8, params);
                 }
                 catch (IOException | TemplateException e) {
-                    throw new TaskExecutionException(e, TaskExecutionException.buildExceptionErrorConfig(e));
+                    throw new TaskExecutionException(e);
                 }
                 List<ConfigurationJson> values;
                 try {
@@ -900,7 +900,7 @@ public class EmrOperatorFactory
                     }
                     catch (InterruptedException e) {
                         Thread.currentThread().interrupt();
-                        throw new TaskExecutionException(e, TaskExecutionException.buildExceptionErrorConfig(e));
+                        throw new TaskExecutionException(e);
                     }
                 }
             }
@@ -940,7 +940,7 @@ public class EmrOperatorFactory
                         bytes = Resources.toByteArray(new URL(reference.reference().get()));
                     }
                     catch (IOException e) {
-                        throw new TaskExecutionException(e, TaskExecutionException.buildExceptionErrorConfig(e));
+                        throw new TaskExecutionException(e);
                     }
                     ObjectMetadata metadata = new ObjectMetadata();
                     metadata.setContentLength(bytes.length);

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/gcp/BaseGcpOperator.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/gcp/BaseGcpOperator.java
@@ -38,7 +38,7 @@ abstract class BaseGcpOperator
         Optional<String> projectId = context.getSecrets().getSecretOptional("gcp.project")
                 .or(credential.projectId());
         if (!projectId.isPresent()) {
-            throw new TaskExecutionException("Missing 'gcp.project' secret", ConfigElement.empty());
+            throw new TaskExecutionException("Missing 'gcp.project' secret");
         }
 
         return projectId.get();

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/gcp/BqJobRunner.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/gcp/BqJobRunner.java
@@ -109,7 +109,7 @@ class BqJobRunner
                         case "RUNNING":
                             return Optional.absent();
                         default:
-                            throw new TaskExecutionException("Unknown job state: " + canonicalJobId + ": " + status.getState(), ConfigElement.empty());
+                            throw new TaskExecutionException("Unknown job state: " + canonicalJobId + ": " + status.getState());
                     }
                 });
 
@@ -121,7 +121,7 @@ class BqJobRunner
             for (ErrorProto error : status.getErrors()) {
                 logger.error(toPrettyString(error));
             }
-            throw new TaskExecutionException("BigQuery job failed: " + canonicalJobId, errorConfig(status.getErrors()));
+            throw new TaskExecutionException("BigQuery job failed: " + canonicalJobId, errorProperties(status.getErrors()));
         }
 
         // Success
@@ -130,13 +130,12 @@ class BqJobRunner
         return completed;
     }
 
-    private static ConfigElement errorConfig(List<ErrorProto> errors)
+    private static Map<String, String> errorProperties(List<ErrorProto> errors)
     {
-        Map<String, String> map = ImmutableMap.of(
+        return ImmutableMap.of(
                 "errors", errors.stream()
                         .map(BqJobRunner::toPrettyString)
                         .collect(Collectors.joining(", ")));
-        return ConfigElement.ofMap(map);
     }
 
     private static String toPrettyString(ErrorProto error)

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/gcp/GcpCredentialProvider.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/gcp/GcpCredentialProvider.java
@@ -11,7 +11,6 @@ import io.digdag.spi.TaskExecutionException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 
-import static io.digdag.spi.TaskExecutionException.buildExceptionErrorConfig;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 class GcpCredentialProvider
@@ -40,7 +39,7 @@ class GcpCredentialProvider
             node = objectMapper.readTree(credential);
         }
         catch (IOException e) {
-            throw new TaskExecutionException("Unable to parse 'gcp.credential' secret", TaskExecutionException.buildExceptionErrorConfig(e));
+            throw new TaskExecutionException("Unable to parse 'gcp.credential' secret", e);
         }
         JsonNode projectId = node.get("project_id");
         if (projectId == null || !projectId.isTextual()) {
@@ -55,7 +54,7 @@ class GcpCredentialProvider
             return GoogleCredential.fromStream(new ByteArrayInputStream(credential.getBytes(UTF_8)));
         }
         catch (IOException e) {
-            throw new TaskExecutionException(e, buildExceptionErrorConfig(e));
+            throw new TaskExecutionException(e);
         }
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcJobOperator.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcJobOperator.java
@@ -18,7 +18,6 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static io.digdag.spi.TaskExecutionException.buildExceptionErrorConfig;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public abstract class AbstractJdbcJobOperator<C>
@@ -163,7 +162,7 @@ public abstract class AbstractJdbcJobOperator<C>
         catch (DatabaseException ex) {
             // expected error that should suppress stacktrace by default
             String message = String.format("%s [%s]", ex.getMessage(), ex.getCause().getMessage());
-            throw new TaskExecutionException(message, buildExceptionErrorConfig(ex));
+            throw new TaskExecutionException(message, ex);
         }
     }
 

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/redshift/BaseRedshiftLoadOperator.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/redshift/BaseRedshiftLoadOperator.java
@@ -30,7 +30,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.UUID;
 
-import static io.digdag.spi.TaskExecutionException.buildExceptionErrorConfig;
 import static io.digdag.standards.operator.state.PollingRetryExecutor.pollingRetryExecutor;
 
 abstract class BaseRedshiftLoadOperator<T extends RedshiftConnection.StatementConfig>
@@ -218,7 +217,7 @@ abstract class BaseRedshiftLoadOperator<T extends RedshiftConnection.StatementCo
         catch (DatabaseException ex) {
             // expected error that should suppress stacktrace by default
             String message = String.format("%s [%s]", ex.getMessage(), ex.getCause().getMessage());
-            throw new TaskExecutionException(message, buildExceptionErrorConfig(ex));
+            throw new TaskExecutionException(message, ex);
         }
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/redshift/RedshiftLoadOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/redshift/RedshiftLoadOperatorFactory.java
@@ -31,8 +31,6 @@ import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 
-import static io.digdag.spi.TaskExecutionException.buildExceptionErrorConfig;
-
 public class RedshiftLoadOperatorFactory
         implements OperatorFactory
 {
@@ -160,7 +158,7 @@ public class RedshiftLoadOperatorFactory
                 }
                 catch (RetryExecutor.RetryGiveupException e) {
                     throw new TaskExecutionException(
-                            "Failed to fetch a manifest file: " + from, buildExceptionErrorConfig(e));
+                            "Failed to fetch a manifest file: " + from, e);
                 }
             }
             return builder.build();

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/state/PollingRetryExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/state/PollingRetryExecutor.java
@@ -183,7 +183,7 @@ public class PollingRetryExecutor
 
             if (!retry(e)) {
                 logger.warn("{}: giving up", formattedErrorMessage, e);
-                throw new TaskExecutionException(e, TaskExecutionException.buildExceptionErrorConfig(e));
+                throw new TaskExecutionException(e);
             }
 
             int retryIteration = retryState.params().get(RETRY, int.class, 0);

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/BaseTdJobOperator.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/BaseTdJobOperator.java
@@ -2,8 +2,11 @@ package io.digdag.standards.operator.td;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
+import com.treasuredata.client.TDClientException;
 import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigElement;
 import io.digdag.spi.OperatorContext;
+import io.digdag.spi.TaskExecutionException;
 import io.digdag.spi.TaskRequest;
 import io.digdag.spi.TaskResult;
 import io.digdag.standards.operator.DurationInterval;
@@ -74,6 +77,14 @@ abstract class BaseTdJobOperator
 
             return taskResult;
         }
+        catch (TDClientException ex) {
+            throw propagateTDClientException(ex);
+        }
+    }
+
+    protected static TaskExecutionException propagateTDClientException(TDClientException ex)
+    {
+        return new TaskExecutionException(ex);
     }
 
     protected abstract String startJob(TDOperator op, String domainKey);

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TDJobOperator.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TDJobOperator.java
@@ -22,7 +22,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.zip.GZIPInputStream;
 
-import static io.digdag.spi.TaskExecutionException.buildExceptionErrorConfig;
 import static io.digdag.standards.operator.td.TDOperator.defaultRetryExecutor;
 
 class TDJobOperator
@@ -146,7 +145,7 @@ class TDJobOperator
             try {
                 TDJob job = getJobInfo();
                 String message = job.getCmdOut() + "\n" + job.getStdErr();
-                throw new TaskExecutionException(message, buildExceptionErrorConfig(ex));
+                throw new TaskExecutionException(message, ex);
             }
             catch (Exception getJobInfoFailed) {
                 getJobInfoFailed.addSuppressed(ex);

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TDOperator.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TDOperator.java
@@ -356,7 +356,7 @@ public class TDOperator
                 throw errorPollingException(state, key, jobState, retryInterval);
             }
             String message = jobInfo.getCmdOut() + "\n" + jobInfo.getStdErr();
-            throw new TaskExecutionException(message, ConfigElement.empty());
+            throw new TaskExecutionException(message);
         }
 
         return job;

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdDdlOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdDdlOperatorFactory.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
+import com.treasuredata.client.TDClientException;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigException;
 import io.digdag.core.Environment;
@@ -30,6 +31,7 @@ import java.util.function.Consumer;
 import static com.google.common.collect.Iterables.concat;
 import static io.digdag.standards.operator.state.PollingRetryExecutor.pollingRetryExecutor;
 import static io.digdag.standards.operator.td.BaseTdJobOperator.configSelectorBuilder;
+import static io.digdag.standards.operator.td.BaseTdJobOperator.propagateTDClientException;
 import static java.util.Locale.ENGLISH;
 
 public class TdDdlOperatorFactory
@@ -165,6 +167,9 @@ public class TdDdlOperatorFactory
                             .withErrorMessage("DDL operation failed")
                             .runAction(s -> o.accept(op));
                 }
+            }
+            catch (TDClientException ex) {
+                throw propagateTDClientException(ex);
             }
 
             return TaskResult.empty(request);

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdForEachOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdForEachOperatorFactory.java
@@ -156,7 +156,7 @@ public class TdForEachOperatorFactory
                                 rows.add(row(columnNames, ite.next().asArrayValue()));
                                 if (rows.size() > Limits.maxWorkflowTasks()) {
                                     TaskLimitExceededException cause = new TaskLimitExceededException("Too many tasks. Limit: " + Limits.maxWorkflowTasks());
-                                    throw new TaskExecutionException(cause, TaskExecutionException.buildExceptionErrorConfig(cause));
+                                    throw new TaskExecutionException(cause);
                                 }
                             }
                             return rows;

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdWaitOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdWaitOperatorFactory.java
@@ -3,6 +3,7 @@ package io.digdag.standards.operator.td;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
+import com.treasuredata.client.TDClientException;
 import com.treasuredata.client.model.TDJobRequest;
 import com.treasuredata.client.model.TDJobRequestBuilder;
 import io.digdag.client.config.Config;
@@ -31,6 +32,7 @@ import java.util.Map;
 
 import static io.digdag.standards.operator.state.PollingRetryExecutor.pollingRetryExecutor;
 import static io.digdag.standards.operator.td.BaseTdJobOperator.configSelectorBuilder;
+import static io.digdag.standards.operator.td.BaseTdJobOperator.propagateTDClientException;
 import static io.digdag.standards.operator.td.TDOperator.isDeterministicClientException;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -126,6 +128,9 @@ public class TdWaitOperatorFactory
                 // The query condition was fulfilled, we're done.
                 return TaskResult.empty(request);
             }
+            catch (TDClientException ex) {
+                throw propagateTDClientException(ex);
+            }
         }
 
         private String startJob(TDOperator op, String domainKey)
@@ -163,7 +168,7 @@ public class TdWaitOperatorFactory
 
             ArrayValue row = firstRow.get();
             if (row.size() < 1) {
-                throw new TaskExecutionException("Got empty row in result of query", ConfigElement.empty());
+                throw new TaskExecutionException("Got empty row in result of query");
             }
 
             Value firstCol = row.get(0);


### PR DESCRIPTION
Throwing TaskExecutionException with an empty ConfigElement ends up
showing empty message in local mode because digdag-cli takes "message"
field of the ConfigElement. Instead, operators needed to use
TaskExecutionException.buildExceptionErrorConfig to build ConfigElement.
However, it seems confusing because already some operators are missing it.
This PR updates TaskExecutionException API so that it becomes impossible to create TaskExecutionException with empty "message" field in ConfigElement.

This assumes #421 to be merged.

Several examples of this change:

### Fixing empty message:

```
2016-12-13 17:22:11 -0800 [ERROR] (0018@+test+test): Task +test+test failed.
Missing SMTP configuration (task execution)
2016-12-13 17:22:11 -0800 [INFO] (0018@+test^failure-alert): type: notify
error:
  * +test+test:
    {}
```

becomes:

```
2016-12-13 17:22:47 -0800 [ERROR] (0018@+test+test): Task +test+test failed.
Missing SMTP configuration
2016-12-13 17:22:47 -0800 [INFO] (0018@+test^failure-alert): type: notify
error:
  * +test+test:
    Missing SMTP configuration
```

Workflow definition is:

```
+test:
  mail>:
  body: foo
  subject: test
  to: [frsyuki@gmail.com]
```

### Wrapping TDClientException in TaskExecutionException to suppress stacktrace:

```
2016-12-13 17:17:58 -0800 [ERROR] (0018@+test+test): Task failed with unexpected error: [INVALID_INPUT] Table name must follow this pattern ^([a-z0-9_]+)$: InsertIntoHere
com.treasuredata.client.TDClientException: [INVALID_INPUT] Table name must follow this pattern ^([a-z0-9_]+)$: InsertIntoHere
        at com.treasuredata.client.TDClient.validateName(TDClient.java:303)
        at com.treasuredata.client.TDClient.validateTableName(TDClient.java:289)
        at com.treasuredata.client.TDClient.createTable(TDClient.java:387)
        at io.digdag.standards.operator.td.TDOperator.lambda$ensureTableCreated$3(TDOperator.java:153)
        at io.digdag.util.RetryExecutor.lambda$run$1(RetryExecutor.java:143)
        at io.digdag.util.RetryExecutor.run(RetryExecutor.java:158)
        at io.digdag.util.RetryExecutor.run(RetryExecutor.java:133)
        at io.digdag.util.RetryExecutor.run(RetryExecutor.java:142)
        at io.digdag.standards.operator.td.TDOperator.ensureTableCreated(TDOperator.java:153)
        at io.digdag.standards.operator.td.TdOperatorFactory.ensureTableCreated(TdOperatorFactory.java:297)
        at io.digdag.standards.operator.td.TdOperatorFactory.access$400(TdOperatorFactory.java:54)
        at io.digdag.standards.operator.td.TdOperatorFactory$TdOperator.startJob(TdOperatorFactory.java:176)
        at io.digdag.standards.operator.td.BaseTdJobOperator.lambda$runTask$0(BaseTdJobOperator.java:60)
        at io.digdag.standards.operator.td.TDOperator.runJob(TDOperator.java:304)
        at io.digdag.standards.operator.td.BaseTdJobOperator.runTask(BaseTdJobOperator.java:60)
        at io.digdag.util.BaseOperator.run(BaseOperator.java:36)
        at io.digdag.core.agent.OperatorManager.callExecutor(OperatorManager.java:324)
        at io.digdag.cli.Run$OperatorManagerWithSkip.callExecutor(Run.java:678)
        at io.digdag.core.agent.OperatorManager.runWithWorkspace(OperatorManager.java:262)
        at io.digdag.core.agent.OperatorManager.lambda$runWithHeartbeat$2(OperatorManager.java:145)
        at io.digdag.core.agent.LocalWorkspaceManager.withExtractedArchive(LocalWorkspaceManager.java:25)
        at io.digdag.core.agent.OperatorManager.runWithHeartbeat(OperatorManager.java:143)
        at io.digdag.core.agent.OperatorManager.run(OperatorManager.java:127)
        at io.digdag.cli.Run$OperatorManagerWithSkip.run(Run.java:660)
        at io.digdag.core.agent.MultiThreadAgent.lambda$run$0(MultiThreadAgent.java:95)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)
2016-12-13 17:17:58 -0800 [INFO] (0018@+test^failure-alert): type: notify
error:
  * +test+test:
    [INVALID_INPUT] Table name must follow this pattern ^([a-z0-9_]+)$: InsertIntoHere
```

becomes:

```
2016-12-13 17:16:53 -0800 [ERROR] (0018@+test+test): Task +test+test failed.
[INVALID_INPUT] Table name must follow this pattern ^([a-z0-9_]+)$: InsertIntoHere (td client)
2016-12-13 17:16:53 -0800 [INFO] (0018@+test^failure-alert): type: notify
error:
  * +test+test:
    [INVALID_INPUT] Table name must follow this pattern ^([a-z0-9_]+)$: InsertIntoHere (td client)
```
