### PR TITLE
Make admin port explicit

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/Server.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Server.java
@@ -22,8 +22,6 @@ import java.util.Properties;
 import static io.digdag.cli.Arguments.loadParams;
 import static io.digdag.cli.SystemExitException.systemExit;
 import static io.digdag.client.DigdagClient.objectMapper;
-import static io.digdag.server.ServerConfig.DEFAULT_ADMIN_BIND;
-import static io.digdag.server.ServerConfig.DEFAULT_ADMIN_PORT;
 import static io.digdag.server.ServerConfig.DEFAULT_BIND;
 import static io.digdag.server.ServerConfig.DEFAULT_PORT;
 
@@ -99,8 +97,8 @@ public class Server
         err.println("  Options:");
         err.println("    -n, --port PORT                  port number to listen for web interface and api clients (default: " + DEFAULT_PORT + ")");
         err.println("    -b, --bind ADDRESS               IP address to listen HTTP clients (default: " + DEFAULT_BIND + ")");
-        err.println("    --admin-port PORT                port number to bind admin api on (default: " + DEFAULT_ADMIN_PORT + ")");
-        err.println("    --admin-bind ADDRESS             IP address to bind admin api on (default: " + DEFAULT_ADMIN_BIND + ")");
+        err.println("    --admin-port PORT                port number to bind admin api on (default: no admin port)");
+        err.println("    --admin-bind ADDRESS             IP address to bind admin api on (default: same address with --bind)");
         err.println("    -m, --memory                     uses memory database");
         err.println("    -o, --database DIR               store status to this database");
         err.println("    -O, --task-log DIR               store task logs to this path");

--- a/digdag-guice-rs-server-undertow/src/main/java/io/digdag/guice/rs/server/undertow/UndertowServerConfig.java
+++ b/digdag-guice-rs-server-undertow/src/main/java/io/digdag/guice/rs/server/undertow/UndertowServerConfig.java
@@ -17,12 +17,12 @@ public interface UndertowServerConfig
     /**
      * Local port to listen on.
      */
-    int getAdminPort();
+    Optional<Integer> getAdminPort();
 
     /**
      * Local address to listen on.
      */
-    String getAdminBind();
+    Optional<String> getAdminBind();
 
     /**
      * Access log path. Null to disable logging.

--- a/digdag-server/src/main/java/io/digdag/server/ServerConfig.java
+++ b/digdag-server/src/main/java/io/digdag/server/ServerConfig.java
@@ -25,9 +25,7 @@ public interface ServerConfig
     extends UndertowServerConfig
 {
     public static final int DEFAULT_PORT = 65432;
-    public static final int DEFAULT_ADMIN_PORT = 65433;
     public static final String DEFAULT_BIND = "127.0.0.1";
-    public static final String DEFAULT_ADMIN_BIND = "127.0.0.1";
     public static final String DEFAULT_ACCESS_LOG_PATTERN = "json";
 
     public Optional<String> getServerRuntimeInfoPath();
@@ -64,8 +62,8 @@ public interface ServerConfig
         return defaultBuilder()
             .port(config.get("server.port", int.class, DEFAULT_PORT))
             .bind(config.get("server.bind", String.class, DEFAULT_BIND))
-            .adminPort(config.get("server.admin.port", int.class, DEFAULT_ADMIN_PORT))
-            .adminBind(config.get("server.admin.bind", String.class, DEFAULT_ADMIN_BIND))
+            .adminPort(config.getOptional("server.admin.port", int.class))
+            .adminBind(config.getOptional("server.admin.bind", String.class))
             .serverRuntimeInfoPath(config.getOptional("server.runtime-info.path", String.class))
             .accessLogPath(config.getOptional("server.access-log.path", String.class))
             .accessLogPattern(config.get("server.access-log.pattern", String.class, DEFAULT_ACCESS_LOG_PATTERN))


### PR DESCRIPTION
Admin port is enabled by default even if --admin-* options are not set
but it may cause unexpected port conflicts because users are not always
aware of it. This change requires users to set --admin-port option to
enable and listen on admin port.