### PR TITLE
Avoid deadlock in lockReadySchedules

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseScheduleStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseScheduleStoreManager.java
@@ -248,12 +248,12 @@ public class DatabaseScheduleStoreManager
     public interface PgDao
             extends Dao
     {
-        @SqlQuery("select schedules.*, wd.name as name from schedules schedules" +
-                " join workflow_definitions wd on wd.id = schedules.workflow_definition_id" +
-                " where schedules.next_run_time <= :currentTime" +
-                " and schedules.disabled_at is null" +
+        @SqlQuery("select s.*, wd.name as name from schedules s" +
+                " join workflow_definitions wd on wd.id = s.workflow_definition_id" +
+                " where s.next_run_time <= :currentTime" +
+                " and s.disabled_at is null" +
                 " limit :limit" +
-                " for update of schedules skip locked")
+                " for update of s skip locked")
         List<StoredSchedule> lockReadySchedulesSkipLocked(@Bind("currentTime") long currentTime, @Bind("limit") int limit);
     }
 

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseScheduleStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseScheduleStoreManager.java
@@ -24,8 +24,10 @@ import javax.sql.DataSource;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class DatabaseScheduleStoreManager
         extends BasicDatabaseStoreManager<DatabaseScheduleStoreManager.Dao>
@@ -34,7 +36,19 @@ public class DatabaseScheduleStoreManager
     @Inject
     public DatabaseScheduleStoreManager(TransactionManager transactionManager, ConfigMapper cfm, DatabaseConfig config)
     {
-        super(config.getType(), Dao.class, transactionManager, cfm);
+        super(config.getType(), dao(config.getType()), transactionManager, cfm);
+    }
+
+    private static Class<? extends Dao> dao(String type)
+    {
+        switch (type) {
+        case "postgresql":
+            return PgDao.class;
+        case "h2":
+            return H2Dao.class;
+        default:
+            throw new IllegalArgumentException("Unknown database type: " + type);
+        }
     }
 
     @Override
@@ -44,24 +58,32 @@ public class DatabaseScheduleStoreManager
     }
 
     @Override
