### PR TITLE
Add to bind CommandLogger on OperatorRegistry

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/agent/OperatorRegistry.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/OperatorRegistry.java
@@ -15,6 +15,7 @@ import io.digdag.spi.OperatorProvider;
 import io.digdag.spi.OperatorFactory;
 import io.digdag.spi.TaskRequest;
 import io.digdag.spi.CommandExecutor;
+import io.digdag.spi.CommandLogger;
 import io.digdag.spi.TemplateEngine;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigFactory;
@@ -33,6 +34,9 @@ public class OperatorRegistry
         protected CommandExecutor commandExecutor;
 
         @Inject
+        protected CommandLogger commandLogger;
+
+        @Inject
         protected TemplateEngine templateEngine;
 
         @Inject
@@ -49,6 +53,7 @@ public class OperatorRegistry
         public void configure(Binder binder)
         {
             binder.bind(CommandExecutor.class).toInstance(commandExecutor);
+            binder.bind(CommandLogger.class).toInstance(commandLogger);
             binder.bind(TemplateEngine.class).toInstance(templateEngine);
             binder.bind(ConfigFactory.class).toInstance(cf);
             binder.bind(Config.class).toInstance(systemConfig);

--- a/digdag-core/src/test/java/io/digdag/core/workflow/OperatorTestingUtils.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/OperatorTestingUtils.java
@@ -17,7 +17,9 @@ import io.digdag.core.Environment;
 import io.digdag.core.agent.ConfigEvalEngine;
 import io.digdag.core.agent.GrantedPrivilegedVariables;
 import io.digdag.core.agent.OperatorRegistry;
+import io.digdag.core.agent.TaskContextCommandLogger;
 import io.digdag.spi.CommandExecutor;
+import io.digdag.spi.CommandLogger;
 import io.digdag.spi.ImmutableTaskRequest;
 import io.digdag.spi.OperatorContext;
 import io.digdag.spi.OperatorFactory;
@@ -44,6 +46,7 @@ public class OperatorTestingUtils
     {
         Injector initInjector = Guice.createInjector((Module) (binder) -> {
             binder.bind(CommandExecutor.class).to(SimpleCommandExecutor.class).in(Scopes.SINGLETON);
+            binder.bind(CommandLogger.class).to(TaskContextCommandLogger.class).in(Scopes.SINGLETON);
             binder.bind(TemplateEngine.class).to(ConfigEvalEngine.class).in(Scopes.SINGLETON);
             binder.bind(ConfigFactory.class).toInstance(ConfigUtils.configFactory);
             binder.bind(Config.class).toInstance(newConfig());


### PR DESCRIPTION
I am creating a custom Operator plugin that implements SPI for Operator ( Opertator, OperatorFactory, OperatorProvider, and so on). And I'd like to use CommandLogger SPI for logging my operator output to task log, but I get a bind error when injecting CommandLogger on my OperatorProvider with following stacktrace:

```
com.google.inject.CreationException: Unable to create injector, see the following errors:

1) No implementation for io.digdag.spi.CommandLogger was bound.
  while locating io.digdag.spi.CommandLogger
    for field at (<point to inject io.digdag.spi.CommandLogger on my OperatorProvider class>)
  at io.digdag.core.plugin.PluginSet$WithInjector.lambda$getServiceProvider$0(PluginSet.java:42)
 
1 error
com.google.inject.CreationException: Unable to create injector, see the following errors:
 
1) No implementation for io.digdag.spi.CommandLogger was bound.
  while locating io.digdag.spi.CommandLogger
    for field at (<point to inject io.digdag.spi.CommandLogger on my OperatorProvider class>)
  at io.digdag.core.plugin.PluginSet$WithInjector.lambda$getServiceProvider$0(PluginSet.java:42)
 

1 error
        at com.google.inject.internal.Errors.throwCreationExceptionIfErrorsExist(Errors.java:466)
        at com.google.inject.internal.InternalInjectorCreator.initializeStatically(InternalInjectorCreator.java:155)
        at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:107)
        at com.google.inject.internal.InjectorImpl.createChildInjector(InjectorImpl.java:226)
        at com.google.inject.internal.InjectorImpl.createChildInjector(InjectorImpl.java:233)
        at io.digdag.core.plugin.PluginSet$WithInjector.getServiceProvider(PluginSet.java:40)
        at io.digdag.core.plugin.PluginSet$WithInjector.getServiceProviders(PluginSet.java:32)
        at io.digdag.core.agent.OperatorRegistry.loadOperatorFactories(OperatorRegistry.java:106)
        at io.digdag.core.agent.OperatorRegistry.lambda$new$0(OperatorRegistry.java:80)
        at io.digdag.core.plugin.DynamicPluginLoader.loadCache(DynamicPluginLoader.java:67)
        at io.digdag.core.plugin.DynamicPluginLoader.lambda$load$0(DynamicPluginLoader.java:54)
        at com.google.common.cache.LocalCache$LocalManualCache$1.load(LocalCache.java:4793)
        at com.google.common.cache.LocalCache$LoadingValueReference.loadFuture(LocalCache.java:3542)
        at com.google.common.cache.LocalCache$Segment.loadSync(LocalCache.java:2323)
        at com.google.common.cache.LocalCache$Segment.lockedGetOrLoad(LocalCache.java:2286)
        at com.google.common.cache.LocalCache$Segment.get(LocalCache.java:2201)
        at com.google.common.cache.LocalCache.get(LocalCache.java:3953)
        at com.google.common.cache.LocalCache$LocalManualCache.get(LocalCache.java:4790)
        at io.digdag.core.plugin.DynamicPluginLoader.load(DynamicPluginLoader.java:54)
        at io.digdag.core.agent.OperatorRegistry.get(OperatorRegistry.java:92)
        at io.digdag.core.agent.OperatorManager.callExecutor(OperatorManager.java:281)
        at io.digdag.cli.Run$OperatorManagerWithSkip.callExecutor(Run.java:686)
        at io.digdag.core.agent.OperatorManager.runWithWorkspace(OperatorManager.java:254)
        at io.digdag.core.agent.OperatorManager.lambda$runWithHeartbeat$2(OperatorManager.java:137)
        at io.digdag.core.agent.LocalWorkspaceManager.withExtractedArchive(LocalWorkspaceManager.java:25)
        at io.digdag.core.agent.OperatorManager.runWithHeartbeat(OperatorManager.java:135)
        at io.digdag.core.agent.OperatorManager.run(OperatorManager.java:119)
        at io.digdag.cli.Run$OperatorManagerWithSkip.run(Run.java:668)
        at io.digdag.core.agent.MultiThreadAgent.lambda$null$0(MultiThreadAgent.java:127)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
        at java.lang.Thread.run(Thread.java:745)
```

This PR fixes the above problems by injecting CommandLogger on DynamicOperatorPluginInjectionModule.

I am not familiar with the internal plugin archetecure of Digdag, so I'm not clear on whether this change is valid. So, if you have a better solution please let me know.

Best Regards,
