### PR TITLE
Add tips for mail.password parameter

### DIFF
--- a/digdag-docs/src/operators/mail.md
+++ b/digdag-docs/src/operators/mail.md
@@ -71,6 +71,16 @@ To use Gmail SMTP server, you need to do either of:
   ```
   mail.password: MyPaSsWoRd
   ```
+  
+  If you encountered `Unsecure 'password' parameter is deprecated.` message, please confirm you used the following command.
+  
+  ```
+  # Server Mode
+  digdag secret --project test_mail --set mail.password=xxxxx
+  
+  # Local Mode stores the parameter into `~/.config/digdag/secrets/mail.password`
+  digdag secret --local --set mail.password=xxxxx
+  ```
 
 * **mail.tls**: BOOLEAN
   Enables TLS handshake.


### PR DESCRIPTION
Sometimes, we get an inquiry about this warning. > `Unsecure 'password' parameter is deprecated.`

For example, https://github.com/treasure-data/digdag/issues/356