### PR TITLE
Avoid unexpected validate because of using dynamic parameters

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/Check.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Check.java
@@ -1,6 +1,5 @@
 package io.digdag.cli;
 
-import com.beust.jcommander.DynamicParameter;
 import com.beust.jcommander.Parameter;
 import com.google.common.base.Optional;
 import com.google.inject.Injector;
@@ -28,8 +27,10 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -47,7 +48,8 @@ public class Check
     @Parameter(names = {"--project"})
     String projectDirName = null;
 
-    @DynamicParameter(names = {"-p", "--param"})
+    @Parameter(names = {"-p", "--param"}, validateWith = ParameterValidator.class)
+    List<String> paramsList = new ArrayList<>();
     Map<String, String> params = new HashMap<>();
 
     @Parameter(names = {"-P", "--params-file"})
@@ -106,6 +108,7 @@ public class Check
         final ConfigLoaderManager loader = injector.getInstance(ConfigLoaderManager.class);
         final ProjectArchiveLoader projectLoader = injector.getInstance(ProjectArchiveLoader.class);
 
+        params = ParameterValidator.toMap(paramsList);
         Config overrideParams = loadParams(cf, loader, loadSystemProperties(), paramsFile, params);
 
         showSystemDefaults();

--- a/digdag-cli/src/main/java/io/digdag/cli/ParameterValidator.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/ParameterValidator.java
@@ -1,0 +1,25 @@
+package io.digdag.cli;
+
+import com.beust.jcommander.IParameterValidator;
+import com.beust.jcommander.ParameterException;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class ParameterValidator implements IParameterValidator
+{
+    public void validate(String name, String value) throws ParameterException
+    {
+        if (!value.contains("=")) {
+            throw new ParameterException("Parameter " + name + " expected a value of the form a=b but got:" + value);
+        }
+    }
+
+    public static Map<String, String> toMap(List<String> list)
+    {
+        Map<String, String> map = new HashMap<>();
+        list.forEach(value -> map.put(value.substring(0, value.indexOf("=")), value.substring(value.indexOf("=")+1)));
+        return map;
+    }
+}

--- a/digdag-cli/src/main/java/io/digdag/cli/ParameterValidator.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/ParameterValidator.java
@@ -19,7 +19,20 @@ public class ParameterValidator implements IParameterValidator
     public static Map<String, String> toMap(List<String> list)
     {
         Map<String, String> map = new HashMap<>();
-        list.forEach(value -> map.put(value.substring(0, value.indexOf("=")), value.substring(value.indexOf("=")+1)));
+        String key = null;
+
+        for (String value : list) {
+            if (value.contains("=")) {
+                key = value.substring(0, value.indexOf("="));
+                String val = value.substring(value.indexOf("=") + 1);
+                map.put(key, val);
+            }
+            else {
+                String val = new StringBuilder(map.get(key)).append(",").append(value).toString();
+                map.put(key, val);
+            }
+        }
+
         return map;
     }
 }

--- a/digdag-cli/src/main/java/io/digdag/cli/Run.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Run.java
@@ -1,6 +1,5 @@
 package io.digdag.cli;
 
-import com.beust.jcommander.DynamicParameter;
 import com.beust.jcommander.Parameter;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
@@ -114,7 +113,8 @@ public class Run
     @Parameter(names = {"--no-save"})
     boolean noSave = false;
 
-    @DynamicParameter(names = {"-p", "--param"})
+    @Parameter(names = {"-p", "--param"}, validateWith = ParameterValidator.class)
+    List<String> paramsList = new ArrayList<>();
     Map<String, String> params = new HashMap<>();
 
     @Parameter(names = {"-P", "--params-file"})
@@ -243,6 +243,7 @@ public class Run
         final ResumeStateManager rsm = injector.getInstance(ResumeStateManager.class);
 
         // read parameters
+        params = ParameterValidator.toMap(paramsList);
         Config overrideParams = loadParams(cf, loader, systemProps, paramsFile, params);
 
         // load workflow definitions

