### PR TITLE
Include digdag-storage-s3 in CLI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -325,7 +325,8 @@ project(':digdag-ui') {
 project(':digdag-cli') {
     apply plugin: 'com.github.johnrengelman.shadow'
 
-    // include digdag-ui in the shadow jar
+    // Include digdag-ui and digdag-storage-s3 in the shadow jar which are not
+    // in the dependencies of digdag-cli but should be included.
     configurations {
         shadow {
             extendsFrom runtime
@@ -333,6 +334,7 @@ project(':digdag-cli') {
     }
     dependencies {
         shadow project(':digdag-ui')
+        shadow project(':digdag-storage-s3')
     }
 
     shadowJar {

--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,7 @@ subprojects {
 
     ext {
         jacksonVersion = "2.6.7"
+        awsJavaSdkVersion = "1.11.63"
     }
 
     tasks.withType(JavaCompile) {

--- a/build.gradle
+++ b/build.gradle
@@ -326,8 +326,8 @@ project(':digdag-ui') {
 project(':digdag-cli') {
     apply plugin: 'com.github.johnrengelman.shadow'
 
-    // Include digdag-ui and digdag-storage-s3 in the shadow jar which are not
-    // in the dependencies of digdag-cli but should be included.
+    // Include digdag-ui in the shadow jar which are not in the dependencies
+    // of digdag-cli but should be included.
     configurations {
         shadow {
             extendsFrom runtime
@@ -335,8 +335,8 @@ project(':digdag-cli') {
     }
     dependencies {
         shadow project(':digdag-ui')
-        shadow project(':digdag-storage-s3')
     }
+    shadowJar.dependsOn(project(':digdag-ui').jar)
 
     shadowJar {
         configurations = [project.configurations.shadow]
@@ -368,8 +368,6 @@ project(':digdag-cli') {
         exclude 'org/weakref/jmx/internal/guava/**/*'
         relocate 'org.weakref.jmx.internal.guava', 'com.google.common'
     }
-
-    shadowJar.dependsOn(project(':digdag-ui').jar)
 
     task classpath(type: Copy, dependsOn: ['jar']) {
         File dest = file("${rootProject.projectDir}/classpath")

--- a/digdag-cli/build.gradle
+++ b/digdag-cli/build.gradle
@@ -10,4 +10,5 @@ dependencies {
     compile 'ch.qos.logback:logback-classic:1.1.5'
     compile 'org.fusesource.jansi:jansi:1.11'
     compile 'com.beust:jcommander:1.55'
+    runtime project(':digdag-storage-s3')  // to include digdag-storage-s3 in CLI (shadow jar)
 }

--- a/digdag-cli/build.gradle
+++ b/digdag-cli/build.gradle
@@ -10,5 +10,8 @@ dependencies {
     compile 'ch.qos.logback:logback-classic:1.1.5'
     compile 'org.fusesource.jansi:jansi:1.11'
     compile 'com.beust:jcommander:1.55'
-    runtime project(':digdag-storage-s3')  // to include digdag-storage-s3 in CLI (shadow jar)
+
+    // This line is for including digdag-storage-s3 in CLI (shadow jar) used through
+    // dynamic class loading. digdag-cli itself doesn't depend on digdag-storage-s3.
+    compile project(':digdag-storage-s3')
 }

--- a/digdag-standards/build.gradle
+++ b/digdag-standards/build.gradle
@@ -28,7 +28,6 @@ dependencies {
     compile "com.amazonaws:aws-java-sdk-s3:${project.ext.awsJavaSdkVersion}"
     compile "com.amazonaws:aws-java-sdk-emr:${project.ext.awsJavaSdkVersion}"
     compile "com.amazonaws:aws-java-sdk-dynamodb:${project.ext.awsJavaSdkVersion}"
-    compile "com.amazonaws:aws-java-sdk-core:${project.ext.awsJavaSdkVersion}"
 
     // bigquery
     compile ('com.google.apis:google-api-services-bigquery:v2-rev325-1.22.0') { exclude group: 'com.google.guava', module: 'guava-jdk5' }

--- a/digdag-standards/build.gradle
+++ b/digdag-standards/build.gradle
@@ -28,6 +28,15 @@ dependencies {
     compile "com.amazonaws:aws-java-sdk-s3:${project.ext.awsJavaSdkVersion}"
     compile "com.amazonaws:aws-java-sdk-emr:${project.ext.awsJavaSdkVersion}"
     compile "com.amazonaws:aws-java-sdk-dynamodb:${project.ext.awsJavaSdkVersion}"
+    compile("com.amazonaws:aws-java-sdk-core:${project.ext.awsJavaSdkVersion}") {
+        // aws-java-sdk-core depends on an old version of commons-logging (version 1.1.3).
+        // It conflicts with org.apache.httpcomponents:httpclient used by resteasy-client.
+        // Here removes dependency to commons-logging:1.1.3...
+        exclude group: 'commons-logging', module: 'commons-logging'
+    }
+    // ...then adds commons-logging:1.2 here. Remove this line if aws-java-sdk-core is updated
+    // to use newer version of commons-logging.
+    compile "commons-logging:commons-logging:1.2"
 
     // bigquery
     compile ('com.google.apis:google-api-services-bigquery:v2-rev325-1.22.0') { exclude group: 'com.google.guava', module: 'guava-jdk5' }

--- a/digdag-standards/build.gradle
+++ b/digdag-standards/build.gradle
@@ -28,15 +28,7 @@ dependencies {
     compile "com.amazonaws:aws-java-sdk-s3:${project.ext.awsJavaSdkVersion}"
     compile "com.amazonaws:aws-java-sdk-emr:${project.ext.awsJavaSdkVersion}"
     compile "com.amazonaws:aws-java-sdk-dynamodb:${project.ext.awsJavaSdkVersion}"
-    compile("com.amazonaws:aws-java-sdk-core:${project.ext.awsJavaSdkVersion}") {
-        // aws-java-sdk-core depends on an old version of commons-logging (version 1.1.3).
-        // It conflicts with org.apache.httpcomponents:httpclient used by resteasy-client.
-        // Here removes dependency to commons-logging:1.1.3...
-        exclude group: 'commons-logging', module: 'commons-logging'
-    }
-    // ...then adds commons-logging:1.2 here. Remove this line if aws-java-sdk-core is updated
-    // to use newer version of commons-logging.
-    compile "commons-logging:commons-logging:1.2"
+    compile "com.amazonaws:aws-java-sdk-core:${project.ext.awsJavaSdkVersion}"
 
     // bigquery
     compile ('com.google.apis:google-api-services-bigquery:v2-rev325-1.22.0') { exclude group: 'com.google.guava', module: 'guava-jdk5' }

--- a/digdag-standards/build.gradle
+++ b/digdag-standards/build.gradle
@@ -23,11 +23,11 @@ dependencies {
     compile 'org.postgresql:postgresql:9.4.1211'
 
     // aws
-    compile 'com.amazonaws:aws-java-sdk-kms:1.11.63'
-    compile 'com.amazonaws:aws-java-sdk-sts:1.11.63'
-    compile 'com.amazonaws:aws-java-sdk-s3:1.11.63'
-    compile 'com.amazonaws:aws-java-sdk-emr:1.11.63'
-    compile 'com.amazonaws:aws-java-sdk-dynamodb:1.11.63'
+    compile "com.amazonaws:aws-java-sdk-kms:${project.ext.awsJavaSdkVersion}"
+    compile "com.amazonaws:aws-java-sdk-sts:${project.ext.awsJavaSdkVersion}"
+    compile "com.amazonaws:aws-java-sdk-s3:${project.ext.awsJavaSdkVersion}"
+    compile "com.amazonaws:aws-java-sdk-emr:${project.ext.awsJavaSdkVersion}"
+    compile "com.amazonaws:aws-java-sdk-dynamodb:${project.ext.awsJavaSdkVersion}"
 
     // bigquery
     compile ('com.google.apis:google-api-services-bigquery:v2-rev325-1.22.0') { exclude group: 'com.google.guava', module: 'guava-jdk5' }

--- a/digdag-storage-s3/build.gradle
+++ b/digdag-storage-s3/build.gradle
@@ -5,4 +5,13 @@ dependencies {
     testCompile project(':digdag-core')
 
     compile "com.amazonaws:aws-java-sdk-s3:${project.ext.awsJavaSdkVersion}"
+
+    // aws-java-sdk-core depends on an old version of commons-logging (version 1.1.3).
+    // It conflicts with the dependencies of org.apache.httpcomponents:httpclient
+    // used by resteasy-client. This digdag-storage-s3 doesn't depend on resteasy-client
+    // because digdag-storage-s3 doesn't depend on digdag-client. This cross-project
+    // dependency conflict causes error with maven. Here then adds commons-logging:1.2
+    // to override dependency of aws-java-sdk-core.
+    // Remove this line if aws-java-sdk-core or resteasy-client is updated.
+    compile 'commons-logging:commons-logging:1.2'
 }

--- a/digdag-storage-s3/build.gradle
+++ b/digdag-storage-s3/build.gradle
@@ -4,6 +4,5 @@ dependencies {
     compile project(':digdag-plugin-utils')
     testCompile project(':digdag-core')
 
-    compile 'com.amazonaws:aws-java-sdk-s3:1.11.63'
-    compile 'commons-logging:commons-logging:1.2'
+    compile "com.amazonaws:aws-java-sdk-s3:${project.ext.awsJavaSdkVersion}"
 }

--- a/digdag-tests/build.gradle
+++ b/digdag-tests/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     testCompile 'com.squareup.okhttp3:okhttp:3.4.1'
     testCompile 'com.squareup.okhttp3:mockwebserver:3.4.1'
     testCompile 'org.littleshoot:littleproxy:1.1.0'
-    testCompile 'com.amazonaws:aws-java-sdk-dynamodb:1.11.63'
+    testCompile "com.amazonaws:aws-java-sdk-dynamodb:${project.ext.awsJavaSdkVersion}"
     testCompile('org.apache.avro:avro:1.8.1') {
         exclude group:'org.apache.commons', module:'commons-compress'
     }


### PR DESCRIPTION
digdag-storage-s3 was not included in shadow jar because it was
increasing CLI's binary size. However, because digdag-cli already
depends on aws-sdk through digdag-standards, there're no negative
impact any more. Including digdag-storage-s3 increases binary size only
20KB.