### PR TITLE
secret-access-policy-file is no longer used

### DIFF
--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -346,7 +346,6 @@ In the config file, following parameters are available
 * log-server.s3.path (string)
 * log-server.s3.credentials.access-key-id (string. default: instance profile)
 * log-server.s3.credentials.secret-access-key (string. default: instance profile)
-* digdag.secret-access-policy-file (filename)
 * digdag.secret-encryption-key = (base64 encoded 128-bit AES encryption key)
 
 


### PR DESCRIPTION
`digdag.secret-access-policy-file` was removed in 0.9.3.

http://docs.digdag.io/releases/release-0.9.3.html

> * Secret access limits and policies have been removed. Operators can now access any secret.