### PR TITLE
add log-server.local.compress property

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/client/ShowLog.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/ShowLog.java
@@ -56,7 +56,7 @@ public class ShowLog
         DigdagClient client = buildClient();
 
         LogLevel level = verbose ? null : LogLevel.INFO;
-        TaskLogWatcher watcher = new TaskLogWatcher(client, attemptId, level, out);
+        TaskLogWatcher watcher = new TaskLogWatcher(client, attemptId, level, out, isFinished(client, attemptId, taskName));
 
         update(client, watcher, attemptId, taskName);
 

--- a/digdag-cli/src/main/java/io/digdag/cli/client/ShowLog.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/ShowLog.java
@@ -56,7 +56,7 @@ public class ShowLog
         DigdagClient client = buildClient();
 
         LogLevel level = verbose ? null : LogLevel.INFO;
-        TaskLogWatcher watcher = new TaskLogWatcher(client, attemptId, level, out, isFinished(client, attemptId, taskName));
+        TaskLogWatcher watcher = new TaskLogWatcher(client, attemptId, level, out);
 
         update(client, watcher, attemptId, taskName);
 

--- a/digdag-core/src/main/java/io/digdag/core/log/AbstractFileLogServer.java
+++ b/digdag-core/src/main/java/io/digdag/core/log/AbstractFileLogServer.java
@@ -85,7 +85,8 @@ public abstract class AbstractFileLogServer
         List<LogFileHandle> handles = new ArrayList<>();
 
         listFiles(dateDir, attemptDir, (name, size, direct) -> {
-            if (name.endsWith(LogFiles.LOG_GZ_FILE_SUFFIX) && (!taskName.isPresent() || name.startsWith(taskName.get()))) {
+            if ((name.endsWith(LogFiles.LOG_GZ_FILE_SUFFIX) || name.endsWith(LogFiles.LOG_PLAIN_TEXT_FILE_SUFFIX)) &&
+                (!taskName.isPresent() || name.startsWith(taskName.get()))) {
                 LogFileHandle handle = LogFiles.buildLogFileHandleFromFileName(name, size);
                 if (handle != null) {
                     if (direct != null) {

--- a/digdag-core/src/main/java/io/digdag/core/log/LocalFileLogServerFactory.java
+++ b/digdag-core/src/main/java/io/digdag/core/log/LocalFileLogServerFactory.java
@@ -220,12 +220,12 @@ public class LocalFileLogServerFactory
 
                     if (realtimeFollow) {
                         // Delaying for deterrence duplicate output in digdag log --follow
-                        try {
-                            Thread.sleep(1000);
-                        }
-                        catch (InterruptedException ex) {
-                            Thread.currentThread().interrupt();
-                        }
+                        // try {
+                        //     Thread.sleep(1000);
+                        // }
+                        // catch (InterruptedException ex) {
+                        //     Thread.currentThread().interrupt();
+                        // }
 
                         try (InputStream in = Files.newInputStream(temporaryPath);
                              OutputStream out = new GZIPOutputStream(Files.newOutputStream(path, CREATE, APPEND), 16*1024)) {

--- a/digdag-core/src/main/java/io/digdag/core/log/LocalFileLogServerFactory.java
+++ b/digdag-core/src/main/java/io/digdag/core/log/LocalFileLogServerFactory.java
@@ -219,14 +219,6 @@ public class LocalFileLogServerFactory
                     output.close();
 
                     if (realtimeFollow) {
-                        // Delaying for deterrence duplicate output in digdag log --follow
-                        // try {
-                        //     Thread.sleep(1000);
-                        // }
-                        // catch (InterruptedException ex) {
-                        //     Thread.currentThread().interrupt();
-                        // }
-
                         try (InputStream in = Files.newInputStream(temporaryPath);
                              OutputStream out = new GZIPOutputStream(Files.newOutputStream(path, CREATE, APPEND), 16*1024)) {
                             ByteStreams.copy(in, out);

--- a/digdag-core/src/main/java/io/digdag/core/log/LocalFileLogServerFactory.java
+++ b/digdag-core/src/main/java/io/digdag/core/log/LocalFileLogServerFactory.java
@@ -137,7 +137,8 @@ public class LocalFileLogServerFactory
 
                         return byteOutput.toByteArray();
                     }
-                } else {
+                }
+                else {
                     return ByteStreams.toByteArray(in);
                 }
             }
@@ -187,7 +188,8 @@ public class LocalFileLogServerFactory
 
                 if (realtimeFollow) {
                     this.output = Files.newOutputStream(temporaryPath, CREATE, APPEND);
-                } else {
+                }
+                else {
                     this.output = new GZIPOutputStream(Files.newOutputStream(path, CREATE, APPEND), 16*1024);
                 }
             }
@@ -218,13 +220,18 @@ public class LocalFileLogServerFactory
 
                     if (realtimeFollow) {
                         // Delaying for deterrence duplicate output in digdag log --follow
-                        try { Thread.sleep(1000); }
-                        catch (InterruptedException ex) {}
+                        try {
+                            Thread.sleep(1000);
+                        }
+                        catch (InterruptedException ex) {
+                            Thread.currentThread().interrupt();
+                        }
 
                         try (InputStream in = Files.newInputStream(temporaryPath);
                              OutputStream out = new GZIPOutputStream(Files.newOutputStream(path, CREATE, APPEND), 16*1024)) {
                             ByteStreams.copy(in, out);
-                        } finally {
+                        }
+                        finally {
                             temporaryPath.toFile().delete();
                         }
                     }

--- a/digdag-core/src/main/java/io/digdag/core/log/LocalFileLogServerFactory.java
+++ b/digdag-core/src/main/java/io/digdag/core/log/LocalFileLogServerFactory.java
@@ -133,7 +133,7 @@ public class LocalFileLogServerFactory
                     try (ByteArrayOutputStream byteOutput = new ByteArrayOutputStream();
                          GZIPOutputStream gzipOutput = new GZIPOutputStream(byteOutput)) {
                         ByteStreams.copy(in, gzipOutput);
-                        gzipOutput.close();
+                        gzipOutput.finish();
 
                         return byteOutput.toByteArray();
                     }

--- a/digdag-core/src/main/java/io/digdag/core/log/LocalFileLogServerFactory.java
+++ b/digdag-core/src/main/java/io/digdag/core/log/LocalFileLogServerFactory.java
@@ -130,20 +130,13 @@ public class LocalFileLogServerFactory
             Path path = getPrefixDir(dateDir, attemptDir).resolve(fileName);
             try (InputStream in = Files.newInputStream(path)) {
                 if (path.toString().endsWith(LogFiles.LOG_PLAIN_TEXT_FILE_SUFFIX)) {
-                    ByteArrayOutputStream byteOutput = new ByteArrayOutputStream();
-                    GZIPOutputStream gzipOutput = new GZIPOutputStream(byteOutput);
-                    byte[] buffer = new byte[1024];
-                    while (true) {
-                        int len = in.read(buffer);
-                        if (len < 0) {
-                            break;
-                        }
-                        gzipOutput.write(buffer, 0, len);
-                    }
-                    byteOutput.close();
-                    gzipOutput.close();
+                    try (ByteArrayOutputStream byteOutput = new ByteArrayOutputStream();
+                         GZIPOutputStream gzipOutput = new GZIPOutputStream(byteOutput)) {
+                        ByteStreams.copy(in, gzipOutput);
+                        gzipOutput.close();
 
-                    return byteOutput.toByteArray();
+                        return byteOutput.toByteArray();
+                    }
                 } else {
                     return ByteStreams.toByteArray(in);
                 }

--- a/digdag-core/src/main/java/io/digdag/core/log/LocalFileLogServerFactory.java
+++ b/digdag-core/src/main/java/io/digdag/core/log/LocalFileLogServerFactory.java
@@ -231,13 +231,15 @@ public class LocalFileLogServerFactory
                              OutputStream out = new GZIPOutputStream(Files.newOutputStream(path, CREATE, APPEND), 16*1024)) {
                             ByteStreams.copy(in, out);
                         }
-                        finally {
-                            temporaryPath.toFile().delete();
-                        }
                     }
                 }
                 catch (IOException ex) {
                     throw Throwables.propagate(ex);
+                }
+                finally {
+                    if (realtimeFollow) {
+                        temporaryPath.toFile().delete();
+                    }
                 }
             }
         }

--- a/digdag-core/src/main/java/io/digdag/core/log/LocalFileLogServerFactory.java
+++ b/digdag-core/src/main/java/io/digdag/core/log/LocalFileLogServerFactory.java
@@ -128,7 +128,6 @@ public class LocalFileLogServerFactory
             throws StorageFileNotFoundException
         {
             Path path = getPrefixDir(dateDir, attemptDir).resolve(fileName);
-            System.out.println("fllowing => " + path);
             try (InputStream in = Files.newInputStream(path)) {
                 if (path.toString().endsWith(LogFiles.LOG_PLAIN_TEXT_FILE_SUFFIX)) {
                     try (ByteArrayOutputStream byteOutput = new ByteArrayOutputStream();

--- a/digdag-core/src/main/java/io/digdag/core/log/LogFiles.java
+++ b/digdag-core/src/main/java/io/digdag/core/log/LogFiles.java
@@ -28,6 +28,15 @@ public class LogFiles
     private static DateTimeFormatter SESSION_TIME_FORMATTER =
         DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmssxx", ENGLISH);
 
+    private static String formatFileNameWithSuffix(String taskName, Instant firstLogTime, String agentId, String suffix) {
+        return String.format(ENGLISH,
+                "%s@%08x%08x.%s",
+                taskName,
+                firstLogTime.getEpochSecond(),
+                firstLogTime.getNano(),
+                agentId) + suffix;
+    }
+
     public static String formatDataDir(LogFilePrefix prefix)
     {
         return CREATE_TIME_FORMATTER.format(prefix.getCreatedAt());
@@ -55,22 +64,12 @@ public class LogFiles
 
     public static String formatFileName(String taskName, Instant firstLogTime, String agentId)
     {
-        return String.format(ENGLISH,
-                "%s@%08x%08x.%s",
-                taskName,
-                firstLogTime.getEpochSecond(),
-                firstLogTime.getNano(),
-                agentId) + LOG_GZ_FILE_SUFFIX;
+        return formatFileNameWithSuffix(taskName, firstLogTime, agentId, LOG_GZ_FILE_SUFFIX);
     }
 
     public static String formatPlainTextFileName(String taskName, Instant firstLogTime, String agentId)
     {
-        return String.format(ENGLISH,
-                "%s@%08x%08x.%s",
-                taskName,
-                firstLogTime.getEpochSecond(),
-                firstLogTime.getNano(),
-                agentId) + LOG_PLAIN_TEXT_FILE_SUFFIX;
+        return formatFileNameWithSuffix(taskName, firstLogTime, agentId, LOG_PLAIN_TEXT_FILE_SUFFIX);
     }
 
     public static LogFileHandle buildLogFileHandleFromFileName(String fileName, long fileSize)

--- a/digdag-core/src/main/java/io/digdag/core/log/LogFiles.java
+++ b/digdag-core/src/main/java/io/digdag/core/log/LogFiles.java
@@ -18,6 +18,7 @@ public class LogFiles
     { }
 
     public static final String LOG_GZ_FILE_SUFFIX = ".log.gz";
+    public static final String LOG_PLAIN_TEXT_FILE_SUFFIX = ".log";
 
     private static DateTimeFormatter CREATE_TIME_FORMATTER =
         DateTimeFormatter.ofPattern("yyyy-MM-dd", ENGLISH)
@@ -60,6 +61,16 @@ public class LogFiles
                 firstLogTime.getEpochSecond(),
                 firstLogTime.getNano(),
                 agentId) + LOG_GZ_FILE_SUFFIX;
+    }
+
+    public static String formatPlainTextFileName(String taskName, Instant firstLogTime, String agentId)
+    {
+        return String.format(ENGLISH,
+                "%s@%08x%08x.%s",
+                taskName,
+                firstLogTime.getEpochSecond(),
+                firstLogTime.getNano(),
+                agentId) + LOG_PLAIN_TEXT_FILE_SUFFIX;
     }
 
     public static LogFileHandle buildLogFileHandleFromFileName(String fileName, long fileSize)

--- a/digdag-core/src/main/java/io/digdag/core/log/LogFiles.java
+++ b/digdag-core/src/main/java/io/digdag/core/log/LogFiles.java
@@ -28,7 +28,8 @@ public class LogFiles
     private static DateTimeFormatter SESSION_TIME_FORMATTER =
         DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmssxx", ENGLISH);
 
-    private static String formatFileNameWithSuffix(String taskName, Instant firstLogTime, String agentId, String suffix) {
+    private static String formatFileNameWithSuffix(String taskName, Instant firstLogTime, String agentId, String suffix)
+    {
         return String.format(ENGLISH,
                 "%s@%08x%08x.%s",
                 taskName,


### PR DESCRIPTION
I added log-server.local.compress that for disable/enable to log compress (by gzip).
Set to the option true (default), task logs will compress as usual.
Set to the option false, task logs will keep plain text format. And then, we can read logs task in progress in realtime.

I think read logs as realtime is important some casesm such as so long time tasks.