### PR TITLE
Add note on scheduling workflow doc

### DIFF
--- a/digdag-docs/src/scheduling_workflow.rst
+++ b/digdag-docs/src/scheduling_workflow.rst
@@ -45,6 +45,11 @@ cron>: ``CRON``                 Use cron format for complex scheduling      cron
           first session time: 2016-02-10 16:00:00 -0800
           first runs at: 2016-02-10 23:00:00 -0800 (11h 16m 32s later)
 
+.. note::
+
+    When a field is starting with ``*`` , enclosing in quotes is neccessary by a limitasion to be a vaild YAML.
+
+
 Running scheduler
 ----------------------------------
 


### PR DESCRIPTION
Some people seem to be confused when using schedule directive to run tasks every minute.
http://recruit.gmo.jp/engineer/jisedai/blog/introduction-to-digdag/
(Japanese)

The reason is that starting field with `*` does not meet valid YAML syntax.
So I added document about that.