### PR TITLE
Support json table schema for bq_load>:

### DIFF
--- a/digdag-docs/src/operators/bq_load.md
+++ b/digdag-docs/src/operators/bq_load.md
@@ -224,6 +224,52 @@
       - ALLOW_FIELD_ADDITION
       - ALLOW_FIELD_RELAXATION
 
+* **schema**: OBJECT | STRING
+
+  A table schema. It can accept object, json or yml file path.
+
+  Example:
+
+  You can write schema within .dag file directly.
+
+  ```yml
+  +step:
+    bq_load>: gs://<bucket>/path/to_file
+    ...
+    schema:
+      - name: "name",
+        type: "string"
+      ...
+  ```
+
+  Or you can write it as external file.
+
+  ```json
+  {
+    "fields": [
+      {"name": "name", "type": "STRING"},
+      ...
+    ]
+  }
+  ```
+  ```yml
+  fields:
+    - name: "name",
+      type: "string"
+    ...
+  ```
+
+  And specify the file path.
+
+  ```yml
+  +step:
+    bq_load>: gs://<bucket>/path/to_file
+    ...
+    schema: path/to/schema.json
+    # or
+    # schema: path/to/schema.yml
+  ```
+
 ## Output parameters
 
 * **bq.last_job_id**

--- a/digdag-docs/src/operators/bq_load.md
+++ b/digdag-docs/src/operators/bq_load.md
@@ -259,7 +259,7 @@
     ...
   ```
 
-  And specify the file path.
+  And specify the file path. Supported formats are YAML and JSON. If an extension of the path is `.json` bq_load try parse as JSON, otherwise YAML.
 
   ```yml
   +step:

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/gcp/BqLoadOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/gcp/BqLoadOperatorFactory.java
@@ -127,7 +127,8 @@ class BqLoadOperatorFactory
                 String schemaString = workspace.templateFile(templateEngine, fileName, UTF_8, params);
                 if (FilenameUtils.getExtension(fileName).equals("json")) {
                     return objectMapper.readValue(schemaString, TableSchema.class);
-                } else {
+                }
+                else {
                     ObjectNode schemaJson = new YamlLoader().loadString(schemaString);
                     return objectMapper.readValue(schemaJson.traverse(), TableSchema.class);
                 }


### PR DESCRIPTION
I'd like to give json file as `schema` parameter of `bq_load>:` because I've used `bq load` cmd with [table_schema json file](https://cloud.google.com/bigquery/bq-command-line-tool?hl=en#creatingtablefromfile) and I want to migrate to digdag with minimum modification.