--- a/digdag-cli/src/main/java/io/digdag/cli/Server.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Server.java
@@ -67,7 +67,8 @@ public class Server
     List<String> paramsList = new ArrayList<>();
     Map<String, String> params = new HashMap<>();
 
-    @DynamicParameter(names= {"-H", "--header"})
+    @Parameter(names= {"-H", "--header"}, validateWith = ParameterValidator.class)
+    List<String> headersList = new ArrayList<>();
     Map<String, String> headers = new HashMap<>();
 
     @Parameter(names = {"-P", "--params-file"})
@@ -179,6 +180,7 @@ public class Server
             props.setProperty("server.executor.enabled", Boolean.toString(false));
         }
 
+        headers = ParameterValidator.toMap(headersList);
         headers.forEach((key, value) -> props.setProperty("server.http.headers." + key, value));
 
         // Load default parameters

--- a/digdag-cli/src/main/java/io/digdag/cli/Server.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Server.java
@@ -15,7 +15,9 @@ import javax.servlet.ServletException;
 
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -61,10 +63,11 @@ public class Server
     @Parameter(names = {"--disable-executor-loop"})
     boolean disableExecutorLoop = false;
 
-    @DynamicParameter(names = {"-p", "--param"})
+    @Parameter(names = {"-p", "--param"}, validateWith = ParameterValidator.class)
+    List<String> paramsList = new ArrayList<>();
     Map<String, String> params = new HashMap<>();
 
-    @DynamicParameter(names = {"-H", "--header"})
+    @DynamicParameter(names= {"-H", "--header"})
     Map<String, String> headers = new HashMap<>();
 
     @Parameter(names = {"-P", "--params-file"})
@@ -180,6 +183,7 @@ public class Server
 
         // Load default parameters
         ConfigFactory cf = new ConfigFactory(objectMapper());
+        params = ParameterValidator.toMap(paramsList);
         Config defaultParams = loadParams(
                 cf, new ConfigLoaderManager(cf, new YamlConfigLoader()),
                 props, paramsFile, params);

--- a/digdag-cli/src/main/java/io/digdag/cli/client/ClientCommand.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/ClientCommand.java
@@ -46,7 +46,8 @@ public abstract class ClientCommand
     @Parameter(names = {"-e", "--endpoint"})
     protected String endpoint = null;
 
-    @DynamicParameter(names = {"-H", "--header"})
+    @Parameter(names = {"-H", "--header"}, validateWith = ParameterValidator.class)
+    List<String> httpHeadersList = new ArrayList<>();
     Map<String, String> httpHeaders = new HashMap<>();
 
     @Parameter(names = {"--disable-version-check"})
@@ -107,6 +108,7 @@ public abstract class ClientCommand
             endpoint = props.getProperty("client.http.endpoint", DEFAULT_ENDPOINT);
         }
 
