### PR TITLE
Add support for response body compression

### DIFF
--- a/digdag-client/build.gradle
+++ b/digdag-client/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     compile 'io.jsonwebtoken:jjwt:0.6.0'
 
     // this dependency is here only to override dependency of resteasy 3.0.13 -> jboss-logging 3.1.4.GA
-    // which conflicts with undertow 1.4.0.Final -> jboss-logging 3.2.1.Final
+    // which conflicts with undertow 1.4.18.Final -> jboss-logging 3.2.1.Final
     compile 'org.jboss.logging:jboss-logging:3.3.0.Final'
 
     testCompile 'com.squareup.okhttp3:okhttp:3.4.1'

--- a/digdag-guice-rs-server-undertow/build.gradle
+++ b/digdag-guice-rs-server-undertow/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     compile project(':digdag-guice-rs')
     compile project(':digdag-guice-rs-server')
 
-    compile 'io.undertow:undertow-servlet:1.4.0.Final'
+    compile 'io.undertow:undertow-servlet:1.4.18.Final'
 
     // for json log formatter
     compile "com.fasterxml.jackson.core:jackson-core:${project.ext.jacksonVersion}"

--- a/digdag-guice-rs-server-undertow/src/main/java/io/digdag/guice/rs/server/undertow/UndertowServer.java
+++ b/digdag-guice-rs-server-undertow/src/main/java/io/digdag/guice/rs/server/undertow/UndertowServer.java
@@ -194,6 +194,10 @@ public class UndertowServer
             }
             handler = Handlers.trace(handler);
 
+            // support "Content-Encoding: gzip | deflate" (request content encoding)
+            handler = new RequestEncodingHandler(handler)
+                .addEncoding("deflate", InflatingStreamSourceConduit.WRAPPER)
+                .addEncoding("gzip", GzipStreamSourceConduit.WRAPPER);
             // support "Accept-Encoding: gzip | deflate" (response content encoding)
             handler = new EncodingHandler(handler,
                     new ContentEncodingRepository()

--- a/digdag-guice-rs-server-undertow/src/main/java/io/digdag/guice/rs/server/undertow/UndertowServer.java
+++ b/digdag-guice-rs-server-undertow/src/main/java/io/digdag/guice/rs/server/undertow/UndertowServer.java
@@ -12,6 +12,8 @@ import io.digdag.guice.rs.server.undertow.UndertowServerConfig.ListenAddress;
 import io.undertow.Handlers;
 import io.undertow.Undertow;
 import io.undertow.UndertowOptions;
+import io.undertow.conduits.GzipStreamSourceConduit;
+import io.undertow.conduits.InflatingStreamSourceConduit;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.server.OpenListener;
@@ -19,6 +21,11 @@ import io.undertow.server.handlers.GracefulShutdownHandler;
 import io.undertow.server.handlers.accesslog.AccessLogHandler;
 import io.undertow.server.handlers.accesslog.AccessLogReceiver;
 import io.undertow.server.handlers.accesslog.DefaultAccessLogReceiver;
+import io.undertow.server.handlers.encoding.ContentEncodingRepository;
+import io.undertow.server.handlers.encoding.DeflateEncodingProvider;
+import io.undertow.server.handlers.encoding.EncodingHandler;
+import io.undertow.server.handlers.encoding.GzipEncodingProvider;
+import io.undertow.server.handlers.encoding.RequestEncodingHandler;
 import io.undertow.servlet.Servlets;
 import io.undertow.servlet.api.DeploymentInfo;
 import io.undertow.servlet.api.DeploymentManager;
@@ -185,7 +192,15 @@ public class UndertowServer
             if (config.getAccessLogPath().isPresent()) {
                 handler = buildAccessLogHandler(config, handler);
             }
-            appHandler = Handlers.trace(handler);
+            handler = Handlers.trace(handler);
+
+            // support "Accept-Encoding: gzip | deflate" (response content encoding)
+            handler = new EncodingHandler(handler,
+                    new ContentEncodingRepository()
+                    .addEncodingHandler("deflate", new DeflateEncodingProvider(), 50)
+                    .addEncodingHandler("gzip", new GzipEncodingProvider(), 60));
+
+            appHandler = handler;
         }
 
         // wrap HttpHandler in GracefulShutdownHandler

