### PR TITLE
Upload and download project archive files to/from S3

### DIFF
--- a/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
+++ b/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
@@ -440,7 +440,9 @@ public class DigdagClient implements AutoCloseable
                 return request.invoke(webTarget);
             }
             catch (WebApplicationException e) {
-                firstRedirectException = e;
+                if (firstRedirectException == null) {
+                    firstRedirectException = e;
+                }
                 Response response = checkNotNull(e.getResponse());
                 int status = response.getStatus();
                 if (status % 100 == 3 && response.getLocation() != null) {

--- a/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
+++ b/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
@@ -22,7 +22,6 @@ import io.digdag.client.api.RestLogFileHandle;
 import io.digdag.client.api.RestLogFileHandleCollection;
 import io.digdag.client.api.RestProject;
 import io.digdag.client.api.RestProjectCollection;
-import io.digdag.client.api.RestRevision;
 import io.digdag.client.api.RestRevisionCollection;
 import io.digdag.client.api.RestSchedule;
 import io.digdag.client.api.RestScheduleCollection;
@@ -36,7 +35,6 @@ import io.digdag.client.api.RestSessionAttempt;
 import io.digdag.client.api.RestSessionAttemptCollection;
 import io.digdag.client.api.RestSessionAttemptRequest;
 import io.digdag.client.api.RestSetSecretRequest;
-import io.digdag.client.api.RestTask;
 import io.digdag.client.api.RestTaskCollection;
 import io.digdag.client.api.RestWorkflowDefinition;
 import io.digdag.client.api.RestWorkflowDefinitionCollection;
@@ -72,10 +70,10 @@ import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.Stream;
 
 import static com.github.rholder.retry.StopStrategies.stopAfterAttempt;
 import static com.github.rholder.retry.WaitStrategies.exponentialWait;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Predicates.not;
 import static java.util.Locale.ENGLISH;
 import static javax.ws.rs.core.HttpHeaders.USER_AGENT;
@@ -86,6 +84,7 @@ public class DigdagClient implements AutoCloseable
 {
     private static final int TOO_MANY_REQUESTS_429 = 429;
     private static final int REQUEST_TIMEOUT_408 = 408;
+    private static final int MAX_REDIRECT = 10;
 
     public static class Builder
     {
@@ -425,17 +424,52 @@ public class DigdagClient implements AutoCloseable
         }
     }
 
+    @FunctionalInterface
+    interface RequestWithFollowingRedirect<T>
+    {
+        T invoke(WebTarget webTarget);
+    }
+
+    private <T> T withFollowingRedirect(WebTarget initialWebTarget, RequestWithFollowingRedirect<T> request)
+    {
+        WebApplicationException firstRedirectException = null;
+        WebTarget webTarget = initialWebTarget;
+
+        for (int i = 0; i < MAX_REDIRECT; i++) {
+            try {
+                return request.invoke(webTarget);
+            }
+            catch (WebApplicationException e) {
+                firstRedirectException = e;
+                Response response = checkNotNull(e.getResponse());
+                int status = response.getStatus();
+                if (status % 100 == 3 && response.getLocation() != null) {
+                    webTarget = client.target(UriBuilder.fromUri(response.getLocation()));
+                    continue;
+                }
+                throw e;
+            }
+        }
+        throw firstRedirectException;
+    }
+
     // TODO getArchive with streaming
     public InputStream getProjectArchive(Id projId, String revision)
     {
-        Invocation request = target("/api/projects/{id}/archive")
-            .resolveTemplate("id", projId)
-            .queryParam("revision", revision)
-            .request()
-            .headers(headers.get())
-            .buildGet();
-        return invokeWithRetry(request)
-            .readEntity(InputStream.class);
+        WebTarget webTarget = target("/api/projects/{id}/archive")
+                .resolveTemplate("id", projId)
+                .queryParam("revision", revision);
+
+        return withFollowingRedirect(webTarget,
+                (x) -> {
+                    Invocation request = x
+                            .request()
+                            .headers(headers.get())
+                            .buildGet();
+                    return invokeWithRetry(request)
+                            .readEntity(InputStream.class);
+                }
+        );
     }
 
     public RestScheduleCollection getSchedules()
@@ -650,7 +684,8 @@ public class DigdagClient implements AutoCloseable
 
     private static boolean isDeterministicError(int status)
     {
-        if (status >= 400 && status < 500) {
+        // Retrying against 3xx doesn't make sense
+        if (status >= 300 && status < 500) {
             switch (status) {
                 case TOO_MANY_REQUESTS_429:
                 case REQUEST_TIMEOUT_408:

--- a/digdag-core/src/main/java/io/digdag/core/storage/ArchiveManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/storage/ArchiveManager.java
@@ -5,25 +5,24 @@ import java.io.ByteArrayInputStream;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.Base64;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import com.google.inject.Inject;
 import com.google.common.base.Optional;
-import com.google.common.base.Throwables;
-import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.digdag.core.repository.ArchiveType;
 import io.digdag.core.repository.ProjectStore;
 import io.digdag.core.repository.StoredRevision;
 import io.digdag.core.repository.ResourceNotFoundException;
-import io.digdag.core.storage.StorageManager;
 import io.digdag.client.config.Config;
 import io.digdag.spi.DirectDownloadHandle;
 import io.digdag.spi.Storage;
 import io.digdag.spi.StorageObject;
 import io.digdag.spi.StorageFileNotFoundException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Locale.ENGLISH;
-import static io.digdag.core.storage.StorageManager.decodeHex;
 
 public class ArchiveManager
 {
@@ -66,6 +65,7 @@ public class ArchiveManager
     private final StorageManager storageManager;
     private final ArchiveType uploadArchiveType;
     private final Config systemConfig;
+    private final String pathPrefix;
 
     @Inject
     public ArchiveManager(StorageManager storageManager, Config systemConfig)
@@ -73,6 +73,19 @@ public class ArchiveManager
         this.storageManager = storageManager;
         this.systemConfig = systemConfig;
         this.uploadArchiveType = systemConfig.get("archive.type", ArchiveType.class, ArchiveType.DB);
+        this.pathPrefix = getArchivePathPrefix(systemConfig, uploadArchiveType);
+    }
+
+    private String getArchivePathPrefix(Config systemConfig, ArchiveType type)
+    {
+        String pathPrefix = systemConfig.get("archive." + type + ".path", String.class, "");
+        if (pathPrefix.startsWith("/")) {
+            pathPrefix = pathPrefix.substring(1);
+        }
+        if (!pathPrefix.endsWith("/") && !pathPrefix.isEmpty()) {
+            pathPrefix = pathPrefix + "/";
+        }
+        return pathPrefix;
     }
 
     public Location newArchiveLocation(
@@ -99,9 +112,17 @@ public class ArchiveManager
     {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(projectName), "projectName");
         Preconditions.checkArgument(!Strings.isNullOrEmpty(revisionName), "revisionName");
+        // It's possible the storage used to store a project archive in doesn't accept some characters.
+        // For instance, AWS S3 says the following characters are generally safe
+        //   - Alphanumeric characters [0-9a-zA-Z]
+        //   - Special characters !, -, _, ., *, ', (, and )
+        //
+        // So we'd better encode a project name into the characters above
+        String encodedProjectName = Base64.getEncoder().encodeToString(projectName.getBytes(UTF_8)).replace("=", "_");
         return String.format(ENGLISH,
-                "%d/%s/%s.%s.tar.gz",
-                siteId, projectName, revisionName, DATE_TIME_SUFFIX_FORMAT.format(Instant.now()));
+                "%s%d/%s/%s.%s.tar.gz",
+                pathPrefix, siteId, encodedProjectName, revisionName,
+                DATE_TIME_SUFFIX_FORMAT.format(Instant.now()));
     }
 
     public Optional<StorageObject> openArchive(ProjectStore ps, int projectId, String revisionName)

--- a/digdag-core/src/main/java/io/digdag/core/storage/ArchiveManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/storage/ArchiveManager.java
@@ -6,9 +6,11 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.util.Base64;
+import java.util.UUID;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import com.google.common.io.BaseEncoding;
 import com.google.inject.Inject;
 import com.google.common.base.Optional;
 import io.digdag.core.repository.ArchiveType;
@@ -120,11 +122,11 @@ public class ArchiveManager
         //   - Special characters !, -, _, ., *, ', (, and )
         //
         // So we'd better encode a project name into the characters above
-        String encodedProjectName = Base64.getEncoder().encodeToString(projectName.getBytes(UTF_8)).replace("=", "_");
+        String encodedProjectName = BaseEncoding.base64Url().omitPadding().encode(projectName.getBytes(UTF_8));
         return String.format(ENGLISH,
                 "%s%d/%s/%s.%s.tar.gz",
                 pathPrefix, siteId, encodedProjectName, revisionName,
-                DATE_TIME_SUFFIX_FORMAT.format(Instant.now()));
+                UUID.randomUUID().toString());
     }
 
     public Optional<StorageObject> openArchive(ProjectStore ps, int projectId, String revisionName)

--- a/digdag-core/src/main/java/io/digdag/core/storage/ArchiveManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/storage/ArchiveManager.java
@@ -66,6 +66,7 @@ public class ArchiveManager
     private final ArchiveType uploadArchiveType;
     private final Config systemConfig;
     private final String pathPrefix;
+    private final boolean directDownloadEnabled;
 
     @Inject
     public ArchiveManager(StorageManager storageManager, Config systemConfig)
@@ -74,6 +75,7 @@ public class ArchiveManager
         this.systemConfig = systemConfig;
         this.uploadArchiveType = systemConfig.get("archive.type", ArchiveType.class, ArchiveType.DB);
         this.pathPrefix = getArchivePathPrefix(systemConfig, uploadArchiveType);
+        this.directDownloadEnabled = systemConfig.get("archive." + uploadArchiveType + ".direct_download", Boolean.class, false);
     }
 
     private String getArchivePathPrefix(Config systemConfig, ArchiveType type)
@@ -185,6 +187,9 @@ public class ArchiveManager
 
                 public Optional<DirectDownloadHandle> getDirectDownloadHandle()
                 {
+                    if (!directDownloadEnabled) {
+                        return Optional.absent();
+                    }
                     return storage.getDirectDownloadHandle(rev.getArchivePath().or(""));
                 }
 

--- a/digdag-core/src/test/java/io/digdag/core/storage/ArchiveManagerTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/storage/ArchiveManagerTest.java
@@ -31,6 +31,7 @@ public class ArchiveManagerTest
         Config config = Config.deserializeFromJackson(objectMapper,
                 objectMapper.readTree(
                         "{\"archive.type\":\"s3\"," +
+                                "\"archive.s3.path\":\"projects\"," +
                                 "\"archive.s3.bucket\":\"digdag-bucket\"," +
                                 "\"archive.s3.credentials.access-key-id\":\"my-access-key-id\"," +
                                 "\"archive.s3.credentials.secret-access-key\":\"my-secret-acccess-key\"}"));

--- a/digdag-core/src/test/java/io/digdag/core/storage/ArchiveManagerTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/storage/ArchiveManagerTest.java
@@ -45,7 +45,7 @@ public class ArchiveManagerTest
         String rev = UUID.randomUUID().toString();
         ArchiveManager.Location location = archiveManager.newArchiveLocation(42, "my-proj", rev, 123456);
         assertThat(location.getArchiveType(), is(ArchiveType.of("s3")));
-        String encodeProjectName = new String(Base64.getEncoder().encode("my-proj".getBytes(UTF_8)), UTF_8).replace("=", "_");
+        String encodeProjectName = new String(Base64.getEncoder().encode("my-proj".getBytes(UTF_8)), UTF_8).replace("=", "");
         assertThat(location.getPath(), is(startsWith(String.format("projects/42/%s/%s.", encodeProjectName, rev))));
         assertThat(location.getPath(), is(endsWith(".tar.gz")));
     }

--- a/digdag-core/src/test/java/io/digdag/core/storage/ArchiveManagerTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/storage/ArchiveManagerTest.java
@@ -1,0 +1,51 @@
+package io.digdag.core.storage;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.digdag.client.DigdagClient;
+import io.digdag.client.config.Config;
+import io.digdag.core.repository.ArchiveType;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.UUID;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.Matchers.startsWith;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+
+public class ArchiveManagerTest
+{
+    private ArchiveManager archiveManager;
+
+    @Before
+    public void setUp()
+            throws IOException
+    {
+        ObjectMapper objectMapper = DigdagClient.objectMapper();
+        StorageManager storageManager = mock(StorageManager.class);
+        Config config = Config.deserializeFromJackson(objectMapper,
+                objectMapper.readTree(
+                        "{\"archive.type\":\"s3\"," +
+                                "\"archive.s3.bucket\":\"digdag-bucket\"," +
+                                "\"archive.s3.credentials.access-key-id\":\"my-access-key-id\"," +
+                                "\"archive.s3.credentials.secret-access-key\":\"my-secret-acccess-key\"}"));
+        archiveManager = new ArchiveManager(storageManager, config);
+    }
+
+    @Test
+    public void newArchiveLocation()
+            throws IOException
+    {
+        String rev = UUID.randomUUID().toString();
+        ArchiveManager.Location location = archiveManager.newArchiveLocation(42, "my-proj", rev, 123456);
+        assertThat(location.getArchiveType(), is(ArchiveType.of("s3")));
+        String encodeProjectName = new String(Base64.getEncoder().encode("my-proj".getBytes(UTF_8)), UTF_8).replace("=", "_");
+        assertThat(location.getPath(), is(startsWith(String.format("projects/42/%s/%s.", encodeProjectName, rev))));
+        assertThat(location.getPath(), is(endsWith(".tar.gz")));
+    }
+}

--- a/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
@@ -80,6 +80,7 @@ import io.digdag.core.session.StoredSessionWithLastAttempt;
 import io.digdag.core.storage.ArchiveManager;
 import io.digdag.core.workflow.WorkflowCompiler;
 import io.digdag.server.GenericJsonExceptionHandler;
+import io.digdag.spi.DirectDownloadHandle;
 import io.digdag.spi.SecretControlStore;
 import io.digdag.spi.SecretControlStoreManager;
 import io.digdag.spi.SecretScopes;
@@ -90,6 +91,8 @@ import io.digdag.util.Md5CountInputStream;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DELETE;
@@ -147,6 +150,7 @@ public class ProjectResource
     // GET  /api/projects/{id}/workflow?name=name        # lookup a workflow of a project by name
     // GET  /api/projects/{id}/workflow?name=name&revision=name    # lookup a workflow of a past revision of a project by name
 
+    private static final Logger logger = LoggerFactory.getLogger(ProjectResource.class);
     private static final int ARCHIVE_TOTAL_SIZE_LIMIT = 2 * 1024 * 1024;
     private static final int ARCHIVE_FILE_SIZE_LIMIT = ARCHIVE_TOTAL_SIZE_LIMIT;
 
@@ -407,16 +411,15 @@ public class ProjectResource
         else {
             ArchiveManager.StoredArchive archive = archiveOrNone.get();
 
-            // TODO DigdagClient doesn't follow redirection. It should be fixed.
-            //Optional<DirectDownloadHandle> direct = archive.getDirectDownloadHandle();
-            //if (direct.isPresent()) {
-            //    try {
-            //        return Response.seeOther(URI.create(direct.get().getUrl())).build();
-            //    }
-            //    catch (IllegalArgumentException ex) {
-            //        // pass-through if invalid url
-            //    }
-            //}
+            Optional<DirectDownloadHandle> direct = archive.getDirectDownloadHandle();
+            if (direct.isPresent()) {
+                try {
+                    return Response.seeOther(URI.create(String.valueOf(direct.get().getUrl()))).build();
+                }
+                catch (IllegalArgumentException ex) {
+                    logger.warn("Failed to create a HTTP response", ex);
+                }
+            }
 
             Optional<byte[]> bytes = archive.getByteArray();
             if (bytes.isPresent()) {

--- a/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
@@ -417,7 +417,8 @@ public class ProjectResource
                     return Response.seeOther(URI.create(String.valueOf(direct.get().getUrl()))).build();
                 }
                 catch (IllegalArgumentException ex) {
-                    logger.warn("Failed to create a HTTP response", ex);
+                    logger.warn("Failed to create a HTTP response to redirect /api/projects/{id}/archive to a direct download URL. " +
+                            "Falling back to fetching from the server.", ex);
                 }
             }
 


### PR DESCRIPTION
If `archive.type` in system configuration is set to `s3`,
- digdag-server stores project archive files on S3
- digdag-cli directly downloads project archive files from S3 when `archive.s3.direct_download` is set to true on server side

The following configurations are needed to be set
- archive.s3.bucket
- archive.s3.credentials.access-key-id
- archive.s3.credentials.secret-access-key