### PR TITLE
Add timeout parameter for http operator

### DIFF
--- a/digdag-standards/build.gradle
+++ b/digdag-standards/build.gradle
@@ -59,4 +59,11 @@ dependencies {
 
     testCompile project(path: ':digdag-client', configuration: 'testArtifacts')
     testCompile project(path: ':digdag-core', configuration: 'testArtifacts')
+
+    // for testing
+    testCompile 'com.github.tomakehurst:wiremock:2.6.0'
+    testCompile 'org.eclipse.jetty:jetty-server:9.3.11.v20160721'
+    testCompile 'org.eclipse.jetty:jetty-servlet:9.3.11.v20160721'
+    testCompile 'org.eclipse.jetty:jetty-servlets:9.3.11.v20160721'
+    testCompile 'org.eclipse.jetty:jetty-webapp:9.3.11.v20160721'
 }

--- a/digdag-standards/build.gradle
+++ b/digdag-standards/build.gradle
@@ -61,7 +61,9 @@ dependencies {
     testCompile project(path: ':digdag-core', configuration: 'testArtifacts')
 
     // for testing
-    testCompile 'com.github.tomakehurst:wiremock:2.6.0'
+    testCompile ('com.github.tomakehurst:wiremock:2.6.0') { exclude group: 'com.fasterxml.jackson.core' }
+
+    // test dependency conflict resolution
     testCompile 'org.eclipse.jetty:jetty-server:9.3.11.v20160721'
     testCompile 'org.eclipse.jetty:jetty-servlet:9.3.11.v20160721'
     testCompile 'org.eclipse.jetty:jetty-servlets:9.3.11.v20160721'

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/HttpOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/HttpOperatorFactory.java
@@ -116,6 +116,7 @@ public class HttpOperatorFactory
         private final Config params;
         private final String method;
         private final boolean retry;
+        private final long timeout;
 
         private HttpOperator(OperatorContext context)
         {
@@ -126,6 +127,7 @@ public class HttpOperatorFactory
             this.method = params.get("method", String.class, "GET").toUpperCase();
             this.retry = params.getOptional("retry", boolean.class)
                     .or(defaultRetry(method));
+            this.timeout = params.get("timeout", Long.class, 30L);
         }
 
         @Override
@@ -163,7 +165,7 @@ public class HttpOperatorFactory
 
             Request request = httpClient.newRequest(uri)
                     .method(method)
-                    .timeout(30, SECONDS);
+                    .timeout(timeout, SECONDS);
 
             if (authorization.isPresent()) {
                 request.header(AUTHORIZATION, authorization.get());

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/HttpOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/HttpOperatorFactoryTest.java
@@ -1,6 +1,7 @@
 package io.digdag.standards.operator;
 
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import io.digdag.client.config.Config;
 import io.digdag.spi.Operator;
 import io.digdag.spi.TaskExecutionException;
 import org.junit.Before;
@@ -14,10 +15,10 @@ import java.nio.file.Path;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static io.digdag.client.config.ConfigUtils.newConfig;
 import static io.digdag.core.workflow.OperatorTestingUtils.newContext;
 import static io.digdag.core.workflow.OperatorTestingUtils.newOperatorFactory;
 import static io.digdag.core.workflow.OperatorTestingUtils.newTaskRequest;
-import static io.digdag.core.workflow.WorkflowTestingUtils.loadYamlResource;
 import static org.junit.Assert.fail;
 
 public class HttpOperatorFactoryTest
@@ -26,16 +27,24 @@ public class HttpOperatorFactoryTest
 	public TemporaryFolder folder = new TemporaryFolder();
 
 	@Rule
-	public WireMockRule wireMockRule = new WireMockRule(8089);
+	public WireMockRule wireMockRule = new WireMockRule(0);
 
 	private Path tempPath;
 	private HttpOperatorFactory factory;
+	private Config config;
 
 	@Before
 	public void createInstance()
 	{
 		this.tempPath = folder.getRoot().toPath();
 		this.factory = newOperatorFactory(HttpOperatorFactory.class);
+
+		Config config = newConfig();
+		config.set("_command", "http://localhost:" + wireMockRule.port() + "/api/foobar");
+		config.set("timeout", 3);
+		config.set("retry", false);
+
+		this.config = config;
 	}
 
 
@@ -48,8 +57,7 @@ public class HttpOperatorFactoryTest
 
 		Operator op = factory.newOperator(newContext(
 				tempPath,
-				newTaskRequest().withConfig(
-						loadYamlResource("/io/digdag/standards/operator/http/basic.yml"))));
+				newTaskRequest().withConfig(config)));
 		try {
 			op.run();
 			fail("should be thrown Exception.");
@@ -66,8 +74,7 @@ public class HttpOperatorFactoryTest
 
 		Operator op = factory.newOperator(newContext(
 				tempPath,
-				newTaskRequest().withConfig(
-						loadYamlResource("/io/digdag/standards/operator/http/basic.yml"))));
+				newTaskRequest().withConfig(config)));
 		try {
 			op.run();
 		} catch (TaskExecutionException ignore) {

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/HttpOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/HttpOperatorFactoryTest.java
@@ -1,0 +1,77 @@
+package io.digdag.standards.operator;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import io.digdag.spi.Operator;
+import io.digdag.spi.TaskExecutionException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static io.digdag.core.workflow.OperatorTestingUtils.newContext;
+import static io.digdag.core.workflow.OperatorTestingUtils.newOperatorFactory;
+import static io.digdag.core.workflow.OperatorTestingUtils.newTaskRequest;
+import static io.digdag.core.workflow.WorkflowTestingUtils.loadYamlResource;
+import static org.junit.Assert.fail;
+
+public class HttpOperatorFactoryTest
+{
+	@Rule
+	public TemporaryFolder folder = new TemporaryFolder();
+
+	@Rule
+	public WireMockRule wireMockRule = new WireMockRule(8089);
+
+	private Path tempPath;
+	private HttpOperatorFactory factory;
+
+	@Before
+	public void createInstance()
+	{
+		this.tempPath = folder.getRoot().toPath();
+		this.factory = newOperatorFactory(HttpOperatorFactory.class);
+	}
+
+
+	@Test
+	public void respondSlowlyThanTimeout() throws IOException {
+		stubFor(get("/api/foobar")
+				.willReturn(aResponse()
+						.withStatus(200)
+						.withFixedDelay(5000)));
+
+		Operator op = factory.newOperator(newContext(
+				tempPath,
+				newTaskRequest().withConfig(
+						loadYamlResource("/io/digdag/standards/operator/http/basic.yml"))));
+		try {
+			op.run();
+			fail("should be thrown Exception.");
+		} catch (TaskExecutionException ignore) {
+		}
+	}
+
+	@Test
+	public void respondQuicklyThanTimeout() throws IOException {
+		stubFor(get("/api/foobar")
+				.willReturn(aResponse()
+						.withStatus(200)
+						.withFixedDelay(1000)));
+
+		Operator op = factory.newOperator(newContext(
+				tempPath,
+				newTaskRequest().withConfig(
+						loadYamlResource("/io/digdag/standards/operator/http/basic.yml"))));
+		try {
+			op.run();
+		} catch (TaskExecutionException ignore) {
+			fail("should be success.");
+		}
+	}
+}

--- a/digdag-standards/src/test/resources/io/digdag/standards/operator/http/basic.yml
+++ b/digdag-standards/src/test/resources/io/digdag/standards/operator/http/basic.yml
@@ -1,3 +1,0 @@
-_command: http://localhost:8089/api/foobar
-timeout: 3
-retry: false

--- a/digdag-standards/src/test/resources/io/digdag/standards/operator/http/basic.yml
+++ b/digdag-standards/src/test/resources/io/digdag/standards/operator/http/basic.yml
@@ -1,0 +1,3 @@
+_command: http://localhost:8089/api/foobar
+timeout: 3
+retry: false


### PR DESCRIPTION
This PR add timeout parameter for http operator.
Any API server response slowly, but http operator set timeout 30 seconds.
I want to set timeout in http operator.

The way to set timeout is...
```yaml
http>: http://example.com
timeout: 60
```
in .dig file.

regards.