### PR TITLE
Fix argument of parallel parameter on redshift_unload document

### DIFF
--- a/digdag-docs/src/operators/redshift_unload.md
+++ b/digdag-docs/src/operators/redshift_unload.md
@@ -25,7 +25,7 @@
         null_as: nULl
         escape: false
         addquotes: true
-        parallel: true
+        parallel: ON
 
 ## Secrets
 


### PR DESCRIPTION
Correct the parameter argument of parallel in the redshift_unload document. I checked the code and the test, and it was true that it should be described as ON.

## Code

https://github.com/treasure-data/digdag/blob/master/digdag-standards/src/main/java/io/digdag/standards/operator/redshift/RedshiftUnloadOperatorFactory.java#L144

## Test

https://github.com/treasure-data/digdag/blob/master/digdag-standards/src/test/java/io/digdag/standards/operator/redshift/RedshiftUnloadOperatorFactoryTest.java#L150