### PR TITLE
Add `task_name` to built-in variables

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/agent/RuntimeParams.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/RuntimeParams.java
@@ -4,10 +4,6 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.util.Arrays;
-import java.util.LinkedList;
-import java.util.List;
-
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigException;
 import io.digdag.client.config.ConfigFactory;
@@ -75,16 +71,8 @@ public class RuntimeParams
 
         params.set("retry_attempt_name", request.getRetryAttemptName().orNull());
 
-        LinkedList<String> taskNames = new LinkedList<>(Arrays.asList(request.getTaskName().split("\\+")));
-        // Remove the head empty item
-        taskNames.remove(0);
-        String workflowName = taskNames.remove(0);
-
-        // workflow_*
-        params.set("workflow_name", workflowName);
-
         // task_*
-        params.set("task_name", taskNames);
+        params.set("task_name", request.getTaskName());
 
         return params;
     }

--- a/digdag-core/src/main/java/io/digdag/core/agent/RuntimeParams.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/RuntimeParams.java
@@ -75,16 +75,16 @@ public class RuntimeParams
 
         params.set("retry_attempt_name", request.getRetryAttemptName().orNull());
 
-        LinkedList<String> taskName = new LinkedList<>(Arrays.asList(request.getTaskName().split("\\+")));
+        LinkedList<String> taskNames = new LinkedList<>(Arrays.asList(request.getTaskName().split("\\+")));
         // Remove the head empty item
-        taskName.remove(0);
-        String workflowName = taskName.remove(0);
+        taskNames.remove(0);
+        String workflowName = taskNames.remove(0);
 
         // workflow_*
         params.set("workflow_name", workflowName);
 
         // task_*
-        params.set("task_name", taskName);
+        params.set("task_name", taskNames);
 
         return params;
     }

--- a/digdag-core/src/main/java/io/digdag/core/agent/RuntimeParams.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/RuntimeParams.java
@@ -4,6 +4,10 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigException;
 import io.digdag.client.config.ConfigFactory;
@@ -71,8 +75,16 @@ public class RuntimeParams
 
         params.set("retry_attempt_name", request.getRetryAttemptName().orNull());
 
+        LinkedList<String> taskNames = new LinkedList<>(Arrays.asList(request.getTaskName().split("\\+")));
+        // Remove the head empty item
+        taskNames.remove(0);
+        String workflowName = taskNames.remove(0);
+
+        // workflow_*
+        params.set("workflow_name", workflowName);
+
         // task_*
-        params.set("task_name", request.getTaskName());
+        params.set("task_name", taskNames);
 
         return params;
     }

--- a/digdag-core/src/main/java/io/digdag/core/agent/RuntimeParams.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/RuntimeParams.java
@@ -75,16 +75,16 @@ public class RuntimeParams
 
         params.set("retry_attempt_name", request.getRetryAttemptName().orNull());
 
-        LinkedList<String> taskNames = new LinkedList<>(Arrays.asList(request.getTaskName().split("\\+")));
+        LinkedList<String> taskName = new LinkedList<>(Arrays.asList(request.getTaskName().split("\\+")));
         // Remove the head empty item
-        taskNames.remove(0);
-        String workflowName = taskNames.remove(0);
+        taskName.remove(0);
+        String workflowName = taskName.remove(0);
 
         // workflow_*
         params.set("workflow_name", workflowName);
 
         // task_*
-        params.set("task_name", taskNames);
+        params.set("task_name", taskName);
 
         return params;
     }

--- a/digdag-core/src/main/java/io/digdag/core/agent/RuntimeParams.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/RuntimeParams.java
@@ -71,6 +71,9 @@ public class RuntimeParams
 
         params.set("retry_attempt_name", request.getRetryAttemptName().orNull());
 
+        // task_*
+        params.set("task_name", request.getTaskName());
+
         return params;
     }
 

--- a/digdag-docs/src/workflow_definition.rst
+++ b/digdag-docs/src/workflow_definition.rst
@@ -63,6 +63,7 @@ Name                            Description                                 Exam
 **session_local_time**          Local time format of session_time           2016-01-30 00:00:00
 **session_tz_offset**           Time zone offset part of session_time       -0800
 **session_unixtime**            Seconds since the epoch time                1454140800
+**task_name**                   Name of this task                           +my_workflow+parent_task+child_task0
 =============================== =========================================== ==========================
 
 If `schedule: option is set <scheduling_workflow.html>`_, **last_session_time** and **next_session_time** are also available as following:

--- a/digdag-docs/src/workflow_definition.rst
+++ b/digdag-docs/src/workflow_definition.rst
@@ -63,7 +63,8 @@ Name                            Description                                 Exam
 **session_local_time**          Local time format of session_time           2016-01-30 00:00:00
 **session_tz_offset**           Time zone offset part of session_time       -0800
 **session_unixtime**            Seconds since the epoch time                1454140800
-**task_name**                   Name of this task                           +my_workflow+parent_task+child_task0
+**workflow_name**               Name of this workflow                       my_workflow
+**task_name**                   Parts of this task name separated with nest [parent_task,child_task3]
 =============================== =========================================== ==========================
 
 If `schedule: option is set <scheduling_workflow.html>`_, **last_session_time** and **next_session_time** are also available as following:

--- a/digdag-docs/src/workflow_definition.rst
+++ b/digdag-docs/src/workflow_definition.rst
@@ -63,8 +63,7 @@ Name                            Description                                 Exam
 **session_local_time**          Local time format of session_time           2016-01-30 00:00:00
 **session_tz_offset**           Time zone offset part of session_time       -0800
 **session_unixtime**            Seconds since the epoch time                1454140800
