### PR TITLE
TransactionManager.autoCommit for submodules that may or may not nested

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/database/ThreadLocalTransactionManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/ThreadLocalTransactionManager.java
@@ -23,6 +23,7 @@ public class ThreadLocalTransactionManager
     private static final Logger logger = LoggerFactory.getLogger(TransactionManager.class);
 
     private final ThreadLocal<Transaction> threadLocalTransaction = new ThreadLocal<>();
+    private final ThreadLocal<Transaction> threadLocalAutoCommitTransaction = new ThreadLocal<>();
     private final DataSource ds;
 
     private static class LazyTransaction
@@ -46,9 +47,6 @@ public class ThreadLocalTransactionManager
             this(ds, false);
         }
 
-        //
-        // DO NOT USE autoAutoCommit IN main CODE.
-        //
         LazyTransaction(DataSource ds, boolean autoAutoCommit)
         {
             this.ds = checkNotNull(ds);
@@ -209,7 +207,10 @@ public class ThreadLocalTransactionManager
     {
         Transaction transaction = threadLocalTransaction.get();
         if (transaction == null) {
-            throw new IllegalStateException("Not in transaction");
+            transaction = threadLocalAutoCommitTransaction.get();
+            if (transaction == null) {
+                throw new IllegalStateException("Not in transaction");
+            }
         }
         return transaction.getHandle(configMapper);
     }
@@ -272,43 +273,52 @@ public class ThreadLocalTransactionManager
     }
 
     @Override
-    public <T> T beginOrReuse(SupplierInTransaction<T, RuntimeException, RuntimeException, RuntimeException> func)
+    public <T> T autoCommit(SupplierInTransaction<T, RuntimeException, RuntimeException, RuntimeException> func)
     {
-        return beginOrReuse(func, RuntimeException.class, RuntimeException.class, RuntimeException.class);
+        return autoCommit(func, RuntimeException.class, RuntimeException.class, RuntimeException.class);
     }
 
     @Override
-    public <T, E1 extends Exception> T beginOrReuse(SupplierInTransaction<T, E1, RuntimeException, RuntimeException> func, Class<E1> e1)
+    public <T, E1 extends Exception> T autoCommit(SupplierInTransaction<T, E1, RuntimeException, RuntimeException> func, Class<E1> e1)
             throws E1
     {
-        return beginOrReuse(func, e1, RuntimeException.class, RuntimeException.class);
+        return autoCommit(func, e1, RuntimeException.class, RuntimeException.class);
     }
 
     @Override
     public <T, E1 extends Exception, E2 extends Exception>
-    T beginOrReuse(SupplierInTransaction<T, E1, E2, RuntimeException> func, Class<E1> e1, Class<E2> e2)
+    T autoCommit(SupplierInTransaction<T, E1, E2, RuntimeException> func, Class<E1> e1, Class<E2> e2)
             throws E1, E2
     {
-        return beginOrReuse(func, e1, e2, RuntimeException.class);
+        return autoCommit(func, e1, e2, RuntimeException.class);
     }
 
+    @Override
     public <T, E1 extends Exception, E2 extends Exception, E3 extends Exception>
