### PR TITLE
Add Connector job name usage to td_load> operator

### DIFF
--- a/digdag-docs/src/operators/td_load.md
+++ b/digdag-docs/src/operators/td_load.md
@@ -21,7 +21,7 @@
 
 * **td_load>**: FILE.yml
 
-  Path to a YAML template file. This configuration needs to be guessed using td command.
+  Path to a YAML template file. This configuration needs to be guessed using td command. If you saved DataConnector job on Treasure Data, you can use job name instead of YAML path.
 
   Examples:
 


### PR DESCRIPTION
td_load> operator can use DataConnector job name which is saved on DataConnector server. It's useful for users. So I would like to add one sentence regarding it.