### PR TITLE
Add an option to disable UI in CLI build

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,10 @@ $ export DIGDAG_TEST_POSTGRESQL="$(cat config/test_postgresql.properties)"
 
 ```
 $ ./gradlew cli
+$ ./gradlew cli -PwithoutUi  # build without integrated UI
 ```
+
+(If the command fails during building UI due to errors from `node` command, you can try to add `-PwithoutUi` argument to exclude the UI from the package).
 
 It makes an executable in `pkg/`, e.g. `pkg/digdag-$VERSION.jar`.
 

--- a/build.gradle
+++ b/build.gradle
@@ -341,10 +341,13 @@ project(':digdag-cli') {
             extendsFrom runtime
         }
     }
-    dependencies {
-        shadow project(':digdag-ui')
+
+    if (!project.hasProperty("withoutUi")) {
+        dependencies {
+            shadow project(':digdag-ui')
+        }
+        shadowJar.dependsOn(project(':digdag-ui').jar)
     }
-    shadowJar.dependsOn(project(':digdag-ui').jar)
 
     shadowJar {
         configurations = [project.configurations.shadow]


### PR DESCRIPTION
Installing full node.js package could be a major friction for many Java
developers to join development of Digdag.