### PR TITLE
Proposal: optional Swagger API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,11 @@ subprojects {
     dependencies {
         compile 'org.slf4j:slf4j-api:1.7.21'
 
+        compile('io.swagger:swagger-jaxrs:1.5.12') {
+            exclude module: 'javax.ws.rs'
+            exclude module: 'jsr311-api'
+        }
+
         compileOnly "org.immutables:value:2.3.9:annotations"
         testCompileOnly "org.immutables:value:2.3.9:annotations"
         apt "org.immutables:value:2.3.9"

--- a/build.gradle
+++ b/build.gradle
@@ -97,11 +97,6 @@ subprojects {
     dependencies {
         compile 'org.slf4j:slf4j-api:1.7.21'
 
-        compile('io.swagger:swagger-jaxrs:1.5.12') {
-            exclude module: 'javax.ws.rs'
-            exclude module: 'jsr311-api'
-        }
-
         compileOnly "org.immutables:value:2.3.9:annotations"
         testCompileOnly "org.immutables:value:2.3.9:annotations"
         apt "org.immutables:value:2.3.9"

--- a/digdag-cli/src/main/java/io/digdag/cli/Server.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Server.java
@@ -63,6 +63,9 @@ public class Server
     @Parameter(names = {"--disable-executor-loop"})
     boolean disableExecutorLoop = false;
 
+    @Parameter(names = {"--enable-swagger"})
+    boolean enableSwagger = false;
+
     @Parameter(names = {"-p", "--param"}, validateWith = ParameterValidator.class)
     List<String> paramsList = new ArrayList<>();
     Map<String, String> params = new HashMap<>();
@@ -110,6 +113,7 @@ public class Server
         err.println("        --max-task-threads N         limit maxium number of task execution threads");
         err.println("        --disable-executor-loop      disable workflow executor loop");
         err.println("        --disable-local-agent        disable local task execution");
+        err.println("        --enable-swagger             enable swagger api");
         err.println("    -p, --param KEY=VALUE            overwrites a parameter (use multiple times to set many parameters)");
         err.println("    -H, --header KEY=VALUE           a header to include in api HTTP responses");
         err.println("    -P, --params-file PATH.yml       reads parameters from a YAML file");
@@ -178,6 +182,10 @@ public class Server
 
         if (disableExecutorLoop) {
             props.setProperty("server.executor.enabled", Boolean.toString(false));
+        }
+
+        if (enableSwagger) {
+            props.setProperty("server.enable-swagger", Boolean.toString(true));
         }
 
         headers = ParameterValidator.toMap(headersList);

--- a/digdag-server/build.gradle
+++ b/digdag-server/build.gradle
@@ -3,4 +3,11 @@ dependencies {
     compile project(':digdag-core')
     compile project(':digdag-client')
     compile project(':digdag-guice-rs-server-undertow')
+
+    compile('io.swagger:swagger-jaxrs:1.5.12') {
+        exclude module: 'javax.ws.rs'
+        exclude module: 'jsr311-api'
+        exclude group: 'com.fasterxml.jackson.core'
+        exclude group: 'com.fasterxml.jackson.dataformat'
+    }
 }

--- a/digdag-server/build.gradle
+++ b/digdag-server/build.gradle
@@ -4,10 +4,8 @@ dependencies {
     compile project(':digdag-client')
     compile project(':digdag-guice-rs-server-undertow')
 
-    compile('io.swagger:swagger-jaxrs:1.5.12') {
+    compile('io.swagger:swagger-jaxrs:1.5.10') {
         exclude module: 'javax.ws.rs'
         exclude module: 'jsr311-api'
-        exclude group: 'com.fasterxml.jackson.core'
-        exclude group: 'com.fasterxml.jackson.dataformat'
     }
 }

--- a/digdag-server/src/main/java/io/digdag/server/ServerBootstrap.java
+++ b/digdag-server/src/main/java/io/digdag/server/ServerBootstrap.java
@@ -64,7 +64,7 @@ public class ServerBootstrap
                 binder.bind(ErrorReporter.class).to(JmxErrorReporter.class).in(Scopes.SINGLETON);
                 newExporter(binder).export(ErrorReporter.class).withGeneratedName();
             })
-            .addModules(new ServerModule());
+            .addModules(new ServerModule(serverConfig));
     }
 
     public static GuiceRsServerControl start(ServerBootstrap bootstrap)

--- a/digdag-server/src/main/java/io/digdag/server/ServerConfig.java
+++ b/digdag-server/src/main/java/io/digdag/server/ServerConfig.java
@@ -42,6 +42,8 @@ public interface ServerConfig
 
     public boolean getExecutorEnabled();
 
+    public boolean getEnableSwagger();
+
     public Map<String, String> getHeaders();
 
     public ConfigElement getSystemConfig();
@@ -85,6 +87,7 @@ public interface ServerConfig
             .jmxPort(config.getOptional("server.jmx.port", Integer.class))
             .enableHttp2(config.get("server.http.enable-http2", boolean.class, false))
             .executorEnabled(config.get("server.executor.enabled", boolean.class, true))
+            .enableSwagger(config.get("server.enable-swagger", boolean.class, false))
             .headers(readPrefixed.apply("server.http.headers."))
             .systemConfig(ConfigElement.copyOf(config))  // systemConfig needs to include other keys such as server.port so that ServerBootstrap.initialize can recover ServerConfig from this systemConfig
             .environment(readPrefixed.apply("server.environment."))

--- a/digdag-server/src/main/java/io/digdag/server/rs/AdminResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/AdminResource.java
@@ -8,6 +8,7 @@ import io.digdag.core.repository.ResourceNotFoundException;
 import io.digdag.core.repository.StoredRevision;
 import io.digdag.core.session.SessionStoreManager;
 import io.digdag.core.session.StoredSessionAttemptWithSession;
+import io.swagger.annotations.Api;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.NotFoundException;
@@ -16,6 +17,7 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 
+@Api("Admin")
 @AdminRestricted
 @Path("/")
 @Produces("application/json")

--- a/digdag-server/src/main/java/io/digdag/server/rs/AttemptResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/AttemptResource.java
@@ -30,7 +30,9 @@ import io.digdag.core.schedule.SchedulerManager;
 import io.digdag.client.config.ConfigFactory;
 import io.digdag.client.api.*;
 import io.digdag.spi.ScheduleTime;
+import io.swagger.annotations.Api;
 
+@Api("Attempt")
 @Path("/")
 @Produces("application/json")
 public class AttemptResource

--- a/digdag-server/src/main/java/io/digdag/server/rs/LogResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/LogResource.java
@@ -23,9 +23,11 @@ import io.digdag.core.repository.*;
 import io.digdag.core.log.LogServerManager;
 import io.digdag.client.api.*;
 import io.digdag.spi.*;
+import io.swagger.annotations.Api;
 
 import static io.digdag.core.log.LogServerManager.logFilePrefixFromSessionAttempt;
 
+@Api("Log")
 @Path("/")
 @Produces("application/json")
 public class LogResource

--- a/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
@@ -92,6 +92,7 @@ import io.digdag.client.api.SecretValidation;
 import io.digdag.spi.StorageFileNotFoundException;
 import io.digdag.spi.StorageObject;
 import io.digdag.util.Md5CountInputStream;
+import io.swagger.annotations.Api;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
@@ -125,6 +126,7 @@ import java.util.stream.Collectors;
 
 import static java.util.Locale.ENGLISH;
 
+@Api("Project")
 @Path("/")
 @Produces("application/json")
 public class ProjectResource

--- a/digdag-server/src/main/java/io/digdag/server/rs/ScheduleResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/ScheduleResource.java
@@ -20,6 +20,7 @@ import io.digdag.core.schedule.ScheduleExecutor;
 import io.digdag.core.schedule.ScheduleStoreManager;
 import io.digdag.core.schedule.StoredSchedule;
 import io.digdag.core.session.StoredSessionAttemptWithSession;
+import io.swagger.annotations.Api;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -32,6 +33,7 @@ import javax.ws.rs.QueryParam;
 import java.time.ZoneId;
 import java.util.List;
 
+@Api("Schedule")
 @Path("/")
 @Produces("application/json")
 public class ScheduleResource

--- a/digdag-server/src/main/java/io/digdag/server/rs/SessionResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/SessionResource.java
@@ -16,6 +16,7 @@ import io.digdag.core.session.SessionStoreManager;
 import io.digdag.core.session.StoredSession;
 import io.digdag.core.session.StoredSessionAttempt;
 import io.digdag.core.session.StoredSessionWithLastAttempt;
+import io.swagger.annotations.Api;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -26,6 +27,7 @@ import javax.ws.rs.QueryParam;
 import java.util.List;
 import java.util.stream.Collectors;
 
+@Api("Session")
 @Path("/")
 @Produces("application/json")
 public class SessionResource

--- a/digdag-server/src/main/java/io/digdag/server/rs/VersionResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/VersionResource.java
@@ -5,12 +5,15 @@ import com.google.inject.Inject;
 import io.digdag.client.Version;
 import io.digdag.client.api.RestVersionCheckResult;
 import io.digdag.server.ClientVersionChecker;
+import io.swagger.annotations.Api;
+
 import java.util.Map;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 
+@Api("Version")
 @Path("/")
 @Produces("application/json")
 public class VersionResource

--- a/digdag-server/src/main/java/io/digdag/server/rs/WorkflowResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/WorkflowResource.java
@@ -39,11 +39,13 @@ import io.digdag.core.config.YamlConfigLoader;
 import io.digdag.spi.ScheduleTime;
 import io.digdag.spi.Scheduler;
 import io.digdag.client.api.*;
+import io.swagger.annotations.Api;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 
+@Api("Workflow")
 @Path("/")
 @Produces("application/json")
 public class WorkflowResource


### PR DESCRIPTION
Add CLI option `--enable-swagger` for REST API document

## Test
Console A: Build digdag & run with `--enable-swagger`
```
./gradlew cli
./pkg/digdag-0.9.13-SNAPSHOT.jar server --memory --enable-swagger
```
Console B: Run Swagger-UI
```
docker run -dp 8080:8080 swaggerapi/swagger-ui
```
Browser: Access Swagger-UI
```
http://localhost:8080/?url=http://localhost:65432/api/swagger.json
```

