### PR TITLE
add a section to build CLI executables to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ Test uses in-memory H2 database by default. To use PostgreSQL, set following env
 $ export DIGDAG_TEST_POSTGRESQL="$(cat config/test_postgresql.properties)"
 ```
 
+## Building CLI executables
+
+```
+$ ./gradlew cli
+```
+
+It makes an executable in `pkg/`, e.g. `pkg/digdag-$VERSION.jar`.
+
 ### Releasing a new version
 
 You need to set Bintray user name and API key in `BINTRAY_USER` and `BINTRAY_KEY` environment variables.


### PR DESCRIPTION
I'm a beginner of digdag and not sure how to make the `digdag` CLI in development.

Adding this section to README makes newbies happy, I believe.