-    T beginOrReuse(SupplierInTransaction<T, E1, E2, E3> func, Class<E1> e1, Class<E2> e2, Class<E3> e3)
+    T autoCommit(SupplierInTransaction<T, E1, E2, E3> func, Class<E1> e1, Class<E2> e2, Class<E3> e3)
             throws E1, E2, E3
     {
-        if (threadLocalTransaction.get() != null) {
-            try {
+        try {
+            if (threadLocalTransaction.get() != null) {
                 return func.get();
             }
-            catch (Exception e) {
-                Throwables.propagateIfInstanceOf(e, e1);
-                Throwables.propagateIfInstanceOf(e, e2);
-                Throwables.propagateIfInstanceOf(e, e3);
-                throw Throwables.propagate(e);
+            else {
+                LazyTransaction transaction = new LazyTransaction(ds, true);
+                threadLocalAutoCommitTransaction.set(transaction);
+                try {
+                    return func.get();
+                }
+                finally {
+                    threadLocalAutoCommitTransaction.set(null);
+                    transaction.close();
+                }
             }
         }
-        else {
-            return begin(func, e1, e2, e3);
+        catch (Exception e) {
+            Throwables.propagateIfInstanceOf(e, e1);
+            Throwables.propagateIfInstanceOf(e, e2);
+            Throwables.propagateIfInstanceOf(e, e3);
+            throw Throwables.propagate(e);
         }
     }
 
@@ -320,36 +330,5 @@ public class ThreadLocalTransactionManager
             throw new IllegalStateException("Not in transaction");
         }
         transaction.reset();
-    }
-
-    @Override
-    public <T> T autoCommit(SupplierInTransaction<T, RuntimeException, RuntimeException, RuntimeException> func)
-    {
-        return autoCommit(func, RuntimeException.class);
-    }
-
-    @Override
-    public <T, E1 extends Exception> T autoCommit(SupplierInTransaction<T, E1, RuntimeException, RuntimeException> func, Class<E1> e1)
-            throws E1
-    {
-        if (threadLocalTransaction.get() != null) {
-            throw new IllegalStateException("Nested transaction is not allowed: " + threadLocalTransaction.get());
-        }
-
-        try {
-            LazyTransaction transaction = new LazyTransaction(ds, true);
-            threadLocalTransaction.set(transaction);
-            try {
-                return func.get();
-            }
-            finally {
-                threadLocalTransaction.set(null);
-                transaction.close();
-            }
-        }
-        catch (Exception e) {
-            Throwables.propagateIfInstanceOf(e, e1);
-            throw Throwables.propagate(e);
-        }
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/database/ThreadLocalTransactionManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/ThreadLocalTransactionManager.java
@@ -272,6 +272,47 @@ public class ThreadLocalTransactionManager
     }
 
     @Override
+    public <T> T beginOrReuse(SupplierInTransaction<T, RuntimeException, RuntimeException, RuntimeException> func)
+    {
+        return beginOrReuse(func, RuntimeException.class, RuntimeException.class, RuntimeException.class);
+    }
+
+    @Override
+    public <T, E1 extends Exception> T beginOrReuse(SupplierInTransaction<T, E1, RuntimeException, RuntimeException> func, Class<E1> e1)
+            throws E1
+    {
+        return beginOrReuse(func, e1, RuntimeException.class, RuntimeException.class);
+    }
+
+    @Override
+    public <T, E1 extends Exception, E2 extends Exception>
+    T beginOrReuse(SupplierInTransaction<T, E1, E2, RuntimeException> func, Class<E1> e1, Class<E2> e2)
+            throws E1, E2
+    {
+        return beginOrReuse(func, e1, e2, RuntimeException.class);
+    }
+
+    public <T, E1 extends Exception, E2 extends Exception, E3 extends Exception>
+    T beginOrReuse(SupplierInTransaction<T, E1, E2, E3> func, Class<E1> e1, Class<E2> e2, Class<E3> e3)
+            throws E1, E2, E3
+    {
+        if (threadLocalTransaction.get() != null) {
+            try {
+                return func.get();
+            }
+            catch (Exception e) {
+                Throwables.propagateIfInstanceOf(e, e1);
+                Throwables.propagateIfInstanceOf(e, e2);
+                Throwables.propagateIfInstanceOf(e, e3);
+                throw Throwables.propagate(e);
+            }
+        }
+        else {
+            return begin(func, e1, e2, e3);
+        }
+    }
+
+    @Override
     public void reset()
     {
         Transaction transaction = threadLocalTransaction.get();

--- a/digdag-core/src/main/java/io/digdag/core/database/TransactionManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/TransactionManager.java
@@ -36,6 +36,32 @@ public interface TransactionManager
         throws E1, E2, E3;
 
     /**
+     * Create a new transaction and set it as the current transaction object, or get current transaction object.
+     */
+    <T> T beginOrReuse(SupplierInTransaction<T, RuntimeException, RuntimeException, RuntimeException> func);
+
+    /**
+     * Create a new transaction and set it as the current transaction object, or get current transaction object.
+     */
+    <T, E1 extends Exception> T beginOrReuse(
+            SupplierInTransaction<T, E1, RuntimeException, RuntimeException> func, Class<E1> e1)
+        throws E1;
+
+    /**
+     * Create a new transaction and set it as the current transaction object, or get current transaction object.
+     */
+    <T, E1 extends Exception, E2 extends Exception> T beginOrReuse(
+            SupplierInTransaction<T, E1, E2, RuntimeException> func, Class<E1> e1, Class<E2> e2)
+        throws E1, E2;
+
+    /**
+     * Create a new transaction and set it as the current transaction object, or get current transaction object.
+     */
+    <T, E1 extends Exception, E2 extends Exception, E3 extends Exception> T beginOrReuse(
+            SupplierInTransaction<T, E1, E2, E3> func, Class<E1> e1, Class<E2> e2, Class<E3> e3)
+        throws E1, E2, E3;
+
+    /**
      * Abort the current transaction and start a new transaction again.
      */
     void reset();

--- a/digdag-core/src/main/java/io/digdag/core/database/TransactionManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/TransactionManager.java
@@ -36,28 +36,28 @@ public interface TransactionManager
         throws E1, E2, E3;
 
     /**
-     * Create a new transaction and set it as the current transaction object, or get current transaction object.
+     * Get the current transaction object if exists, otherwise uses a temporary transaction object with auto-commit mode.
      */
-    <T> T beginOrReuse(SupplierInTransaction<T, RuntimeException, RuntimeException, RuntimeException> func);
+    <T> T autoCommit(SupplierInTransaction<T, RuntimeException, RuntimeException, RuntimeException> func);
 
     /**
-     * Create a new transaction and set it as the current transaction object, or get current transaction object.
+     * Get the current transaction object if exists, otherwise uses a temporary transaction object with auto-commit mode.
      */
-    <T, E1 extends Exception> T beginOrReuse(
+    <T, E1 extends Exception> T autoCommit(
             SupplierInTransaction<T, E1, RuntimeException, RuntimeException> func, Class<E1> e1)
         throws E1;
 
     /**
-     * Create a new transaction and set it as the current transaction object, or get current transaction object.
+     * Get the current transaction object if exists, otherwise uses a temporary transaction object with auto-commit mode.
      */
-    <T, E1 extends Exception, E2 extends Exception> T beginOrReuse(
+    <T, E1 extends Exception, E2 extends Exception> T autoCommit(
             SupplierInTransaction<T, E1, E2, RuntimeException> func, Class<E1> e1, Class<E2> e2)
         throws E1, E2;
 
     /**
-     * Create a new transaction and set it as the current transaction object, or get current transaction object.
+     * Get the current transaction object if exists, otherwise uses a temporary transaction object with auto-commit mode.
      */
-    <T, E1 extends Exception, E2 extends Exception, E3 extends Exception> T beginOrReuse(
+    <T, E1 extends Exception, E2 extends Exception, E3 extends Exception> T autoCommit(
             SupplierInTransaction<T, E1, E2, E3> func, Class<E1> e1, Class<E2> e2, Class<E3> e3)
         throws E1, E2, E3;
 
@@ -65,18 +65,6 @@ public interface TransactionManager
      * Abort the current transaction and start a new transaction again.
      */
     void reset();
-
-    /**
-     * Enable auto commit for testing purpose.
-     */
-    <T> T autoCommit(SupplierInTransaction<T, RuntimeException, RuntimeException, RuntimeException> func);
-
-    /**
-     * Enable auto commit for testing purpose.
-     */
-    <T, E1 extends Exception> T autoCommit(
-            SupplierInTransaction<T, E1, RuntimeException, RuntimeException> func, Class<E1> e1)
-        throws E1;
 
     @FunctionalInterface
     interface SupplierInTransaction<T, E1 extends Exception, E2 extends Exception, E3 extends Exception>

--- a/digdag-core/src/test/java/io/digdag/core/database/ThreadLocalTransactionManagerTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/database/ThreadLocalTransactionManagerTest.java
@@ -1,0 +1,108 @@
+package io.digdag.core.database;
+
+import io.digdag.core.repository.Project;
+import io.digdag.core.repository.ProjectStore;
+import io.digdag.core.repository.ResourceConflictException;
+import io.digdag.core.repository.ResourceNotFoundException;
+import io.digdag.core.repository.StoredProject;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
+public class ThreadLocalTransactionManagerTest
+{
+    private DatabaseFactory factory;
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        factory = DatabaseTestingUtils.setupDatabase();
+    }
+
+    @Test
+    public void nestedTransactionIsNotAllowed()
+            throws Exception
+    {
+        exception.expectMessage(containsString("Nested transaction is not allowed"));
+        exception.expect(IllegalStateException.class);
+        factory.get().begin(() -> {
+            return factory.get().begin(() -> {
+                fail();
+                return null;
+            });
+        });
+    }
+
+    @Test
+    public void reuseTransaction()
+            throws Exception
+    {
+        Project proj1 = Project.of("proj1");
+
+        factory.get().<Void, ResourceNotFoundException, ResourceConflictException>begin(() -> {
+            factory.get().beginOrReuse(() -> {
+                factory.getProjectStoreManager().getProjectStore(0)
+                    .putAndLockProject(proj1, (store, stored) -> stored);
+                return null;
+            }, ResourceConflictException.class);
+
+            // This transaction can read the stored project
+            StoredProject proj2 = factory.getProjectStoreManager().getProjectStore(0)
+                .getProjectByName("proj1");
+            assertThat(proj2, is(notNullValue()));
+
+            // Another transaction can't read it until committed
+            try {
+                StoredProject proj3 = CompletableFuture.supplyAsync(() -> {
+                    return factory.get().beginOrReuse(() -> {
+                        try {
+                            return factory.getProjectStoreManager().getProjectStore(0)
+                                .getProjectByName("proj1");
+                        }
+                        catch (ResourceNotFoundException ex) {
+                            return null;
+                        }
+                    });
+                }).get();
+                assertThat(proj3, is(nullValue()));
+            }
+            catch (ExecutionException | InterruptedException ex) {
+                assertThat(ex, is(nullValue()));
+            }
+
+            return null;
+        }, ResourceNotFoundException.class, ResourceConflictException.class);
+
+        // Another transaction can read after commit
+        try {
+            StoredProject proj4 = CompletableFuture.supplyAsync(() -> {
+                return factory.get().beginOrReuse(() -> {
+                    try {
+                        return factory.getProjectStoreManager().getProjectStore(0)
+                            .getProjectByName("proj1");
+                    }
+                    catch (ResourceNotFoundException ex) {
+                        return null;
+                    }
+                });
+            }).get();
+            assertThat(proj4, is(notNullValue()));
+        }
+        catch (ExecutionException | InterruptedException ex) {
+            assertThat(ex, is(nullValue()));
+        }
+    }
+}

--- a/digdag-core/src/test/java/io/digdag/core/database/ThreadLocalTransactionManagerTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/database/ThreadLocalTransactionManagerTest.java
@@ -53,7 +53,7 @@ public class ThreadLocalTransactionManagerTest
         Project proj1 = Project.of("proj1");
 
         factory.get().<Void, ResourceNotFoundException, ResourceConflictException>begin(() -> {
-            factory.get().beginOrReuse(() -> {
+            factory.get().autoCommit(() -> {
                 factory.getProjectStoreManager().getProjectStore(0)
                     .putAndLockProject(proj1, (store, stored) -> stored);
                 return null;
@@ -67,7 +67,7 @@ public class ThreadLocalTransactionManagerTest
             // Another transaction can't read it until committed
             try {
                 StoredProject proj3 = CompletableFuture.supplyAsync(() -> {
-                    return factory.get().beginOrReuse(() -> {
+                    return factory.get().autoCommit(() -> {
                         try {
                             return factory.getProjectStoreManager().getProjectStore(0)
                                 .getProjectByName("proj1");
@@ -89,7 +89,7 @@ public class ThreadLocalTransactionManagerTest
         // Another transaction can read after commit
         try {
             StoredProject proj4 = CompletableFuture.supplyAsync(() -> {
-                return factory.get().beginOrReuse(() -> {
+                return factory.get().autoCommit(() -> {
                     try {
                         return factory.getProjectStoreManager().getProjectStore(0)
                             .getProjectByName("proj1");


### PR DESCRIPTION
Following-up of #635.

One thing we found is that transaction doesn't match well with
object-oriented programming because it always causes layer violation.

Idea here is making it possible to ignore about transactions when
transaction is unnecessary. In fact, most of cases don't need
transactions.

The new autoCommit method is allowed in nested way. All of following
code is valid:

```
autoCommit(() -> autoCommit(() -> ...))  // keeps auto commit mode
begin(() -> autoCommit(() -> ...))  // outer starts a transaction, inner shares it
autoCommit(() -> begin(() -> ...))  // outer runs as auto commit, inner starts a transaction
```
