### PR TITLE
Loading workflow should always override _workdir

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/archive/ProjectArchiveLoader.java
+++ b/digdag-core/src/main/java/io/digdag/core/archive/ProjectArchiveLoader.java
@@ -82,8 +82,7 @@ public class ProjectArchiveLoader
         int posSlash = workflowName.lastIndexOf('/');
         if (posSlash >= 0) {
             // workflow is in a subdirectory. set _workdir accordingly.
-            String workdir = overrideParams.getOptional("_workdir", String.class)  // overrideParams has higher priority
-                .or(workflowName.substring(0, posSlash));
+            String workdir = workflowName.substring(0, posSlash);
             workflowFile.setBaseWorkdir(workdir);
         }
 

--- a/digdag-tests/src/test/java/acceptance/CallIT.java
+++ b/digdag-tests/src/test/java/acceptance/CallIT.java
@@ -64,6 +64,11 @@ public class CallIT
         Files.createDirectories(projectDir.resolve("sub").resolve("subsub"));
         Files.write(projectDir.resolve("sub").resolve("child.dig"), childWf.getBytes(UTF_8));
         Files.write(projectDir.resolve("sub").resolve("subsub").resolve("child.dig"), childWf.getBytes(UTF_8));
+
+        Files.createDirectories(projectDir.resolve("nested2").resolve("nested3"));
+        copyResource("acceptance/call/nested1.dig", projectDir.resolve("nested1.dig"));
+        copyResource("acceptance/call/nested2.dig", projectDir.resolve("nested2").resolve("nested2.dig"));
+        copyResource("acceptance/call/nested3.dig", projectDir.resolve("nested2").resolve("nested3").resolve("nested3.dig"));
     }
 
     @Test
@@ -135,5 +140,32 @@ public class CallIT
         assertThat(subPath.getFileName(), is(Paths.get("sub")));
         assertThat(subsubPath.getFileName(), is(Paths.get("subsub")));
         assertThat(subsubPath.getParent().getFileName(), is(Paths.get("sub")));
+    }
+
+    @Test
+    public void nestedWorkdir()
+            throws Exception
+    {
+        initCallProject();
+
+        CommandStatus status = main("run",
+                "-c", config.toString(),
+                "--project", projectDir.toString(),
+                "nested1.dig",
+                "-p", "outdir=" + root());
+        assertThat(status.errUtf8(), status.code(), is(0));
+
+        assertThat(Files.exists(root().resolve("nested1.out")), is(true));
+        assertThat(Files.exists(root().resolve("nested2.out")), is(true));
+        assertThat(Files.exists(root().resolve("nested3.out")), is(true));
+        assertThat(
+                new String(Files.readAllBytes(root().resolve("nested1.out")), UTF_8).trim(),
+                is("undefined"));
+        assertThat(
+                new String(Files.readAllBytes(root().resolve("nested2.out")), UTF_8).trim(),
+                is("nested2"));
+        assertThat(
+                new String(Files.readAllBytes(root().resolve("nested3.out")), UTF_8).trim(),
+                is("nested2/nested3"));
     }
 }

--- a/digdag-tests/src/test/resources/acceptance/call/nested1.dig
+++ b/digdag-tests/src/test/resources/acceptance/call/nested1.dig
@@ -1,0 +1,5 @@
++nested1_out:
+  sh>: echo "${typeof _workdir}" > ${outdir}/nested1.out
+
++nested1:
+  call>: nested2/nested2.dig

--- a/digdag-tests/src/test/resources/acceptance/call/nested2.dig
+++ b/digdag-tests/src/test/resources/acceptance/call/nested2.dig
@@ -1,0 +1,5 @@
++nested2_out:
+  sh>: echo "${_workdir}" > ${outdir}/nested2.out
+
++nested2:
+  call>: nested3/nested3.dig

--- a/digdag-tests/src/test/resources/acceptance/call/nested3.dig
+++ b/digdag-tests/src/test/resources/acceptance/call/nested3.dig
@@ -1,0 +1,2 @@
++nested3_out:
+  sh>: echo "${_workdir}" > ${outdir}/nested3.out


### PR DESCRIPTION
Call operator passes its all exported/stored parameters to project
archive loader. And project archive loader respects _workdir if it's
already set. But it causes unexpected behavior: there're 3 workflows A,
B, and C. A calls B, B calls C. When A calls B, it sets _workdir. When B
calls C, it doesn't set _workdir because it's already set. Therefore, C
uses B's _workdir.
This change fixes this issue by ignoring _workdir when it's already set.
