### PR TITLE
Skip checking of locked task to avoid lock contention leading long wait

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/session/SessionStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/session/SessionStoreManager.java
@@ -69,11 +69,13 @@ public interface SessionStoreManager
         T call(TaskControlStore lockedTask, StoredTask storedTask);
     }
 
-    // overload for polling
     <T> Optional<T> lockTaskIfExists(long taskId, TaskLockAction<T> func);
 
-    // overload for taskFinished
+    <T> Optional<T> lockTaskIfNotLocked(long taskId, TaskLockAction<T> func);
+
     <T> Optional<T> lockTaskIfExists(long taskId, TaskLockActionWithDetails<T> func);
+
+    <T> Optional<T> lockTaskIfNotLocked(long taskId, TaskLockActionWithDetails<T> func);
 
     interface SessionMonitorAction
     {


### PR DESCRIPTION
`pg_stat_statements` shows that `select id from tasks where id = $1 for
update` is the most frequently called statement and its max execution
time is occasionally more than 1 second while mean execution time is
less than 1 millisecond. This suggests that FOR UPDATE is blocked due to
lock contention and blocking WorflowExecutor loop for long time. This
leads unexpected delay of workflow execution.

```
digdag_production=> select now(), pg_stat_statements_reset();
              now              | pg_stat_statements_reset
-------------------------------+--------------------------
 2017-12-20 23:03:16.567576+00 |
(1 row)

digdag_production=> select now(), substr(query, 0, 100) as query,calls,total_time,mean_time,min_time,max_time FROM pg_stat_statements where query like '%tasks%' ORDER BY total_time DESC LIMIT 10;
              now              |                                                query                                                | calls |    total_time    |     mean_time      | min_time | max_time
-------------------------------+-----------------------------------------------------------------------------------------------------+-------+------------------+--------------------+----------+----------
 2017-12-20 23:03:26.506733+00 | select id from tasks where id = $1 for update                                                       |  4482 | 1416.68899999996 |  0.316084114234718 |    0.009 | 1332.793
 2017-12-20 23:03:26.506733+00 | select t.*, td.full_name, td.local_config, td.export_config, (select array_to_string(array_agg(upst |  2420 | 73.5460000000005 | 0.0303909090909091 |     0.02 |    0.179
 2017-12-20 23:03:26.506733+00 | select id from tasks where parent_id = $1 and (state in (?, ?, ?, ?, ?) or (state = ? and not exist |  2353 | 62.0500000000005 | 0.0263705907352316 |    0.008 |    0.211
 2017-12-20 23:03:26.506733+00 | update tasks set updated_at = now(), state = case when task_type = ? then ? when state_flags & ? != |  2062 | 49.7250000000001 | 0.0241149369544132 |    0.008 |    0.366
 2017-12-20 23:03:26.506733+00 | select lock_shared_tasks($1, $2, $3, $4, $5)                                                        |    47 |           18.023 |  0.383468085106383 |    0.013 |    3.017
 2017-12-20 23:03:26.506733+00 | update tasks set updated_at = now(), retry_at = ?, state = ? where state in (?,?) and retry_at <= n |    14 |            9.357 |  0.668357142857143 |    0.456 |    1.154
 2017-12-20 23:03:26.506733+00 | select distinct parent_id from tasks where parent_id > $1 and state = ? order by parent_id limit $2 |    44 |            6.135 |  0.139431818181818 |    0.004 |    0.977
 2017-12-20 23:03:26.506733+00 | select t.*, td.full_name, td.local_config, td.export_config, td.resuming_task_id, ts.subtask_config |     5 |            2.744 |             0.5488 |    0.006 |    2.715
 2017-12-20 23:03:26.506733+00 | select id, parent_id, (select array_to_string(array_agg(upstream_id), ?) from task_dependencies whe |    20 |            2.192 |             0.1096 |    0.021 |    0.713
 2017-12-20 23:03:26.506733+00 | select id from tasks where state = $1 and id > $2 order by id asc limit $3                          |    44 |            2.068 |              0.047 |    0.004 |    0.115
(10 rows)
```

This explains that locking a task happened 4482 times within 10 seconds and some
of them took 1332 milliseconds. Because mean_time is short, most likely cause is lock
contention.

This mitigates the problem by changing the repeating status check
methods (propagateBlockedChildrenToReady, propagateAllPlannedToDone,
and enqueueReadyTasks) to skip tasks if one is locked by another process.
They are safe to skip matching tasks because they're repeated anyways.