### PR TITLE
[WIP] Reuse ScriptEngine to avoid leak of compiled expressions in Nashorn

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/agent/ConfigEvalEngine.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/ConfigEvalEngine.java
@@ -129,8 +129,7 @@ public class ConfigEvalEngine
             return (Invocable) jsEngines.get(ReusableScriptEngineKey.of(timeZone, Thread.currentThread()));
         }
         catch (ExecutionException ex) {
-            Throwables.throwIfUnchecked(ex.getCause());
-            throw new RuntimeException(ex.getCause());
+            throw Throwables.propagate(ex.getCause());
         }
     }
 

--- a/digdag-core/src/main/resources/io/digdag/core/agent/digdag.js
+++ b/digdag-core/src/main/resources/io/digdag/core/agent/digdag.js
@@ -50,7 +50,7 @@ function template(code, variables)
   if (typeof variables == "string") {
     variables = JSON.parse(variables);
   }
-  vs = func.call(variables);
+  var vs = func.call(variables);
 
   return vs;
 }


### PR DESCRIPTION
Evaluating moment.js using a new ScriptEngine is causing memory leak.
Number of idk.nashorn.internal.ir.BinaryNode instance keeps increasing.
Sharing one ScriptEngine solves it but different workflows should not
share context for security reasons.
This change shares make it possible by freezing global context of
ScriptEngine.