### PR TITLE
Mitigate exit code 137 (OOM) on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ before_install:
     -v `pwd`/:/digdag \
     -v $HOME/.gradle:/root/.gradle \
     $BUILD_IMAGE \
-    ./gradlew testClasses
+    ./gradlew testClasses --no-daemon
   - ci/validate.sh
 
 install: true

--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,7 @@ dependencies:
       -v `pwd`/:/digdag \
       -v ~/.gradle:/root/.gradle \
       $BUILD_IMAGE \
-      ./gradlew testClasses
+      ./gradlew testClasses --no-daemon
 
 test:
   pre:

--- a/circle.yml
+++ b/circle.yml
@@ -14,13 +14,8 @@ dependencies:
     - "~/.gradle"
     - "~/.m2"
   override:
-    - | # download and cache dependencies
-      docker run \
-      -w /digdag \
-      -v `pwd`/:/digdag \
-      -v ~/.gradle:/root/.gradle \
-      $BUILD_IMAGE \
-      ./gradlew testClasses --no-daemon
+    # download and cache dependencies
+    - "docker run -w /digdag -v `pwd`/:/digdag -v ~/.gradle:/root/.gradle $BUILD_IMAGE ./gradlew testClasses --no-daemon":
         timeout: 3600
 
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -21,6 +21,7 @@ dependencies:
       -v ~/.gradle:/root/.gradle \
       $BUILD_IMAGE \
       ./gradlew testClasses --no-daemon
+        timeout: 3600
 
 test:
   pre:


### PR DESCRIPTION
Travis CI is occasionally causing this error:

    The command "travis_wait 40 ci/run_test.sh" exited with 137

Exit code 137 means 128 + 9 where 9 means SIGKILL. Likely this means
that the outer environment or kernel killed the process.

I guess this is same with the problem described at
https://docs.travis-ci.com/user/common-build-problems/#My-build-script-is-killed-without-any-error

A possible cause is shortage of memory. Most of ./gradlew commands are
running with --no-daemon but some are not. This means that two gradlew
processes (daemon and non-daemon) run. Adding --no-daemon saves memory.