-    public void lockReadySchedules(Instant currentTime, ScheduleAction func)
+    public int lockReadySchedules(Instant currentTime, int limit, ScheduleAction func)
     {
-        List<RuntimeException> exceptions = transaction((handle, dao) -> {
-            return dao.lockReadySchedules(currentTime.getEpochSecond(), 10)  // TODO 10 should be configurable?
-                .stream()
-                .map(schedId -> {
-                    // TODO JOIN + FOR UPDATE doesn't work with H2 database
-                    StoredSchedule sched = dao.getScheduleByIdInternal(schedId);
+        List<RuntimeException> exceptions = new ArrayList<>();
+
+        long count = transaction((handle, dao) -> {
+            Stream<StoredSchedule> schedStream;
+            if (dao instanceof PgDao) {
+                schedStream = ((PgDao) dao).lockReadySchedulesSkipLocked(currentTime.getEpochSecond(), limit)
+                    .stream();
+            }
+            else {
+                // H2 database doesn't support JOIN + FOR UPDATE OF
+                schedStream = dao.lockReadyScheduleIds(currentTime.getEpochSecond(), limit)
+                    .stream()
+                    .map(dao::getScheduleByIdInternal);
+            }
+            return schedStream.mapToInt(sched -> {
                     try {
                         func.schedule(new DatabaseScheduleControlStore(handle), sched);
-                        return null;
                     }
                     catch (RuntimeException ex) {
-                        return ex;
+                        exceptions.add(ex);
                     }
+                    return 1;
                 })
-                .filter(exception -> exception != null)
-                .collect(Collectors.toList());
+                .sum();
         });
 
         if (!exceptions.isEmpty()) {
@@ -71,6 +93,8 @@ public class DatabaseScheduleStoreManager
             }
             throw first;
         }
+
+        return (int) count;
     }
 
     private interface ScheduleCombinedLockAction <T, E extends Exception>
@@ -216,6 +240,23 @@ public class DatabaseScheduleStoreManager
         }
     }
 
+    public interface H2Dao
+            extends Dao
+    {
+    }
+
+    public interface PgDao
+            extends Dao
+    {
+        @SqlQuery("select schedules.*, wd.name as name from schedules schedules" +
+                " join workflow_definitions wd on wd.id = schedules.workflow_definition_id" +
+                " where schedules.next_run_time <= :currentTime" +
+                " and schedules.disabled_at is null" +
+                " limit :limit" +
+                " for update of schedules skip locked")
+        List<StoredSchedule> lockReadySchedulesSkipLocked(@Bind("currentTime") long currentTime, @Bind("limit") int limit);
+    }
+
     public interface Dao
     {
         @SqlQuery("select s.*, wd.name as name from schedules s" +
@@ -274,7 +315,7 @@ public class DatabaseScheduleStoreManager
                 " and disabled_at is null" +
                 " limit :limit" +
                 " for update")
-        List<Integer> lockReadySchedules(@Bind("currentTime") long currentTime, @Bind("limit") int limit);
+        List<Integer> lockReadyScheduleIds(@Bind("currentTime") long currentTime, @Bind("limit") int limit);
 
         @SqlQuery("select * from schedules" +
                 " where id = :id" +

--- a/digdag-core/src/main/java/io/digdag/core/schedule/ScheduleExecutor.java
+++ b/digdag-core/src/main/java/io/digdag/core/schedule/ScheduleExecutor.java
@@ -131,25 +131,29 @@ public class ScheduleExecutor
         runSchedules(Instant.now());
     }
 
-    @VisibleForTesting
-    void runSchedules(Instant now)
+    private void runSchedules(Instant now)
     {
         try {
-            int count;
-            do {
-                count = tm.begin(() -> {
-                    // here uses limit=1 because selecting multiple rows with FOR UPDATE
-                    // has risk of too often deadlock.
-                    return sm.lockReadySchedules(now, 1, (store, storedSchedule) -> {
-                        runSchedule(new ScheduleControl(store, storedSchedule));
-                    });
-                });
-            } while (count > 0);  // repeat while some schedules ready
+            while (runScheduleOnce(now))
+                ;  // repeat while some schedules ready
         }
         catch (Throwable t) {
             logger.error("An uncaught exception is ignored. Scheduling will be retried.", t);
             errorReporter.reportUncaughtError(t);
         }
+    }
+
+    @VisibleForTesting
+    boolean runScheduleOnce(Instant now)
+    {
+        int count = tm.begin(() -> {
+            // here uses limit=1 because selecting multiple rows with FOR UPDATE
+            // has risk of too often deadlock.
+            return sm.lockReadySchedules(now, 1, (store, storedSchedule) -> {
+                runSchedule(new ScheduleControl(store, storedSchedule));
+            });
+        });
+        return count > 0;
     }
 
     private void runDelayedAttempts()

--- a/digdag-core/src/main/java/io/digdag/core/schedule/ScheduleStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/schedule/ScheduleStoreManager.java
@@ -16,5 +16,5 @@ public interface ScheduleStoreManager
         void schedule(ScheduleControlStore store, StoredSchedule schedule);
     }
 
-    void lockReadySchedules(Instant currentTime, ScheduleAction func);
+    int lockReadySchedules(Instant currentTime, int limit, ScheduleAction func);
 }

--- a/digdag-core/src/test/java/io/digdag/core/database/DatabaseScheduleStoreManagerTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/database/DatabaseScheduleStoreManagerTest.java
@@ -207,20 +207,20 @@ public class DatabaseScheduleStoreManagerTest
             assertEquals(sched4.getId(), (long) schedStore.lockScheduleById(sched4.getId(), (store, schedule) -> schedule.getId()));
 
             List<Integer> lockedByRuntime1 = new ArrayList<>();
