### PR TITLE
Add { credentials: 'include' } to fetch in JS

### DIFF
--- a/digdag-ui/console.jsx
+++ b/digdag-ui/console.jsx
@@ -1737,7 +1737,7 @@ class VersionView extends React.Component {
 
   componentDidMount () {
     const url = DIGDAG_CONFIG.url + 'version'
-    fetch(url).then(response => {
+    fetch(url, { credentials: 'include' }).then(response => {
       if (!response.ok) {
         throw new Error(response.statusText)
       }

--- a/digdag-ui/model.js
+++ b/digdag-ui/model.js
@@ -481,7 +481,7 @@ export class Model {
   }
 
   fetchArrayBuffer (url: string) {
-    return fetch(url).then(response => {
+    return fetch(url, { credentials: 'include' }).then(response => {
       if (!response.ok) {
         throw new Error(response.statusText)
       }

--- a/digdag-ui/model.js
+++ b/digdag-ui/model.js
@@ -481,7 +481,10 @@ export class Model {
   }
 
   fetchArrayBuffer (url: string) {
-    return fetch(url, { credentials: 'include' }).then(response => {
+    return fetch(url, {
+      credentials: 'include',
+      headers: this.headers()
+    }).then(response => {
       if (!response.ok) {
         throw new Error(response.statusText)
       }


### PR DESCRIPTION
I added `{ credentials: 'include' }` to fetch(url) option in JavaScript, due to using Digdag-UI with basic authentication.
https://developers.google.com/web/updates/2015/03/introduction-to-fetch#sending_credentials_with_a_fetch_request

Currently, we catched the following errors:

```
Uncaught (in promise) Error: Unauthorized at console.jsx:1742
Error: Unauthorized at model.js:486
```

Thank you for your cooperation, in advance!