### PR TITLE
Fix selfupdate on Windows

### DIFF
--- a/digdag-cli/src/main/resources/digdag/cli/selfcopy.bat
+++ b/digdag-cli/src/main/resources/digdag/cli/selfcopy.bat
@@ -1,0 +1,11 @@
+@echo off
+set i=0
+:repeat
+  if %i% leq 30 (goto move) else goto :done
+:move
+  ping 1.1.1.1 -n 1 -w 500 >NUL 2>NUL
+  move /Y %1 %2 >NUL 2>NUL
+  set /a "i = i + 1"
+  if exist %1 goto repeat
+:done
+del %0

--- a/digdag-cli/src/main/resources/digdag/cli/selfcopy.bat
+++ b/digdag-cli/src/main/resources/digdag/cli/selfcopy.bat
@@ -8,4 +8,4 @@ set i=0
   set /a "i = i + 1"
   if exist %1 goto repeat
 :done
-del %0
+del "%~f0"

--- a/digdag-cli/src/main/sh/selfrun.sh
+++ b/digdag-cli/src/main/sh/selfrun.sh
@@ -37,7 +37,7 @@ if "%optimize%" == "true" (
     set java_args=-XX:+AggressiveOpts -XX:TieredStopAtLevel=1 -Xverify:none %java_args%
 )
 
-java %java_args% -jar "%this%" %args%
+java -Dio.digdag.cli.launcher=selfrun %java_args% -jar "%this%" %args%
 
 endlocal
 
@@ -135,5 +135,5 @@ else
     java_args="-XX:+AggressiveOpts -XX:TieredStopAtLevel=1 -Xverify:none $java_args"
 fi
 
-exec java $java_args -jar "$0" "$@"
+exec java -Dio.digdag.cli.launcher=selfrun $java_args -jar "$0" "$@"
 exit 127


### PR DESCRIPTION
On Windows, a process can't change or delete a file if it is executing.
`selfupdate` command was failing due to this limitation. This change
uses a background process on Windows so that it repeats moving the file
until the execution finishes. The background process deletes itself at
the end using an exceptional behavior of Windows where a bat script can
delete itself.