### PR TITLE
Show "Canceled" instead of "Failure" on attempt status view

### DIFF
--- a/digdag-ui/console.jsx
+++ b/digdag-ui/console.jsx
@@ -327,6 +327,8 @@ const AttemptStatusView = ({attempt}) => {
   if (attempt.done) {
     if (attempt.success) {
       return <span><span className='glyphicon glyphicon-ok text-success' /> Success</span>
+    } else if (attempt.cancelRequested) {
+      return <span><span className='glyphicon glyphicon-exclamation-sign text-warning' /> Canceled</span>
     } else {
       return <span><span className='glyphicon glyphicon-exclamation-sign text-danger' /> Failure</span>
     }


### PR DESCRIPTION
Status of a session shows "Failure" if the session was canceled. But because cancelation usually means intentional cancel, it seems better to show different color from failure which is usually unintentional.

![c04e9c2be21deeb9fe699200857dfa18](https://user-images.githubusercontent.com/40720/29696094-7eedbcdc-88fb-11e7-9a1a-af12989086a5.png)
