### PR TITLE
UI: Use model for versionview

### DIFF
--- a/digdag-ui/console.jsx
+++ b/digdag-ui/console.jsx
@@ -1731,13 +1731,7 @@ class VersionView extends React.Component {
   };
 
   componentDidMount () {
-    const url = DIGDAG_CONFIG.url + 'version'
-    fetch(url).then(response => {
-      if (!response.ok) {
-        throw new Error(response.statusText)
-      }
-      return response.json()
-    }).then(version => {
+    model().fetchVersion().then(version => {
       this.setState(version)
     })
   }

--- a/digdag-ui/model.js
+++ b/digdag-ui/model.js
@@ -388,6 +388,10 @@ export class Model {
     return this.get(`projects/${projectId}/schedules?workflow=${workflowName}`)
   }
 
+  fetchVersion () {
+    return this.get('version')
+  }
+
   enableSchedule (scheduleId: string) : Promise<*> {
     return this.post(`schedules/${scheduleId}/enable`)
   }


### PR DESCRIPTION
This is tightly related to https://github.com/treasure-data/digdag/pull/529 and @morizyun requirement/efforts.  Looking at the PR i noticed that `VersionView` was calling fetch directly (when it should call it thru `model` instead