### PR TITLE
Expose embulk stderr

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/operator/EmbulkOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/EmbulkOperatorFactory.java
@@ -110,6 +110,7 @@ public class EmbulkOperatorFactory
             }
 
             ProcessBuilder pb = new ProcessBuilder("embulk", "run", tempFile);
+            pb.redirectErrorStream(true);
             pb.directory(workspace.getPath().toFile());
 
             int ecode;


### PR DESCRIPTION
Hi maintainers,

Currently, embulk operator does not expose embulk stderr, so it's difficult to know why embulk execution is failed. This p-r is to expose the stderr.