-            schedManager.lockReadySchedules(runTime1, 1, (store, schedule) -> {
+            schedManager.lockReadySchedules(runTime1, 10, (store, schedule) -> {
                 lockedByRuntime1.add(schedule.getId());
             });
             assertEquals(ImmutableList.of(sched1.getId()), lockedByRuntime1);
 
             List<Integer> lockedByRuntime2 = new ArrayList<>();
-            schedManager.lockReadySchedules(runTime2, 1, (store, schedule) -> {
+            schedManager.lockReadySchedules(runTime2, 10, (store, schedule) -> {
                 lockedByRuntime2.add(schedule.getId());
             });
             assertEquals(ImmutableList.of(sched3.getId(), sched4.getId()), lockedByRuntime2);
 
             // exception during lockReadySchedules
             try {
-                schedManager.lockReadySchedules(runTime2, 1, (store, schedule) -> {
+                schedManager.lockReadySchedules(runTime2, 10, (store, schedule) -> {
                     throw new RuntimeException("processing " + schedule.getId());
                 });
                 fail();
@@ -238,7 +238,7 @@ public class DatabaseScheduleStoreManagerTest
             Instant schedTime4 = now.plusSeconds(40);
 
             try {
-                schedManager.lockReadySchedules(runTime2, 1, (store, schedule) -> {
+                schedManager.lockReadySchedules(runTime2, 10, (store, schedule) -> {
                     if (schedule.getId() == sched3.getId()) {
                         throw new RuntimeException();
                     }
@@ -257,7 +257,7 @@ public class DatabaseScheduleStoreManagerTest
             }
 
             List<Integer> updated = new ArrayList<>();
-            schedManager.lockReadySchedules(runTime2, 1, (store, schedule) -> {
+            schedManager.lockReadySchedules(runTime2, 10, (store, schedule) -> {
                 updated.add(schedule.getId());
                 try {
                     store.updateNextScheduleTimeAndLastSessionTime(schedule.getId(), ScheduleTime.of(schedTime4, runTime4), schedTime1);
@@ -332,7 +332,7 @@ public class DatabaseScheduleStoreManagerTest
             });
             {
                 List<Integer> ready = new ArrayList<>();
-                schedManager.lockReadySchedules(Instant.now(), 1, (store, schedule) -> ready.add(schedule.getId()));
+                schedManager.lockReadySchedules(Instant.now(), 10, (store, schedule) -> ready.add(schedule.getId()));
                 assertThat(ready, containsInAnyOrder(sched1.getId(), sched2.getId()));
             }
 
@@ -343,7 +343,7 @@ public class DatabaseScheduleStoreManagerTest
             });
             {
                 List<Integer> ready = new ArrayList<>();
-                schedManager.lockReadySchedules(Instant.now(), 1, (store, schedule) -> ready.add(schedule.getId()));
+                schedManager.lockReadySchedules(Instant.now(), 10, (store, schedule) -> ready.add(schedule.getId()));
                 assertThat(ready, contains(sched2.getId()));
             }
 
@@ -371,7 +371,7 @@ public class DatabaseScheduleStoreManagerTest
             });
             {
                 List<Integer> ready = new ArrayList<>();
-                schedManager.lockReadySchedules(Instant.now(), 1, (store, schedule) -> ready.add(schedule.getId()));
+                schedManager.lockReadySchedules(Instant.now(), 10, (store, schedule) -> ready.add(schedule.getId()));
                 assertThat(ready, containsInAnyOrder(sched1.getId(), sched2.getId()));
             }
 
@@ -382,7 +382,7 @@ public class DatabaseScheduleStoreManagerTest
             });
             {
                 List<Integer> ready = new ArrayList<>();
-                schedManager.lockReadySchedules(Instant.now(), 1, (store, schedule) -> ready.add(schedule.getId()));
+                schedManager.lockReadySchedules(Instant.now(), 10, (store, schedule) -> ready.add(schedule.getId()));
                 assertThat(ready, containsInAnyOrder(sched1.getId(), sched2.getId()));
             }
         });

--- a/digdag-core/src/test/java/io/digdag/core/database/DatabaseScheduleStoreManagerTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/database/DatabaseScheduleStoreManagerTest.java
@@ -207,20 +207,20 @@ public class DatabaseScheduleStoreManagerTest
             assertEquals(sched4.getId(), (long) schedStore.lockScheduleById(sched4.getId(), (store, schedule) -> schedule.getId()));
 
             List<Integer> lockedByRuntime1 = new ArrayList<>();
-            schedManager.lockReadySchedules(runTime1, (store, schedule) -> {
+            schedManager.lockReadySchedules(runTime1, 1, (store, schedule) -> {
                 lockedByRuntime1.add(schedule.getId());
             });
             assertEquals(ImmutableList.of(sched1.getId()), lockedByRuntime1);
 
             List<Integer> lockedByRuntime2 = new ArrayList<>();
-            schedManager.lockReadySchedules(runTime2, (store, schedule) -> {
+            schedManager.lockReadySchedules(runTime2, 1, (store, schedule) -> {
                 lockedByRuntime2.add(schedule.getId());
             });
             assertEquals(ImmutableList.of(sched3.getId(), sched4.getId()), lockedByRuntime2);
 
             // exception during lockReadySchedules
             try {
-                schedManager.lockReadySchedules(runTime2, (store, schedule) -> {
+                schedManager.lockReadySchedules(runTime2, 1, (store, schedule) -> {
                     throw new RuntimeException("processing " + schedule.getId());
                 });
                 fail();
@@ -238,7 +238,7 @@ public class DatabaseScheduleStoreManagerTest
             Instant schedTime4 = now.plusSeconds(40);
 
             try {
-                schedManager.lockReadySchedules(runTime2, (store, schedule) -> {
+                schedManager.lockReadySchedules(runTime2, 1, (store, schedule) -> {
                     if (schedule.getId() == sched3.getId()) {
                         throw new RuntimeException();
                     }
@@ -257,7 +257,7 @@ public class DatabaseScheduleStoreManagerTest
             }
 
             List<Integer> updated = new ArrayList<>();
-            schedManager.lockReadySchedules(runTime2, (store, schedule) -> {
+            schedManager.lockReadySchedules(runTime2, 1, (store, schedule) -> {
                 updated.add(schedule.getId());
                 try {
                     store.updateNextScheduleTimeAndLastSessionTime(schedule.getId(), ScheduleTime.of(schedTime4, runTime4), schedTime1);
@@ -332,7 +332,7 @@ public class DatabaseScheduleStoreManagerTest
             });
             {
                 List<Integer> ready = new ArrayList<>();
-                schedManager.lockReadySchedules(Instant.now(), (store, schedule) -> ready.add(schedule.getId()));
+                schedManager.lockReadySchedules(Instant.now(), 1, (store, schedule) -> ready.add(schedule.getId()));
                 assertThat(ready, containsInAnyOrder(sched1.getId(), sched2.getId()));
             }
 
@@ -343,7 +343,7 @@ public class DatabaseScheduleStoreManagerTest
             });
             {
                 List<Integer> ready = new ArrayList<>();
-                schedManager.lockReadySchedules(Instant.now(), (store, schedule) -> ready.add(schedule.getId()));
+                schedManager.lockReadySchedules(Instant.now(), 1, (store, schedule) -> ready.add(schedule.getId()));
                 assertThat(ready, contains(sched2.getId()));
             }
 
@@ -371,7 +371,7 @@ public class DatabaseScheduleStoreManagerTest
             });
             {
                 List<Integer> ready = new ArrayList<>();
-                schedManager.lockReadySchedules(Instant.now(), (store, schedule) -> ready.add(schedule.getId()));
+                schedManager.lockReadySchedules(Instant.now(), 1, (store, schedule) -> ready.add(schedule.getId()));
                 assertThat(ready, containsInAnyOrder(sched1.getId(), sched2.getId()));
             }
 
@@ -382,7 +382,7 @@ public class DatabaseScheduleStoreManagerTest
             });
             {
                 List<Integer> ready = new ArrayList<>();
-                schedManager.lockReadySchedules(Instant.now(), (store, schedule) -> ready.add(schedule.getId()));
+                schedManager.lockReadySchedules(Instant.now(), 1, (store, schedule) -> ready.add(schedule.getId()));
                 assertThat(ready, containsInAnyOrder(sched1.getId(), sched2.getId()));
             }
         });

--- a/digdag-core/src/test/java/io/digdag/core/schedule/ScheduleExecutorTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/schedule/ScheduleExecutorTest.java
@@ -113,10 +113,10 @@ public class ScheduleExecutorTest
         when(projectStoreManager.getWorkflowDetailsById(WORKFLOW_DEFINITION_ID)).thenReturn(workflowDefinition);
 
         doAnswer(invocation -> {
-            ScheduleStoreManager.ScheduleAction func = invocation.getArgumentAt(1, ScheduleStoreManager.ScheduleAction.class);
+            ScheduleStoreManager.ScheduleAction func = invocation.getArgumentAt(2, ScheduleStoreManager.ScheduleAction.class);
             func.schedule(scs, schedule);
             return null;
-        }).when(scheduleStoreManager).lockReadySchedules(any(Instant.class), 1, any(ScheduleStoreManager.ScheduleAction.class));
+        }).when(scheduleStoreManager).lockReadySchedules(any(Instant.class), eq(1), any(ScheduleStoreManager.ScheduleAction.class));
     }
 
     @Test
@@ -133,7 +133,7 @@ public class ScheduleExecutorTest
                 .thenReturn(ImmutableList.of(attempt));
 
         // Run the schedule executor...
-        scheduleExecutor.runSchedules(now);
+        scheduleExecutor.runScheduleOnce(now);
 
         // Verify that another attempt was not started
         verify(scheduleExecutor, never()).startSchedule(any(StoredSchedule.class), any(Scheduler.class), any(StoredWorkflowDefinitionWithProject.class));
@@ -155,7 +155,7 @@ public class ScheduleExecutorTest
                 .thenReturn(ImmutableList.of(attempt));
 
         // Run the schedule executor...
-        scheduleExecutor.runSchedules(now);
+        scheduleExecutor.runScheduleOnce(now);
 
         // Verify that another attempt was started
         verify(scheduleExecutor).startSchedule(any(StoredSchedule.class), any(Scheduler.class), any(StoredWorkflowDefinitionWithProject.class));

--- a/digdag-core/src/test/java/io/digdag/core/schedule/ScheduleExecutorTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/schedule/ScheduleExecutorTest.java
@@ -116,7 +116,7 @@ public class ScheduleExecutorTest
             ScheduleStoreManager.ScheduleAction func = invocation.getArgumentAt(1, ScheduleStoreManager.ScheduleAction.class);
             func.schedule(scs, schedule);
             return null;
-        }).when(scheduleStoreManager).lockReadySchedules(any(Instant.class), any(ScheduleStoreManager.ScheduleAction.class));
+        }).when(scheduleStoreManager).lockReadySchedules(any(Instant.class), 1, any(ScheduleStoreManager.ScheduleAction.class));
     }
 
     @Test


### PR DESCRIPTION
`DatabaseScheduleStoreManager#lockReadySchedules` had lisk of too often
deadlock because it may lock rows using SELECT ... FOR UPDATE without
ORDER BY.

In addition to it, lockReadySchedules was using two statements
(selecting id with FOR UPDATE and then selecting schedules joined with
workflow_definitions) because H2 database doesn't support SELECT ... FOR
UPDATE with JOIN. However, there is a possible risk of wrong scheduling
in case of a bug around transaction control and underlaying PostgreSQL
uses the default read committed transaction isolation level. Although
this never happens as long as updating schedules run in the same
transaction, it's better to select id and other columns in a single
statement in PostgreSQL.

`SKIP LOCKED` is available only from PostgreSQL 9.5. Digdag requires
PostgreSQL >= 9.5 already since
bcd590f9ccde7ba151b869aac2a141ef185512aa.