### PR TITLE
Fix wrong "_background|_after is not used" message

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowCompiler.java
+++ b/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowCompiler.java
@@ -236,7 +236,7 @@ public class WorkflowCompiler
                     Map<String, TaskBuilder> names = new HashMap<>();
                     for (TaskBuilder subtask : subtasks) {
                         if (subtask.getConfig().get("_background", boolean.class, false)) {
-                            throw new ConfigException("Setting \"_background: true\" option is invalid (unnecessary) is its parent task has \"_parallel: true\" option");
+                            throw new ConfigException("Setting \"_background: true\" option is invalid (unnecessary) if its parent task has \"_parallel: true\" option");
                         }
                         for (String upName : subtask.getConfig().getListOrEmpty("_after", String.class)) {
                             TaskBuilder up = names.get(upName);
@@ -253,7 +253,7 @@ public class WorkflowCompiler
                     List<TaskBuilder> beforeList = new ArrayList<>();
                     for (TaskBuilder subtask : subtasks) {
                         if (subtask.getConfig().has("_after")) {
-                            throw new ConfigException("Option \"_after\" is valid only if its parent task has \"_parallel: true\"");
+                            throw new ConfigException("Setting \"_after\" option is invalid if its parent task doesn't have \"_parallel: true\" option");
                         }
                         if (subtask.getConfig().get("_background", boolean.class, false)) {
                             beforeList.add(subtask);

--- a/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowCompiler.java
+++ b/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowCompiler.java
@@ -58,7 +58,7 @@ public class WorkflowCompiler
         private final String name;
         private final String fullName;
         private final TaskType taskType;
-        private final Config config;
+        private Config config;
         private final List<TaskBuilder> children = new ArrayList<TaskBuilder>();
         private final List<TaskBuilder> upstreams = new ArrayList<TaskBuilder>();
 
@@ -90,6 +90,13 @@ public class WorkflowCompiler
         public Config getConfig()
         {
             return config;
+        }
+
+        public Config modifyConfig()
+        {
+            Config newConfig = config.deepCopy();  // keep the original config immutable
+            this.config = newConfig;
+            return newConfig;
         }
 
         private void addChild(TaskBuilder child)
@@ -238,6 +245,7 @@ public class WorkflowCompiler
                             }
                             subtask.addUpstream(up);
                         }
+                        subtask.modifyConfig().remove("_after");  // suppress "Parameter '_after' is not used" warning message
                         names.put(subtask.getName(), subtask);
                     }
                 }
@@ -257,6 +265,7 @@ public class WorkflowCompiler
                             beforeList.clear();
                             beforeList.add(subtask);
                         }
+                        subtask.modifyConfig().remove("_background");  // suppress "Parameter '_background' is not used" warning message
                     }
                 }
 

--- a/digdag-tests/src/test/java/acceptance/BackgroundAfterIT.java
+++ b/digdag-tests/src/test/java/acceptance/BackgroundAfterIT.java
@@ -73,7 +73,7 @@ public class BackgroundAfterIT
         CommandStatus runStatus = runResource("background_with_parallel.dig");
 
         assertThat(runStatus.errUtf8(), runStatus.code(), not(is(0)));
-        assertThat(runStatus.errUtf8(), containsString("error: Setting \"_background: true\" option is invalid (unnecessary) is its parent task has \"_parallel: true\" option"));
+        assertThat(runStatus.errUtf8(), containsString("error: Setting \"_background: true\" option is invalid (unnecessary) if its parent task has \"_parallel: true\" option"));
     }
 
     @Test
@@ -109,7 +109,7 @@ public class BackgroundAfterIT
         CommandStatus runStatus = runResource("after_without_parallel.dig");
 
         assertThat(runStatus.errUtf8(), runStatus.code(), not(is(0)));
-        assertThat(runStatus.errUtf8(), containsString("Option \"_after\" is valid only if its parent task has \"_parallel: true\""));
+        assertThat(runStatus.errUtf8(), containsString("error: Setting \"_after\" option is invalid if its parent task doesn't have \"_parallel: true\" option"));
     }
 
     private void assertOutputContents(String name, String contents)

