### PR TITLE
Update digdag-ui schedules timeformat

### DIFF
--- a/digdag-ui/console.jsx
+++ b/digdag-ui/console.jsx
@@ -558,8 +558,8 @@ class ScheduleListView extends React.Component {
           <td>{schedule.revision}</td>
           <td><Link to={`/projects/${schedule.project.id}`}>{schedule.project.name}</Link></td>
           <td><Link to={`/workflows/${schedule.workflow.id}`}>{schedule.workflow.name}</Link></td>
-          <td>{schedule.nextRunTime}</td>
-          <td>{schedule.nextScheduleTime}</td>
+          <td><FullTimestamp showAgo={Boolean(true)} t={schedule.nextRunTime} /></td>
+          <td><SessionTime t={schedule.nextScheduleTime} /></td>
         </tr>
       )
     })


### PR DESCRIPTION
I'm updating digdag-ui schedules time format.  
Because nextRunTime time format is UTC.

Before:  
![2017-07-09 17 01 13](https://user-images.githubusercontent.com/4961885/27992182-684d75aa-64c8-11e7-8e8e-3fad0501e3a5.png)

After (if merged this PR) :  
![2017-07-09 16 59 32](https://user-images.githubusercontent.com/4961885/27992166-17a78a6e-64c8-11e7-9344-e115854a7be7.png)