### PR TITLE
executor.task_ttl should not kill tasks BLOCKED, PLANNED or READY for long time

### DIFF
--- a/digdag-server/src/main/java/io/digdag/server/WorkflowExecutionTimeoutEnforcer.java
+++ b/digdag-server/src/main/java/io/digdag/server/WorkflowExecutionTimeoutEnforcer.java
@@ -45,6 +45,14 @@ public class WorkflowExecutionTimeoutEnforcer
     private static final Duration DEFAULT_TASK_TTL = Duration.ofDays(1);
     private static final Duration DEFAULT_REAPING_INTERVAL = Duration.ofSeconds(5);
 
+    // This is similar to TaskStateCode.notDoneStates() but BLOCKED and PLANNED are excluded
+    private static final TaskStateCode[] TaskTTLEnforcedTaskStates = new TaskStateCode[] {
+        TaskStateCode.READY,
+        TaskStateCode.RETRY_WAITING,
+        TaskStateCode.GROUP_RETRY_WAITING,
+        TaskStateCode.RUNNING,
+    };
+
     private final ScheduledExecutorService scheduledExecutorService;
     private final SessionStoreManager ssm;
     private final Notifier notifier;
@@ -134,7 +142,7 @@ public class WorkflowExecutionTimeoutEnforcer
     {
         Instant startDeadline = ssm.getStoreTime().minus(taskTTL);
 
-        List<TaskAttemptSummary> expiredTasks = ssm.findTasksStartedBeforeWithState(TaskStateCode.notDoneStates(), startDeadline, (long) 0, 100);
+        List<TaskAttemptSummary> expiredTasks = ssm.findTasksStartedBeforeWithState(TaskTTLEnforcedTaskStates, startDeadline, (long) 0, 100);
 
         Map<Long, List<TaskAttemptSummary>> attempts = expiredTasks.stream()
                 .collect(groupingBy(TaskAttemptSummary::getAttemptId));

--- a/digdag-server/src/main/java/io/digdag/server/WorkflowExecutionTimeoutEnforcer.java
+++ b/digdag-server/src/main/java/io/digdag/server/WorkflowExecutionTimeoutEnforcer.java
@@ -48,7 +48,7 @@ public class WorkflowExecutionTimeoutEnforcer
     // This is similar to TaskStateCode.notDoneStates() but BLOCKED, PLANNED, and READY are excluded.
     // BLOCKED and PLANNED are excluded because there're other running tasks that should be enforced instead.
     // READY is excluded the workflow itself is working correctly and number of threads is insufficient.
-    private static final TaskStateCode[] TaskTTLEnforcedTaskStates = new TaskStateCode[] {
+    private static final TaskStateCode[] TASK_TTL_ENFORCED_STATE_CODES = new TaskStateCode[] {
         TaskStateCode.RETRY_WAITING,
         TaskStateCode.GROUP_RETRY_WAITING,
         TaskStateCode.RUNNING,
@@ -143,7 +143,7 @@ public class WorkflowExecutionTimeoutEnforcer
     {
         Instant startDeadline = ssm.getStoreTime().minus(taskTTL);
 
-        List<TaskAttemptSummary> expiredTasks = ssm.findTasksStartedBeforeWithState(TaskTTLEnforcedTaskStates, startDeadline, (long) 0, 100);
+        List<TaskAttemptSummary> expiredTasks = ssm.findTasksStartedBeforeWithState(TASK_TTL_ENFORCED_STATE_CODES, startDeadline, (long) 0, 100);
 
         Map<Long, List<TaskAttemptSummary>> attempts = expiredTasks.stream()
                 .collect(groupingBy(TaskAttemptSummary::getAttemptId));

--- a/digdag-server/src/main/java/io/digdag/server/WorkflowExecutionTimeoutEnforcer.java
+++ b/digdag-server/src/main/java/io/digdag/server/WorkflowExecutionTimeoutEnforcer.java
@@ -45,9 +45,10 @@ public class WorkflowExecutionTimeoutEnforcer
     private static final Duration DEFAULT_TASK_TTL = Duration.ofDays(1);
     private static final Duration DEFAULT_REAPING_INTERVAL = Duration.ofSeconds(5);
 
-    // This is similar to TaskStateCode.notDoneStates() but BLOCKED and PLANNED are excluded
+    // This is similar to TaskStateCode.notDoneStates() but BLOCKED, PLANNED, and READY are excluded.
+    // BLOCKED and PLANNED are excluded because there're other running tasks that should be enforced instead.
+    // READY is excluded the workflow itself is working correctly and number of threads is insufficient.
     private static final TaskStateCode[] TaskTTLEnforcedTaskStates = new TaskStateCode[] {
-        TaskStateCode.READY,
         TaskStateCode.RETRY_WAITING,
         TaskStateCode.GROUP_RETRY_WAITING,
         TaskStateCode.RUNNING,

--- a/digdag-tests/src/test/java/acceptance/ExecutionTimeoutIT.java
+++ b/digdag-tests/src/test/java/acceptance/ExecutionTimeoutIT.java
@@ -106,7 +106,6 @@ public class ExecutionTimeoutIT
     public static class AttemptTimeoutIT
             extends ExecutionTimeoutIT
     {
-
         @Test
         public void testAttemptTimeout()
                 throws Exception
@@ -158,6 +157,32 @@ public class ExecutionTimeoutIT
 
             // TODO: implement termination of blocking tasks
             // TODO: verify that blocking tasks are terminated when the attempt is canceled
+
+            RestSessionAttempt attempt = client.getSessionAttempt(attemptId);
+            assertThat(attempt.getCancelRequested(), is(true));
+        }
+    }
+
+    public static class TaskNotTimeoutIT
+            extends ExecutionTimeoutIT
+    {
+        @Test
+        public void testTaskNotTimeout()
+                throws Exception
+        {
+            setup("executor.attempt_ttl = 20s",
+                    "executor.task_ttl = 10s",
+                    "executor.ttl_reaping_interval = 1s");
+
+            addWorkflow(projectDir, "acceptance/attempt_timeout/task_not_timeout.dig", WORKFLOW_NAME + ".dig");
+            pushProject(server.endpoint(), projectDir, PROJECT_NAME);
+            Id attemptId = startWorkflow(server.endpoint(), PROJECT_NAME, WORKFLOW_NAME);
+
+            // Expect the attempt to get canceled
+            expect(Duration.ofMinutes(2), () -> client.getSessionAttempt(attemptId).getCancelRequested());
+
+            // Expect a notification to be sent with attempt's timeout message
+            expectNotification(attemptId, Duration.ofMinutes(2), "Workflow execution timeout"::equals);
 
             RestSessionAttempt attempt = client.getSessionAttempt(attemptId);
             assertThat(attempt.getCancelRequested(), is(true));

--- a/digdag-tests/src/test/java/acceptance/ExecutionTimeoutIT.java
+++ b/digdag-tests/src/test/java/acceptance/ExecutionTimeoutIT.java
@@ -170,8 +170,8 @@ public class ExecutionTimeoutIT
         public void testTaskNotTimeout()
                 throws Exception
         {
-            setup("executor.attempt_ttl = 20s",
-                    "executor.task_ttl = 10s",
+            setup("executor.attempt_ttl = 25s",
+                    "executor.task_ttl = 20s",
                     "executor.ttl_reaping_interval = 1s");
 
             addWorkflow(projectDir, "acceptance/attempt_timeout/task_not_timeout.dig", WORKFLOW_NAME + ".dig");

--- a/digdag-tests/src/test/resources/acceptance/attempt_timeout/task_not_timeout.dig
+++ b/digdag-tests/src/test/resources/acceptance/attempt_timeout/task_not_timeout.dig
@@ -1,0 +1,9 @@
+
++loop:
+  loop>: 500
+  _do:
+    sh>: sleep 2
+
++dependent:
+  echo>: don't kill this task by task timeout
+


### PR DESCRIPTION
BLOCKED and PLANNED states mean that there're other tasks running in the
attempt (BLOCKED: running dependent tasks, PLANNED: running child tasks).
Purpose of task_ttl is killing tasks without any progress for long time,
killing BLOCKED / PLANNED tasks don't make sense. Instead, it should
only kill leaf tasks.

READY is also excluded because having task in READY state for long time means
that the workflow is progressing expectedly but simply number of threads is
insufficient.

To kill long-running attempt, attempt_ttl should be used instead.