### PR TITLE
Fix admin port restriction when server listens on 0.0.0.0

### DIFF
--- a/digdag-guice-rs-server-undertow/src/main/java/io/digdag/guice/rs/server/undertow/UndertowServerControl.java
+++ b/digdag-guice-rs-server-undertow/src/main/java/io/digdag/guice/rs/server/undertow/UndertowServerControl.java
@@ -16,19 +16,20 @@ import javax.servlet.ServletException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xnio.XnioWorker;
+import io.undertow.server.HttpServerExchange;
 
 public class UndertowServerControl
         implements GuiceRsServerControl
 {
     private static final Logger logger = LoggerFactory.getLogger(UndertowServer.class);
 
+    private UndertowServerRuntimeInfo runtimeInfo = new UndertowServerRuntimeInfo();
     private DeploymentManager deployment = null;
     private Injector injector = null;
     private List<GracefulShutdownHandler> handlers = Collections.synchronizedList(new ArrayList<>());
     private XnioWorker worker = null;
     private Undertow server = null;
     private boolean started = false;
-    private Map<String, List<InetSocketAddress>> listenAddresses = null;
     private ServerLifeCycleManager lifeCycleManager = null;
 
     UndertowServerControl()
@@ -59,10 +60,9 @@ public class UndertowServerControl
         this.server = server;
     }
 
-    void serverStarted(Map<String, List<InetSocketAddress>> listenAddresses)
+    void serverStarted()
     {
         this.started = true;
-        this.listenAddresses = listenAddresses;
     }
 
     boolean isServerStarted()
@@ -84,9 +84,9 @@ public class UndertowServerControl
     }
 
     @Override
-    public Map<String, List<InetSocketAddress>> getListenAddresses()
+    public UndertowServerRuntimeInfo getRuntimeInfo()
     {
-        return this.listenAddresses;
+        return runtimeInfo;
     }
 
     @Override

--- a/digdag-guice-rs-server-undertow/src/main/java/io/digdag/guice/rs/server/undertow/UndertowServerRuntimeInfo.java
+++ b/digdag-guice-rs-server-undertow/src/main/java/io/digdag/guice/rs/server/undertow/UndertowServerRuntimeInfo.java
@@ -1,0 +1,43 @@
+package io.digdag.guice.rs.server.undertow;
+
+import io.digdag.guice.rs.GuiceRsServerRuntimeInfo;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import static java.util.Collections.unmodifiableList;
+
+public class UndertowServerRuntimeInfo
+        implements GuiceRsServerRuntimeInfo
+{
+    private final List<ListenAddress> addresses;
+
+    public UndertowServerRuntimeInfo()
+    {
+        this.addresses = new ArrayList<>();
+    }
+
+    void addListenAddress(final String name, final InetSocketAddress socketAddress)
+    {
+        addresses.add(
+                new GuiceRsServerRuntimeInfo.ListenAddress()
+                {
+                    @Override
+                    public String getName()
+                    {
+                        return name;
+                    }
+
+                    @Override
+                    public InetSocketAddress getSocketAddress()
+                    {
+                        return socketAddress;
+                    }
+                });
+    }
+
+    @Override
+    public List<ListenAddress> getListenAddresses()
+    {
+        return unmodifiableList(addresses);
+    }
+}

--- a/digdag-guice-rs/src/main/java/io/digdag/guice/rs/GuiceRsServerControl.java
+++ b/digdag-guice-rs/src/main/java/io/digdag/guice/rs/GuiceRsServerControl.java
@@ -10,5 +10,5 @@ public interface GuiceRsServerControl
 
     public void destroy();
 
-    Map<String, List<InetSocketAddress>> getListenAddresses();
+    public GuiceRsServerRuntimeInfo getRuntimeInfo();
 }

