### PR TITLE
fix config doc

### DIFF
--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -308,7 +308,7 @@ In the config file, following parameters are available
 * server.admin.port (integer)
 * server.access-log.path (string. same with --access-log)
 * server.access-log.pattern (string, "json", "combined" or "common")
-* server.http.io-threads (number of HTTP IO threads in integer. default: available CPU cores * 2)
+* server.http.io-threads (number of HTTP IO threads in integer. default: available CPU cores or 2, whichever is greater)
 * server.http.worker-threads (number of HTTP worker threads in integer. default: server.http.io-threads * 8)
 * server.http.no-request-timeout (maximum allowed time for clients to keep a connection open without sending requests or receiving responses in seconds. default: 60)
 * server.http.request-parse-timeout (maximum allowed time of reading a HTTP request in seconds. this doesn't affect on reading request body. default: 30)


### PR DESCRIPTION
fix server.http.io-threads default

ref: https://github.com/treasure-data/digdag/blob/7c8c695/digdag-guice-rs-server-undertow/src/main/java/io/digdag/guice/rs/server/undertow/UndertowServer.java#L202