### PR TITLE
Avoid bad query plan at DatabaseSessionStore.getSessions

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
@@ -1513,7 +1513,7 @@ public class DatabaseSessionStoreManager
         @SqlQuery("select s.*, sa.site_id, sa.attempt_name, sa.workflow_definition_id, sa.state_flags, sa.timezone, sa.params, sa.created_at, sa.finished_at, sa.index" +
                 " from sessions s" +
                 " join session_attempts sa on sa.id = s.last_attempt_id" +
-                " where s.project_id in (select id from projects where site_id = :siteId)" +
+                " where s.project_id = any(array(select id from projects where site_id = :siteId))" +
                 " and s.id < :lastId" +
                 " order by s.id desc" +
                 " limit :limit")


### PR DESCRIPTION
This statement was using some different query plans. Good plan is:

```
                                                                        QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=40.52..639.38 rows=100 width=247) (actual time=0.327..10.167 rows=100 loops=1)
   InitPlan 1 (returns $0)
     ->  Index Scan using projects_on_site_id_and_name on projects  (cost=0.28..39.67 rows=204 width=4) (actual time=0.017..0.192 rows=200 loops=1)
           Index Cond: (site_id = 1)
   ->  Nested Loop  (cost=0.85..76307.49 rows=12742 width=247) (actual time=0.326..10.111 rows=100 loops=1)
         ->  Index Scan Backward using sessions_pkey on sessions s  (cost=0.42..47157.15 rows=13414 width=67) (actual time=0.317..9.484 rows=100 loops=1)
               Index Cond: (id < '9223372036854775807'::bigint)
               Filter: (project_id = ANY ($0))
               Rows Removed by Filter: 1811
         ->  Index Scan using session_attempts_pkey on session_attempts sa  (cost=0.42..2.16 rows=1 width=188) (actual time=0.004..0.004 rows=1 loops=100)
               Index Cond: (id = s.last_attempt_id)
 Planning time: 1.119 ms
 Execution time: 10.251 ms
```

But it occasionally uses a bad plan:

```
                                                                              QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=1.13..1464.51 rows=100 width=247) (actual time=16.939..10153.332 rows=21 loops=1)
   ->  Nested Loop  (cost=1.13..130417.68 rows=8912 width=247) (actual time=16.938..10153.313 rows=21 loops=1)
         ->  Nested Loop Semi Join  (cost=0.71..125655.01 rows=9394 width=67) (actual time=16.925..10153.104 rows=21 loops=1)
               Join Filter: (s.project_id = projects.id)
               Rows Removed by Join Filter: 10177788
               ->  Index Scan Backward using sessions_pkey on sessions s  (cost=0.42..36585.74 rows=848161 width=67) (actual time=0.013..764.128 rows=848161 loops=1)
                     Index Cond: (id < '9223372036854775807'::bigint)
               ->  Materialize  (cost=0.28..12.38 rows=7 width=4) (actual time=0.000..0.005 rows=12 loops=848161)
                     ->  Index Scan using projects_on_site_id_and_name on projects  (cost=0.28..12.35 rows=7 width=4) (actual time=0.008..0.019 rows=12 loops=1)
                           Index Cond: (site_id = 1)
         ->  Index Scan using session_attempts_pkey on session_attempts sa  (cost=0.42..0.50 rows=1 width=188) (actual time=0.006..0.006 rows=1 loops=21)
               Index Cond: (id = s.last_attempt_id)
 Planning time: 0.933 ms
 Execution time: 10153.394 ms
```

This plan scans almost all rows from sessions table and takes very long time.
Although the detailed mechanism of PostgreSQL is unknown, this change makes PostgreSQL use following query plan consistently:

```
                                                                        QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=13.20..612.06 rows=100 width=247) (actual time=2.879..364.563 rows=21 loops=1)
   InitPlan 1 (returns $0)
     ->  Index Scan using projects_on_site_id_and_name on projects  (cost=0.28..12.35 rows=7 width=4) (actual time=0.007..0.014 rows=12 loops=1)
           Index Cond: (site_id = 1)
   ->  Nested Loop  (cost=0.85..76307.49 rows=12742 width=247) (actual time=2.878..364.556 rows=21 loops=1)
         ->  Index Scan Backward using sessions_pkey on sessions s  (cost=0.42..47157.15 rows=13414 width=67) (actual time=2.866..364.419 rows=21 loops=1)
               Index Cond: (id < '9223372036854775807'::bigint)
               Filter: (project_id = ANY ($0))
               Rows Removed by Filter: 848130
         ->  Index Scan using session_attempts_pkey on session_attempts sa  (cost=0.42..2.16 rows=1 width=188) (actual time=0.004..0.004 rows=1 loops=21)
               Index Cond: (id = s.last_attempt_id)
 Planning time: 0.389 ms
 Execution time: 364.631 ms
```

This is much faster.