### PR TITLE
Fix retry in http operator #513

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/operator/HttpOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/HttpOperatorFactory.java
@@ -255,12 +255,12 @@ public class HttpOperatorFactory
                 throw error(req, uriIsSecret, e.getResponse());
             }
             catch (RuntimeException e) {
-                logger.info("Exception without response: {} {}", req.getMethod(), safeUri);
-                if(retry){
+                logger.warn("Exception without response: {} {}", req.getMethod(), safeUri);
+                if (retry) {
                     throw e;
                 }
                 else {
-                    throw new TaskExecutionException(e.toString());
+                    throw new TaskExecutionException(e);
                 }
             }
 

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/HttpOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/HttpOperatorFactory.java
@@ -257,7 +257,7 @@ public class HttpOperatorFactory
             catch (RuntimeException e) {
                 logger.info("Exception without response: {} {}", req.getMethod(), safeUri);
                 if(retry){
-                    throw new RuntimeException(e.toString());
+                    throw e;
                 }
                 else {
                     throw new TaskExecutionException(e.toString());

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/HttpOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/HttpOperatorFactory.java
@@ -254,6 +254,15 @@ public class HttpOperatorFactory
             catch (HttpResponseException e) {
                 throw error(req, uriIsSecret, e.getResponse());
             }
+            catch (RuntimeException e) {
+                logger.info("Exception without response: {} {}", req.getMethod(), safeUri);
+                if(retry){
+                    throw new RuntimeException(e.toString());
+                }
+                else {
+                    throw new TaskExecutionException(e.toString());
+                }
+            }
 
             logger.info("Received HTTP response: {} {}: {}", req.getMethod(), safeUri, res);
 


### PR DESCRIPTION
To fix #513 issue,  Catch RuntimeException in execute() and if retry is set to false, throw TaskExecutionException to abort the task.