--- a/digdag-guice-rs/build.gradle
+++ b/digdag-guice-rs/build.gradle
@@ -6,6 +6,6 @@ dependencies {
     compile 'org.jboss.resteasy:async-http-servlet-3.0:3.0.13.Final'
 
     // this dependency is here only to override dependency of resteasy 3.0.13 -> jboss-logging 3.1.4.GA
-    // which conflicts with undertow 1.4.0.Final -> jboss-logging 3.2.1.Final
+    // which conflicts with undertow 1.4.18.Final -> jboss-logging 3.2.1.Final
     compile 'org.jboss.logging:jboss-logging:3.3.0.Final'
 }

--- a/digdag-tests/src/test/java/acceptance/HttpContentEncodingIT.java
+++ b/digdag-tests/src/test/java/acceptance/HttpContentEncodingIT.java
@@ -1,0 +1,58 @@
+package acceptance;
+
+import com.google.common.io.ByteStreams;
+import java.io.ByteArrayOutputStream;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.apache.http.client.entity.DeflateInputStream;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import utils.TemporaryDigdagServer;
+
+public class HttpContentEncodingIT
+{
+    @Rule
+    public TemporaryDigdagServer server = TemporaryDigdagServer.of();
+
+    private OkHttpClient client;
+
+    @Before
+    public void setup()
+    {
+        client = new OkHttpClient();
+    }
+
+    @Test
+    public void testRequestContentEncoding()
+            throws Exception
+    {
+        String dummyRequest = "{\"fromTime\":\"1987-01-01T00:00:00+00:00\",\"dryRun\":true,\"attemptName\":\"\"}";
+        byte[] compressedRequest;
+        {
+            ByteArrayOutputStream bo = new ByteArrayOutputStream();
+            try (GZIPOutputStream gz = new GZIPOutputStream(bo)) {
+                gz.write(dummyRequest.getBytes(UTF_8));
+            }
+            compressedRequest = bo.toByteArray();
+        }
+        Response response = client.newCall(new Request.Builder()
+                .url(server.endpoint() + "/api/schedules/99999/backfill")
+                .header("Content-Encoding", "gzip")
+                .post(RequestBody.create(MediaType.parse("application/json"), compressedRequest))
+                .build())
+                .execute();
+        assertThat(response.code(), is(404));  // If Content-Encoding is not handled, this should be other code
+        // because returning 404 means that the server succeeded to decode RestScheduleBackfillRequest object.
+        assertThat(response.header("Content-Encoding"), nullValue());
+    }
+}

--- a/digdag-tests/src/test/java/acceptance/HttpContentEncodingIT.java
+++ b/digdag-tests/src/test/java/acceptance/HttpContentEncodingIT.java
@@ -33,6 +33,40 @@ public class HttpContentEncodingIT
     }
 
     @Test
+    public void testResponseContentEncoding()
+            throws Exception
+    {
+        Response response = client.newCall(new Request.Builder()
+                .url(server.endpoint() + "/api/version")
+                .header("Accept-Encoding", "deflate")
+                .build())
+                .execute();
+        assertThat(response.code(), is(200));
+        assertThat(response.header("Content-Encoding"), is("deflate"));
+        try (DeflateInputStream in = new DeflateInputStream(response.body().byteStream())) {
+            String body = new String(ByteStreams.toByteArray(in), UTF_8);
+            assertThat(body.startsWith("{"), is(true));
+        }
+    }
+
+    @Test
+    public void testResponseContentEncodingPriority()
+            throws Exception
+    {
+        Response response = client.newCall(new Request.Builder()
+                .url(server.endpoint() + "/api/version")
+                .header("Accept-Encoding", "deflate,gzip")
+                .build())
+                .execute();
+        assertThat(response.code(), is(200));
+        assertThat(response.header("Content-Encoding"), is("gzip"));  // gzip has higher priority
+        try (GZIPInputStream in = new GZIPInputStream(response.body().byteStream())) {
+            String body = new String(ByteStreams.toByteArray(in), UTF_8);
+            assertThat(body.startsWith("{"), is(true));
+        }
+    }
+
+    @Test
     public void testRequestContentEncoding()
             throws Exception
     {


### PR DESCRIPTION
Add support for response body compression …This change lets Undertow compress response body using gzip or deflate
if client sends requests with `Accept-Encoding: gzip` or
`Accept-Encoding: deflate` header.

This change assumes #589.

When client sends `Accept-Encoding: gzip, deflate`, the server uses `gzip` (gzip has higher priority). This is because the client has a bug with deflate. See #590.
