### PR TITLE
Update RedshiftPersistentTransactionHelper to not leave garbage tables

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/operator/redshift/RedshiftConnection.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/redshift/RedshiftConnection.java
@@ -289,7 +289,7 @@ public class RedshiftConnection
         private boolean createLockedTableWithStatusRow(UUID queryId)
         {
             String sql = String.format(ENGLISH,
-                    "CREATE TABLE IF NOT EXISTS %s" +
+                    "CREATE TABLE %s" +
                     " (query_id, created_at, completed_at)" +
                     " AS SELECT '%s'::text, CURRENT_TIMESTAMP::timestamptz, NULL::timestamptz",
                     escapeIdent(statusTableName(queryId)),


### PR DESCRIPTION
This fixes following issues:

* doesn't leave garbage status tables even when action fails
  after prepare() (which commits CREATE TABLE)
  before updateStatusRowAndCommit() (which commits INSERT INTO).
* fixes help message that suggests schema name in status_table option.
  because status table name is escaped using escapeIdent, the option
  can't include schema name.