### PR TITLE
/api/attempts?project=&workflow= should lookup workflow by name

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
@@ -1145,20 +1145,20 @@ public class DatabaseSessionStoreManager
         }
 
         @Override
-        public List<StoredSessionAttemptWithSession> getAttemptsOfWorkflow(boolean withRetriedAttempts, long workflowDefinitionId, int pageSize, Optional<Long> lastId)
+        public List<StoredSessionAttemptWithSession> getAttemptsOfWorkflow(boolean withRetriedAttempts, int projectId, String workflowName, int pageSize, Optional<Long> lastId)
         {
             if (withRetriedAttempts) {
-                return autoCommit((handle, dao) -> dao.getAttemptsOfWorkflowWithRetries(siteId, workflowDefinitionId, pageSize, lastId.or(Long.MAX_VALUE)));
+                return autoCommit((handle, dao) -> dao.getAttemptsOfWorkflowWithRetries(siteId, projectId, workflowName, pageSize, lastId.or(Long.MAX_VALUE)));
             }
             else {
-                return autoCommit((handle, dao) -> dao.getAttemptsOfWorkflow(siteId, workflowDefinitionId, pageSize, lastId.or(Long.MAX_VALUE)));
+                return autoCommit((handle, dao) -> dao.getAttemptsOfWorkflow(siteId, projectId, workflowName, pageSize, lastId.or(Long.MAX_VALUE)));
             }
         }
 
         @Override
-        public List<StoredSessionAttemptWithSession> getActiveAttemptsOfWorkflow(long workflowDefinitionId, int pageSize, Optional<Long> lastId)
+        public List<StoredSessionAttemptWithSession> getActiveAttemptsOfWorkflow(int projectId, String workflowName, int pageSize, Optional<Long> lastId)
         {
-            return autoCommit((handle, dao) -> dao.getActiveAttemptsOfWorkflow(siteId, workflowDefinitionId, pageSize, lastId.or(Long.MAX_VALUE)));
+            return autoCommit((handle, dao) -> dao.getActiveAttemptsOfWorkflow(siteId, projectId, workflowName, pageSize, lastId.or(Long.MAX_VALUE)));
         }
 
         @Override
@@ -1570,34 +1570,37 @@ public class DatabaseSessionStoreManager
         @SqlQuery("select sa.*, s.session_uuid, s.workflow_name, s.session_time" +
                 " from session_attempts sa" +
                 " join sessions s on s.last_attempt_id = sa.id" +
-                " where sa.workflow_definition_id = :wfId" +
+                " where s.project_id = :projectId" +
+                " and s.workflow_name = :workflowName" +
                 " and sa.site_id = :siteId" +
                 " and sa.id < :lastId" +
                 " order by sa.id desc" +
                 " limit :limit")
-        List<StoredSessionAttemptWithSession> getAttemptsOfWorkflow(@Bind("siteId") int siteId, @Bind("wfId") long wfId, @Bind("limit") int limit, @Bind("lastId") long lastId);
+        List<StoredSessionAttemptWithSession> getAttemptsOfWorkflow(@Bind("siteId") int siteId, @Bind("projectId") int projectId, @Bind("workflowName") String workflowName, @Bind("limit") int limit, @Bind("lastId") long lastId);
 
         @SqlQuery("select sa.*, s.session_uuid, s.workflow_name, s.session_time" +
                 " from session_attempts sa" +
                 " join sessions s on s.id = sa.session_id" +
-                " where sa.workflow_definition_id = :wfId" +
+                " where s.project_id = :projectId" +
+                " and s.workflow_name = :workflowName" +
                 " and sa.site_id = :siteId" +
                 " and s.last_attempt_id is not null" +
                 " and sa.id < :lastId" +
                 " order by sa.id desc" +
                 " limit :limit")
-        List<StoredSessionAttemptWithSession> getAttemptsOfWorkflowWithRetries(@Bind("siteId") int siteId, @Bind("wfId") long wfId, @Bind("limit") int limit, @Bind("lastId") long lastId);
+        List<StoredSessionAttemptWithSession> getAttemptsOfWorkflowWithRetries(@Bind("siteId") int siteId, @Bind("projectId") int projectId, @Bind("workflowName") String workflowName, @Bind("limit") int limit, @Bind("lastId") long lastId);
 
         @SqlQuery("select sa.*, s.session_uuid, s.workflow_name, s.session_time" +
                 " from session_attempts sa" +
                 " join sessions s on s.last_attempt_id = sa.id" +
-                " where sa.workflow_definition_id = :wfId" +
+                " where s.project_id = :projectId" +
+                " and s.workflow_name = :workflowName" +
                 " and sa.state_flags = 0" +
                 " and sa.site_id = :siteId" +
                 " and sa.id < :lastId" +
                 " order by sa.id desc" +
                 " limit :limit")
