### PR TITLE
Allow BigQuery operators to have partition decorator in table name

### DIFF
--- a/digdag-docs/src/operators/bq.md
+++ b/digdag-docs/src/operators/bq.md
@@ -74,6 +74,13 @@ Note: The **bq>** operator uses [standard SQL](https://cloud.google.com/bigquery
   destination_table: some_project:some_dataset.some_table
   ```
 
+  You can append a date as `$YYYYMMDD` form at the end of table name to store data in a specific partition.
+  See [Creating and Updating Date-Partitioned Tables](https://cloud.google.com/bigquery/docs/creating-partitioned-tables) document for details.
+
+  ```
+  destination_table: some_dataset.some_partitioned_table$20160101
+  ```
+
 * **create_disposition**: CREATE_IF_NEEDED | CREATE_NEVER
 
   Specifies whether the destination table should be automatically created when executing the query.

--- a/digdag-docs/src/operators/bq_load.md
+++ b/digdag-docs/src/operators/bq_load.md
@@ -71,6 +71,13 @@
   destination_table: some_project:some_dataset.some_table
   ```
 
+  You can append a date as `$YYYYMMDD` form at the end of table name to store data in a specific partition.
+  See [Creating and Updating Date-Partitioned Tables](https://cloud.google.com/bigquery/docs/creating-partitioned-tables) document for details.
+
+  ```
+  destination_table: some_dataset.some_partitioned_table$20160101
+  ```
+
 * **project**: NAME
 
   The project that the table is located in or should be created in. Can also be specified directly in the table reference or the dataset parameter.

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/gcp/Bq.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/gcp/Bq.java
@@ -9,7 +9,7 @@ import java.util.regex.Pattern;
 
 class Bq
 {
-    private static final Pattern TABLE_REFERENCE_PATTERN = Pattern.compile("^(?:(?<project>[^:]+):)?(?:(?<dataset>[^.]+)\\.)?(?<table>[a-zA-Z0-9_]{1,1024})$");
+    private static final Pattern TABLE_REFERENCE_PATTERN = Pattern.compile("^(?:(?<project>[^:]+):)?(?:(?<dataset>[^.]+)\\.)?(?<table>[a-zA-Z0-9_]{1,1024}(?:\\$[0-9]{8})?)$");
 
     static TableReference tableReference(String defaultProjectId, Optional<DatasetReference> defaultDataset, String s)
     {


### PR DESCRIPTION
"Addressing table partitions" section of this document describes about
partition decorator:
https://cloud.google.com/bigquery/docs/partitioned-tables