### PR TITLE
Add docs for params option in server mode

### DIFF
--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -299,6 +299,16 @@ Runs a digdag server. --memory or --database option is required. Examples:
 
   Example: ``--disable-executor-loop``
 
+:command:`-p, --param KEY=VALUE`
+  Add a session parameter (use multiple times to set many parameters) in KEY=VALUE syntax. This parameter is availabe using ``${...}`` syntax in the YAML file, or using language API.
+
+  Example: ``-p environment=staging``
+
+:command:`-P, --params-file PATH`
+  Read parameters from a YAML file. Nested parameter (like {mysql: {user: me}}) are accessible using "." syntax (like \${mysql.user}).
+
+  Example: ``-P params.dig``
+
 :command:`-c, --config PATH`
   Server configuration property path. See the followings for details.
 

--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -307,7 +307,7 @@ Runs a digdag server. --memory or --database option is required. Examples:
 :command:`-P, --params-file PATH`
   Read parameters from a YAML file. Nested parameter (like {mysql: {user: me}}) are accessible using "." syntax (like \${mysql.user}).
 
-  Example: ``-P params.dig``
+  Example: ``-P params.yml``
 
 :command:`-c, --config PATH`
   Server configuration property path. See the followings for details.


### PR DESCRIPTION
Hello.  
I added docs for params option in server mode. This is the useful options for users because we can set parameters that change for each environment.
