### PR TITLE
Let users configure default Treasure Data API endpoint

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/BaseTdJobOperator.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/BaseTdJobOperator.java
@@ -8,6 +8,7 @@ import io.digdag.spi.TaskExecutionException;
 import io.digdag.spi.TaskResult;
 import io.digdag.standards.operator.DurationInterval;
 import io.digdag.standards.operator.state.TaskState;
+import io.digdag.standards.operator.td.TDOperator.SystemDefaultConfig;
 import io.digdag.util.BaseOperator;
 
 import java.util.Map;
@@ -23,6 +24,7 @@ abstract class BaseTdJobOperator
 
     protected final DurationInterval pollInterval;
     protected final DurationInterval retryInterval;
+    protected final SystemDefaultConfig systemDefaultConfig;
 
     BaseTdJobOperator(OperatorContext context, Map<String, String> env, Config systemConfig)
     {
@@ -36,13 +38,13 @@ abstract class BaseTdJobOperator
 
         this.pollInterval = TDOperator.pollInterval(systemConfig);
         this.retryInterval = TDOperator.retryInterval(systemConfig);
+        this.systemDefaultConfig = TDOperator.systemDefaultConfig(systemConfig);
     }
 
     @Override
     public final TaskResult runTask()
     {
-        try (TDOperator op = TDOperator.fromConfig(env, params, context.getSecrets().getSecrets("td"))) {
-
+        try (TDOperator op = TDOperator.fromConfig(systemDefaultConfig, env, params, context.getSecrets().getSecrets("td"))) {
             Optional<String> doneJobId = state.params().getOptional(DONE_JOB_ID, String.class);
             TDJobOperator job;
             if (!doneJobId.isPresent()) {

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TDClientFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TDClientFactory.java
@@ -9,6 +9,7 @@ import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigException;
 import io.digdag.spi.SecretProvider;
 import io.digdag.standards.Proxies;
+import io.digdag.standards.operator.td.TDOperator.SystemDefaultConfig;
 
 import java.util.Map;
 
@@ -17,7 +18,7 @@ import static org.jboss.resteasy.util.Encode.decode;
 class TDClientFactory
 {
     @VisibleForTesting
-    static TDClientBuilder clientBuilderFromConfig(Map<String, String> env, Config params, SecretProvider secrets)
+    static TDClientBuilder clientBuilderFromConfig(SystemDefaultConfig systemDefaultConfig, Map<String, String> env, Config params, SecretProvider secrets)
     {
         TDClientBuilder builder = TDClient.newBuilder(false);
 
@@ -44,18 +45,18 @@ class TDClientFactory
         if (apikey.get().isEmpty()) {
             throw new ConfigException("The 'td.apikey' secret is empty");
         }
-        
+
         return builder
-                .setEndpoint(secrets.getSecretOptional("endpoint").or(() -> params.get("endpoint", String.class, "api.treasuredata.com")))
+                .setEndpoint(secrets.getSecretOptional("endpoint").or(() -> params.get("endpoint", String.class, systemDefaultConfig.getEndpoint())))
                 .setUseSSL(useSSL)
                 .setApiKey(apikey.get())
                 .setRetryLimit(0)  // disable td-client's retry mechanism
                 ;
     }
 
-    static TDClient clientFromConfig(Map<String, String> env, Config params, SecretProvider secrets)
+    static TDClient clientFromConfig(SystemDefaultConfig systemDefaultConfig, Map<String, String> env, Config params, SecretProvider secrets)
     {
-        return clientBuilderFromConfig(env, params, secrets).build();
+        return clientBuilderFromConfig(systemDefaultConfig, env, params, secrets).build();
     }
 
     private static ProxyConfig proxyConfig(Config config, SecretProvider secrets)

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdDdlOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdDdlOperatorFactory.java
@@ -13,6 +13,7 @@ import io.digdag.spi.OperatorContext;
 import io.digdag.spi.TaskResult;
 import io.digdag.standards.operator.DurationInterval;
 import io.digdag.standards.operator.state.TaskState;
+import io.digdag.standards.operator.td.TDOperator.SystemDefaultConfig;
 import io.digdag.util.BaseOperator;
 import org.immutables.value.Value;
 import org.slf4j.Logger;
@@ -34,12 +35,14 @@ public class TdDdlOperatorFactory
     private static Logger logger = LoggerFactory.getLogger(TdDdlOperatorFactory.class);
     private final Map<String, String> env;
     private final DurationInterval retryInterval;
+    private final SystemDefaultConfig systemDefaultConfig;
 
     @Inject
     public TdDdlOperatorFactory(@Environment Map<String, String> env, Config systemConfig)
     {
         this.env = env;
         this.retryInterval = TDOperator.retryInterval(systemConfig);
+        this.systemDefaultConfig = TDOperator.systemDefaultConfig(systemConfig);
     }
 
     public String getType()
@@ -119,7 +122,7 @@ public class TdDdlOperatorFactory
                 });
             }
 
-            try (TDOperator op = TDOperator.fromConfig(env, params, context.getSecrets().getSecrets("td"))) {
+            try (TDOperator op = TDOperator.fromConfig(systemDefaultConfig, env, params, context.getSecrets().getSecrets("td"))) {
                 // make sure that all "from" tables exist so that ignoring 404 Not Found in
                 // op.ensureExistentTableRenamed is valid.
                 if (!renameTableList.isEmpty()) {

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdWaitOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdWaitOperatorFactory.java
@@ -16,6 +16,7 @@ import io.digdag.spi.TaskResult;
 import io.digdag.spi.TemplateEngine;
 import io.digdag.standards.operator.DurationInterval;
 import io.digdag.standards.operator.state.TaskState;
+import io.digdag.standards.operator.td.TDOperator.SystemDefaultConfig;
 import io.digdag.util.BaseOperator;
 import org.msgpack.value.ArrayValue;
 import org.msgpack.value.Value;
@@ -41,6 +42,7 @@ public class TdWaitOperatorFactory
     private final Map<String, String> env;
     private final DurationInterval pollInterval;
     private final DurationInterval retryInterval;
+    private final SystemDefaultConfig systemDefaultConfig;
 
     @Inject
     public TdWaitOperatorFactory(TemplateEngine templateEngine, Config systemConfig, @Environment Map<String, String> env)
@@ -50,6 +52,7 @@ public class TdWaitOperatorFactory
         this.env = env;
         this.pollInterval = TDOperator.pollInterval(systemConfig);
         this.retryInterval = TDOperator.retryInterval(systemConfig);
+        this.systemDefaultConfig = TDOperator.systemDefaultConfig(systemConfig);
     }
 
     public String getType()
@@ -94,8 +97,7 @@ public class TdWaitOperatorFactory
         @Override
         public TaskResult runTask()
         {
-            try (TDOperator op = TDOperator.fromConfig(env, params, context.getSecrets().getSecrets("td"))) {
-
+            try (TDOperator op = TDOperator.fromConfig(systemDefaultConfig, env, params, context.getSecrets().getSecrets("td"))) {
                 TDJobOperator job = op.runJob(state, POLL_JOB, pollInterval, retryInterval, this::startJob);
 
                 // Fetch the job output to see if the query condition has been fulfilled

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdWaitTableOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdWaitTableOperatorFactory.java
@@ -15,6 +15,7 @@ import io.digdag.spi.TaskExecutionException;
 import io.digdag.spi.TaskResult;
 import io.digdag.standards.operator.DurationInterval;
 import io.digdag.standards.operator.state.TaskState;
+import io.digdag.standards.operator.td.TDOperator.SystemDefaultConfig;
 import io.digdag.util.BaseOperator;
 import org.msgpack.core.MessageTypeCastException;
 import org.msgpack.value.ArrayValue;
@@ -44,6 +45,7 @@ public class TdWaitTableOperatorFactory
     private final Map<String, String> env;
     private final DurationInterval pollInterval;
     private final DurationInterval retryInterval;
+    private final SystemDefaultConfig systemDefaultConfig;
 
     @Inject
     public TdWaitTableOperatorFactory(Config systemConfig, @Environment Map<String, String> env)
@@ -51,6 +53,7 @@ public class TdWaitTableOperatorFactory
         super(systemConfig);
         this.pollInterval = TDOperator.pollInterval(systemConfig);
         this.retryInterval = TDOperator.retryInterval(systemConfig);
+        this.systemDefaultConfig = TDOperator.systemDefaultConfig(systemConfig);
         this.env = env;
     }
 
@@ -100,7 +103,7 @@ public class TdWaitTableOperatorFactory
         @Override
         public TaskResult runTask()
         {
-            try (TDOperator op = TDOperator.fromConfig(env, params, context.getSecrets().getSecrets("td"))) {
+            try (TDOperator op = TDOperator.fromConfig(systemDefaultConfig, env, params, context.getSecrets().getSecrets("td"))) {
 
                 // Check if table exists using rest api
                 if (!state.params().get(TABLE_EXISTS, Boolean.class, false)) {

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/td/AbstractWaitOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/td/AbstractWaitOperatorFactoryTest.java
@@ -18,7 +18,6 @@ import static org.junit.Assert.assertThat;
 
 public class AbstractWaitOperatorFactoryTest
 {
-
     private static final ObjectMapper MAPPER = new ObjectMapper()
             .registerModule(new GuavaModule());
 

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/td/TDClientFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/td/TDClientFactoryTest.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static io.digdag.standards.operator.td.TDOperatorTest.DEFAULT_DEFAULT_SYSTEM_CONFIG;
 
 public class TDClientFactoryTest
 {
@@ -46,7 +47,7 @@ public class TDClientFactoryTest
                                 .set("use_ssl", true));
 
         TDClientBuilder builder = TDClientFactory.clientBuilderFromConfig(
-                ImmutableMap.of(), config, SECRETS);
+                DEFAULT_DEFAULT_SYSTEM_CONFIG, ImmutableMap.of(), config, SECRETS);
         TDClientConfig clientConfig = builder.buildConfig();
 
         assertThat(clientConfig.proxy.get().getUser(), is(Optional.of("me")));
@@ -59,7 +60,8 @@ public class TDClientFactoryTest
     {
         Map<String, String> env = ImmutableMap.of("http_proxy", "https://me:%27(%23%25@example.com:9119");
 
-        TDClientBuilder builder = TDClientFactory.clientBuilderFromConfig(env, newConfig(), SECRETS);
+        TDClientBuilder builder = TDClientFactory.clientBuilderFromConfig(
+                DEFAULT_DEFAULT_SYSTEM_CONFIG, env, newConfig(), SECRETS);
         TDClientConfig clientConfig = builder.buildConfig();
 
         assertThat(clientConfig.proxy.get().getUser(), is(Optional.of("me")));

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/td/TDOperatorTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/td/TDOperatorTest.java
@@ -410,8 +410,7 @@ public class TDOperatorTest
         assertThat(defaultDefaults.getEndpoint(), is("api.treasuredata.com"));
 
         Config overrideConfig = configFactory.create()
-                .set("config.td.default_endpoint", "api.treasuredata.co.jp")
-                ;
+                .set("config.td.default_endpoint", "api.treasuredata.co.jp");
         SystemDefaultConfig overrides = TDOperator.systemDefaultConfig(overrideConfig);
         assertThat(overrides.getEndpoint(), is("api.treasuredata.co.jp"));
     }

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/td/TDOperatorTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/td/TDOperatorTest.java
@@ -20,6 +20,7 @@ import io.digdag.spi.SecretProvider;
 import io.digdag.spi.TaskExecutionException;
 import io.digdag.standards.operator.DurationInterval;
 import io.digdag.standards.operator.state.TaskState;
+import io.digdag.standards.operator.td.TDOperator.SystemDefaultConfig;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -46,6 +47,15 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class TDOperatorTest
 {
+    static SystemDefaultConfig DEFAULT_DEFAULT_SYSTEM_CONFIG = new SystemDefaultConfig()
+    {
+        @Override
+        public String getEndpoint()
+        {
+            return "api.treasuredata.com";
+        }
+    };
+
     private static final ImmutableMap<String, String> EMPTY_ENV = ImmutableMap.of();
 
     @Rule public final ExpectedException exception = ExpectedException.none();
@@ -78,7 +88,7 @@ public class TDOperatorTest
                 ImmutableMap.of("apikey", "foobar").get(key));
 
         exception.expect(ConfigException.class);
-        TDOperator.fromConfig(EMPTY_ENV, config, secrets);
+        TDOperator.fromConfig(DEFAULT_DEFAULT_SYSTEM_CONFIG, EMPTY_ENV, config, secrets);
     }
 
     @Test
@@ -92,7 +102,7 @@ public class TDOperatorTest
                 ImmutableMap.of("apikey", "foobar").get(key));
 
         exception.expect(ConfigException.class);
-        TDOperator.fromConfig(EMPTY_ENV, config, secrets);
+        TDOperator.fromConfig(DEFAULT_DEFAULT_SYSTEM_CONFIG, EMPTY_ENV, config, secrets);
     }
 
     @Test
@@ -106,7 +116,7 @@ public class TDOperatorTest
                 ImmutableMap.of("apikey", "").get(key));
 
         exception.expect(ConfigException.class);
-        TDOperator.fromConfig(EMPTY_ENV, config, secrets);
+        TDOperator.fromConfig(DEFAULT_DEFAULT_SYSTEM_CONFIG, EMPTY_ENV, config, secrets);
     }
 
     @Test
@@ -120,7 +130,7 @@ public class TDOperatorTest
                 ImmutableMap.of("apikey", " \n\t").get(key));
 
         exception.expect(ConfigException.class);
-        TDOperator.fromConfig(EMPTY_ENV, config, secrets);
+        TDOperator.fromConfig(DEFAULT_DEFAULT_SYSTEM_CONFIG, EMPTY_ENV, config, secrets);
     }
 
     @Test
@@ -131,7 +141,7 @@ public class TDOperatorTest
                 .set("database", "foobar");
         SecretProvider secrets = key -> Optional.fromNullable(
                 ImmutableMap.of("apikey", "quux").get(key));
-        TDOperator.fromConfig(EMPTY_ENV, config, secrets);
+        TDOperator.fromConfig(DEFAULT_DEFAULT_SYSTEM_CONFIG, EMPTY_ENV, config, secrets);
     }
 
     @Test
@@ -391,6 +401,19 @@ public class TDOperatorTest
                 .withJobId(jobId)
                 .withDomainKey(domainKey)
                 .withPollIteration(pollIteration + 1)));
+    }
+
+    @Test
+    public void testSystemDefaultConfig()
+    {
+        SystemDefaultConfig defaultDefaults = TDOperator.systemDefaultConfig(configFactory.create());
+        assertThat(defaultDefaults.getEndpoint(), is("api.treasuredata.com"));
+
+        Config overrideConfig = configFactory.create()
+                .set("config.td.default_endpoint", "api.treasuredata.co.jp")
+                ;
+        SystemDefaultConfig overrides = TDOperator.systemDefaultConfig(overrideConfig);
+        assertThat(overrides.getEndpoint(), is("api.treasuredata.co.jp"));
     }
 
     private TDJobSummary summary(String jobId, TDJob.Status status) {


### PR DESCRIPTION
This change let users configure default td.endpoint of all td-related
operators using system config. This is helpful especially for system
integrators who provides a digdag server for customers with a
pre-configured td.endpoint.

It doesn't use JVM system property because system property affects globally. It may impact badly when we want to support remote agents. On the other hand, with system config, remote agents will be able to get the config from the central server when it starts. This approach guarantees that all remote agents use consistent configuration.

There are some inconsistency around the word "endpoint" because some configuration assumes that "endpoint" contains "http" or "https", but td.endpoint doesn't. But it's ignored for now.
