### PR TITLE
[Doc] Change ISO8601 format

### DIFF
--- a/digdag-docs/src/operators/require.md
+++ b/digdag-docs/src/operators/require.md
@@ -33,7 +33,7 @@
 
   ```
   require>: another_workflow
-  session_time: 20170101T00:00:00+0000
+  session_time: 2017-01-01T00:00:00+00:00
   ```
 
   ```


### PR DESCRIPTION
This PR fix the `require>:` operator document.

I got the following error if `session_itme: 20170101T00:00:00+0000` used. 
It seems that `session_time:` require `YYYY-mm-ddTHH:MM:SS+ZZ:ZZ` format

```yaml
timezone: 'Asia/Tokyo'

+test:
  require>: hoge
  session_time: "20170101T00:00:00+0000"
```


```
2017-06-16 17:53:09 +0900 [ERROR] (0017@[0:default]+session_time+test): Configuration error at task +session_time+test: Expected class java.time.Instant for key 'session_time' but got "20170101T00:00:00+0000" (string) (config)
> Invalid ISO time format: %s20170101T00:00:00+0000 (json mapping)
> Text '20170101T00:00:00+0000' could not be parsed at index 0 (date time parse)
```