### PR TITLE
(Markdown Doc) Add code quote for sample code

### DIFF
--- a/digdag-docs/src/operators/http.md
+++ b/digdag-docs/src/operators/http.md
@@ -142,10 +142,12 @@
 
   Additional custom headers to send with the HTTP request.
 
+  ```
     headers:
       - Accept: application/json
       - X-Foo: bar
       - Baz: quux
+  ```
 
 * **retry**: BOOLEAN
 


### PR DESCRIPTION
It need quote for sample code.

https://docs.digdag.io/operators/http.html
![image](https://user-images.githubusercontent.com/1734549/32210833-1a35cbbc-be53-11e7-8dd8-a10e3aa53e6d.png)
