### PR TITLE
Less restricted client version checking

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/Main.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Main.java
@@ -44,7 +44,7 @@ import java.util.Map;
 
 import static io.digdag.cli.ConfigUtil.defaultConfigPath;
 import static io.digdag.cli.SystemExitException.systemExit;
-import static io.digdag.client.Version.buildVersion;
+import static io.digdag.client.DigdagVersion.buildVersion;
 import static io.digdag.core.agent.OperatorManager.formatExceptionMessage;
 
 public class Main
@@ -89,7 +89,7 @@ public class Main
     {
         for (String arg : args) {
             if ("--version".equals(arg)) {
-                out.println(version.version());
+                out.println(version.toString());
                 return 0;
             }
         }

--- a/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
+++ b/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
@@ -36,6 +36,7 @@ import io.digdag.client.api.RestSessionAttemptCollection;
 import io.digdag.client.api.RestSessionAttemptRequest;
 import io.digdag.client.api.RestSetSecretRequest;
 import io.digdag.client.api.RestTaskCollection;
+import io.digdag.client.api.RestVersionCheckResult;
 import io.digdag.client.api.RestWorkflowDefinition;
 import io.digdag.client.api.RestWorkflowDefinitionCollection;
 import io.digdag.client.api.RestWorkflowSessionTime;
@@ -75,6 +76,7 @@ import static com.github.rholder.retry.StopStrategies.stopAfterAttempt;
 import static com.github.rholder.retry.WaitStrategies.exponentialWait;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Predicates.not;
+import static io.digdag.client.DigdagVersion.buildVersion;
 import static java.util.Locale.ENGLISH;
 import static javax.ws.rs.core.HttpHeaders.USER_AGENT;
 import static javax.ws.rs.core.Response.Status.Family.SUCCESSFUL;
@@ -228,7 +230,7 @@ public class DigdagClient implements AutoCloseable
         ObjectMapper mapper = objectMapper();
 
         ResteasyClientBuilder clientBuilder = new ResteasyClientBuilder()
-                .register(new UserAgentFilter("DigdagClient/" + io.digdag.client.Version.buildVersion()))
+                .register(new UserAgentFilter("DigdagClient/" + buildVersion()))
                 .register(new JacksonJsonProvider(mapper));
 
         // TODO: support proxy user/pass
@@ -801,6 +803,13 @@ public class DigdagClient implements AutoCloseable
     public Map<String, Object> getVersion()
     {
         return doGet(Version.class, target("/api/version")).get();
+    }
+
+    public RestVersionCheckResult checkClientVersion(String clientVersion)
+    {
+        return doGet(RestVersionCheckResult.class,
+                target("/api/version/check")
+                .queryParam("client", clientVersion));
     }
 
     public void setProjectSecret(Id projectId, String key, String value)

--- a/digdag-client/src/main/java/io/digdag/client/DigdagVersion.java
+++ b/digdag-client/src/main/java/io/digdag/client/DigdagVersion.java
@@ -1,0 +1,33 @@
+package io.digdag.client;
+
+import com.google.common.base.Throwables;
+import com.google.common.io.Resources;
+import java.io.IOException;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class DigdagVersion
+{
+    public static final String VERSION_PROPERTY = Version.class.getName() + ".version";
+
+    public static Version buildVersion()
+    {
+        return Version.parse(versionString());
+    }
+
+    private static String versionString()
+    {
+        // First read version from system property
+        String propertyVersion = System.getProperty(VERSION_PROPERTY);
+        if (propertyVersion != null) {
+            return propertyVersion;
+        }
+
+        // Then read version file
+        try {
+            return Resources.toString(Resources.getResource(Version.class, "version.txt"), UTF_8).trim();
+        }
+        catch (IOException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+}

--- a/digdag-client/src/main/java/io/digdag/client/Version.java
+++ b/digdag-client/src/main/java/io/digdag/client/Version.java
@@ -1,53 +1,97 @@
 package io.digdag.client;
 
-import com.google.common.base.Throwables;
-import com.google.common.io.Resources;
-
-import java.io.IOException;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class Version
+    implements Comparable<Version>
 {
-    public static final String VERSION_PROPERTY = Version.class.getName() + ".version";
+    private final static Pattern DIGDAG_VERSION_PATTERN =
+        Pattern.compile("((?:0|[1-9][0-9]*)(?:\\.(?:0|[1-9][0-9]*))*)(?:\\-([a-zA-Z0-9_\\-\\.]+))?");
 
-    private final String version;
+    private final List<Integer> versionNumbers;
+    private final Optional<String> qualifier;
 
-    private Version(String version)
+    private Version(List<Integer> versionNumbers, Optional<String> qualifier)
     {
-        this.version = version;
+        this.versionNumbers = versionNumbers;
+        this.qualifier = qualifier;
     }
 
-    public static Version buildVersion()
+    public static Version parse(String versionString)
     {
-        return Version.of(versionString());
-    }
-
-    private static String versionString()
-    {
-        // First read version from system property
-        String propertyVersion = System.getProperty(VERSION_PROPERTY);
-        if (propertyVersion != null) {
-            return propertyVersion;
+        Matcher m = DIGDAG_VERSION_PATTERN.matcher(versionString);
+        if (!m.matches()) {
+            throw new IllegalArgumentException("Invalid version string: " + versionString);
         }
 
-        // Then read version file
-        try {
-            return Resources.toString(Resources.getResource(Version.class, "version.txt"), UTF_8).trim();
+        ImmutableList.Builder<Integer> numbers = ImmutableList.builder();
+        for (String number : m.group(1).split("\\.")) {
+            try {
+                numbers.add(Integer.parseInt(number));
+            }
+            catch (NumberFormatException ex) {
+                throw new IllegalArgumentException("Too big version number: " + versionString, ex);
+            }
         }
-        catch (IOException e) {
-            throw Throwables.propagate(e);
-        }
+        Optional<String> qualifier = Optional.fromNullable(m.group(2));
+
+        return new Version(numbers.build(), qualifier);
     }
 
-    public String version()
+    public int getMajorVersion()
     {
-        return version;
+        return versionNumbers.get(0);
     }
 
-    public static Version of(String versionString)
+    @Override
+    public int compareTo(Version another)
     {
-        return new Version(versionString);
+        int longer = Math.max(versionNumbers.size(), another.versionNumbers.size());
+        for (int i = 0; i < longer; i++) {
+            int left = versionNumbers.size() > i ? versionNumbers.get(i) : 0;
+            int right = another.versionNumbers.size() > i ? another.versionNumbers.get(i) : 0;
+            if (left < right) {
+                return -1;
+            }
+            else if (left > right) {
+                return 1;
+            }
+        }
+
+        // if one of them has qualifier, it's newer
+        if (!qualifier.isPresent() && another.qualifier.isPresent()) {
+            return -1;
+        }
+        else if (qualifier.isPresent() && !another.qualifier.isPresent()) {
+            return 1;
+        }
+
+        // if both has qualifier, compare with dictionary order
+        if (qualifier.isPresent() && another.qualifier.isPresent()) {
+            int c = qualifier.get().compareTo(another.qualifier.get());
+            if (c < 0) {
+                return -1;
+            }
+            else if (c > 0) {
+                return 1;
+            }
+        }
+
+        return 0;
+    }
+
+    public boolean isNewer(Version another)
+    {
+        return compareTo(another) > 0;
+    }
+
+    public boolean isOlder(Version another)
+    {
+        return compareTo(another) < 0;
     }
 
     @Override
@@ -60,20 +104,35 @@ public class Version
             return false;
         }
 
-        Version version1 = (Version) o;
+        Version another = (Version) o;
 
-        return version != null ? version.equals(version1.version) : version1.version == null;
+        return versionNumbers.equals(another.versionNumbers) &&
+            qualifier.equals(another.qualifier);
     }
 
     @Override
     public int hashCode()
     {
-        return version != null ? version.hashCode() : 0;
+        return toString().hashCode();
     }
 
     @Override
     public String toString()
     {
-        return version;
+        StringBuilder sb = new StringBuilder();
+        boolean first = true;
+        for (int number : versionNumbers) {
+            if (first) {
+                first = false;
+            }
+            else {
+                sb.append(".");
+            }
+            sb.append(Integer.toString(number));
+        }
+        if (qualifier.isPresent()) {
+            sb.append("-").append(qualifier.get());
+        }
+        return sb.toString();
     }
 }

--- a/digdag-client/src/main/java/io/digdag/client/api/RestVersionCheckResult.java
+++ b/digdag-client/src/main/java/io/digdag/client/api/RestVersionCheckResult.java
@@ -1,0 +1,20 @@
+package io.digdag.client.api;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonDeserialize(as = ImmutableRestVersionCheckResult.class)
+public interface RestVersionCheckResult
+{
+    String getServerVersion();
+
+    boolean getUpgradeRecommended();
+
+    boolean getApiCompatible();
+
+    static ImmutableRestVersionCheckResult.Builder builder()
+    {
+        return ImmutableRestVersionCheckResult.builder();
+    }
+}

--- a/digdag-client/src/test/java/io/digdag/client/DigdagClientTest.java
+++ b/digdag-client/src/test/java/io/digdag/client/DigdagClientTest.java
@@ -24,7 +24,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.time.Instant;
 
-import static io.digdag.client.Version.buildVersion;
+import static io.digdag.client.DigdagVersion.buildVersion;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.temporal.ChronoUnit.SECONDS;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;

--- a/digdag-client/src/test/java/io/digdag/client/VersionTest.java
+++ b/digdag-client/src/test/java/io/digdag/client/VersionTest.java
@@ -1,0 +1,99 @@
+package io.digdag.client;
+
+import org.junit.Test;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+public class VersionTest
+{
+    @Test
+    public void testValidVersions()
+    {
+        assertValidVersion("0");
+        assertValidVersion("1");
+        assertValidVersion("10");
+        assertValidVersion("0.2");
+        assertValidVersion("0.23");
+        assertValidVersion("0.4.5");
+        assertValidVersion("0.4.56");
+        assertValidVersion("0.4.50");
+        assertValidVersion("0.0.6");
+        assertValidVersion("0.0.6.7");
+        assertValidVersion("8.9.10.11");
+        assertValidVersion("0-SNAPSHOT");
+        assertValidVersion("0.8.32-20170117T115910-a60cad1343c71489d752f39250470e10109e3425");
+        assertValidVersion(DigdagVersion.getBuildVersion().toString());
+    }
+
+    private void assertValidVersion(String versionString)
+    {
+        Version parsed;
+        try {
+            parsed = Version.parse(versionString);
+        }
+        catch (IllegalArgumentException ex) {
+            fail();
+            throw ex;
+        }
+        assertThat(parsed.toString(), is(versionString));
+        assertTrue(parsed.equals(Version.parse(versionString)));
+        assertFalse(parsed.isOlder(Version.parse(versionString)));
+        assertFalse(parsed.isNewer(Version.parse(versionString)));
+        assertThat(parsed.compareTo(Version.parse(versionString)), is(0));
+    }
+
+    @Test
+    public void testInvalidVersions()
+    {
+        assertInvalidVersion("", "Invalid version string: ");
+        assertInvalidVersion("10.02", "Invalid version string: 10.02");
+        assertInvalidVersion("00", "Invalid version string: 00");
+        assertInvalidVersion("01", "Invalid version string: 01");
+        assertInvalidVersion("-SNAPSHOT", "Invalid version string: -SNAPSHOT");
+        assertInvalidVersion("0.1v", "Invalid version string: 0.1v");
+        assertInvalidVersion("0..1", "Invalid version string: 0..1");
+        assertInvalidVersion("1..", "Invalid version string: 1..");
+        assertInvalidVersion("932132232132132131", "Too big version number: 932132232132132131");
+    }
+
+    private void assertInvalidVersion(String versionString, String message)
+    {
+        try {
+            Version.parse(versionString);
+            fail();
+        }
+        catch (IllegalArgumentException ex) {
+            assertThat(ex.getMessage(), is(message));
+        }
+    }
+
+    @Test
+    public void testOrder()
+    {
+        assertOrder("0.1", "0.2");
+        assertOrder("0.1", "0.1.1");
+        assertOrder("0.2", "0.10");
+        assertOrder("0", "0.10");
+        assertOrder("1.0-2016T01", "1.0-2016T02");
+        assertOrder("1.0-2016T01", "1.0-2016T01-02");
+    }
+
+    public void assertOrder(String a, String b)
+    {
+        Version v1 = Version.parse(a);
+        Version v2 = Version.parse(b);
+
+        assertTrue(v1.isOlder(v2));
+        assertFalse(v1.isNewer(v2));
+        assertThat(v1.compareTo(v2), is(-1));
+        assertFalse(v1.equals(v2));
+
+        assertFalse(v2.isOlder(v1));
+        assertTrue(v2.isNewer(v1));
+        assertThat(v2.compareTo(v1), is(1));
+        assertFalse(v2.equals(v1));
+    }
+}

--- a/digdag-client/src/test/java/io/digdag/client/VersionTest.java
+++ b/digdag-client/src/test/java/io/digdag/client/VersionTest.java
@@ -25,7 +25,7 @@ public class VersionTest
         assertValidVersion("8.9.10.11");
         assertValidVersion("0-SNAPSHOT");
         assertValidVersion("0.8.32-20170117T115910-a60cad1343c71489d752f39250470e10109e3425");
-        assertValidVersion(DigdagVersion.getBuildVersion().toString());
+        assertValidVersion(DigdagVersion.buildVersion().toString());
     }
 
     private void assertValidVersion(String versionString)

--- a/digdag-server/src/main/java/io/digdag/server/ClientVersionChecker.java
+++ b/digdag-server/src/main/java/io/digdag/server/ClientVersionChecker.java
@@ -1,0 +1,43 @@
+package io.digdag.server;
+
+import com.google.common.base.Optional;
+import io.digdag.client.Version;
+import io.digdag.client.config.Config;
+
+public class ClientVersionChecker
+{
+    public static ClientVersionChecker fromSystemConfig(Config systemConfig)
+    {
+        return new ClientVersionChecker(
+                systemConfig.getOptional("server.client-version-check.upgrade-recommended-if-older", String.class).transform(Version::parse),
+                systemConfig.getOptional("server.client-version-check.api-incompatible-if-older", String.class).transform(Version::parse));
+    }
+
+    private final Optional<Version> upgradeRecommendedUntil;
+    private final Optional<Version> apiIncompatibleUntil;
+
+    private ClientVersionChecker(
+            Optional<Version> upgradeRecommendedUntil,
+            Optional<Version> apiIncompatibleUntil)
+    {
+        this.upgradeRecommendedUntil = upgradeRecommendedUntil;
+        this.apiIncompatibleUntil = apiIncompatibleUntil;
+    }
+
+    public boolean isUpgradeRecommended(Version clientVesrion)
+    {
+        if (!upgradeRecommendedUntil.isPresent()) {
+            return false;
+        }
+        return clientVesrion.isOlder(upgradeRecommendedUntil.get());
+    }
+
+    public boolean isApiCompatible(Version clientVesrion)
+    {
+        if (!apiIncompatibleUntil.isPresent()) {
+            return true;
+        }
+        boolean incompatible = clientVesrion.isOlder(apiIncompatibleUntil.get());
+        return !incompatible;
+    }
+}

--- a/digdag-server/src/main/java/io/digdag/server/ClientVersionChecker.java
+++ b/digdag-server/src/main/java/io/digdag/server/ClientVersionChecker.java
@@ -24,20 +24,20 @@ public class ClientVersionChecker
         this.apiIncompatibleUntil = apiIncompatibleUntil;
     }
 
-    public boolean isUpgradeRecommended(Version clientVesrion)
+    public boolean isUpgradeRecommended(Version clientVersion)
     {
         if (!upgradeRecommendedUntil.isPresent()) {
             return false;
         }
-        return clientVesrion.isOlder(upgradeRecommendedUntil.get());
+        return clientVersion.isOlder(upgradeRecommendedUntil.get());
     }
 
-    public boolean isApiCompatible(Version clientVesrion)
+    public boolean isApiCompatible(Version clientVersion)
     {
         if (!apiIncompatibleUntil.isPresent()) {
             return true;
         }
-        boolean incompatible = clientVesrion.isOlder(apiIncompatibleUntil.get());
+        boolean incompatible = clientVersion.isOlder(apiIncompatibleUntil.get());
         return !incompatible;
     }
 }