-        List<StoredSessionAttemptWithSession> getActiveAttemptsOfWorkflow(@Bind("siteId") int siteId, @Bind("wfId") long wfId, @Bind("limit") int limit, @Bind("lastId") long lastId);
+        List<StoredSessionAttemptWithSession> getActiveAttemptsOfWorkflow(@Bind("siteId") int siteId, @Bind("projectId") int projectId, @Bind("workflowName") String workflowName, @Bind("limit") int limit, @Bind("lastId") long lastId);
 
         @SqlQuery("select * from session_attempts" +
                 " where session_id = :sessionId" +

--- a/digdag-core/src/main/java/io/digdag/core/schedule/ScheduleExecutor.java
+++ b/digdag-core/src/main/java/io/digdag/core/schedule/ScheduleExecutor.java
@@ -185,7 +185,7 @@ public class ScheduleExecutor
             StoredWorkflowDefinitionWithProject def = rm.getWorkflowDetailsById(sched.getWorkflowDefinitionId());
 
             SessionStore ss = sessionStoreManager.getSessionStore(def.getProject().getSiteId());
-            List<StoredSessionAttemptWithSession> activeAttempts = ss.getActiveAttemptsOfWorkflow(def.getId(), 1, Optional.absent());
+            List<StoredSessionAttemptWithSession> activeAttempts = ss.getActiveAttemptsOfWorkflow(def.getProject().getId(), def.getName(), 1, Optional.absent());
 
             Scheduler sr = srm.getScheduler(def);
 

--- a/digdag-core/src/main/java/io/digdag/core/session/SessionStore.java
+++ b/digdag-core/src/main/java/io/digdag/core/session/SessionStore.java
@@ -22,9 +22,9 @@ public interface SessionStore
 
     List<StoredSessionAttemptWithSession> getAttemptsOfProject(boolean withRetriedAttempts, int projectId, int pageSize, Optional<Long> lastId);
 
-    List<StoredSessionAttemptWithSession> getAttemptsOfWorkflow(boolean withRetriedAttempts, long workflowDefinitionId, int pageSize, Optional<Long> lastId);
+    List<StoredSessionAttemptWithSession> getAttemptsOfWorkflow(boolean withRetriedAttempts, int projectId, String workflowName, int pageSize, Optional<Long> lastId);
 
-    List<StoredSessionAttemptWithSession> getActiveAttemptsOfWorkflow(long workflowDefinitionId, int pageSize, Optional<Long> lastId);
+    List<StoredSessionAttemptWithSession> getActiveAttemptsOfWorkflow(int projectId, String workflowName, int pageSize, Optional<Long> lastId);
 
     List<StoredSessionAttempt> getAttemptsOfSession(long sessionId, int pageSize, Optional<Long> lastId);
 

--- a/digdag-core/src/test/java/io/digdag/core/database/DatabaseSessionStoreManagerTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/database/DatabaseSessionStoreManagerTest.java
@@ -263,8 +263,8 @@ public class DatabaseSessionStoreManagerTest
             assertThat(ImmutableList.of(session1), is(store.getSessionsOfProject(proj.getId(), 100, Optional.absent())));
             assertThat(ImmutableList.of(session1), is(store.getSessionsOfWorkflowByName(proj.getId(), wf1.getName(), 100, Optional.absent())));
             assertEmpty(store.getSessionsOfWorkflowByName(proj.getId(), wf2.getName(), 100, Optional.absent()));
-            assertThat(store.getActiveAttemptsOfWorkflow(wf1.getId(), 100, Optional.absent()), containsInAnyOrder(attempt1));
-            assertThat(store.getActiveAttemptsOfWorkflow(wf2.getId(), 100, Optional.absent()), is(Matchers.empty()));
+            assertThat(store.getActiveAttemptsOfWorkflow(proj.getId(), wf1.getName(), 100, Optional.absent()), containsInAnyOrder(attempt1));
+            assertThat(store.getActiveAttemptsOfWorkflow(proj.getId(), wf2.getName(), 100, Optional.absent()), is(Matchers.empty()));
 
             // session + different session time
             AttemptRequest ar2 = attemptBuilder.buildFromStoredWorkflow(
@@ -280,8 +280,8 @@ public class DatabaseSessionStoreManagerTest
             assertThat(ImmutableList.of(session2, session1), is(store.getSessionsOfProject(proj.getId(), 100, Optional.absent())));
             assertThat(ImmutableList.of(session2, session1), is(store.getSessionsOfWorkflowByName(proj.getId(), wf1.getName(), 100, Optional.absent())));
             assertEmpty(store.getSessionsOfWorkflowByName(proj.getId(), wf2.getName(), 100, Optional.absent()));
-            assertThat(store.getActiveAttemptsOfWorkflow(wf1.getId(), 100, Optional.absent()), containsInAnyOrder(attempt1, attempt2));
-            assertThat(store.getActiveAttemptsOfWorkflow(wf2.getId(), 100, Optional.absent()), is(Matchers.empty()));
+            assertThat(store.getActiveAttemptsOfWorkflow(proj.getId(), wf1.getName(), 100, Optional.absent()), containsInAnyOrder(attempt1, attempt2));
+            assertThat(store.getActiveAttemptsOfWorkflow(proj.getId(), wf2.getName(), 100, Optional.absent()), is(Matchers.empty()));
 
             // session + different retry attempt name
             String retryAttemptName = "attempt3";
@@ -302,8 +302,8 @@ public class DatabaseSessionStoreManagerTest
             assertThat(ImmutableList.of(session2AfterRetry, session1), is(store.getSessionsOfProject(proj.getId(), 100, Optional.absent())));
             assertThat(ImmutableList.of(session2AfterRetry, session1), is(store.getSessionsOfWorkflowByName(proj.getId(), wf1.getName(), 100, Optional.absent())));
             assertEmpty(store.getSessionsOfWorkflowByName(proj.getId(), wf2.getName(), 100, Optional.absent()));
-            assertThat(store.getActiveAttemptsOfWorkflow(wf1.getId(), 100, Optional.absent()), containsInAnyOrder(attempt1, attempt3));
-            assertThat(store.getActiveAttemptsOfWorkflow(wf2.getId(), 100, Optional.absent()), is(Matchers.empty()));
+            assertThat(store.getActiveAttemptsOfWorkflow(proj.getId(), wf1.getName(), 100, Optional.absent()), containsInAnyOrder(attempt1, attempt3));
+            assertThat(store.getActiveAttemptsOfWorkflow(proj.getId(), wf2.getName(), 100, Optional.absent()), is(Matchers.empty()));
 
             SessionStore anotherSite = manager.getSessionStore(1);
 
@@ -373,23 +373,23 @@ public class DatabaseSessionStoreManagerTest
             // TODO test with another project
 
             assertThat(ImmutableList.of(attempt3, attempt1),
-                    is(store.getAttemptsOfWorkflow(false, wf1.getId(), 100, Optional.absent())));
+                    is(store.getAttemptsOfWorkflow(false, proj.getId(), wf1.getName(), 100, Optional.absent())));
             assertThat(ImmutableList.of(attempt3),
-                    is(store.getAttemptsOfWorkflow(false, wf1.getId(), 1, Optional.absent())));
+                    is(store.getAttemptsOfWorkflow(false, proj.getId(), wf1.getName(), 1, Optional.absent())));
             assertThat(ImmutableList.of(attempt1),
-                    is(store.getAttemptsOfWorkflow(false, wf1.getId(), 100, Optional.of(attempt3.getId()))));
-            assertEmpty(anotherSite.getAttemptsOfWorkflow(false, wf1.getId(), 100, Optional.absent()));
-            assertEmpty(store.getAttemptsOfWorkflow(false, wf2.getId(), 100, Optional.absent()));
+                    is(store.getAttemptsOfWorkflow(false, proj.getId(), wf1.getName(), 100, Optional.of(attempt3.getId()))));
+            assertEmpty(anotherSite.getAttemptsOfWorkflow(false, proj.getId(), wf1.getName(), 100, Optional.absent()));
+            assertEmpty(store.getAttemptsOfWorkflow(false, proj.getId(), wf2.getName(), 100, Optional.absent()));
             // TODO test with another workflow
 
             assertThat(ImmutableList.of(attempt3, attempt2, attempt1),
-                    is(store.getAttemptsOfWorkflow(true, wf1.getId(), 100, Optional.absent())));
+                    is(store.getAttemptsOfWorkflow(true, proj.getId(), wf1.getName(), 100, Optional.absent())));
             assertThat(ImmutableList.of(attempt3, attempt2),
-                    is(store.getAttemptsOfWorkflow(true, wf1.getId(), 2, Optional.absent())));
+                    is(store.getAttemptsOfWorkflow(true, proj.getId(), wf1.getName(), 2, Optional.absent())));
             assertThat(ImmutableList.of(attempt2, attempt1),
-                    is(store.getAttemptsOfWorkflow(true, wf1.getId(), 100, Optional.of(attempt3.getId()))));
-            assertEmpty(anotherSite.getAttemptsOfWorkflow(true, wf1.getId(), 100, Optional.absent()));
-            assertEmpty(store.getAttemptsOfWorkflow(true, wf2.getId(), 100, Optional.absent()));
+                    is(store.getAttemptsOfWorkflow(true, proj.getId(), wf1.getName(), 100, Optional.of(attempt3.getId()))));
+            assertEmpty(anotherSite.getAttemptsOfWorkflow(true, proj.getId(), wf1.getName(), 100, Optional.absent()));
+            assertEmpty(store.getAttemptsOfWorkflow(true, proj.getId(), wf2.getName(), 100, Optional.absent()));
             // TODO test with another workflow
 
             StoredSessionAttempt rawAttempt1 = StoredSessionAttempt.copyOf(attempt1);

