### PR TITLE
Add session_id to the runtime parameter

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/agent/RuntimeParams.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/RuntimeParams.java
@@ -22,6 +22,7 @@ public class RuntimeParams
         // session_*
         params.set("session_uuid", request.getSessionUuid().toString());
         params.set("session_time", formatSessionTime(request.getSessionTime(), timeZone));
+        params.set("session_id", request.getSessionId());
         setTimeParameters(params, "session_", timeZone, request.getSessionTime());
 
         // last_session_*

--- a/digdag-docs/src/workflow_definition.rst
+++ b/digdag-docs/src/workflow_definition.rst
@@ -56,6 +56,7 @@ Name                            Description                                 Exam
 =============================== =========================================== ==========================
 **timezone**                    Timezone of this workflow                   America/Los_Angeles
 **session_uuid**                Unique UUID of this session                 414a8b9e-b365-4394-916a-f0ed9987bd2b
+**session_id**                  Integer ID of this session                  2381
 **session_time**                Time of this session with time zone         2016-01-30T00:00:00-08:00
 **session_date**                Date part of session_time                   2016-01-30
 **session_date_compact**        Date part of session_time (compact)         20160130

--- a/digdag-tests/src/test/java/acceptance/BuiltInVariablesIT.java
+++ b/digdag-tests/src/test/java/acceptance/BuiltInVariablesIT.java
@@ -54,6 +54,7 @@ public class BuiltInVariablesIT
         Map<String, Matcher<String>> expectedOutput = ImmutableMap.<String, Matcher<String>>builder()
                 .put("session_tz_offset", is("+0000"))
                 .put("session_time", is("2016-01-02T03:04:05+00:00"))
+                .put("session_id", is("1"))
                 .put("session_uuid", is(validUuid()))
                 .put("timezone", is("UTC"))
                 .put("session_local_time", is("2016-01-02 03:04:05"))

--- a/digdag-tests/src/test/resources/acceptance/built_in_variables/built_in_variables.dig
+++ b/digdag-tests/src/test/resources/acceptance/built_in_variables/built_in_variables.dig
@@ -10,6 +10,8 @@ schedule:
   _parallel: true
   +timezone:
     sh>: "echo timezone: \\'${timezone}\\' >> output.yml"
+  +session_id:
+    sh>: "echo session_id: \\'${session_id}\\' >> output.yml"
   +session_uuid:
     sh>: "echo session_uuid: \\'${session_uuid}\\' >> output.yml"
   +session_time:


### PR DESCRIPTION
`session_id` was removed once because there was a unclear design decision
around session and attempt. Now, there is an idea to add attempt index
to replace attempt_id. Therefore, session_id is now becoming a stable
concept. `session_id` is used both in REST API and CLI interface.

Fixes #469.