### PR TITLE
Fix stored parameter visibility order not to depend on underlaying DB

### DIFF
--- a/digdag-tests/src/test/java/acceptance/RunParamsVisibilityIT.java
+++ b/digdag-tests/src/test/java/acceptance/RunParamsVisibilityIT.java
@@ -26,10 +26,7 @@ public class RunParamsVisibilityIT
     public void runAll()
             throws IOException
     {
-        copyResource("acceptance/params_visibility/params_visibility.dig", root().resolve("params_visibility.dig"));
         copyResource("acceptance/params_visibility/helper.py", root().resolve("helper.py"));
-        CommandStatus runStatus = main("run", "-o", root().toString(), "--project", root().toString(), "params_visibility.dig", "--session", "2016-01-01 00:00:00");
-        assertThat(runStatus.errUtf8(), runStatus.code(), is(0));
     }
 
     private Path root()
@@ -49,6 +46,10 @@ public class RunParamsVisibilityIT
     public void testParams()
             throws Exception
     {
+        copyResource("acceptance/params_visibility/params_visibility.dig", root().resolve("params_visibility.dig"));
+        CommandStatus runStatus = main("run", "-o", root().toString(), "--project", root().toString(), "params_visibility.dig", "--session", "2016-01-01 00:00:00");
+        assertThat(runStatus.errUtf8(), runStatus.code(), is(0));
+
         assertOutputContents("simple_export", "simple_export");
         assertOutputContents("export_overwrite", "export_overwrite");
         assertOutputContents("simple_store", "simple_store");
@@ -58,5 +59,21 @@ public class RunParamsVisibilityIT
         assertOutputContents("parallel_store_fork_b", "b");
         assertOutputContents("parallel_store_fork_c", "prepare");
         assertOutputContents("parallel_store_fork_join", "b");
+    }
+
+    @Test
+    public void testDynamicTasksParams()
+            throws Exception
+    {
+        copyResource("acceptance/params_visibility/dynamic_tasks_visibility.dig", root().resolve("dynamic_tasks_visibility.dig"));
+        CommandStatus runStatus = main("run", "-o", root().toString(), "--project", root().toString(), "dynamic_tasks_visibility.dig", "--session", "2016-01-01 00:00:00");
+        assertThat(runStatus.errUtf8(), runStatus.code(), is(0));
+
+        for (int outer = 1; outer <= 5; outer++) {
+            for (int inner = 1; inner <= 5; inner++) {
+                assertOutputContents("parallel_get_first_" + outer + "_" + inner, "initial");
+                assertOutputContents("parallel_override_" + outer + "_" + inner, "override_" + outer + "_" + inner);
+            }
+        }
     }
 }

--- a/digdag-tests/src/test/resources/acceptance/params_visibility/dynamic_tasks_visibility.dig
+++ b/digdag-tests/src/test/resources/acceptance/params_visibility/dynamic_tasks_visibility.dig
@@ -1,0 +1,29 @@
+
++initialize:
+  +task:
+    py>: helper.store_v
+    value: initial
+
++loop:
+  for_each>:
+    outer: [1, 2, 3, 4, 5]
+  _parallel: true
+  _do:
+    for_each>:
+      inner: [1, 2, 3, 4, 5]
+    _parallel: true
+    _do:
+      +get:
+        sh>: echo ${v} > parallel_get_first_${outer}_${inner}.out
+
+      +dynamic_override_in_parallel:
+        if>: true
+        _do:
+          py>: helper.store_v
+          value: override_${outer}_${inner}
+
+      +dynamic_get_in_parallel:
+        if>: true
+        _do:
+          sh>: echo ${v} > parallel_override_${outer}_${inner}.out
+


### PR DESCRIPTION
WorkflowExecutor.collectParams collects parameters to decide which
parameters are visible by a task. Father (earlier) tasks have lower
priority, and closer (later) tasks override them. Order is important. TaskTree.getRecursiveParentsUpstreamChildrenIdListFromFar is the
method that implements the logic to get ids of dependent tasks in order.

So, TaskTree.getRecursiveParentsUpstreamChildrenIdListFromFar should
return farther tasks first. However, it didn't contain explicit ordering logic.
DatabaseSessionStoreManager.getTaskRelations doesn't have ORDER BY.
Therefore, result depends on the underlaying database's implementation.
Usually, H2 and PostgreSQL return first-inserted records first, or
first-indexed records first if SELECT uses an index. However, it's not
guaranteed especially if the DB decided to use full-table scan and VACUUM
ran between dynamic generation of tasks.

This change fixes this issue by sorting the tasks explicitly in the
code.

Parameter visibility is tested at https://github.com/treasure-data/digdag/blob/19f338cdad497c01bd9c8c520d32de6162e55bc5/digdag-tests/src/test/java/acceptance/RunParamsVisibilityIT.java.