--- a/digdag-server/src/main/java/io/digdag/server/ServerBootstrap.java
+++ b/digdag-server/src/main/java/io/digdag/server/ServerBootstrap.java
@@ -1,10 +1,13 @@
 package io.digdag.server;
 
+import com.google.inject.Inject;
+import com.google.inject.Provider;
 import com.google.inject.Scopes;
 
 import io.digdag.core.DigdagEmbed;
 import io.digdag.core.ErrorReporter;
 import io.digdag.client.Version;
+import io.digdag.client.config.Config;
 import io.digdag.core.agent.ExtractArchiveWorkspaceManager;
 import io.digdag.core.agent.WorkspaceManager;
 import io.digdag.guice.rs.GuiceRsServerControl;
@@ -56,6 +59,7 @@ public class ServerBootstrap
                 binder.bind(ServerConfig.class).toInstance(serverConfig);
                 binder.bind(WorkflowExecutorLoop.class).asEagerSingleton();
                 binder.bind(WorkflowExecutionTimeoutEnforcer.class).asEagerSingleton();
+                binder.bind(ClientVersionChecker.class).toProvider(ClientVersionCheckerProvider.class);
 
                 binder.bind(ErrorReporter.class).to(JmxErrorReporter.class).in(Scopes.SINGLETON);
                 newExporter(binder).export(ErrorReporter.class).withGeneratedName();
