### PR TITLE
Fix "Not in transaction" error with scheduler command

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/RevisionAutoReloader.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/RevisionAutoReloader.java
@@ -69,7 +69,10 @@ class RevisionAutoReloader
     void watch(ProjectArchive project)
             throws ResourceConflictException, ResourceNotFoundException
     {
-        targets.add(new ReloadTarget(project));
+        transactionManager.<Void, ResourceConflictException, ResourceNotFoundException>begin(() -> {
+            targets.add(new ReloadTarget(project));
+            return null;
+        }, ResourceConflictException.class, ResourceNotFoundException.class);
         startAutoReload();
     }
 

--- a/digdag-tests/src/test/java/acceptance/SchedulerIT.java
+++ b/digdag-tests/src/test/java/acceptance/SchedulerIT.java
@@ -1,0 +1,45 @@
+package acceptance;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import utils.CommandStatus;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static utils.TestUtils.copyResource;
+import static utils.TestUtils.main;
+
+public class SchedulerIT
+{
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private Path root()
+    {
+        return folder.getRoot().toPath().toAbsolutePath();
+    }
+
+    @Test
+    public void testScheduler()
+            throws Exception
+    {
+        copyResource("acceptance/scheduler/simple.dig", root().resolve("test.dig"));
+        CommandStatus status = main("scheduler", "--project", root().toString());
+        assertThat(status.errUtf8(), status.code(), is(0));
+
+        for (int i = 0; i < 90; i++) {
+            if (Files.exists(root().resolve("foo.out"))) {
+                assertTrue(true);
+                return;
+            }
+            TimeUnit.SECONDS.sleep(2);
+        }
+        assertTrue(false);
+    }
+}

--- a/digdag-tests/src/test/resources/acceptance/scheduler/simple.dig
+++ b/digdag-tests/src/test/resources/acceptance/scheduler/simple.dig
@@ -1,0 +1,7 @@
+timezone: "Asia/Tokyo"
+
+schedule:
+  minutes_interval>: 1
+
++touch_foo_out:
+  sh>: "touch foo.out"