-**workflow_name**               Name of this workflow                       my_workflow
-**task_name**                   Parts of this task name separated with nest [parent_task,child_task3]
+**task_name**                   Name of this task                           +my_workflow+parent_task+child_task0
 =============================== =========================================== ==========================
 
 If `schedule: option is set <scheduling_workflow.html>`_, **last_session_time** and **next_session_time** are also available as following:

--- a/digdag-tests/src/test/java/acceptance/BuiltInVariablesIT.java
+++ b/digdag-tests/src/test/java/acceptance/BuiltInVariablesIT.java
@@ -73,9 +73,7 @@ public class BuiltInVariablesIT
                 .put("next_session_local_time", is("2016-01-03 00:00:00"))
                 .put("next_session_tz_offset", is("+0000"))
                 .put("next_session_unixtime", is("1451779200"))
-                .put("workflow_name", is("built_in_variables"))
-                .put("task_name_full", is("[get_variables,task_name_full]"))
-                .put("task_name_edge", is("task_name_edge"))
+                .put("task_name", is("+built_in_variables+get_variables+task_name"))
                 .build();
 
         assertThat(values.entrySet().size(), is(expectedOutput.size()));

--- a/digdag-tests/src/test/java/acceptance/BuiltInVariablesIT.java
+++ b/digdag-tests/src/test/java/acceptance/BuiltInVariablesIT.java
@@ -73,6 +73,7 @@ public class BuiltInVariablesIT
                 .put("next_session_local_time", is("2016-01-03 00:00:00"))
                 .put("next_session_tz_offset", is("+0000"))
                 .put("next_session_unixtime", is("1451779200"))
+                .put("task_name", is("+built_in_variables+get_variables+task_name"))
                 .build();
 
         assertThat(values.entrySet().size(), is(expectedOutput.size()));

--- a/digdag-tests/src/test/java/acceptance/BuiltInVariablesIT.java
+++ b/digdag-tests/src/test/java/acceptance/BuiltInVariablesIT.java
@@ -73,7 +73,9 @@ public class BuiltInVariablesIT
                 .put("next_session_local_time", is("2016-01-03 00:00:00"))
                 .put("next_session_tz_offset", is("+0000"))
                 .put("next_session_unixtime", is("1451779200"))
-                .put("task_name", is("+built_in_variables+get_variables+task_name"))
+                .put("workflow_name", is("built_in_variables"))
+                .put("task_name_full", is("[get_variables,task_name_full]"))
+                .put("task_name_edge", is("task_name_edge"))
                 .build();
 
         assertThat(values.entrySet().size(), is(expectedOutput.size()));

--- a/digdag-tests/src/test/resources/acceptance/built_in_variables/built_in_variables.dig
+++ b/digdag-tests/src/test/resources/acceptance/built_in_variables/built_in_variables.dig
@@ -50,5 +50,9 @@ schedule:
     sh>: "echo next_session_tz_offset: \\'${next_session_tz_offset}\\' >> output.yml"
   +next_session_unixtime:
     sh>: "echo next_session_unixtime: \\'${next_session_unixtime}\\' >> output.yml"
-  +task_name:
-    sh>: "echo task_name: \\'${task_name}\\' >> output.yml"
+  +workflow_name:
+    sh>: "echo workflow_name: \\'${workflow_name}\\' >> output.yml"
+  +task_name_full:
+    sh>: "echo task_name_full: \\'${task_name}\\' >> output.yml"
+  +task_name_edge:
+    sh>: "echo task_name_edge: \\'${task_name[task_name.length - 1]}\\' >> output.yml"

--- a/digdag-tests/src/test/resources/acceptance/built_in_variables/built_in_variables.dig
+++ b/digdag-tests/src/test/resources/acceptance/built_in_variables/built_in_variables.dig
@@ -50,9 +50,5 @@ schedule:
     sh>: "echo next_session_tz_offset: \\'${next_session_tz_offset}\\' >> output.yml"
   +next_session_unixtime:
     sh>: "echo next_session_unixtime: \\'${next_session_unixtime}\\' >> output.yml"
-  +workflow_name:
-    sh>: "echo workflow_name: \\'${workflow_name}\\' >> output.yml"
-  +task_name_full:
-    sh>: "echo task_name_full: \\'${task_name}\\' >> output.yml"
-  +task_name_edge:
-    sh>: "echo task_name_edge: \\'${task_name[task_name.length - 1]}\\' >> output.yml"
+  +task_name:
+    sh>: "echo task_name: \\'${task_name}\\' >> output.yml"

--- a/digdag-tests/src/test/resources/acceptance/built_in_variables/built_in_variables.dig
+++ b/digdag-tests/src/test/resources/acceptance/built_in_variables/built_in_variables.dig
@@ -50,3 +50,5 @@ schedule:
     sh>: "echo next_session_tz_offset: \\'${next_session_tz_offset}\\' >> output.yml"
   +next_session_unixtime:
     sh>: "echo next_session_unixtime: \\'${next_session_unixtime}\\' >> output.yml"
+  +task_name:
+    sh>: "echo task_name: \\'${task_name}\\' >> output.yml"


### PR DESCRIPTION
With this feature, users can use a task name in workflow like this:
```
+task1:
    td>: queries/${task_name.replace(/\+/g, '_')}.sql    # >>> "_myworkflow_task1.sql"
    insert_into: hourly_summary
```