@@ -75,5 +79,23 @@ public class ServerBootstrap
         }, "shutdown"));
 
         return control;
+    }
+
+    private static class ClientVersionCheckerProvider
+            implements Provider<ClientVersionChecker>
+    {
+        private final Config systemConfig;
+
+        @Inject
+        public ClientVersionCheckerProvider(Config systemConfig)
+        {
+            this.systemConfig = systemConfig;
+        }
+
+        @Override
+        public ClientVersionChecker get()
+        {
+            return ClientVersionChecker.fromSystemConfig(systemConfig);
+        }
     }
 }

--- a/digdag-server/src/main/java/io/digdag/server/rs/VersionResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/VersionResource.java
@@ -3,29 +3,47 @@ package io.digdag.server.rs;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import io.digdag.client.Version;
-
+import io.digdag.client.api.RestVersionCheckResult;
+import io.digdag.server.ClientVersionChecker;
+import java.util.Map;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-
-import java.util.Map;
+import javax.ws.rs.QueryParam;
 
 @Path("/")
 @Produces("application/json")
 public class VersionResource
 {
+    // GET  /api/version                                     # returns version of this server
+    // GET  /api/version/check?client=                       # checks given version and returns its result
+
     private final Version version;
+    private final ClientVersionChecker clientVersionChecker;
 
     @Inject
-    public VersionResource(Version version)
+    public VersionResource(Version version, ClientVersionChecker clientVersionChecker)
     {
         this.version = version;
+        this.clientVersionChecker = clientVersionChecker;
     }
 
     @GET
     @Path("/api/version")
     public Map<String, Object> getVersion()
     {
-        return ImmutableMap.of("version", version.version());
+        return ImmutableMap.of("version", version.toString());
+    }
+
+    @GET
+    @Path("/api/version/check")
+    public RestVersionCheckResult checkClientVersion(@QueryParam("client") String clientVersionString)
+    {
+        Version clientVersion = Version.parse(clientVersionString);
+        return RestVersionCheckResult.builder()
+            .serverVersion(version.toString())
+            .upgradeRecommended(clientVersionChecker.isUpgradeRecommended(clientVersion))
+            .apiCompatible(clientVersionChecker.isApiCompatible(clientVersion))
+            .build();
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/HttpOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/HttpOperatorFactory.java
@@ -14,7 +14,7 @@ import io.digdag.client.config.ConfigException;
 import io.digdag.client.config.ConfigFactory;
 import io.digdag.client.config.ConfigKey;
 import io.digdag.core.Environment;
-import io.digdag.client.Version;
+import io.digdag.client.DigdagVersion;
 import io.digdag.spi.ImmutableTaskResult;
 import io.digdag.spi.Operator;
 import io.digdag.spi.OperatorContext;
@@ -81,7 +81,7 @@ public class HttpOperatorFactory
         this.maxRedirects = systemConfig.get("config.http.max_redirects", int.class, 8);
         this.maxStoredResponseContentSize = systemConfig.get("config.http.max_stored_response_content_size", int.class, 64 * 1024);
         this.env = env;
-        this.userAgent = systemConfig.get("config.http.user_agent", String.class, "Digdag/" + Version.buildVersion());
+        this.userAgent = systemConfig.get("config.http.user_agent", String.class, "Digdag/" + DigdagVersion.buildVersion());
     }
 
     private static Optional<ProxyConfiguration.Proxy> systemProxy(Config systemConfig)

--- a/digdag-tests/src/test/java/acceptance/CliProxyEnvVarIT.java
+++ b/digdag-tests/src/test/java/acceptance/CliProxyEnvVarIT.java
@@ -1,7 +1,6 @@
 package acceptance;
 
 import com.google.common.collect.ImmutableMap;
-import io.digdag.client.Version;
 import io.netty.handler.codec.http.HttpRequest;
 import okhttp3.internal.tls.SslClient;
 import okhttp3.mockwebserver.MockResponse;
@@ -22,6 +21,7 @@ import utils.CommandStatus;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import static io.digdag.client.DigdagVersion.buildVersion;
 import static io.netty.handler.codec.http.HttpHeaders.Names.CONTENT_TYPE;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
@@ -32,7 +32,7 @@ public class CliProxyEnvVarIT
     private static final Logger logger = LoggerFactory.getLogger(CliProxyEnvVarIT.class);
 
     private static final MockResponse VERSION_RESPONSE = new MockResponse()
-            .setBody("{\"version\":\"" + Version.buildVersion() + "\"}")
+            .setBody("{\"version\":\"" + buildVersion() + "\"}")
             .setHeader(CONTENT_TYPE, "application/json");
 
     private HttpProxyServer httpProxy;
@@ -133,7 +133,7 @@ public class CliProxyEnvVarIT
         assertThat(versionStatus.errUtf8(), versionStatus.code(), is(0));
         assertThat(server.getRequestCount(), is(1));
         assertThat(proxyRequestTracker.clientRequestsReceived.get(), is(1));
-        assertThat(versionStatus.outUtf8(), Matchers.containsString("Server version: " + Version.buildVersion()));
+        assertThat(versionStatus.outUtf8(), Matchers.containsString("Server version: " + buildVersion()));
     }
 
     private class HttpProxyRequestTracker