--- a/digdag-core/src/test/java/io/digdag/core/schedule/ScheduleExecutorTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/schedule/ScheduleExecutorTest.java
@@ -42,8 +42,10 @@ import static org.mockito.Mockito.spy;
 public class ScheduleExecutorTest
 {
     private static final int SCHEDULE_ID = 13;
+    private static final int PROJECT_ID = 9;
     private static final int SITE_ID = 7;
     private static final long WORKFLOW_DEFINITION_ID = 17;
+    private static final String WORKFLOW_NAME = "wfwf";
 
     private static final ConfigFactory CONFIG_FACTORY = new ConfigFactory(DigdagClient.objectMapper());
 
@@ -88,12 +90,14 @@ public class ScheduleExecutorTest
 
         now = Instant.now();
 
+        when(project.getId()).thenReturn(PROJECT_ID);
         when(project.getSiteId()).thenReturn(SITE_ID);
 
         workflowConfig = CONFIG_FACTORY.create();
 
         when(workflowDefinition.getTimeZone()).thenReturn(UTC);
         when(workflowDefinition.getId()).thenReturn(WORKFLOW_DEFINITION_ID);
+        when(workflowDefinition.getName()).thenReturn(WORKFLOW_NAME);
         when(workflowDefinition.getProject()).thenReturn(project);
         when(workflowDefinition.getConfig()).thenReturn(workflowConfig);
 
@@ -125,7 +129,7 @@ public class ScheduleExecutorTest
                 .set("daily>", "12:00:00");
 
         // Indicate that there is an active attempt for this workflow
-        when(sessionStore.getActiveAttemptsOfWorkflow(eq(WORKFLOW_DEFINITION_ID), anyInt(), any(Optional.class)))
+        when(sessionStore.getActiveAttemptsOfWorkflow(eq(PROJECT_ID), eq(WORKFLOW_NAME), anyInt(), any(Optional.class)))
                 .thenReturn(ImmutableList.of(attempt));
 
         // Run the schedule executor...
@@ -147,7 +151,7 @@ public class ScheduleExecutorTest
                 .set("daily>", "12:00:00");
 
         // Indicate that there is an active attempt for this workflow
-        when(sessionStore.getActiveAttemptsOfWorkflow(eq(WORKFLOW_DEFINITION_ID), anyInt(), any(Optional.class)))
+        when(sessionStore.getActiveAttemptsOfWorkflow(eq(PROJECT_ID), eq(WORKFLOW_NAME), anyInt(), any(Optional.class)))
                 .thenReturn(ImmutableList.of(attempt));
 
         // Run the schedule executor...

--- a/digdag-server/src/main/java/io/digdag/server/rs/AttemptResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/AttemptResource.java
@@ -91,8 +91,7 @@ public class AttemptResource
                 StoredProject proj = rs.getProjectByName(projName);
                 if (wfName != null) {
                     // of workflow
-                    StoredWorkflowDefinition wf = rs.getLatestWorkflowDefinitionByName(proj.getId(), wfName);
-                    attempts = ss.getAttemptsOfWorkflow(includeRetried, wf.getId(), 100, Optional.fromNullable(lastId));
+                    attempts = ss.getAttemptsOfWorkflow(includeRetried, proj.getId(), wfName, 100, Optional.fromNullable(lastId));
                 }
                 else {
                     // of project


### PR DESCRIPTION
A workflow in a project is identified by projectId and name because
workflow ID changes every revision. Therefore, listing up attempts by
workflow name should not use workflow ID when querying on database.
Otherwise, before this fix, the REST API was listing up attempts that
were exected by the latest revision only.

Scheduler's `skip_on_overtime` option also had the same problem. It
should list up workflows by name so that workflows with the same name
shouldn't run in parallel. It's unexpected if a workflow doesn't get
skipped when a new revision is pushed even though the workflow name or
definition is not changed.