### PR TITLE
Add Release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,8 @@ This might not always update all necessary files (Sphinx doesn't manage update d
 
 It builds index.html at digdag-docs/build/html/index.html.
 
+### Release Notes
+
+The list of release note is [here](https://github.com/treasure-data/digdag/tree/master/digdag-docs/src/releases).
+
+


### PR DESCRIPTION
http://docs.digdag.io/releases.html is not updated sometimes.
So, on Github, it might be better to link to https://github.com/treasure-data/digdag/tree/master/digdag-docs/src/releases instead of the doc.