### PR TITLE
[WIP] Clear environment variables for docker

### DIFF
--- a/digdag-core/src/test/java/io/digdag/core/workflow/SimpleCommandExecutor.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/SimpleCommandExecutor.java
@@ -3,6 +3,8 @@ package io.digdag.core.workflow;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Map;
+
 import com.google.inject.Inject;
 import com.google.common.base.Optional;
 import io.digdag.spi.CommandExecutor;
@@ -15,7 +17,7 @@ public class SimpleCommandExecutor
     public SimpleCommandExecutor()
     { }
 
-    public Process start(Path projectPath, TaskRequest request, ProcessBuilder pb)
+    public Process start(Path projectPath, TaskRequest request, ProcessBuilder pb, Map<String, String> environment)
         throws IOException
     {
         return pb.start();

--- a/digdag-spi/src/main/java/io/digdag/spi/CommandExecutor.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/CommandExecutor.java
@@ -2,9 +2,10 @@ package io.digdag.spi;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Map;
 
 public interface CommandExecutor
 {
-    Process start(Path projectPath, TaskRequest request, ProcessBuilder pb)
+    Process start(Path projectPath, TaskRequest request, ProcessBuilder pb, Map<String, String> environment)
         throws IOException;
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/SimpleCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/SimpleCommandExecutor.java
@@ -3,6 +3,7 @@ package io.digdag.standards.command;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Map;
 import com.google.inject.Inject;
 import com.google.common.base.Optional;
 import io.digdag.spi.CommandExecutor;
@@ -15,10 +16,11 @@ public class SimpleCommandExecutor
     public SimpleCommandExecutor()
     { }
 
-    public Process start(Path projectPath, TaskRequest request, ProcessBuilder pb)
+    public Process start(Path projectPath, TaskRequest request, ProcessBuilder pb, Map<String, String> environments)
         throws IOException
     {
         // TODO set TZ environment variable
+        pb.environment().putAll(environments);
         return pb.start();
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/EmbulkOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/EmbulkOperatorFactory.java
@@ -5,6 +5,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Files;
+import java.util.Collections;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.io.ByteStreams;
@@ -118,7 +119,7 @@ public class EmbulkOperatorFactory
 
             int ecode;
             try {
-                Process p = exec.start(workspace.getPath(), request, pb);
+                Process p = exec.start(workspace.getPath(), request, pb, Collections.emptyMap());
                 p.getOutputStream().close();
 
                 // copy stdout to System.out and logger

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/PyOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/PyOperatorFactory.java
@@ -1,5 +1,6 @@
 package io.digdag.standards.operator;
 
+import java.util.HashMap;
 import java.util.List;
 import java.io.Writer;
 import java.io.BufferedWriter;
@@ -134,10 +135,10 @@ public class PyOperatorFactory
             pb.redirectErrorStream(true);
 
             // Set up process environment according to env config. This can also refer to secrets.
-            Map<String, String> env = pb.environment();
+            Map<String, String> env = new HashMap<>();
             collectEnvironmentVariables(env, context.getPrivilegedVariables());
 
-            Process p = exec.start(workspace.getPath(), request, pb);
+            Process p = exec.start(workspace.getPath(), request, pb, env);
 
             // feed script to stdin
             try (Writer writer = new BufferedWriter(new OutputStreamWriter(p.getOutputStream()))) {

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/RbOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/RbOperatorFactory.java
@@ -1,5 +1,6 @@
 package io.digdag.standards.operator;
 
+import java.util.HashMap;
 import java.util.List;
 import java.io.Writer;
 import java.io.BufferedWriter;
@@ -141,10 +142,10 @@ public class RbOperatorFactory
             pb.redirectErrorStream(true);
 
             // Set up process environment according to env config. This can also refer to secrets.
-            Map<String, String> env = pb.environment();
+            Map<String, String> env = new HashMap<>();
             collectEnvironmentVariables(env, context.getPrivilegedVariables());
 
-            Process p = exec.start(workspace.getPath(), request, pb);
+            Process p = exec.start(workspace.getPath(), request, pb, env);
 
             // feed script to stdin
             try (Writer writer = new BufferedWriter(new OutputStreamWriter(p.getOutputStream()))) {

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/ShOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/ShOperatorFactory.java
@@ -28,12 +28,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Pattern;
 
 public class ShOperatorFactory
@@ -88,7 +83,7 @@ public class ShOperatorFactory
             ProcessBuilder pb = new ProcessBuilder(shell);
             pb.directory(workspace.getPath().toFile());
 
-            final Map<String, String> env = pb.environment();
+            Map<String, String> env = new HashMap<>();
             params.getKeys()
                 .forEach(key -> {
                     if (isValidEnvKey(key)) {
@@ -123,7 +118,7 @@ public class ShOperatorFactory
 
             int ecode;
             try {
-                Process p = exec.start(workspace.getPath(), request, pb);
+                Process p = exec.start(workspace.getPath(), request, pb, env);
 
                 // feed command to stdin
                 try (Writer writer = new BufferedWriter(new OutputStreamWriter(p.getOutputStream()))) {


### PR DESCRIPTION
dealing with #609 and [the issue](https://github.com/treasure-data/digdag/pull/611#issuecomment-319858743) based on #611.
I think CommandExecutor interface should be modified to have digdag host environment variables and digdag workflow variables separately.