+        httpHeaders = ParameterValidator.toMap(httpHeadersList);
         DigdagClient client = buildClient(endpoint, env, props, disableCertValidation, httpHeaders, clientConfigurators);
 
         if (checkServerVersion && !disableVersionCheck) {

--- a/digdag-cli/src/main/java/io/digdag/cli/client/ClientCommand.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/ClientCommand.java
@@ -9,6 +9,7 @@ import com.google.inject.Injector;
 import com.treasuredata.client.ProxyConfig;
 import io.digdag.cli.Command;
 import io.digdag.cli.Main;
+import io.digdag.cli.ParameterValidator;
 import io.digdag.cli.SystemExitException;
 import io.digdag.cli.YamlMapper;
 import io.digdag.client.DigdagClient;
@@ -25,11 +26,11 @@ import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.core.Response;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 
 import static io.digdag.cli.SystemExitException.systemExit;
 

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Retry.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Retry.java
@@ -1,8 +1,8 @@
 package io.digdag.cli.client;
 
-import com.beust.jcommander.DynamicParameter;
 import com.beust.jcommander.Parameter;
 import com.google.common.base.Optional;
+import io.digdag.cli.ParameterValidator;
 import io.digdag.cli.SystemExitException;
 import io.digdag.cli.TimeUtil;
 import io.digdag.client.DigdagClient;
@@ -11,7 +11,9 @@ import io.digdag.client.api.RestSessionAttempt;
 import io.digdag.client.api.RestSessionAttemptRequest;
 import io.digdag.client.api.RestWorkflowDefinition;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -21,7 +23,8 @@ import static java.util.Locale.ENGLISH;
 public class Retry
     extends ClientCommand
 {
-    @DynamicParameter(names = {"-p", "--param"})
+    @Parameter(names = {"-p", "--param"}, validateWith = ParameterValidator.class)
+    List<String> paramsList = new ArrayList<>();
     Map<String, String> params = new HashMap<>();
 
     @Parameter(names = {"-P", "--params-file"})

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Start.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Start.java
@@ -1,10 +1,10 @@
 package io.digdag.cli.client;
 
-import com.beust.jcommander.DynamicParameter;
 import com.beust.jcommander.Parameter;
 import com.google.common.base.Optional;
 import com.google.inject.Injector;
 import com.google.inject.Scopes;
+import io.digdag.cli.ParameterValidator;
 import io.digdag.cli.SystemExitException;
 import io.digdag.cli.TimeUtil;
 import io.digdag.client.DigdagClient;
@@ -24,7 +24,9 @@ import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.core.Response;
 
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static io.digdag.cli.Arguments.loadParams;
@@ -34,7 +36,8 @@ import static java.util.Locale.ENGLISH;
 public class Start
     extends ClientCommand
 {
-    @DynamicParameter(names = {"-p", "--param"})
+    @Parameter(names = {"-p", "--param"}, validateWith = ParameterValidator.class)
+    List<String> paramsList = new ArrayList<>();
     Map<String, String> params = new HashMap<>();
 
     @Parameter(names = {"-P", "--params-file"})
@@ -101,6 +104,7 @@ public class Start
         final ConfigFactory cf = injector.getInstance(ConfigFactory.class);
         final ConfigLoaderManager loader = injector.getInstance(ConfigLoaderManager.class);
 
+        params = ParameterValidator.toMap(paramsList);
         Config overrideParams = loadParams(cf, loader, loadSystemProperties(), paramsFile, params);
 
         LocalTimeOrInstant time;


### PR DESCRIPTION
I found a bug that digdag-cli's `--params-file` option broken.

According to [JCommander - 22. Dynamic parameters](http://jcommander.org/#_dynamic_parameters),
  
> JCommander allows you to specify parameters that are not known at compile time, such as "-Da=b -Dc=d". 

So that, this issue is caused by a `--params-file` option that is to be included in dynamic parameter (`--params`).

e.g. When I want to start digdag server (using params file)...

```
### I want to use these params 
$ cat params/develop.yml
---
ENV: develop
DEBUG: true

### OK
$ digdag server --bind 0.0.0.0 --memory -P params/develop.yml
2017-03-23 02:43:00 +0000: Digdag v0.9.6
2017-03-23 02:43:06 +0000 [INFO] (main): secret encryption engine: disabled
2017-03-23 02:43:07 +0000 [INFO] (main): XNIO version 3.3.6.Final
2017-03-23 02:43:07 +0000 [INFO] (main): XNIO NIO Implementation Version 3.3.6.Final
2017-03-23 02:43:07 +0000 [INFO] (main): Starting server on 0.0.0.0:65432
2017-03-23 02:43:07 +0000 [INFO] (main): Bound api on /0:0:0:0:0:0:0:0:65432

### NG
$ digdag server --bind 0.0.0.0 --memory --params-file params/develop.yml
2017-03-23 02:43:33 +0000: Digdag v0.9.6
error: Dynamic parameter expected a value of the form a=b but got:s-file # Dynamic perameter's validation error
```

So, I created ParameterValidator class and using `@Parameter` instead of `@DynamicParameter` and List covert to Map.   
Also, these params validate key=value.