### PR TITLE
Support NULL-able values on `pg` operator's `download_file` option

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcResultSet.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcResultSet.java
@@ -1,5 +1,6 @@
 package io.digdag.standards.operator.jdbc;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.sql.SQLException;
 import java.sql.ResultSet;
@@ -52,12 +53,12 @@ public abstract class AbstractJdbcResultSet
 
     private List<Object> getObjects() throws SQLException
     {
-        Object[] results = new Object[columnNames.size()];
-        for (int i=0; i < results.length; i++) {
+        List<Object> results = new ArrayList<>(columnNames.size());
+        for (int i = 0; i < columnNames.size(); i++) {
             Object raw = resultSet.getObject(i + 1);  // JDBC column index begins from 1
-            results[i] = serializableObject(raw);
+            results.add(serializableObject(raw));
         }
-        return ImmutableList.copyOf(results);
+        return results;
     }
 
     protected abstract Object serializableObject(Object raw)


### PR DESCRIPTION
`io.digdag.standards.operator.jdbc.AbstractJdbcResultSet#getObjects` wrapped result values with `com.google.common.collect.ImmutableList`, but it doesn't accept null values. So this change uses just `ArrayList` instead of `ImmutableList`.

This pull request is to fix https://github.com/treasure-data/digdag/issues/628. 