### PR TITLE
Fix user secret filter of Operator

### DIFF
--- a/ci/run_test_pg.sh
+++ b/ci/run_test_pg.sh
@@ -7,7 +7,7 @@ port = 5432
 user = digdag_test
 password =
 database = digdag_test
-idleTimeout = 5
+idleTimeout = 10
 minimumPoolSize = 0
 "
 

--- a/digdag-core/src/main/java/io/digdag/core/agent/DefaultSecretProvider.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/DefaultSecretProvider.java
@@ -22,7 +22,7 @@ import static java.util.Locale.ENGLISH;
 class DefaultSecretProvider
         implements SecretProvider
 {
-    static interface OperatorSecretFilter
+    interface OperatorSecretFilter
     {
         boolean test(String key, boolean userGranted);
     }
@@ -53,10 +53,12 @@ class DefaultSecretProvider
 
         //// Secret access control:
         // 1. If users explicitly grant access using _secret directive in workflow definition (Config grants):
-        //    1-a. Allow if the operator wants to use it (operatorSecretFilter)
+        //    1-a. Allow if the operator wants to use it (operatorSecretFilter.test(key, true)).
+        //         This lets operators access to the secrets not declared in OperatorFactory.getSecretAccessList.
         //    1-b. Reject.
         // 2. If the system access policy file (SecretAccessPolicy) allows:
-        //    2-a. Allow if the operator wants to use it (operatorSecretFilter)
+        //    2-a. Allow if the operator wants to use it (operatorSecretFilter.test(key, false)).
+        //         Operators must declare the name of the key in OperatorFactory.getSecretAccessList in advance.
         //    2-b. Reject.
         // 3. Otherwise, reject.
 

--- a/digdag-core/src/test/java/io/digdag/core/agent/OperatorSecretFilterTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/agent/OperatorSecretFilterTest.java
@@ -71,7 +71,7 @@ public class OperatorSecretFilterTest
         @Override
         public boolean testUserSecretAccess(String key)
         {
-            return key.equals("user_key");
+            return key.equals("user_key") || key.equals("statically_declared_key");
         }
 
         @Override
@@ -135,7 +135,7 @@ public class OperatorSecretFilterTest
     @Test
     public void verifyUserGrantedAccessAllowed()
     {
-        Config config = newConfig().set("get", "user_key").set("_secret", newConfig().set("user_key", true));
+        Config config = newConfig().set("get", "user_key").set("_secrets", newConfig().set("user_key", true));
         Config stored = run("secret_access", config);
         assertThat(stored.get("got", String.class), is("user_key.value"));
     }
@@ -146,7 +146,7 @@ public class OperatorSecretFilterTest
         exception.expect(SecretAccessFilteredException.class);
         exception.expectMessage(containsString("kkk"));
 
-        Config config = newConfig().set("get", "kkk").set("_secret", newConfig().set("kkk", true));
+        Config config = newConfig().set("get", "kkk").set("_secrets", newConfig().set("kkk", true));
         run("secret_access", config);
     }
 

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/aws/EmrOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/aws/EmrOperatorFactory.java
@@ -159,6 +159,7 @@ public class EmrOperatorFactory
                 .addSecretOnlyAccess("emr.endpoint", "s3.endpoint", "kms.endpoint")
                 .addSecretOnlyAccess("access_key_id", "secret_access_key", "role_arn", "role_session_name")
                 .addSecretOnlyAccess("emr.access_key_id", "emr.secret_access_key", "emr.role_arn", "emr.role_session_name")
+                .addSecretOnlyAccess("emr.kms_key_id")
                 .build();
     }
 

--- a/digdag-tests/src/test/resources/acceptance/emr/emr.dig
+++ b/digdag-tests/src/test/resources/acceptance/emr/emr.dig
@@ -2,6 +2,8 @@
   _secrets:
     td:
       apikey: true
+    foo:
+      bar: true
   emr>:
   cluster: ${test_cluster}
   staging: ${test_s3_folder}/staging/


### PR DESCRIPTION
Operator should be able to drop granted access to a secret key. On the
other hand, Operator must declare all keys if they are not granted by
users.