### PR TITLE
Add userInfo field to revision

### DIFF
--- a/digdag-client/src/main/java/io/digdag/client/api/RestRevision.java
+++ b/digdag-client/src/main/java/io/digdag/client/api/RestRevision.java
@@ -2,6 +2,7 @@ package io.digdag.client.api;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.Optional;
+import io.digdag.client.config.Config;
 import java.time.Instant;
 import org.immutables.value.Value;
 
@@ -16,6 +17,10 @@ public interface RestRevision
     String getArchiveType();
 
     Optional<byte[]> getArchiveMd5();
+
+    // userInfo is Optional only to keep backward compatibility. Ideally, it
+    // should fill {} (empty object) by default instead of making it Optional.
+    Optional<Config> getUserInfo();
 
     static ImmutableRestRevision.Builder builder()
     {

--- a/digdag-client/src/test/java/io/digdag/client/api/ModelCompatibilityTest.java
+++ b/digdag-client/src/test/java/io/digdag/client/api/ModelCompatibilityTest.java
@@ -1,14 +1,14 @@
 package io.digdag.client.api;
 
-import java.time.OffsetDateTime;
-import java.time.ZoneId;
-import java.util.UUID;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Optional;
 import io.digdag.client.DigdagClient;
 import java.io.IOException;
 import java.time.Instant;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.util.UUID;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -19,9 +19,6 @@ import static org.junit.Assert.assertThat;
 public class ModelCompatibilityTest
 {
     private ObjectMapper mapper = DigdagClient.objectMapper();
-
-    @Rule
-    public final ExpectedException exception = ExpectedException.none();
 
     @Test
     public void testSessionAttemptIndex()
@@ -46,6 +43,21 @@ public class ModelCompatibilityTest
         assertThat(attempt.getIndex(), is(3));
         String oldVersion = removeField(mapper.writeValueAsString(attempt), "index");
         mapper.readValue(oldVersion, RestSessionAttempt.class);
+    }
+
+    @Test
+    public void testRestRevisionDefaultUserInfo()
+            throws Exception
+    {
+        RestRevision rev = RestRevision.builder()
+            .revision("rev1")
+            .createdAt(Instant.now())
+            .archiveType("none")
+            .archiveMd5(Optional.absent())
+            .userInfo(newConfig())
+            .build();
+        String oldVersion = removeField(mapper.writeValueAsString(rev), "userInfo");
+        mapper.readValue(oldVersion, RestRevision.class);
     }
 
     private String removeField(String json, String field)

--- a/digdag-server/src/main/java/io/digdag/server/rs/RestModels.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/RestModels.java
@@ -1,5 +1,6 @@
 package io.digdag.server.rs;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import io.digdag.client.api.Id;
 import io.digdag.client.api.IdAndName;

--- a/digdag-server/src/main/java/io/digdag/server/rs/RestModels.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/RestModels.java
@@ -83,6 +83,7 @@ public final class RestModels
             .createdAt(rev.getCreatedAt())
             .archiveType(rev.getArchiveType().getName())
             .archiveMd5(rev.getArchiveMd5())
+            .userInfo(Optional.of(rev.getUserInfo()))
             .build();
     }
 


### PR DESCRIPTION
userInfo is information of an user who pushed the revision. UserInfo is
an opaque JSON object that is set by Authenticator module. Authenticator
module creates userInfo when it authorizes requests comming from a
client to push a new revision.
Authenticator module is supposed to be customized by system integrators.
The default Authenticator (authenticator that doesn't authenticate)
always sets an empty object.