### PR TITLE
Divide a large transaction into small transactions to prevent potential dead locks

### DIFF
--- a/digdag-core/src/test/java/io/digdag/core/workflow/WorkflowExecutorTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/WorkflowExecutorTest.java
@@ -1,28 +1,11 @@
 package io.digdag.core.workflow;
 
-import java.util.*;
 import java.nio.file.Files;
-import java.io.IOException;
-import java.time.Instant;
-import java.time.ZoneId;
-import java.util.concurrent.atomic.AtomicReference;
 
 import io.digdag.core.database.TransactionManager;
-import org.skife.jdbi.v2.IDBI;
-import com.google.common.base.Optional;
-import com.google.common.base.Throwables;
-import com.google.common.collect.*;
-import com.google.common.io.Resources;
 import io.digdag.core.LocalSite;
-import io.digdag.core.archive.*;
-import io.digdag.core.repository.*;
-import io.digdag.core.schedule.*;
-import io.digdag.core.session.*;
-import io.digdag.core.workflow.*;
-import io.digdag.spi.ScheduleTime;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigException;
-import io.digdag.client.config.ConfigFactory;
 import io.digdag.core.DigdagEmbed;
 import org.junit.After;
 import org.junit.Before;


### PR DESCRIPTION
As discussed at https://github.com/treasure-data/digdag/pull/515#pullrequestreview-28222799, there is a room to improve database transactions to prevent potential dead lock. This pull request addresses them.