### PR TITLE
Fix character encoding of email subject

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/operator/MailOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/MailOperatorFactory.java
@@ -138,7 +138,7 @@ public class MailOperatorFactory
                                 .map(it -> newAddress(it))
                                 .toArray(InternetAddress[]::new));
 
-                msg.setSubject(subject);
+                msg.setSubject(subject, "utf-8");
 
                 List<AttachConfig> attachFiles = attachConfigs(params);
                 if (attachFiles.isEmpty()) {


### PR DESCRIPTION
`mail>` operator was not setting character encoding to the subject which
means that it was using platform's default encoding. If the platform's
default encoding is UTF-8, it's not a problem. However, especially if
digdag is running in a minimal docker container, characters that can't
be encoded using the default encoding are replaced by `?`.