### PR TITLE
Faster startup and less memory consumption in integration tests

### DIFF
--- a/digdag-tests/src/test/java/utils/TemporaryDigdagServer.java
+++ b/digdag-tests/src/test/java/utils/TemporaryDigdagServer.java
@@ -311,6 +311,7 @@ public class TemporaryDigdagServer
             processArgs.add(java.toString());
             processArgs.addAll(asList(
                     "-cp", classPath,
+                    "-XX:TieredStopAtLevel=1", "-Xverify:none",  // for faster startup and less memory consumption on CI
                     "-Xms128m", "-Xmx128m"));
             if (version.isPresent()) {
                 processArgs.add("-D" + VERSION_PROPERTY + "=" + version.get());


### PR DESCRIPTION
Adding -XX:TieredStopAtLevel=1 has similar effect with obsoleted -client
option. -Xverify:none simply skips validation of jar files and makes
startup of JVM faster.

This might mitigate the problem described at #624.