--- a/digdag-tests/src/test/java/acceptance/BackgroundAfterIT.java
+++ b/digdag-tests/src/test/java/acceptance/BackgroundAfterIT.java
@@ -1,0 +1,122 @@
+package acceptance;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Files;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static utils.TestUtils.copyResource;
+import static utils.TestUtils.main;
+import utils.CommandStatus;
+
+public class BackgroundAfterIT
+{
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private Path root()
+    {
+        return folder.getRoot().toPath().toAbsolutePath();
+    }
+
+    private CommandStatus runResource(String name)
+            throws IOException
+    {
+        copyResource("acceptance/background_after/" + name, root().resolve(name));
+
+        return main("run",
+                "-c", "/dev/null",
+                "-o", root().toString(),
+                "-p", "outdir=" + root(),
+                "--project", root().toString(),
+                name);
+    }
+
+    @Test
+    public void backgroundTask()
+            throws IOException
+    {
+        CommandStatus runStatus = runResource("background_task.dig");
+
+        assertThat(runStatus.errUtf8(), runStatus.code(), is(0));
+        assertThat(runStatus.errUtf8(), not(containsString("is not used")));
+        assertThat(runStatus.outUtf8(), not(containsString("is not used")));
+
+        assertOutputContents("background_task.txt", "ok");
+    }
+
+    @Test
+    public void backgroundGroup()
+            throws IOException
+    {
+        CommandStatus runStatus = runResource("background_group.dig");
+
+        assertThat(runStatus.errUtf8(), runStatus.code(), is(0));
+        assertThat(runStatus.errUtf8(), not(containsString("is not used")));
+        assertThat(runStatus.outUtf8(), not(containsString("is not used")));
+
+        assertOutputContents("background_group.txt", "ok");
+    }
+
+    @Test
+    public void rejectBackgroundWithParallel()
+            throws IOException
+    {
+        CommandStatus runStatus = runResource("background_with_parallel.dig");
+
+        assertThat(runStatus.errUtf8(), runStatus.code(), not(is(0)));
+        assertThat(runStatus.errUtf8(), containsString("error: Setting \"_background: true\" option is invalid (unnecessary) is its parent task has \"_parallel: true\" option"));
+    }
+
+    @Test
+    public void afterTask()
+            throws IOException
+    {
+        CommandStatus runStatus = runResource("after_task.dig");
+
+        assertThat(runStatus.errUtf8(), runStatus.code(), is(0));
+        assertThat(runStatus.errUtf8(), not(containsString("is not used")));
+        assertThat(runStatus.outUtf8(), not(containsString("is not used")));
+
+        assertOutputContents("after_task.txt", "ok");
+    }
+
+    @Test
+    public void afterGroup()
+            throws IOException
+    {
+        CommandStatus runStatus = runResource("after_group.dig");
+
+        assertThat(runStatus.errUtf8(), runStatus.code(), is(0));
+        assertThat(runStatus.errUtf8(), not(containsString("is not used")));
+        assertThat(runStatus.outUtf8(), not(containsString("is not used")));
+
+        assertOutputContents("after_group.txt", "ok");
+    }
+
+    @Test
+    public void rejectAfterWithoutParallel()
+            throws IOException
+    {
+        CommandStatus runStatus = runResource("after_without_parallel.dig");
+
+        assertThat(runStatus.errUtf8(), runStatus.code(), not(is(0)));
+        assertThat(runStatus.errUtf8(), containsString("Option \"_after\" is valid only if its parent task has \"_parallel: true\""));
+    }
+
+    private void assertOutputContents(String name, String contents)
+            throws IOException
+    {
+        assertThat(
+                new String(Files.readAllBytes(root().resolve(name)), UTF_8).trim(),
+                is(contents));
+    }
+}

--- a/digdag-tests/src/test/resources/acceptance/background_after/after_group.dig
+++ b/digdag-tests/src/test/resources/acceptance/background_after/after_group.dig
@@ -1,0 +1,11 @@
++group:
+  _parallel: true
+
+  +before:
+    sh>: touch ${outdir}/before.txt
+
+  +after_group:
+    _after: [+before]
+    +task:
+      sh>: test -f ${outdir}/before.txt && echo ok > ${outdir}/after_group.txt
+

--- a/digdag-tests/src/test/resources/acceptance/background_after/after_task.dig
+++ b/digdag-tests/src/test/resources/acceptance/background_after/after_task.dig
@@ -1,0 +1,10 @@
++group:
+  _parallel: true
+
+  +before:
+    sh>: touch ${outdir}/before.txt
+
+  +after_task:
+    _after: [+before]
+    sh>: test -f ${outdir}/before.txt && echo ok > ${outdir}/after_task.txt
+

--- a/digdag-tests/src/test/resources/acceptance/background_after/after_without_parallel.dig
+++ b/digdag-tests/src/test/resources/acceptance/background_after/after_without_parallel.dig
@@ -1,0 +1,7 @@
++group:
+  +before:
+    echo>: before
+
+  +after:
+    _after: [+before]
+    echo>: background

--- a/digdag-tests/src/test/resources/acceptance/background_after/background_group.dig
+++ b/digdag-tests/src/test/resources/acceptance/background_after/background_group.dig
@@ -1,0 +1,17 @@
++group:
+  +forward_task:
+    sh>: for t in 1 2 4 8 16; do test -f ${outdir}/background_done.txt && echo ok > ${outdir}/background_group.txt && break || sleep $t; done
+
+  +background_group:
+    _background: true
+    +task:
+      sh>: touch ${outdir}/background_done.txt
+
+  +following_task:
+    # workflow fails if test fails
+    sh>: test -f ${outdir}/background_done.txt
+
+  +following_group:
+    +task:
+      # workflow fails if test fails
+      sh>: test -f ${outdir}/background_done.txt

--- a/digdag-tests/src/test/resources/acceptance/background_after/background_task.dig
+++ b/digdag-tests/src/test/resources/acceptance/background_after/background_task.dig
@@ -1,0 +1,16 @@
++group:
+  +forward_task:
+    sh>: for t in 1 2 4 8 16; do test -f ${outdir}/background_done.txt && echo ok > ${outdir}/background_task.txt && break || sleep $t; done
+
+  +background_task:
+    _background: true
+    sh>: touch ${outdir}/background_done.txt
+
+  +following_task:
+    # workflow fails if test fails
+    sh>: test -f ${outdir}/background_done.txt
+
+  +following_group:
+    +task:
+      # workflow fails if test fails
+      sh>: test -f ${outdir}/background_done.txt

--- a/digdag-tests/src/test/resources/acceptance/background_after/background_with_parallel.dig
+++ b/digdag-tests/src/test/resources/acceptance/background_after/background_with_parallel.dig
@@ -1,0 +1,10 @@
++group:
+  _parallel: true
+
+  +forward_task:
+    echo>: forward
+
+  +background:
+    _background: true
+    echo>: background
+


### PR DESCRIPTION
Setting _background or _after option is working but it was showing
`Parameter '_background' is not used` or `Parameter '_after' is not used`
warning messages wrongly.

Fixes #641.