### PR TITLE
Remove unsupported "Accept-Encoding: deflate" from client requests

### DIFF
--- a/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
+++ b/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
@@ -216,7 +216,18 @@ public class DigdagClient implements AutoCloseable
             }
         }
 
-        final Map<String, String> baseHeaders = builder.baseHeaders;
+        // Set "Accept-Encoding: gzip". This is necessary to override "Accept-Encoding: gzip, deflate"
+        // header set by org.apache.httpcomponents:httpclient automatically. If server returns response
+        // with deflate compression, this client throws an exception (JsonParseException). It's because
+        // response body parsing is parsed by RESTEasy's GZIPDecodingInterceptor and it apparently runs
+        // before httpclient's decompression. It means that this client actually doesn't support
+        // deflate compression.
+        ImmutableMap.Builder<String, String> baseHeadersBuilder = ImmutableMap.builder();
+        baseHeadersBuilder.put("Accept-Encoding", "gzip");
+        baseHeadersBuilder.putAll(builder.baseHeaders);
+
+        final Map<String, String> baseHeaders = baseHeadersBuilder.build();
+
         final Function<Map<String, String>, Map<String, String>> headerBuilder = builder.headerBuilder;
 
         if (headerBuilder != null) {

--- a/digdag-client/src/test/java/io/digdag/client/DigdagClientTest.java
+++ b/digdag-client/src/test/java/io/digdag/client/DigdagClientTest.java
@@ -27,6 +27,7 @@ import java.time.Instant;
 import static io.digdag.client.DigdagVersion.buildVersion;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.time.temporal.ChronoUnit.SECONDS;
+import static javax.ws.rs.core.HttpHeaders.ACCEPT_ENCODING;
 import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.HttpHeaders.USER_AGENT;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
@@ -247,6 +248,21 @@ public class DigdagClientTest
         RecordedRequest request = mockWebServer.takeRequest();
 
         assertThat(request.getHeader(USER_AGENT), is("DigdagClient/" + buildVersion()));
+    }
+
+    @Test
+    public void testAcceptEncoding()
+            throws InterruptedException
+    {
+        mockWebServer.enqueue(new MockResponse().setResponseCode(200)
+                .setHeader(CONTENT_TYPE, "application/json")
+                .setBody("{\"version\":\"1.2.3\"}"));
+
+        client.getVersion();
+
+        RecordedRequest request = mockWebServer.takeRequest();
+
+        assertThat(request.getHeader(ACCEPT_ENCODING), is("gzip"));
     }
 
     @Test


### PR DESCRIPTION
DigdagClient uses apache httpclient and it adds
`Accept-Encoding: gzip, deflate` autoamtically:

Server:

```
$ nc -l 8765
GET /api/version HTTP/1.1
Accept-Encoding: gzip, deflate
User-Agent: DigdagClient/0.9.12
Host: localhost:8765
Connection: Keep-Alive
```

Client command: `digdag -e http://localhost:8765 version`

However, if server encodes using deflate and returns
`Content-Encoding: deflate` header, client causes an error:

```
        at org.jboss.resteasy.client.jaxrs.internal.ClientResponse.readFrom(ClientResponse.java:285)
        at org.jboss.resteasy.client.jaxrs.internal.ClientResponse.readEntity(ClientResponse.java:181)
        at org.jboss.resteasy.specimpl.BuiltResponse.readEntity(BuiltResponse.java:219)
        at io.digdag.client.DigdagClient.doGet(DigdagClient.java:885)
        at io.digdag.client.DigdagClient.getVersion(DigdagClient.java:809)
        at utils.TemporaryDigdagServer.start(TemporaryDigdagServer.java:374)
...(snip)...
    Caused by: com.fasterxml.jackson.core.JsonParseException: Unrecognized token 'ªV': was expecting ('true', 'false' or 'null')
     at [Source: org.apache.http.conn.EofSensorInputStream@74bed930; line: 1, column: 4]
        at com.fasterxml.jackson.core.JsonParser._constructError(JsonParser.java:1581)
        at com.fasterxml.jackson.core.base.ParserMinimalBase._reportError(ParserMinimalBase.java:533)
        at com.fasterxml.jackson.core.json.UTF8StreamJsonParser._reportInvalidToken(UTF8StreamJsonParser.java:3451)
        at com.fasterxml.jackson.core.json.UTF8StreamJsonParser._handleUnexpectedValue(UTF8StreamJsonParser.java:2610)
        at com.fasterxml.jackson.core.json.UTF8StreamJsonParser._nextTokenNotInObject(UTF8StreamJsonParser.java:841)
        at com.fasterxml.jackson.core.json.UTF8StreamJsonParser.nextToken(UTF8StreamJsonParser.java:737)
        at com.fasterxml.jackson.jaxrs.base.ProviderBase.readFrom(ProviderBase.java:770)
        at org.jboss.resteasy.core.interception.AbstractReaderInterceptorContext.readFrom(AbstractReaderInterceptorContext.java:61)
        at org.jboss.resteasy.core.interception.AbstractReaderInterceptorContext.proceed(AbstractReaderInterceptorContext.java:53)
        at org.jboss.resteasy.plugins.interceptors.encoding.GZIPDecodingInterceptor.aroundReadFrom(GZIPDecodingInterceptor.java:59)
        at org.jboss.resteasy.core.interception.AbstractReaderInterceptorContext.proceed(AbstractReaderInterceptorContext.java:55)
        at org.jboss.resteasy.client.jaxrs.internal.ClientResponse.readFrom(ClientResponse.java:251)
        ... 46 more
```

`Content-Encoding: gzip` is ok. This is probably because RESTEasy's GZIPDecodingInterceptor intercepts response body parsing before apache httpclient decompresses the body, and it doesn't support deflate. Apache httpclient sets `Accept-Encoding: gzip, deflate` automatically on the other hand.

This change removes "deflate" from the default Accept-Encoding header to
prevent potential problems.