### PR TITLE
td: Add support for ${secret:...} syntax in result_url option

### DIFF
--- a/digdag-tests/src/test/java/acceptance/td/TdIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/TdIT.java
@@ -360,6 +360,15 @@ public class TdIT
     }
 
     @Test
+    public void testRunResultUrlSecret()
+            throws Exception
+    {
+        copyResource("acceptance/td/td/td_result_url.dig", projectDir.resolve("workflow.dig"));
+        copyResource("acceptance/td/td/query.sql", projectDir.resolve("query.sql"));
+        assertWorkflowRunsSuccessfully("td.database=" + database);
+    }
+
+    @Test
     public void testRetries()
             throws Exception
     {

--- a/digdag-tests/src/test/resources/acceptance/td/td/td_result_url.dig
+++ b/digdag-tests/src/test/resources/acceptance/td/td/td_result_url.dig
@@ -1,0 +1,8 @@
+timezone: UTC
+
++run:
+  td>: query.sql
+  result_url: td://${secret:td.apikey}@/${td.database}/result_url
+
++post:
+  sh>: touch ${outfile}


### PR DESCRIPTION
This lets users to set password without writing it in plain text.