### PR TITLE
Add log-server.<type>.direct_download for workarounding CORS issues  …

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/log/LogServerManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/log/LogServerManager.java
@@ -52,6 +52,7 @@ public class LogServerManager
         Storage storage = storageManager.create(type, systemConfig, "log-server.");
 
         String logPath = systemConfig.get("log-server." + type + ".path", String.class, "");
+        boolean directDownload = systemConfig.get("log-server." + type + ".direct_download", boolean.class, false);
         if (logPath.startsWith("/")) {
             logPath = logPath.substring(1);
         }
@@ -59,7 +60,7 @@ public class LogServerManager
             logPath = logPath + "/";
         }
 
-        return new StorageFileLogServer(storage, logPath);
+        return new StorageFileLogServer(storage, logPath, directDownload);
     }
 
     public LogServer getLogServer()

--- a/digdag-core/src/main/java/io/digdag/core/log/StorageFileLogServer.java
+++ b/digdag-core/src/main/java/io/digdag/core/log/StorageFileLogServer.java
@@ -18,11 +18,13 @@ public class StorageFileLogServer
 {
     private final Storage storage;
     private final String logPath;
+    private final boolean directDownloadEnabled;
 
-    public StorageFileLogServer(Storage storage, String logPath)
+    public StorageFileLogServer(Storage storage, String logPath, boolean directDownloadEnabled)
     {
         this.storage = storage;
         this.logPath = logPath;
+        this.directDownloadEnabled = directDownloadEnabled;
     }
 
     private String getPrefixDir(String dateDir, String attemptDir)
@@ -83,7 +85,7 @@ public class StorageFileLogServer
                     consumer.accept(
                             fileName,
                             meta.getContentLength(),
-                            storage.getDirectDownloadHandle(key).orNull());
+                            directDownloadEnabled ? storage.getDirectDownloadHandle(key).orNull() : null);
             });
         });
     }

--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -345,6 +345,7 @@ In the config file, following parameters are available
 * log-server.s3.endpoint (string, default: "s3.amazonaws.com")
 * log-server.s3.bucket (string)
 * log-server.s3.path (string)
+* log-server.s3.direct_download (boolean. default: false)
 * log-server.s3.credentials.access-key-id (string. default: instance profile)
 * log-server.s3.credentials.secret-access-key (string. default: instance profile)
 * log-server.s3.path-style-access (boolean. default: false)

--- a/digdag-tests/src/test/java/acceptance/S3StorageIT.java
+++ b/digdag-tests/src/test/java/acceptance/S3StorageIT.java
@@ -56,6 +56,7 @@ public class S3StorageIT
                     "log-server.type = s3",
                     "log-server.s3.endpoint = " + TEST_S3_ENDPOINT,
                     "log-server.s3.bucket = " + logStorageBucket,
+                    "log-server.s3.direct_download = true",
                     "log-server.s3.path = storage-log-test",
                     "log-server.s3.credentials.access-key-id = " + TEST_S3_ACCESS_KEY_ID,
                     "log-server.s3.credentials.secret-access-key = " + TEST_S3_SECRET_ACCESS_KEY,


### PR DESCRIPTION
In some environments, setting up CORS is not easy, or endpoint is
reachable only from the digdag server. In this case, browsers fail to
download task log files using direct download URL.

This new option lets users to configure direct download as a part of
server configuration. Default is false.
