### PR TITLE
Fix order of generated tasks on UI

### DIFF
--- a/digdag-ui/console.jsx
+++ b/digdag-ui/console.jsx
@@ -1302,8 +1302,8 @@ const JobLink = ({storeParams, stateParams}:{storeParams: Object, stateParams: O
 }
 
 function sortTasksForTreeView (tasks: Array<Task>): Array<Task> {
-  let collectChildrenRecursively = function (result: Array<Task>, taskGroups: Map<string, Array<Task>>, parentTask: Task) {
-    let group: ?Array<Task> = taskGroups.get(parentTask.id)
+  function collectChildrenRecursively (result: Array<Task>, taskGroups: Map<string, Array<Task>>, parentTask: Task) {
+    const group: ?Array<Task> = taskGroups.get(parentTask.id)
     if (group != null) {
       taskGroups.delete(parentTask.id)
       group.forEach(t => {
@@ -1314,12 +1314,12 @@ function sortTasksForTreeView (tasks: Array<Task>): Array<Task> {
   }
 
   // First, divide tasks into rootTasks and taskGroups.
-  let rootTasks: Array<Task> = []
-  let taskGroups: Map<string, Array<Task>> = new Map();  // {parentId => Array<Task>}
+  const rootTasks: Array<Task> = []
+  const taskGroups: Map<string, Array<Task>> = new Map();  // {parentId => Array<Task>}
   tasks.forEach(t => {
-    if (t.parentId != null) {
-      let parentId: string = t.parentId
-      let group: ?Array<Task> = taskGroups.get(parentId)
+    const parentId: ?string = t.parentId
+    if (parentId != null) {
+      const group: ?Array<Task> = taskGroups.get(parentId)
       if (group != null) {
         group.push(t)
       } else {
@@ -1331,7 +1331,7 @@ function sortTasksForTreeView (tasks: Array<Task>): Array<Task> {
   })
 
   // For each root task, push it to the result, and push its children to the result.
-  let result: Array<Task> = []
+  const result: Array<Task> = []
   rootTasks.forEach(t => {
     result.push(t)
     // collect children recursively


### PR DESCRIPTION
Timeline view of tasks shows tasks in tree. It was not showing tasks in
correct order if some tasks are generated dynamically. This PR
fixes the problem by sorting the tasks before display.

Example:

```yaml
# a.dig
+loop1:
  for_each>:
    k: [1, 2]
  _do:
    echo>: ${k}

+loop2:
  for_each>:
    v: ['a', 'b']
  _do:
    echo>: ${v}
```

Before fix:

![8a11aa5bbc8278ac2d22ae167a36abba](https://user-images.githubusercontent.com/40720/29197283-227cbf8c-7def-11e7-86a6-19f281d54df2.png)

After fix:

![cfa9d2143578568bad29bc32d5f6a2ed](https://user-images.githubusercontent.com/40720/29197245-d891f34c-7dee-11e7-9039-04762bb07d7a.png)