### PR DESCRIPTION
Fix this error
```
$ digdag scheduler
2017-05-09 10:01:31 -0700: Digdag v0.9.10
2017-05-09 10:01:33 -0700 [INFO] (main): secret encryption engine: disabled
Exception in thread "main" java.lang.Error: java.lang.reflect.InvocationTargetException
        at org.embulk.guice.LifeCycleModule$1$1.afterInjection(LifeCycleModule.java:81)
        at com.google.inject.internal.MembersInjectorImpl.notifyListeners(MembersInjectorImpl.java:119)
        at com.google.inject.internal.ConstructorInjector.provision(ConstructorInjector.java:115)
        at com.google.inject.internal.ConstructorInjector.construct(ConstructorInjector.java:85)
        at com.google.inject.internal.ConstructorBindingImpl$Factory.get(ConstructorBindingImpl.java:267)
        at com.google.inject.internal.ProviderToInternalFactoryAdapter$1.call(ProviderToInternalFactoryAdapter.java:46)
        at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1103)
        at com.google.inject.internal.ProviderToInternalFactoryAdapter.get(ProviderToInternalFactoryAdapter.java:40)
        at com.google.inject.internal.SingletonScope$1.get(SingletonScope.java:145)
        at com.google.inject.internal.InternalFactoryToProviderAdapter.get(InternalFactoryToProviderAdapter.java:41)
        at com.google.inject.internal.InternalInjectorCreator$1.call(InternalInjectorCreator.java:205)
        at com.google.inject.internal.InternalInjectorCreator$1.call(InternalInjectorCreator.java:199)
        at com.google.inject.internal.InjectorImpl.callInContext(InjectorImpl.java:1092)
        at com.google.inject.internal.InternalInjectorCreator.loadEagerSingletons(InternalInjectorCreator.java:199)
        at com.google.inject.internal.InternalInjectorCreator.injectDynamically(InternalInjectorCreator.java:180)
        at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:110)
        at com.google.inject.Guice.createInjector(Guice.java:96)
        at org.embulk.guice.Bootstrap.start(Bootstrap.java:155)
        at org.embulk.guice.Bootstrap.build(Bootstrap.java:117)
        at org.embulk.guice.Bootstrap.initializeCloseable(Bootstrap.java:112)
        at io.digdag.guice.rs.server.undertow.UndertowBootstrap.initialize(UndertowBootstrap.java:70)
        at io.digdag.guice.rs.GuiceRsServletContainerInitializer.processBootstrap(GuiceRsServletContainerInitializer.java:61)
        at io.digdag.guice.rs.GuiceRsServletContainerInitializer.onStartup(GuiceRsServletContainerInitializer.java:36)
        at io.undertow.servlet.core.DeploymentManagerImpl$1.call(DeploymentManagerImpl.java:186)
        at io.undertow.servlet.core.DeploymentManagerImpl$1.call(DeploymentManagerImpl.java:171)
        at io.undertow.servlet.core.ServletRequestContextThreadSetupAction$1.call(ServletRequestContextThreadSetupAction.java:42)
        at io.undertow.servlet.core.ContextClassLoaderSetupAction$1.call(ContextClassLoaderSetupAction.java:43)
        at io.undertow.servlet.core.DeploymentManagerImpl.deploy(DeploymentManagerImpl.java:234)
        at io.digdag.guice.rs.server.undertow.UndertowServer.start(UndertowServer.java:179)
        at io.digdag.server.ServerBootstrap.start(ServerBootstrap.java:73)
        at io.digdag.cli.Sched.startScheduler(Sched.java:108)
        at io.digdag.cli.Sched.main(Sched.java:55)
        at io.digdag.cli.Main.cli(Main.java:187)
        at io.digdag.cli.Main.main(Main.java:82)
Caused by: java.lang.reflect.InvocationTargetException
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.embulk.guice.LifeCycleManager.startInstance(LifeCycleManager.java:203)
        at org.embulk.guice.LifeCycleManager.addInstance(LifeCycleManager.java:185)
        at org.embulk.guice.LifeCycleModule$1$1.afterInjection(LifeCycleModule.java:78)
        ... 33 more
Caused by: java.lang.RuntimeException: java.lang.IllegalStateException: Not in transaction
        at io.digdag.cli.Sched$RevisionAutoReloaderStarter.start(Sched.java:158)
        ... 40 more
Caused by: java.lang.IllegalStateException: Not in transaction
        at io.digdag.core.database.ThreadLocalTransactionManager.getHandle(ThreadLocalTransactionManager.java:212)
        at io.digdag.core.database.BasicDatabaseStoreManager.transaction(BasicDatabaseStoreManager.java:191)
        at io.digdag.core.database.BasicDatabaseStoreManager.transaction(BasicDatabaseStoreManager.java:171)
        at io.digdag.core.database.DatabaseProjectStoreManager$DatabaseProjectStore.putAndLockProject(DatabaseProjectStoreManager.java:179)
        at io.digdag.core.LocalSite.storeLocalWorkflowsImpl(LocalSite.java:98)
        at io.digdag.core.LocalSite.storeLocalWorkflows(LocalSite.java:136)
        at io.digdag.cli.RevisionAutoReloader$ReloadTarget.storeProject(RevisionAutoReloader.java:131)
        at io.digdag.cli.RevisionAutoReloader$ReloadTarget.<init>(RevisionAutoReloader.java:120)
        at io.digdag.cli.RevisionAutoReloader$ReloadTarget.<init>(RevisionAutoReloader.java:108)
        at io.digdag.cli.RevisionAutoReloader.watch(RevisionAutoReloader.java:72)
        at io.digdag.cli.Sched$RevisionAutoReloaderStarter.start(Sched.java:155)
        ... 40 more
```

with this simple workflow:

```
timezone: "Asia/Tokyo"

schedule:
  minutes_interval>: 1

+echo_hello:
  sh>: echo "hello"
```