### PR TITLE
Add "RETRY FAILED" button

### DIFF
--- a/digdag-ui/model.js
+++ b/digdag-ui/model.js
@@ -353,7 +353,7 @@ export class Model {
   }
 
   resumeSessionWithLatestRevision (session: Session, attemptName: string, attemptId: number) {
-    const { lastAttempt } = session
+    const { lastAttempt, project, workflow } = session
     const model = this
     return this.fetchProjectWorkflow(project.id, workflow.name).then((result) =>
       model.put('attempts', {

--- a/digdag-ui/model.js
+++ b/digdag-ui/model.js
@@ -339,17 +339,7 @@ export class Model {
     return this.put('attempts', { workflowId, sessionTime, params })
   }
 
-  retrySession (session: Session, sessionUUID: string) {
-    const { lastAttempt } = session
-    return this.put('attempts', {
-      workflowId: session.workflow.id,
-      params: lastAttempt && lastAttempt.params,
-      sessionTime: session.sessionTime,
-      retryAttemptName: sessionUUID
-    })
-  }
-
-  retrySessionWithLatestRevision (session: Session, sessionUUID: string) {
+  retrySessionWithLatestRevision (session: Session, attemptName: string) {
     const { lastAttempt, project, workflow } = session
     const model = this
     return this.fetchProjectWorkflow(project.id, workflow.name).then((result) =>
@@ -357,7 +347,24 @@ export class Model {
         workflowId: result.id,
         params: lastAttempt && lastAttempt.params,
         sessionTime: session.sessionTime,
-        retryAttemptName: sessionUUID
+        retryAttemptName: attemptName
+      })
+    )
+  }
+
+  resumeSessionWithLatestRevision (session: Session, attemptName: string, attemptId: number) {
+    const { lastAttempt } = session
+    const model = this
+    return this.fetchProjectWorkflow(project.id, workflow.name).then((result) =>
+      model.put('attempts', {
+        workflowId: result.id,
+        params: lastAttempt && lastAttempt.params,
+        sessionTime: session.sessionTime,
+        retryAttemptName: attemptName,
+        resume: {
+          mode: "failed",
+          attemptId: attemptId
+        }
       })
     )
   }


### PR DESCRIPTION
Session page is showing "RETRY LATEST" and "RETRY" buttons. But it's
confusing that "what's latest?" or "what's the difference?"

This changes the buttons to "RETRY FAILED" and "RETRY ALL". Both of
them use the latest revision. RETRY FAILED button skips successfully
finished tasks.

"RETRY ALL" button always appears.
"RETRY FAILED" button appears when the attempt failed.

Current:

![](https://i.gyazo.com/fd0b05eb1b9708e1bb171fa5b645ccd5.png)

Changed:

![](https://i.gyazo.com/47d4a391f6402886f4671df73dd52785.png)