--- a/digdag-tests/src/test/java/acceptance/VersionIT.java
+++ b/digdag-tests/src/test/java/acceptance/VersionIT.java
@@ -6,6 +6,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import utils.CommandStatus;
+import utils.LocalVersion;
 import utils.TemporaryDigdagServer;
 
 import java.nio.file.Files;
@@ -19,13 +20,17 @@ import static org.junit.Assert.assertThat;
 
 public class VersionIT
 {
-    private static final Version REMOTE_VERSION = Version.of("4.5.6");
+    private static final Version REMOTE_VERSION = Version.parse("4.5.6");
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 
     @Rule
-    public TemporaryDigdagServer server = TemporaryDigdagServer.of(REMOTE_VERSION);
+    public TemporaryDigdagServer server = TemporaryDigdagServer.builder()
+        .version(REMOTE_VERSION)
+        .configuration("server.client-version-check.upgrade-recommended-if-older = 4.5.0")
+        .configuration("server.client-version-check.api-incompatible-if-older = 4.0.0")
+        .build();
 
     private Path config;
 
@@ -41,31 +46,73 @@ public class VersionIT
             throws Exception
     {
         String versionString = "3.14.15";
-        CommandStatus status = main(Version.of(versionString), "-c", config.toString());
+        CommandStatus status = main(LocalVersion.of(Version.parse(versionString)), "-c", config.toString());
         assertThat(status.errUtf8(), containsString("Digdag v" + versionString));
     }
 
     @Test
-    public void testVersion()
+    public void testVersionCheckWithCompatibleVersion()
             throws Exception
     {
-        String localVersion = REMOTE_VERSION + "-NOT";
-        CommandStatus status = main(Version.of(localVersion), "version", "-e", server.endpoint(), "-c", config.toString());
-        assertThat(status.outUtf8(), containsString("Client version: " + localVersion));
-        assertThat(status.outUtf8(), containsString("Server version: " + REMOTE_VERSION));
+        Version localVersion = Version.parse("4.5.0");
+
+        // interactive succeeds
+        CommandStatus interactive = main(LocalVersion.of(localVersion).withBatchModeCheck(false), "workflows", "-e", server.endpoint(), "-c", config.toString());
+        assertThat(interactive.code(), is(0));  // success
+
+        // batch succeeds
+        CommandStatus batch = main(LocalVersion.of(localVersion).withBatchModeCheck(true), "workflows", "-e", server.endpoint(), "-c", config.toString());
+        assertThat(batch.code(), is(0));  // success
     }
 
     @Test
-    public void verifyVersionMismatchRejected()
+    public void testVersionCheckWithUpgradeRecommendeVersion()
             throws Exception
     {
-        String localVersionString = REMOTE_VERSION + "-NOT";
-        CommandStatus status = main(Version.of(localVersionString), "workflows", "-e", server.endpoint(), "-c", config.toString());
-        assertThat(status.code(), is(not(0)));
-        assertThat(status.errUtf8(), containsString("Client: " + localVersionString));
-        assertThat(status.errUtf8(), containsString("Server: " + REMOTE_VERSION));
-        assertThat(status.errUtf8(), containsString("digdag selfupdate "  + REMOTE_VERSION));
-        assertThat(status.errUtf8(), containsString(
-                "Please run following command locally to download a compatible version with the server"));
+        Version localVersion = Version.parse("4.4.3");
+
+        // interactive mode aborts
+        CommandStatus interactive = main(LocalVersion.of(localVersion).withBatchModeCheck(false), "workflows", "-e", server.endpoint(), "-c", config.toString());
+        assertThat(interactive.code(), is(not(0)));  // fail
+        assertThat(interactive.errUtf8(), containsString("client: " + localVersion));
+        assertThat(interactive.errUtf8(), containsString("server: " + REMOTE_VERSION));
+        assertThat(interactive.errUtf8(), containsString(
+                    "This client version is obsoleted. It is recommended to upgrade"));
+        assertThat(interactive.errUtf8(), containsString(
+                    "Please run following command locally to upgrade to the latest version compatible to the server:"));
+        assertThat(interactive.errUtf8(), containsString("digdag selfupdate "  + REMOTE_VERSION));
+
+        // batch mode warns
+        CommandStatus batch = main(LocalVersion.of(localVersion).withBatchModeCheck(true), "workflows", "-e", server.endpoint(), "-c", config.toString());
+        assertThat(batch.code(), is(0));  // success
+    }
+
+    @Test
+    public void testVersionCheckWithApiIncompatibleVersion()
+            throws Exception
+    {
+        Version localVersion = Version.parse("3.9");
+
+        // interactive mode aborts
+        CommandStatus interactive = main(LocalVersion.of(localVersion).withBatchModeCheck(false), "workflows", "-e", server.endpoint(), "-c", config.toString());
+        assertThat(interactive.code(), is(not(0)));  // fail
+        assertThat(interactive.errUtf8(), containsString("client: " + localVersion));
+        assertThat(interactive.errUtf8(), containsString("server: " + REMOTE_VERSION));
+        assertThat(interactive.errUtf8(), containsString(
+                    "This client version is not API compatible to the server"));
+        assertThat(interactive.errUtf8(), containsString(
+                    "Please run following command locally to upgrade to a compatible version with the server:"));
+        assertThat(interactive.errUtf8(), containsString("digdag selfupdate "  + REMOTE_VERSION));
+
+        // batch mode aborts
+        CommandStatus batch = main(LocalVersion.of(localVersion).withBatchModeCheck(true), "workflows", "-e", server.endpoint(), "-c", config.toString());
+        assertThat(batch.code(), is(not(0)));  // fail
+        assertThat(batch.errUtf8(), containsString("client: " + localVersion));
+        assertThat(batch.errUtf8(), containsString("server: " + REMOTE_VERSION));
+        assertThat(batch.errUtf8(), containsString(
+                    "This client version is not API compatible to the server"));
+        assertThat(batch.errUtf8(), containsString(
+                    "Please run following command locally to upgrade to a compatible version with the server:"));
+        assertThat(batch.errUtf8(), containsString("digdag selfupdate "  + REMOTE_VERSION));
     }
 }

