### PR TITLE
Release digdag-ui package

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -264,7 +264,7 @@ subprojects {
 
     publishing {
         publications {
-            if (![project(":digdag-ui"), project(":digdag-docs")].contains(project)) {
+            if (![project(":digdag-docs")].contains(project)) {
                 mavenJava(MavenPublication) {
                     from components.java
                     artifact testsJar


### PR DESCRIPTION
This lets system integrators serve digdag-ui beside REST API while they
inject custom modules.