### PR TITLE
Add cancelRequested flag to tasks in REST API

### DIFF
--- a/digdag-client/src/main/java/io/digdag/client/api/RestTask.java
+++ b/digdag-client/src/main/java/io/digdag/client/api/RestTask.java
@@ -25,6 +25,15 @@ public interface RestTask
 
     String getState();
 
+    // Note: Only reason why here sets a default value is for backward compatibility.
+    // Because older versions don't contain cancelRequested field, default value is
+    // necessary to avoid "cancelRequsted field doesn't exist" errors.
+    @Value.Default
+    default boolean isCancelRequested()
+    {
+        return false;
+    }
+
     Config getExportParams();
 
     Config getStoreParams();

--- a/digdag-server/src/main/java/io/digdag/server/rs/RestModels.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/RestModels.java
@@ -312,6 +312,7 @@ public final class RestModels
                     .collect(Collectors.toList()))
             .isGroup(task.getTaskType().isGroupingOnly())
             .state(task.getState().toString().toLowerCase())
+            .isCancelRequested(task.getStateFlags().isCancelRequested())
             .exportParams(task.getConfig().getExport().deepCopy().merge(task.getExportParams()))
             .storeParams(task.getStoreParams())
             .stateParams(task.getStateParams())

--- a/digdag-ui/model.js
+++ b/digdag-ui/model.js
@@ -73,6 +73,7 @@ export type Task = {
   upstreams: Array<string>;
   isGroup: boolean;
   state: string;
+  cancelRequested: boolean;
   exportParams: Object;
   storeParams: Object;
   stateParams: Object;


### PR DESCRIPTION
When a workflow is canceled, cancelRequested flag of attempt becomes
true in REST API. However, because tasks don't have cancelRequested
flag, it's relatively hard to reflect canceling state to the tasks on
console.

This change adds cancelRequested to tasks for console. Default value for
CLI clients is false for backward compatibility.