### PR TITLE
td_table_export> supports some inefficients format but they're obsoleted

### DIFF
--- a/digdag-docs/src/operators/td_table_export.md
+++ b/digdag-docs/src/operators/td_table_export.md
@@ -64,7 +64,7 @@ NOTE: We're limiting export capability to only us-east region S3 bucket. In gene
 
 * **file_format**: TYPE
 
-  Output file format. Available formats are `tsv.gz` (gzip-compressed tab-separated values) and `jsonl.gz` (gzip-compressed json per line).
+  Output file format. Available formats are `tsv.gz` (tab-separated values per line) and `jsonl.gz` (json record per line).
 
   `json.gz` and `line-json.gz` are available only for backward compatibility purpose.
 

--- a/digdag-docs/src/operators/td_table_export.md
+++ b/digdag-docs/src/operators/td_table_export.md
@@ -64,7 +64,9 @@ NOTE: We're limiting export capability to only us-east region S3 bucket. In gene
 
 * **file_format**: TYPE
 
-  Output file format. Available formats are `tsv.gz`, `jsonl.gz`, `json.gz`, `json-line.gz`.
+  Output file format. Available formats are `tsv.gz` (gzip-compressed tab-separated values) and `jsonl.gz` (gzip-compressed json per line).
+
+  `json.gz` and `line-json.gz` are available only for backward compatibility purpose.
 
   Examples:
 

--- a/digdag-standards/build.gradle
+++ b/digdag-standards/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     compile 'com.sun.mail:javax.mail:1.5.6'   // 'com.sun.mail:smtp' doesn't work because enabling mail.debug property throws java.lang.NoClassDefFoundError: com/sun/mail/util/MailLogger
 
     // td
-    compile 'com.treasuredata.client:td-client:0.7.34'
+    compile 'com.treasuredata.client:td-client:0.7.36'
     compile 'org.msgpack:msgpack-core:0.8.11'
     compile 'org.yaml:snakeyaml:1.17'
 


### PR DESCRIPTION
* `json-line.gz`: simply wrong. `line-json.gz` is the correct name.
* `line-json.gz`: obsoleted implementation. `jsonl.gz` is much faster alternative.
* `json.gz`: obsoleted implementation.
