### PR TITLE
Show warning message if "push" is uploading an archive with no workflows

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/client/Push.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Push.java
@@ -24,6 +24,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Instant;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static io.digdag.cli.Arguments.loadParams;
@@ -101,7 +102,19 @@ public class Push
         Path projectPath = (projectDirName == null) ?
             Paths.get("").toAbsolutePath() :
             Paths.get(projectDirName).normalize().toAbsolutePath();
-        injector.getInstance(Archiver.class).createArchive(projectPath, archivePath);
+        List<String> workflows = injector.getInstance(Archiver.class).createArchive(projectPath, archivePath);
+        out.println("Workflows:");
+        if (workflows.isEmpty()) {
+            out.println("  WARNING: This project doesn't include workflows. Usually, this is a mistake.");
+            out.println("           Please make sure that all *.dig files are on the top directory.");
+            out.println("           *.dig files in subdirectories are not recognized as workflows.");
+            out.println("");
+        }
+        else {
+            for (String workflow : workflows) {
+                out.println("  " + workflow);
+            }
+        }
 
         DigdagClient client = buildClient();
         if ("".equals(revision)) {


### PR DESCRIPTION
If there're no workflows in a project, usually it's a mistake. This
change tries to prevent such common mistake by showing a warning
message.

Example message:

```
2017-04-03 11:16:00 -0700: Digdag v0.9.9-SNAPSHOT
Creating .digdag/tmp/archive-5051289385624456034.tar.gz...
  Archiving a
Workflows:
  WARNING: This project doesn't include workflows. Usually, this is a mistake.
           Please make sure that all *.dig files are on the top directory.
           *.dig files in subdirectories are not recognized as workflows.

```

If workflow exists,

```
2017-04-03 11:15:05 -0700: Digdag v0.9.9-SNAPSHOT
Creating .digdag/tmp/archive-6554652179977764401.tar.gz...
  Archiving a
  Archiving x.dig
  Archiving y.dig
Workflows:
  x.dig
  y.dig
```