### PR TITLE
Fix race condition between cancel-request and subtask generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_cache:
   - sudo chown `id -u`:`id -g` -R $HOME/.gradle $HOME/.m2  # make them cachable
 
 script:
-  - ci/run_test.sh
+  - travis_wait ci/run_test.sh
 
 after_success:
   - ci/travis_report_coverage.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_cache:
   - sudo chown `id -u`:`id -g` -R $HOME/.gradle $HOME/.m2  # make them cachable
 
 script:
-  - travis_wait ci/run_test.sh
+  - travis_wait 40 ci/run_test.sh
 
 after_success:
   - ci/travis_report_coverage.sh

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
@@ -382,6 +382,26 @@ public class DatabaseSessionStoreManager
     public boolean requestCancelAttempt(long attemptId)
     {
         return transaction((handle, dao) -> {
+            // Lock all running tasks.
+            handle.createQuery("select id from tasks" +
+                    " where attempt_id = :attemptId" +
+                    " and state = " + TaskStateCode.RUNNING_CODE +
+                    " for update")
+                .bind("attemptId", attemptId)
+                .mapTo(Long.class)
+                .list();
+            // Locking running tasks is necessary to avoid following scenario:
+            //   Thread-A: WorkflowExecutor.taskSucceeded or taskFailed
+            //   Thread-B: requestCancelAttempt
+            //   1. Thread-A locks task1 (lockTaskIfExists).
+            //   2. Thread-A checks stateFlags of task1 => not cancel-requested.
+            //   3. Thread-B issues UPDATE to set cancel-requested flag to all tasks.
+            //      This can set cancel-requested flag to some tasks immediately, but
+            //      updating task1 blocks because it's locked.
+            //   4. Thread-A inserts some generated subtasks: task2.
+            //   5. Thread-A unlocks task1.
+            //   6. Thread-B continues UPDATE statement. It updates task1. But it
+            //      might not update task2 depending on processing order.
             int n = handle.createStatement("update tasks" +
                     " set state_flags = " + bitOr("state_flags", Integer.toString(TaskStateFlags.CANCEL_REQUESTED)) +
                     " where attempt_id = :attemptId" +

--- a/digdag-tests/src/test/java/acceptance/ExecutionTimeoutIT.java
+++ b/digdag-tests/src/test/java/acceptance/ExecutionTimeoutIT.java
@@ -119,10 +119,10 @@ public class ExecutionTimeoutIT
             Id attemptId = startWorkflow(server.endpoint(), PROJECT_NAME, WORKFLOW_NAME);
 
             // Expect the attempt to get canceled
-            expect(Duration.ofMinutes(2), () -> client.getSessionAttempt(attemptId).getCancelRequested());
+            expect(Duration.ofMinutes(4), () -> client.getSessionAttempt(attemptId).getCancelRequested(), Duration.ofSeconds(10));
 
             // And then the attempt should be done pretty soon
-            expect(Duration.ofMinutes(2), () -> client.getSessionAttempt(attemptId).getDone());
+            expect(Duration.ofMinutes(4), () -> client.getSessionAttempt(attemptId).getDone(), Duration.ofSeconds(10));
 
             // Expect a notification to be sent
             expectNotification(attemptId, Duration.ofMinutes(2), "Workflow execution timeout"::equals);

--- a/digdag-tests/src/test/java/acceptance/td/BigQueryIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/BigQueryIT.java
@@ -410,7 +410,7 @@ public class BigQueryIT
                     .put("outfile", outfile.toString())
                     .build());
 
-            expect(Duration.ofMinutes(5), attemptSuccess(server.endpoint(), attemptId));
+            expect(Duration.ofMinutes(10), attemptSuccess(server.endpoint(), attemptId), Duration.ofSeconds(20));
 
             assertThat(Files.exists(outfile), is(true));
 

--- a/digdag-tests/src/test/java/acceptance/td/BigQueryIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/BigQueryIT.java
@@ -20,10 +20,13 @@ import com.google.api.services.storage.Storage;
 import com.google.api.services.storage.StorageScopes;
 import com.google.api.services.storage.model.StorageObject;
 import com.google.common.base.Joiner;
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import io.digdag.client.DigdagClient;
 import io.digdag.client.api.Id;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpResponseStatus;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -39,6 +42,7 @@ import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static acceptance.td.GcpUtil.BQ_TAG;
 import static acceptance.td.GcpUtil.GCP_CREDENTIAL;
@@ -91,7 +95,15 @@ public class BigQueryIT
     {
         assumeThat(GCP_CREDENTIAL, not(isEmptyOrNullString()));
 
-        proxyServer = TestUtils.startRequestFailingProxy(2);
+        proxyServer = TestUtils.startRequestFailingProxy(2, new ConcurrentHashMap<>(), HttpResponseStatus.INTERNAL_SERVER_ERROR,
+                (req, reqCount) -> {
+                    // io.digdag.standards.operator.gcp.BqJobRunner sends "CONNECT www.googleapis.com" frequently. It can easily cause infinite retry.
+                    // So the following custom logic should be used for that kind of requests.
+                    if (req.getMethod().equals(HttpMethod.CONNECT)) {
+                        return Optional.of(reqCount % 5 == 0);
+                    }
+                    return Optional.absent();
+                });
 
         server = TemporaryDigdagServer.builder()
                 .environment(ImmutableMap.of(

--- a/digdag-tests/src/test/java/utils/TestUtils.java
+++ b/digdag-tests/src/test/java/utils/TestUtils.java
@@ -318,7 +318,7 @@ public class TestUtils
         expect(timeout, condition, Duration.ofSeconds(5));
     }
 
-    public static void expect(TemporalAmount timeout, Callable<Boolean> condition, TemporalAmount interval)
+    public static void expect(TemporalAmount timeout, Callable<Boolean> condition, Duration interval)
             throws Exception
     {
         Instant deadline = Instant.now().plus(timeout);
@@ -326,7 +326,7 @@ public class TestUtils
             if (condition.call()) {
                 return;
             }
-            Thread.sleep(interval.get(ChronoUnit.SECONDS) * 1000);
+            Thread.sleep(interval.toMillis());
         }
 
         fail("Timeout after: " + timeout);
@@ -338,7 +338,7 @@ public class TestUtils
         return expectValue(timeout, condition, Duration.ofSeconds(5));
     }
 
-    public static <T> T expectValue(TemporalAmount timeout, Callable<T> condition, TemporalAmount interval)
+    public static <T> T expectValue(TemporalAmount timeout, Callable<T> condition, Duration interval)
             throws Exception
     {
         Instant deadline = Instant.now().plus(timeout);
@@ -351,7 +351,7 @@ public class TestUtils
             }
             catch (Exception ignore) {
             }
-            Thread.sleep(interval.get(ChronoUnit.SECONDS) * 1000);
+            Thread.sleep(interval.toMillis());
         }
 
         throw new AssertionError("Timeout after: " + timeout);

--- a/digdag-tests/src/test/java/utils/TestUtils.java
+++ b/digdag-tests/src/test/java/utils/TestUtils.java
@@ -21,7 +21,6 @@ import com.google.common.io.Resources;
 import io.digdag.cli.Main;
 import io.digdag.cli.YamlMapper;
 import io.digdag.client.DigdagClient;
-import io.digdag.client.Version;
 import io.digdag.client.api.Id;
 import io.digdag.client.api.JacksonTimeModule;
 import io.digdag.client.api.RestLogFileHandle;
@@ -64,7 +63,9 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.time.temporal.TemporalAmount;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -314,18 +315,30 @@ public class TestUtils
     public static void expect(TemporalAmount timeout, Callable<Boolean> condition)
             throws Exception
     {
+        expect(timeout, condition, Duration.ofSeconds(5));
+    }
+
+    public static void expect(TemporalAmount timeout, Callable<Boolean> condition, TemporalAmount interval)
+            throws Exception
+    {
         Instant deadline = Instant.now().plus(timeout);
         while (Instant.now().toEpochMilli() < deadline.toEpochMilli()) {
             if (condition.call()) {
                 return;
             }
-            Thread.sleep(1000);
+            Thread.sleep(interval.get(ChronoUnit.SECONDS) * 1000);
         }
 
         fail("Timeout after: " + timeout);
     }
 
     public static <T> T expectValue(TemporalAmount timeout, Callable<T> condition)
+            throws Exception
+    {
+        return expectValue(timeout, condition, Duration.ofSeconds(5));
+    }
+
+    public static <T> T expectValue(TemporalAmount timeout, Callable<T> condition, TemporalAmount interval)
             throws Exception
     {
         Instant deadline = Instant.now().plus(timeout);
@@ -338,7 +351,7 @@ public class TestUtils
             }
             catch (Exception ignore) {
             }
-            Thread.sleep(1000);
+            Thread.sleep(interval.get(ChronoUnit.SECONDS) * 1000);
         }
 
         throw new AssertionError("Timeout after: " + timeout);

--- a/digdag-tests/src/test/resources/acceptance/server_graceful_shutdown/sleep.dig
+++ b/digdag-tests/src/test/resources/acceptance/server_graceful_shutdown/sleep.dig
@@ -4,10 +4,10 @@ timezone: UTC
   _parallel: true
 
   +sleep:
-    sh>: sleep 5
+    sh>: sleep 10
 
   +sleep_and_touch:
-    sh>: sleep 5; touch ${outdir}/done.out
+    sh>: sleep 10; touch ${outdir}/done.out
 
   +start_checker:
     echo>: started


### PR DESCRIPTION
This fixes a possible race condition between cancel-request of an attempt and task-generating tasks (_error, loop>, etc.) as commented at https://github.com/treasure-data/digdag/compare/fix-cancel-request-race?expand=1#diff-d2d86ab5df03d4398a9ebc299b9183c5.
This PR assumes #612.

This also includes improvement of WorkflowExecutionTimeoutEnforcer:

* WorkflowExecutionTimeoutEnforcer should use smaller transactions so
  that it unlikely causes rollback. sendTimeoutNotification is a
  possible cause of rollback.

* Once sendTimeoutNotification completes successfully, cancel-request of
  the attempt should not rollback.

* `requestCancelAttempt` locks many records. WorkflowExecutionTimeoutEnforcer should unlock the records as soon as possible to avoid possible deadlock or performance degradation.