--- a/digdag-guice-rs/src/main/java/io/digdag/guice/rs/GuiceRsServerRuntimeInfo.java
+++ b/digdag-guice-rs/src/main/java/io/digdag/guice/rs/GuiceRsServerRuntimeInfo.java
@@ -1,0 +1,18 @@
+package io.digdag.guice.rs;
+
+import java.net.InetSocketAddress;
+import java.util.List;
+
+public interface GuiceRsServerRuntimeInfo
+{
+    static final String LISTEN_ADDRESS_NAME_ATTRIBUTE = "io.digdag.guice.rs.server.ListenAddress.name";
+
+    interface ListenAddress
+    {
+        String getName();
+
+        InetSocketAddress getSocketAddress();
+    }
+
+    List<ListenAddress> getListenAddresses();
+}

--- a/digdag-server/src/main/java/io/digdag/server/ServerRuntimeInfoWriter.java
+++ b/digdag-server/src/main/java/io/digdag/server/ServerRuntimeInfoWriter.java
@@ -34,25 +34,22 @@ public class ServerRuntimeInfoWriter
     public void postStart()
     {
         if (serverInfoPath.isPresent()) {
-            List<InetSocketAddress> apiAddresses = serverControl.getListenAddresses().get(ServerConfig.API_ADDRESS);
-            List<InetSocketAddress> adminAddresses = serverControl.getListenAddresses().get(ServerConfig.ADMIN_ADDRESS);
-
-            if (apiAddresses == null) {
-                apiAddresses = ImmutableList.of();
-            }
-            if (adminAddresses == null) {
-                adminAddresses = ImmutableList.of();
-            }
+            List<ServerRuntimeInfo.Address> apiAddresses = serverControl.getRuntimeInfo().getListenAddresses()
+                .stream()
+                .filter(a -> a.getName().equals(ServerConfig.API_ADDRESS))
+                .map(a -> a.getSocketAddress())
+                .map(sa -> ServerRuntimeInfo.Address.of(sa.getHostString(), sa.getPort()))
+                .collect(Collectors.toList());
+            List<ServerRuntimeInfo.Address> adminAddresses = serverControl.getRuntimeInfo().getListenAddresses()
+                .stream()
+                .filter(a -> a.getName().equals(ServerConfig.ADMIN_ADDRESS))
+                .map(a -> a.getSocketAddress())
+                .map(sa -> ServerRuntimeInfo.Address.of(sa.getHostString(), sa.getPort()))
+                .collect(Collectors.toList());
 
             ServerRuntimeInfo serverRuntimeInfo = ServerRuntimeInfo.builder()
-                .localAddresses(
-                        apiAddresses.stream()
-                        .map(a -> ServerRuntimeInfo.Address.of(a.getHostString(), a.getPort()))
-                        .collect(Collectors.toList()))
-                .localAdminAddresses(
-                        adminAddresses.stream()
-                        .map(a -> ServerRuntimeInfo.Address.of(a.getHostString(), a.getPort()))
-                        .collect(Collectors.toList()))
+                .localAddresses(apiAddresses)
+                .localAdminAddresses(adminAddresses)
                 .build();
 
             ObjectMapper mapper = new ObjectMapper();


### PR DESCRIPTION
`control.getListenAddresses` was returning listen addresses taken from
`Undertow.ListenerInfo`. On the other hand,
`HttpServletRequest.getAddress()` returns socket's local address.
They become a same address if server listens on a specific IP such as
`192.168.0.1`. However, if server listens on `0.0.0.0`, listen address
is `0.0.0.0` but socket's local address is `127.0.0.1`. Therefore,
AdminRestrictedFilter rejects all requests if server listens on 0.0.0.0.

To solve this issue,, this change removes use of listen address or
socket address. Instead, it works as following:

1. When Undertow handles a request, it sets listen address name on
   `HttpServerExchange` instance. This is done by
   `UndertowServer.SetListenAddressNameHandler` class.

2. `HttpServerExchange` instance is not visible from Servlet interface
   (or RESTEasy which is running on top of Servlet) because it's
   Undertow's interface. Therefore, a servlet filter
   `UndertowServer.SetListenAddressNameServletFilter` taskes listen
   address name from `HttpServerExchange`, and sets it to
   `ServletRequest`.

3. Servlet applications can get the name using
  `Object ServletRequest.getAttribute(String)` method.
  JAX-RS applications can use the name using
  `Object ContainerRequestContext.getProperty(String)` method
  which internally calls `ServletRequest.getAttribute(String)`.