### PR TITLE
Make AWS region & endpoint configurable for EMR Operator

### DIFF
--- a/digdag-docs/src/operators/emr.md
+++ b/digdag-docs/src/operators/emr.md
@@ -41,6 +41,30 @@ For detailed information about EMR, see the [Amazon Elastic MapReduce Documentat
 
   The AWS Role to assume when submitting EMR jobs.
 
+* **aws.emr.region, aws.region**
+
+  The AWS region to use for EMR service.
+
+* **aws.emr.endpoint**
+
+  The AWS EMR [endpoint address](http://docs.aws.amazon.com/general/latest/gr/rande.html) to use.
+
+* **aws.s3.region, aws.region**
+
+  The AWS region to use for S3 service to store staging files.
+
+* **aws.s3.endpoint**
+
+  The AWS S3 [endpoint address](http://docs.aws.amazon.com/general/latest/gr/rande.html) to use for staging files.
+
+* **aws.kms.region, aws.region**
+
+  The AWS region to use for KMS service to encrypt variables passed to EMR jobs.
+
+* **aws.kms.endpoint**
+
+  The AWS KMS [endpoint address](http://docs.aws.amazon.com/general/latest/gr/rande.html) to use for EMR variable encryption.
+
 ## Options
 
 * **cluster**: STRING | OBJECT
@@ -106,6 +130,30 @@ For detailed information about EMR, see the [Amazon Elastic MapReduce Documentat
   ```
   staging: s3://my-bucket/staging/
   ```
+
+* **emr.region**
+
+  The AWS region to use for EMR service.
+
+* **emr.endpoint**
+
+  The AWS EMR [endpoint address](http://docs.aws.amazon.com/general/latest/gr/rande.html) to use.
+
+* **s3.region**
+
+  The AWS region to use for S3 service to store staging files.
+
+* **s3.endpoint**
+
+  The AWS S3 [endpoint address](http://docs.aws.amazon.com/general/latest/gr/rande.html) to use for staging files.
+
+* **kms.region**
+
+  The AWS region to use for KMS service to encrypt variables passed to EMR jobs.
+
+* **kms.endpoint**
+
+  The AWS KMS [endpoint address](http://docs.aws.amazon.com/general/latest/gr/rande.html) to use for EMR variable encryption.
 
 * **steps**: LIST
 

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/aws/Aws.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/aws/Aws.java
@@ -1,10 +1,14 @@
 package io.digdag.standards.operator.aws;
 
 import com.amazonaws.AmazonServiceException;
+import com.amazonaws.AmazonWebServiceClient;
 import com.amazonaws.ClientConfiguration;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
 import com.google.common.base.Optional;
 import com.google.common.base.Supplier;
 import com.treasuredata.client.ProxyConfig;
+import io.digdag.client.config.ConfigException;
 import io.digdag.standards.Proxies;
 import org.eclipse.jetty.http.HttpStatus;
 
@@ -51,6 +55,24 @@ class Aws
         Optional<String> password = proxyConfig.getPassword();
         if (password.isPresent()) {
             configuration.setProxyPassword(password.get());
+        }
+    }
+
+    static void configureServiceClient(AmazonWebServiceClient client, Optional<String> endpoint, Optional<String> regionName)
+    {
+        // Configure endpoint or region. Endpoint takes precedence over region.
+        if (endpoint.isPresent()) {
+            client.setEndpoint(endpoint.get());
+        }
+        else if (regionName.isPresent()) {
+            Regions region;
+            try {
+                region = Regions.fromName(regionName.get());
+            }
+            catch (IllegalArgumentException e) {
+                throw new ConfigException("Illegal AWS region: " + regionName.get());
+            }
+            client.setRegion(Region.getRegion(region));
         }
     }
 

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/aws/S3WaitOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/aws/S3WaitOperatorFactory.java
@@ -4,8 +4,6 @@ import com.amazonaws.AmazonServiceException;
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.regions.Region;
-import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.S3ClientOptions;
 import com.amazonaws.services.s3.model.AmazonS3Exception;
@@ -141,26 +139,14 @@ public class S3WaitOperatorFactory
             AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
             AmazonS3Client s3Client = s3ClientFactory.create(credentials, configuration);
 
+            Aws.configureServiceClient(s3Client, endpoint, regionName);
+
             S3ClientOptions clientOptions = new S3ClientOptions();
             if (pathStyleAccess.isPresent()) {
                 clientOptions.setPathStyleAccess(pathStyleAccess.get());
             }
             s3Client.setS3ClientOptions(clientOptions);
 
-            // Configure endpoint or region. Endpoint takes precedence over region.
-            if (endpoint.isPresent()) {
-                s3Client.setEndpoint(endpoint.get());
-            }
-            else if (regionName.isPresent()) {
-                Regions region;
-                try {
-                    region = Regions.fromName(regionName.get());
-                }
-                catch (IllegalArgumentException e) {
-                    throw new ConfigException("Illegal AWS region: " + regionName.get());
-                }
-                s3Client.setRegion(Region.getRegion(region));
-            }
 
             GetObjectMetadataRequest req = new GetObjectMetadataRequest(bucket.get(), key.get());
 


### PR DESCRIPTION
This allows to configure either AWS region or endpoint for AWS service clients
that are used in EMR operator.