### PR TITLE
Fix #651. use encode file_name parameter except '^'

### DIFF
--- a/digdag-server/src/main/java/io/digdag/server/rs/LogResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/LogResource.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import java.io.InputStream;
 import java.io.IOException;
 import javax.ws.rs.Consumes;
+import javax.ws.rs.Encoded;
 import javax.ws.rs.Produces;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -119,6 +120,7 @@ public class LogResource
     @GET
     @Produces("application/gzip")
     @Path("/api/logs/{attempt_id}/files/{file_name}")
+    @Encoded
     public byte[] getFile(
             @PathParam("attempt_id") long attemptId,
             @PathParam("file_name") String fileName)
@@ -126,7 +128,7 @@ public class LogResource
     {
         return tm.<byte[], ResourceNotFoundException, IOException, StorageFileNotFoundException>begin(() -> {
             LogFilePrefix prefix = getPrefix(attemptId);
-            return logServer.getFile(prefix, fileName);
+            return logServer.getFile(prefix, fileName.replaceFirst("%5E", "^"));
         }, ResourceNotFoundException.class, IOException.class, StorageFileNotFoundException.class);
     }
 


### PR DESCRIPTION
@frsyuki @komamitsu 

Please take a look when you can.

Fix #651. 

What do you think this PR? especially `fileName.replaceFirst("%5E", "^")` part.
(I think It's better to create separate class/method)

* digdag-ui client request `/api/logs/#{attempt_id}/files/#{file_name}` with following `file_name` parameter.

`+test+step2+repeat%5Esub+for-0=param=2=%7B%22key%22%3A%22+substep@59cb79c5163b8740.19948@hostname.local.log.gz`

* Current implementation decodes % encoding like `+test+step2+repeat^sub+for-0=param=2={"key":"`.
So I Add `@Encode` annotation. 

* But `%5E` character needs decode as `^`. because file name begin with `+test+step2+repeat^sub+for-`



![digdag](https://user-images.githubusercontent.com/767650/30915439-d28af5a8-a3d1-11e7-849d-6a720b0c385e.png)
