### PR TITLE
URI encoding is missing at fetchLogFile

### DIFF
--- a/digdag-ui/model.js
+++ b/digdag-ui/model.js
@@ -299,7 +299,7 @@ export class Model {
 
   fetchLogFile (attemptId: string, file: LogFileHandle) {
     if (!file.direct) {
-      return this.fetchArrayBuffer(`${this.config.url}logs/${attemptId}/files/${file.fileName}`)
+      return this.fetchArrayBuffer(`${this.config.url}logs/${attemptId}/files/${encodeURIComponent(file.fileName)}`)
     }
     return this.fetchArrayBuffer(file.direct)
   }


### PR DESCRIPTION
Fixes #651. See also #652.