### PR TITLE
Fix `digdag retry --resume` option in document

### DIFF
--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -456,7 +456,7 @@ Examples:
 :command:`--all`
   Retries all tasks.
 
-:command:`--resume +NAME`
+:command:`--resume`
   Retry only failed tasks. Successfully finished tasks are skipped.
 
 :command:`--resume-from +NAME`


### PR DESCRIPTION
I think `digdag retry --resume` cannot specify the task name option.