### PR TITLE
TransactionManager.getOrReuse for submodules that may or may not nested

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/database/TransactionManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/TransactionManager.java
@@ -36,6 +36,32 @@ public interface TransactionManager
         throws E1, E2, E3;
 
     /**
+     * Create a new transaction and set it as the current transaction object, or get current transaction object.
+     */
+    <T> T beginOrReuse(SupplierInTransaction<T, RuntimeException, RuntimeException, RuntimeException> func);
+
+    /**
+     * Create a new transaction and set it as the current transaction object, or get current transaction object.
+     */
+    <T, E1 extends Exception> T beginOrReuse(
+            SupplierInTransaction<T, E1, RuntimeException, RuntimeException> func, Class<E1> e1)
+        throws E1;
+
+    /**
+     * Create a new transaction and set it as the current transaction object, or get current transaction object.
+     */
+    <T, E1 extends Exception, E2 extends Exception> T beginOrReuse(
+            SupplierInTransaction<T, E1, E2, RuntimeException> func, Class<E1> e1, Class<E2> e2)
+        throws E1, E2;
+
+    /**
+     * Create a new transaction and set it as the current transaction object, or get current transaction object.
+     */
+    <T, E1 extends Exception, E2 extends Exception, E3 extends Exception> T beginOrReuse(
+            SupplierInTransaction<T, E1, E2, E3> func, Class<E1> e1, Class<E2> e2, Class<E3> e3)
+        throws E1, E2, E3;
+
+    /**
      * Abort the current transaction and start a new transaction again.
      */
     void reset();

--- a/digdag-core/src/test/java/io/digdag/core/database/ThreadLocalTransactionManagerTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/database/ThreadLocalTransactionManagerTest.java
@@ -1,0 +1,108 @@
+package io.digdag.core.database;
+
+import io.digdag.core.repository.Project;
+import io.digdag.core.repository.ProjectStore;
+import io.digdag.core.repository.ResourceConflictException;
+import io.digdag.core.repository.ResourceNotFoundException;
+import io.digdag.core.repository.StoredProject;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class ThreadLocalTransactionManagerTest
+{
+    private DatabaseFactory factory;
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        factory = DatabaseTestingUtils.setupDatabase();
+    }
+
+    @Test
+    public void nestedTransactionIsNotAllowed()
+            throws Exception
+    {
+        exception.expectMessage(containsString("Nested transaction is not allowed"));
+        exception.expect(IllegalStateException.class);
+        factory.get().begin(() -> {
+            return factory.get().begin(() -> {
+                fail();
+                return null;
+            });
+        });
+    }
+
+    @Test
+    public void reuseTransaction()
+            throws Exception
+    {
+        Project proj1 = Project.of("proj1");
+
+        factory.get().<Void, ResourceNotFoundException, ResourceConflictException>begin(() -> {
+            factory.get().beginOrReuse(() -> {
+                factory.getProjectStoreManager().getProjectStore(0)
+                    .putAndLockProject(proj1, (store, stored) -> stored);
+                return null;
+            }, ResourceConflictException.class);
+
+            // This transaction can read the stored project
+            StoredProject proj2 = factory.getProjectStoreManager().getProjectStore(0)
+                .getProjectByName("proj1");
+            assertThat(proj2, is(notNullValue()));
+
+            // Another transaction can't read it until committed
+            try {
+                StoredProject proj3 = CompletableFuture.supplyAsync(() -> {
+                    return factory.get().beginOrReuse(() -> {
+                        try {
+                            return factory.getProjectStoreManager().getProjectStore(0)
+                                .getProjectByName("proj1");
+                        }
+                        catch (ResourceNotFoundException ex) {
+                            return null;
+                        }
+                    });
+                }).get();
+                assertThat(proj3, is(nullValue()));
+            }
+            catch (ExecutionException | InterruptedException ex) {
+                assertThat(ex, is(nullValue()));
+            }
+
+            return null;
+        }, ResourceNotFoundException.class, ResourceConflictException.class);
+
+        // Another transaction can read after commit
+        try {
+            StoredProject proj4 = CompletableFuture.supplyAsync(() -> {
+                return factory.get().beginOrReuse(() -> {
+                    try {
+                        return factory.getProjectStoreManager().getProjectStore(0)
+                            .getProjectByName("proj1");
+                    }
+                    catch (ResourceNotFoundException ex) {
+                        return null;
+                    }
+                });
+            }).get();
+            assertThat(proj4, is(notNullValue()));
+        }
+        catch (ExecutionException | InterruptedException ex) {
+            assertThat(ex, is(nullValue()));
+        }
+    }
+}


### PR DESCRIPTION
Some modules such as NotificationSender may or may not in transaction
depending on its context. Accessing database from those modules have an
issue where it causes deadlock due to lack of connections in connection
pool, or causes "Nested transaction is not allowed" error.

TransactionManager.getOrReuse lets those modules share the same
transaction context with the external caller such as
WorkflowExecutionTimeoutEnforcer, while it can start a new transaction
if the external caller is not in transaction such as
NotifyOperatorFactory.

In fact, WorkflowExecutionTimeoutEnforcer should not call
NotificationSender synchronously. Instead, it should create a
notification task and send notification asynchronously. But here it's
postponed.