### PR TITLE
Add site ID and project name to a thread name

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/Run.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Run.java
@@ -654,8 +654,9 @@ public class Run
         {
             String fullName = request.getTaskName();
             TaskResult result = cmd.skipTaskReports.apply(fullName);
+            String origThreadName = String.format("[%d:%s]%s", request.getSiteId(), request.getProjectName().or("----"), request.getTaskName());
             if (result != null) {
-                try (SetThreadName threadName = new SetThreadName(fullName)) {
+                try (SetThreadName threadName = new SetThreadName(origThreadName)) {
                     logger.warn("Skipped");
                 }
                 callback.taskSucceeded(request.getSiteId(),

--- a/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
@@ -107,9 +107,10 @@ public class OperatorManager
     public void run(TaskRequest request)
     {
         long taskId = request.getTaskId();
+        String origThreadName = String.format("[%d:%s]%s", request.getSiteId(), request.getProjectName().or("----"), request.getTaskName());
 
         // set task name to thread name so that logger shows it
-        try (SetThreadName threadName = new SetThreadName(request.getTaskName())) {
+        try (SetThreadName threadName = new SetThreadName(origThreadName)) {
             try (TaskLogger taskLogger = callback.newTaskLogger(request)) {
                 TaskContextLogging.enter(LogLevel.DEBUG, taskLogger);
                 try {


### PR DESCRIPTION
so that we can easily find which site ID and project is affected by
an issue searching log files