### PR TITLE
Keep state params when task failed

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
@@ -1826,7 +1826,7 @@ public class DatabaseSessionStoreManager
         long setStartedState(@Bind("id") long taskId, @Bind("oldState") short oldState, @Bind("newState") short newState);
 
         @SqlUpdate("update tasks" +
-                " set updated_at = now(), state = :newState, state_params = NULL" +  // always set state_params = NULL
+                " set updated_at = now(), state = :newState" +
                 " where id = :id" +
                 " and state = :oldState")
         long setDoneState(@Bind("id") long taskId, @Bind("oldState") short oldState, @Bind("newState") short newState);


### PR DESCRIPTION
This PR changes to keep state params when task failed.

In the current implementation, state params are keep stored when the task is successful, but is deleted when the task failed.

The state params is useful for tracking and troubleshooting of the failed task by CLI or WebUI, so I think the session should keep stored state params even if task failed.