--- a/digdag-tests/src/test/java/acceptance/VersionIT.java
+++ b/digdag-tests/src/test/java/acceptance/VersionIT.java
@@ -66,7 +66,7 @@ public class VersionIT
     }
 
     @Test
-    public void testVersionCheckWithUpgradeRecommendeVersion()
+    public void testVersionCheckWithUpgradeRecommendedVersion()
             throws Exception
     {
         Version localVersion = Version.parse("4.4.3");

--- a/digdag-tests/src/test/java/utils/DevServer.java
+++ b/digdag-tests/src/test/java/utils/DevServer.java
@@ -2,11 +2,12 @@ package utils;
 
 import com.google.common.collect.ImmutableMap;
 import io.digdag.cli.Main;
-import io.digdag.client.Version;
 
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+
+import static io.digdag.client.DigdagVersion.buildVersion;
 
 public class DevServer
 {
@@ -14,7 +15,7 @@ public class DevServer
             throws IOException
     {
         Path logdir = Files.createTempDirectory("digdag-task-logs");
-        Main main = new Main(Version.buildVersion(), ImmutableMap.of(), System.out, System.err, System.in);
+        Main main = new Main(buildVersion(), ImmutableMap.of(), System.out, System.err, System.in);
         main.cli("server",
                 "-c", "/dev/null",
                 "-m",

--- a/digdag-tests/src/test/java/utils/LocalVersion.java
+++ b/digdag-tests/src/test/java/utils/LocalVersion.java
@@ -1,0 +1,41 @@
+package utils;
+
+import io.digdag.client.Version;
+import static io.digdag.client.DigdagVersion.buildVersion;
+
+public class LocalVersion
+{
+    public static LocalVersion of()
+    {
+        return of(buildVersion());
+    }
+
+    public static LocalVersion of(Version version)
+    {
+        return new LocalVersion(version, false);
+    }
+
+    private final Version version;
+    private final boolean batchModeCheck;
+
+    private LocalVersion(Version version, boolean batchModeCheck)
+    {
+        this.version = version;
+        this.batchModeCheck = batchModeCheck;
+    }
+
+    public LocalVersion withBatchModeCheck(boolean enabled)
+    {
+        return new LocalVersion(version, enabled);
+    }
+
+    public Version getVersion()
+    {
+        return version;
+    }
+
+    public boolean isBatchModeCheck()
+    {
+        return batchModeCheck;
+    }
+}

--- a/digdag-tests/src/test/java/utils/TemporaryDigdagServer.java
+++ b/digdag-tests/src/test/java/utils/TemporaryDigdagServer.java
@@ -56,6 +56,8 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadLocalRandom;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
+import static io.digdag.client.DigdagVersion.buildVersion;
+import static io.digdag.client.DigdagVersion.VERSION_PROPERTY;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -296,7 +298,7 @@ public class TemporaryDigdagServer
             executor.execute(() -> {
                 OutputStream out = fanout(this.out, System.out);
                 OutputStream err = fanout(this.err, System.err);
-                main(environment, version.or(Version.buildVersion()), args, out, err, in);
+                main(environment, LocalVersion.of(version.or(buildVersion())), args, out, err, in);
             });
         }
         else {
@@ -311,7 +313,7 @@ public class TemporaryDigdagServer
                     "-cp", classPath,
                     "-Xms128m", "-Xmx128m"));
             if (version.isPresent()) {
-                processArgs.add("-D" + Version.VERSION_PROPERTY + "=" + version.get());
+                processArgs.add("-D" + VERSION_PROPERTY + "=" + version.get());
             }
             for (String key : properties.stringPropertyNames()) {
                 processArgs.add("-D" + key + "=" + properties.getProperty(key));
@@ -676,11 +678,6 @@ public class TemporaryDigdagServer
     public static TemporaryDigdagServer of()
     {
         return builder().build();
-    }
-
-    public static TemporaryDigdagServer of(Version version)
-    {
-        return builder().version(version).build();
     }
 
     public static class Builder

--- a/digdag-tests/src/test/java/utils/TestUtils.java
+++ b/digdag-tests/src/test/java/utils/TestUtils.java
@@ -82,7 +82,6 @@ import java.util.stream.Collectors;
 import java.util.zip.GZIPInputStream;
 
 import static com.google.common.primitives.Bytes.concat;
-import static io.digdag.client.Version.buildVersion;
 import static io.digdag.util.RetryExecutor.retryExecutor;
 import static io.netty.handler.codec.http.HttpHeaders.Names.CONNECTION;
 import static io.netty.handler.codec.http.HttpHeaders.Values.CLOSE;
@@ -116,12 +115,12 @@ public class TestUtils
 
     public static CommandStatus main(String... args)
     {
-        return main(buildVersion(), args);
+        return main(LocalVersion.of(), args);
     }
 
     public static CommandStatus main(InputStream in, String... args)
     {
-        return main(buildVersion(), in, asList(args));
+        return main(LocalVersion.of(), in, asList(args));
     }
 
     public static CommandStatus main(Map<String, String> env, String... args)
@@ -134,27 +133,27 @@ public class TestUtils
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         ByteArrayOutputStream err = new ByteArrayOutputStream();
         InputStream in = new ByteArrayInputStream(new byte[0]);
-        int code = main(env, buildVersion(), args, out, err, in);
+        int code = main(env, LocalVersion.of(), args, out, err, in);
         return CommandStatus.of(code, out.toByteArray(), err.toByteArray());
     }
 
     public static CommandStatus main(Collection<String> args)
     {
-        return main(buildVersion(), args);
+        return main(LocalVersion.of(), args);
     }
 
-    public static CommandStatus main(Version localVersion, String... args)
+    public static CommandStatus main(LocalVersion localVersion, String... args)
     {
         return main(localVersion, asList(args));
     }
 
-    public static CommandStatus main(Version localVersion, Collection<String> args)
+    public static CommandStatus main(LocalVersion localVersion, Collection<String> args)
     {
         InputStream in = new ByteArrayInputStream(new byte[0]);
         return main(localVersion, in, args);
     }
 
-    public static CommandStatus main(Version localVersion, InputStream in, Collection<String> args)
+    public static CommandStatus main(LocalVersion localVersion, InputStream in, Collection<String> args)
     {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         ByteArrayOutputStream err = new ByteArrayOutputStream();
@@ -162,13 +161,14 @@ public class TestUtils
         return CommandStatus.of(code, out.toByteArray(), err.toByteArray());
     }
 
-    public static int main(Map<String, String> env, Version localVersion, Collection<String> args, OutputStream out, OutputStream err, InputStream in)
+    public static int main(Map<String, String> env, LocalVersion localVersion, Collection<String> args, OutputStream out, OutputStream err, InputStream in)
     {
         try (
                 PrintStream outp = new PrintStream(out, true, "UTF-8");
                 PrintStream errp = new PrintStream(err, true, "UTF-8");
         ) {
-            Main main = new Main(localVersion, env, outp, errp, in);
+            Main main = new Main(localVersion.getVersion(), env, outp, errp, in);
+            System.setProperty("io.digdag.cli.versionCheckMode", localVersion.isBatchModeCheck() ? "batch" : "interactive");
             return main.cli(args.stream().toArray(String[]::new));
         }
         catch (RuntimeException | UnsupportedEncodingException e) {


### PR DESCRIPTION
This is how it works:

* digdag-cli sends its version to the server (unless `--disable-version-check`
  is set)

* If server returns `apiCompatible: false`, client aborts. Client must
  upgrade.
  This is useful when there are too old clients and they may cause
  unexpected problems due to incompatible REST API version. But most
  likely, digdag shouldn't introduce such incompatible REST API changes.

* If server returns `upgradeRecommended: true`

  * If STDOUT is TTY, client aborts. Client must upgrade.
    This is useful when system administrator of the server wants to
    force all users upgrade to make technical support eassy.

  * Otherwise, show warning and continue processing.
    This is necessary when digdag command is run by a script where
    the command shouldn't abort.

Server returns `apiCompatible: false` when client version is older than
`server.client-version-check.api-incompatible-if-older` property.

Server returns `upgradeRecommended: true` when client version is older than
`server.client-version-check.upgrade-recommended-if-older` property.
