### PR TITLE
Refactoring of use of Throwables.propagate.

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/database/ThreadLocalTransactionManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/ThreadLocalTransactionManager.java
@@ -256,7 +256,7 @@ public class ThreadLocalTransactionManager
             Throwables.propagateIfInstanceOf(e, e1);
             Throwables.propagateIfInstanceOf(e, e2);
             Throwables.propagateIfInstanceOf(e, e3);
-            Throwables.propagate(e);
+            throw Throwables.propagate(e);
         }
         finally {
             threadLocalTransaction.set(null);
@@ -269,7 +269,6 @@ public class ThreadLocalTransactionManager
                 transaction.close();
             }
         }
-        throw new IllegalStateException("Shouldn't reach here");
     }
 
     @Override
@@ -309,8 +308,7 @@ public class ThreadLocalTransactionManager
         }
         catch (Exception e) {
             Throwables.propagateIfInstanceOf(e, e1);
-            Throwables.propagate(e);
+            throw Throwables.propagate(e);
         }
-        throw new IllegalStateException("Shouldn't reach here");
     }
 }

--- a/digdag-core/src/test/java/io/digdag/core/database/DatabaseSecretStoreTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/database/DatabaseSecretStoreTest.java
@@ -222,7 +222,7 @@ public class DatabaseSecretStoreTest
                     });
                 }
                 catch (Exception e) {
-                    Throwables.propagate(e);
+                    throw Throwables.propagate(e);
                 }
             }));
         }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcConnectionConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcConnectionConfig.java
@@ -46,7 +46,7 @@ public abstract class AbstractJdbcConnectionConfig
             Class.forName(jdbcDriverName());
         }
         catch (ClassNotFoundException e) {
-            Throwables.propagate(e);
+            throw Throwables.propagate(e);
         }
 
         try {

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/redshift/RedshiftLoadOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/redshift/RedshiftLoadOperatorFactory.java
@@ -123,7 +123,7 @@ public class RedshiftLoadOperatorFactory
                                     value = objectMapper.readValue(in, new TypeReference<Map<String, Object>>() {});
                                 }
                                 catch (IOException e) {
-                                    Throwables.propagate(e);
+                                    throw Throwables.propagate(e);
                                 }
                                 @SuppressWarnings("unchecked")
                                 List<Map<String, String>> entries = (List<Map<String, String>>) value.get("entries");

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/redshift/RedshiftUnloadOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/redshift/RedshiftUnloadOperatorFactory.java
@@ -166,7 +166,7 @@ public class RedshiftUnloadOperatorFactory
                 });
             }
             catch (RetryExecutor.RetryGiveupException e) {
-                Throwables.propagate(e);
+                throw Throwables.propagate(e);
             }
         }
     }


### PR DESCRIPTION
As guava's document says, adding throw to Throwables.propagate can let
compilers know that following statements after the call are unreachable.
Behavior doesn't change because Throwable.propagate never returns.