### PR TITLE
Fix require> operator to fail if dependent session fails

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/agent/InProcessTaskCallbackApi.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/InProcessTaskCallbackApi.java
@@ -20,7 +20,7 @@ import io.digdag.core.workflow.AttemptBuilder;
 import io.digdag.core.workflow.WorkflowExecutor;
 import io.digdag.core.workflow.SessionAttemptConflictException;
 import io.digdag.core.session.SessionStoreManager;
-import io.digdag.core.session.AttemptStateFlags;
+import io.digdag.core.session.StoredSessionAttempt;
 import io.digdag.core.session.StoredSessionAttemptWithSession;
 import io.digdag.core.repository.StoredRevision;
 import io.digdag.core.repository.ArchiveType;
@@ -159,7 +159,7 @@ public class InProcessTaskCallbackApi
     }
 
     @Override
-    public AttemptStateFlags startSession(
+    public StoredSessionAttempt startSession(
             int siteId,
             int projectId,
             String workflowName,
@@ -184,12 +184,13 @@ public class InProcessTaskCallbackApi
                 Optional.absent());
 
         // TODO FIXME SessionMonitor monitors is not set
+        StoredSessionAttemptWithSession attempt;
         try {
-            StoredSessionAttemptWithSession attempt = exec.submitWorkflow(siteId, ar, def);
-            return attempt.getStateFlags();
+            attempt = exec.submitWorkflow(siteId, ar, def);
         }
         catch (SessionAttemptConflictException ex) {
-            return ex.getConflictedSession().getStateFlags();
+            attempt = ex.getConflictedSession();
         }
+        return attempt;
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/agent/TaskCallbackApi.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/TaskCallbackApi.java
@@ -9,7 +9,7 @@ import io.digdag.core.log.TaskLogger;
 import io.digdag.spi.TaskResult;
 import io.digdag.spi.TaskRequest;
 import io.digdag.spi.StorageObject;
-import io.digdag.core.session.AttemptStateFlags;
+import io.digdag.core.session.StoredSessionAttempt;
 import io.digdag.core.repository.ResourceLimitExceededException;
 import io.digdag.core.repository.ResourceNotFoundException;
 
@@ -36,7 +36,7 @@ public interface TaskCallbackApi
             int retryInterval, Config retryStateParams,
             Optional<Config> error);
 
-    AttemptStateFlags startSession(
+    StoredSessionAttempt startSession(
             int siteId,
             int projectId,
             String workflowName,

--- a/digdag-docs/src/operators/require.md
+++ b/digdag-docs/src/operators/require.md
@@ -49,3 +49,14 @@
       session_time: ${moment(last_session_time).add(i, 'day')}
   ```
 
+* **ignore_failure**: BOOLEAN
+
+  This operator fails when the dependent workflow finished with errors by default.
+
+  But if `ignore_failure: true` is set, this operator succeeds even when the workflow finished with errors.
+
+  ```
+  require>: another_workflow
+  ignore_failure: true
+  ```
+

--- a/digdag-tests/src/test/resources/acceptance/require/fail.dig
+++ b/digdag-tests/src/test/resources/acceptance/require/fail.dig
@@ -1,0 +1,2 @@
++fail:
+  fail>: expected failure

--- a/digdag-tests/src/test/resources/acceptance/require/parent_ignore_failure.dig
+++ b/digdag-tests/src/test/resources/acceptance/require/parent_ignore_failure.dig
@@ -1,0 +1,3 @@
++require:
+  require>: child
+  ignore_failure: true


### PR DESCRIPTION
`require>` operator was ignoring failure of dependent session. This is
inconsistent from `call>` operator which seems unexpected. With this
change, `require>` operator fails if dependent session is done with
success=false flag. This happens if the latest attempt of the session fails,
or is canceled.

This change also adds `ignore_failure` option to require operator so
that users can still make the workflow succeeded even when dependent
workflow fails.