### PR TITLE
Fix Guava version not to use the latest available version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -104,6 +104,7 @@ subprojects {
     ext {
         jacksonVersion = "2.6.7"
         awsJavaSdkVersion = "1.11.63"
+        guavaVersion = "19.0"
     }
 
     tasks.withType(JavaCompile) {

--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,6 @@ subprojects {
 
     dependencies {
         compile 'org.slf4j:slf4j-api:1.7.21'
-        compile 'com.google.guava:guava:19.0'
 
         testCompile 'junit:junit:4.12'
         testCompile 'org.hamcrest:hamcrest-library:1.3'

--- a/digdag-client/build.gradle
+++ b/digdag-client/build.gradle
@@ -7,7 +7,12 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-databind:${project.ext.jacksonVersion}"
     compile "com.fasterxml.jackson.datatype:jackson-datatype-guava:${project.ext.jacksonVersion}"
 
-    compile "com.github.rholder:guava-retrying:2.0.0"
+    compile("com.github.rholder:guava-retrying:2.0.0") {
+        // guava-retrying depends on guava:[10.+,). Gradle solves it to the latest
+        // available version of guava at the moment (e.g. 21.0). This is not good.
+        exclude group: 'com.google.guava', module: 'guava'
+    }
+    compile 'com.google.guava:guava:19.0'
 
     compile 'org.jboss.resteasy:resteasy-client:3.0.13.Final'
     compile 'org.apache.commons:commons-compress:1.10'

--- a/digdag-client/build.gradle
+++ b/digdag-client/build.gradle
@@ -12,7 +12,7 @@ dependencies {
         // available version of guava at the moment (e.g. 21.0). This is not good.
         exclude group: 'com.google.guava', module: 'guava'
     }
-    compile 'com.google.guava:guava:19.0'
+    compile "com.google.guava:guava:19.0"
 
     compile 'org.jboss.resteasy:resteasy-client:3.0.13.Final'
     compile 'org.apache.commons:commons-compress:1.10'

--- a/digdag-tests/build.gradle
+++ b/digdag-tests/build.gradle
@@ -6,7 +6,10 @@ dependencies {
     testCompile 'org.subethamail:subethasmtp:3.1.7'
     testCompile 'com.squareup.okhttp3:okhttp:3.4.1'
     testCompile 'com.squareup.okhttp3:mockwebserver:3.4.1'
-    testCompile 'org.littleshoot:littleproxy:1.1.0'
+    testCompile('org.littleshoot:littleproxy:1.1.0') {
+        // littleproxy depends on guava:18 and it conflicts with digdag-client
+        exclude group: 'com.google.guava', module: 'guava'
+    }
     testCompile "com.amazonaws:aws-java-sdk-dynamodb:${project.ext.awsJavaSdkVersion}"
     testCompile('org.apache.avro:avro:1.8.1') {
         exclude group:'org.apache.commons', module:'commons-compress'


### PR DESCRIPTION
`guava-retrying:2.0.0` depends on `guava:[10.+,)`. `:digdag-client`
depends on `guava-retrying:2.0.0` but doesn't depend on
guava directly.

In this case, apparently, gradle and maven solve the dependency
differently. Maven uses the latest guava across all dependencies to
guava (19.0 because dependency graph includes dependencies to guava:15,
16, 18 and 19). On the other hand, Gradle uses the latest available
version of guava (21.0 at this moment).

This change fixes this issue by changing dependency of digdag-client so
that it depends on guava:19 directly.

Problem happened with `Throwables.throwIfUnchecked ` method. This method is added since 20.0 and `Throwables.propagate` method is deprecated (this has big impact, by the way). CI failed when it uses maven, but local compile using gradle succeeded: https://travis-ci.org/treasure-data/digdag/builds/208784320
