### PR TITLE
modify mail usage in digdag-docs

### DIFF
--- a/digdag-docs/src/operators/mail.md
+++ b/digdag-docs/src/operators/mail.md
@@ -104,7 +104,7 @@ To use Gmail SMTP server, you need to do either of:
   mail>: mail_body.txt
   ```
 
-  * or :command:`mail>: {body: Hello, this is from Digdag}`
+  * or :command:`mail>: {data: "Hello, this is from Digdag"}`
 
 * **subject**: SUBJECT
 


### PR DESCRIPTION
There's a wrong parameter explanation in mail operator. Could you review and merge it? @frsyuki 