### PR TITLE
add --max-task-threads to `digdag run`

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/Run.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Run.java
@@ -137,6 +137,9 @@ public class Run
     @Parameter(names = {"-dE"})
     boolean dryRunAndShowParams = false;
 
+    @Parameter(names = {"--max-task-threads"})
+    int maxTaskThreads = 0;
+
     private Path resumeStatePath;
 
     @Override
@@ -194,6 +197,7 @@ public class Run
         err.println("    -E, --show-params                show task parameters before running a task");
         err.println("        --session <daily | hourly | schedule | last | \"yyyy-MM-dd[ HH:mm:ss]\">  set session_time to this time");
         err.println("                                     (default: last, reuses the latest session time stored at .digdag/status)");
+        err.println("    --max-task-threads               Limit maxium number of task execution threads on the execution");
         Main.showCommonOptions(env, err);
         return systemExit(error);
     }
@@ -214,6 +218,10 @@ public class Run
             throws Exception
     {
         Properties systemProps = loadSystemProperties();
+
+        if (maxTaskThreads > 0) {
+            systemProps.setProperty("agent.max-task-threads", String.valueOf(maxTaskThreads));
+        }
 
         try (DigdagEmbed digdag = new DigdagEmbed.Bootstrap()
                 .setEnvironment(env)


### PR DESCRIPTION
This PR adds `digdag run --max-task-threads N` as the same feature in `~/.config/digdag/config`'s `agent.max-task-threads=N`, which allows setting max-task-threads per execution.

Can you review it please?

(related to #567, not the best solution though)

---

(edit)

I found `-X agent.max-task-threads=N` has the same effect as this PR, so this PR is redundant. However, it is somewhat useful because `digdag server` and `digdag scheduler` have `--max-task-threads`.