### PR TITLE
Take care of dollar signs in secrets values

### DIFF
--- a/digdag-plugin-utils/src/main/java/io/digdag/util/UserSecretTemplate.java
+++ b/digdag-plugin-utils/src/main/java/io/digdag/util/UserSecretTemplate.java
@@ -61,7 +61,8 @@ public class UserSecretTemplate
 
         Matcher m = pattern.matcher(source);
         while (m.find()) {
-            m.appendReplacement(sb, converter.apply(m));
+            m.appendReplacement(sb,
+                    Matcher.quoteReplacement(converter.apply(m)));
         }
         m.appendTail(sb);
 

--- a/digdag-plugin-utils/src/test/java/io/digdag/util/UserSecretTemplateTest.java
+++ b/digdag-plugin-utils/src/test/java/io/digdag/util/UserSecretTemplateTest.java
@@ -17,6 +17,8 @@ public class UserSecretTemplateTest
         assertThat(UserSecretTemplate.of("${}").format(key -> Optional.of("bar")), is("${}"));
         assertThat(UserSecretTemplate.of("${foo}").format(key -> Optional.of("bar")), is("${foo}"));
         assertThat(UserSecretTemplate.of("${secret:foo}").format(key -> Optional.of("bar")), is("bar"));
+        assertThat(UserSecretTemplate.of("${secret:foo}").format(key -> Optional.of("$b$a$r$")), is("$b$a$r$"));
+        assertThat(UserSecretTemplate.of("${secret:foo}").format(key -> Optional.of("\\$b\\$a\\$r\\$")), is("\\$b\\$a\\$r\\$"));
         assertThat(UserSecretTemplate.of("hello ${secret:foo} world").format(key -> Optional.of("bar")), is("hello bar world"));
         assertThat(UserSecretTemplate.of("hello ${secret:foo} world ${secret:bar}").format(key -> {
             switch (key) {

--- a/digdag-tests/src/test/java/acceptance/SecretsIT.java
+++ b/digdag-tests/src/test/java/acceptance/SecretsIT.java
@@ -246,8 +246,7 @@ public class SecretsIT
         assertThat(listedKeys2, containsInAnyOrder(key4, key5, key6, key7, key8));
     }
 
-    @Test
-    public void testUseProjectSecret()
+    private void testUseProjectSecret(String baseValue)
             throws Exception
     {
         startServer();
@@ -264,8 +263,8 @@ public class SecretsIT
         String key1 = "key1";
         String key2 = "key2";
 
-        String value1 = "value1";
-        String value2 = "value2";
+        String value1 = baseValue + "1";
+        String value2 = baseValue + "2";
 
         // Set secrets
         {
@@ -328,7 +327,28 @@ public class SecretsIT
     }
 
     @Test
-    public void testUseLocalSecret()
+    public void useProjectSecretWithNormalValue()
+            throws Exception
+    {
+        testUseProjectSecret("value");
+    }
+
+    @Test
+    public void useProjectSecretWithSymbolValue()
+            throws Exception
+    {
+        testUseProjectSecret("!#$%*+-=?@^_$");
+    }
+
+    @Test
+    public void useProjectSecretWithSymbolValueConsideringCompatibility()
+            throws Exception
+    {
+        testUseProjectSecret("!#\\$%*+-=?@^_\\$");
+    }
+
+    @Test
+    public void testUseProjectSecret()
             throws Exception
     {
         addWorkflow(projectDir, "acceptance/secrets/echo_secret.dig");


### PR DESCRIPTION
https://docs.oracle.com/javase/8/docs/api/java/util/regex/Matcher.html#appendReplacement-java.lang.StringBuffer-java.lang.String-

> A dollar sign ($) may be included as a literal in the replacement string by preceding it with a backslash (\$).

This change addresses it and also adds a few cases that an user is already using an escaped secrets value (e.g. `value\$1234`) and this change works well with the workaround.

Fix https://github.com/treasure-data/digdag/issues/687
