### PR TITLE
[DOC] Add missing executor parameters.

### DIFF
--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -350,7 +350,7 @@ In the config file, following parameters are available
 * log-server.s3.credentials.secret-access-key (string. default: instance profile)
 * log-server.s3.path-style-access (boolean. default: false)
 * digdag.secret-encryption-key = (base64 encoded 128-bit AES encryption key)
-* executor.task_ttl (string. default: 1d. A task is killed if a single task is running longer than this period.)
+* executor.task_ttl (string. default: 1d. A task is killed if it is running longer than this period.)
 * executor.attempt_ttl (string. default: 7d. An attempt is killed if it is running longer than this period.)
 
 

--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -350,8 +350,8 @@ In the config file, following parameters are available
 * log-server.s3.credentials.secret-access-key (string. default: instance profile)
 * log-server.s3.path-style-access (boolean. default: false)
 * digdag.secret-encryption-key = (base64 encoded 128-bit AES encryption key)
-* executor.task_ttl (A task kills if a single task is running longer than this period. string. default: 1d)
-* executor.attempt_ttl (An attempt is killed if it is running longer than this period. string. default: 7d)
+* executor.task_ttl (string. default: 1d. A task is killed if a single task is running longer than this period.)
+* executor.attempt_ttl (string. default: 7d. An attempt is killed if it is running longer than this period.)
 
 
 Secret Encryption Key

--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -350,6 +350,8 @@ In the config file, following parameters are available
 * log-server.s3.credentials.secret-access-key (string. default: instance profile)
 * log-server.s3.path-style-access (boolean. default: false)
 * digdag.secret-encryption-key = (base64 encoded 128-bit AES encryption key)
+* executor.task_ttl (A task kills if a single task is running longer than this period. string. default: 1d)
+* executor.attempt_ttl (An attempt is killed if it is running longer than this period. string. default: 7d)
 
 
 Secret Encryption Key


### PR DESCRIPTION
Add missing `executor.task_ttl ` and `executor.attempt_ttl ` documentation.

Ref: https://twitter.com/toyama0919/status/933979861382610949