### PR TITLE
Fix issue #423

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcConnection.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcConnection.java
@@ -57,8 +57,11 @@ public abstract class AbstractJdbcConnection
     @Override
     public SQLException validateStatement(String sql)
     {
-        // if JDBC or DBMS does not use server-side prepared statements by default,
-        // subclass needs to override this method.
+        // Here uses nativeSQL() instead of Connection#prepareStatement because
+        // prepareStatement() validates a SQL by creating a server-side prepared statement
+        // and RDBMS wrongly decides that the SQL is broken in this case:
+        //   * the SQL includes multiple statements
+        //   * a statement creates a table and a later statement uses it in the SQL
         try {
             connection.nativeSQL(sql);
             return null;

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcConnection.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcConnection.java
@@ -60,9 +60,7 @@ public abstract class AbstractJdbcConnection
         // if JDBC or DBMS does not use server-side prepared statements by default,
         // subclass needs to override this method.
         try {
-            try (PreparedStatement pstmt = connection.prepareStatement(sql)) {
-                pstmt.getMetaData();
-            }
+            connection.nativeSQL(sql);
             return null;
         }
         catch (SQLException ex) {


### PR DESCRIPTION
PostgreSQL's prepared statement is a server-side object. So if
the query creates a table and refers it later,
JdbcConnection#validateStatement fails. Replacing
Connection#prepareStatement with Connection#nativeSQL would
be a better solution. That's a local side validation.