### PR TITLE
Skip set permission if extract file is symlink.

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/archive/ProjectArchives.java
+++ b/digdag-core/src/main/java/io/digdag/core/archive/ProjectArchives.java
@@ -79,7 +79,9 @@ public class ProjectArchives
                     ByteStreams.copy(archive, out);
                 }
             }
-            Files.setPosixFilePermissions(path, getPosixFilePermissions(entry));
+            if (!Files.isSymbolicLink(path)) {
+                Files.setPosixFilePermissions(path, getPosixFilePermissions(entry));
+            }
         }
     }
 


### PR DESCRIPTION
Fix #643. digdag download command sometimes
extracts symbolic link file before extract regular file.
In this case, NoSuchFileException raise.
For avoiding it, skip set permission
if the target is a symbolic link file.

```
digdag-0.9.17-SNAPSHOT.jar download test
2017-09-09 00:41:04 +0900: Digdag v0.9.17-SNAPSHOT
  test/0.sh -> 1.sh
  test/1.sh
  test/testting.dig
Extracted project 'test' revision 'f5446a63-a2b1-4782-a018-f955ceec4364' to test.
```