### PR TITLE
Recommend using Result output to S3

### DIFF
--- a/digdag-docs/src/operators/td_table_export.md
+++ b/digdag-docs/src/operators/td_table_export.md
@@ -1,6 +1,6 @@
 # td_table_export>: Treasure Data table export to S3
 
-NOTE: We're limiting export capability to only us-east region S3 bucket. In general, please use Result Output to S3 feature using td operator.
+NOTE: We're limiting export capability to only us-east region S3 bucket. In general, please use Result Output to S3 feature using td operator. This workflow example is [here](https://github.com/treasure-data/workflow-examples/tree/master/td/s3).
 
 **td_table_export>** operator loads data from storages, databases, or services.
 

--- a/digdag-docs/src/operators/td_table_export.md
+++ b/digdag-docs/src/operators/td_table_export.md
@@ -1,5 +1,7 @@
 # td_table_export>: Treasure Data table export to S3
 
+NOTE: We're limiting export capability to only us-east region S3 bucket. In general, please use Result Output to S3 feature using td operator.
+
 **td_table_export>** operator loads data from storages, databases, or services.
 
     +step1:


### PR DESCRIPTION
table:export feature has some limitations.
For general use-case, we recommend using Result Output to S3 using td operator with result_url.