### PR TITLE
Selfupdate should not always use system's default java command

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/SelfUpdate.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/SelfUpdate.java
@@ -221,7 +221,7 @@ public class SelfUpdate
             String javaPath =
                 Paths.get(System.getProperty("java.home"))
                 .resolve("bin")
-                .resolve(isWindows() ? "java.exe" : "java")
+                .resolve("java")
                 .toString();
             cmdline = ImmutableList.<String>builder()
                 .add(javaPath.toString())


### PR DESCRIPTION
This fixes `selfupdate` command so that it uses the same `java` command used to execute this digdag command. This is useful when the system doesn't have `java` in PATH and users use a custom java installation to run digdag.
This assumes #435.