### PR TITLE
Fix display format of past time by CLI

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/TimeUtil.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/TimeUtil.java
@@ -50,7 +50,7 @@ public class TimeUtil
 
     public static String formatTimeDiff(Instant now, Instant from)
     {
-        long seconds = now.until(from, ChronoUnit.SECONDS);
+        long seconds = Math.abs(now.until(from, ChronoUnit.SECONDS));
         long hours = seconds / 3600;
         seconds %= 3600;
         long minutes = seconds / 60;


### PR DESCRIPTION
This PR fixes  display format of past time difference by CLI.

In the current implementation,  the difference in past time only seconds are shown.

Before fix:
```
  disabled at: 2017-07-18 16:17:11 +0900 (-32s ago)
```

After fix:

```
  disabled at: 2017-07-18 16:17:11 +0900 (16m 36s ago)
```