### PR TITLE
Change docker's pull-aways option to pull_always for consistency

### DIFF
--- a/digdag-docs/src/architecture.md
+++ b/digdag-docs/src/architecture.md
@@ -53,6 +53,16 @@ You can use [Docker](https://www.docker.com/) to run tasks in a container.  If `
     +step1:
       py>: tasks.MyWorkflow.step1
 
+Digdag caches pulled image and reuses it. By default, currently, Digdag uses the cached image consistently even if there is an update. You can set `pull_always: true` option so that Digdag checks update of the image every time when a task starts.
+
+    _export:
+      docker:
+        image: ubuntu:latest
+        pull_always: true
+    
+    +step1:
+      py>: tasks.MyWorkflow.step1
+
 ## Next steps
 
 * [Concepts](concepts.html)

--- a/digdag-docs/src/architecture.md
+++ b/digdag-docs/src/architecture.md
@@ -53,7 +53,7 @@ You can use [Docker](https://www.docker.com/) to run tasks in a container.  If `
     +step1:
       py>: tasks.MyWorkflow.step1
 
-Digdag caches pulled image and reuses it. By default, currently, Digdag uses the cached image consistently even if there is an update. You can set `pull_always: true` option so that Digdag checks update of the image every time when a task starts.
+Digdag caches pulled image and reuses it. By default, currently, Digdag uses the cached image consistently even if there is an update. You can set `pull_always: true` option so that Digdag checks update and pulls the latest image of the tag every time when a task starts.
 
     _export:
       docker:

--- a/digdag-standards/src/main/java/io/digdag/standards/command/DockerCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/DockerCommandExecutor.java
@@ -70,7 +70,7 @@ public class DockerCommandExecutor
         }
         else {
             imageName = baseImageName;
-            if (dockerConfig.get("pull-always", Boolean.class, false)) {
+            if (dockerConfig.get("pull_always", Boolean.class, false)) {
                 pullImage(imageName);
             }
         }


### PR DESCRIPTION
Operators use underscore as the separator.
This change also adds document for the option.
pull-always was added by #601 and it's not released yet. This change doesn't affect backward compatibility.