### PR TITLE
[WIP] Prefer use of auto commit if transaction is unnecessary

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSecretStore.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSecretStore.java
@@ -33,7 +33,7 @@ class DatabaseSecretStore
     public Optional<String> getSecret(int projectId, String scope, String key)
     {
         EncryptedSecret secret =
-                tm.begin(() -> autoCommit((handle, dao) -> dao.getProjectSecret(siteId, projectId, scope, key)));
+                tm.autoCommit(() -> autoCommit((handle, dao) -> dao.getProjectSecret(siteId, projectId, scope, key)));
 
         if (secret == null) {
             return Optional.absent();

--- a/digdag-core/src/test/java/io/digdag/core/workflow/WorkflowTestingUtils.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/WorkflowTestingUtils.java
@@ -110,7 +110,8 @@ public class WorkflowTestingUtils
                 submitWorkflow(embed.getLocalSite(), projectPath, workflowName, config), Exception.class
             );
             embed.getLocalSite().runUntilDone(attempt.getId());
-            return tm.begin(() -> embed.getLocalSite().getSessionStore().getAttemptById(attempt.getId()),
+            return tm.autoCommit(
+                    () -> embed.getLocalSite().getSessionStore().getAttemptById(attempt.getId()),
                     ResourceNotFoundException.class);
         }
         catch (ResourceNotFoundException | ResourceConflictException | ResourceLimitExceededException ex) {

--- a/digdag-server/src/main/java/io/digdag/server/WorkflowExecutionTimeoutEnforcer.java
+++ b/digdag-server/src/main/java/io/digdag/server/WorkflowExecutionTimeoutEnforcer.java
@@ -123,7 +123,7 @@ public class WorkflowExecutionTimeoutEnforcer
 
     private void enforceAttemptTTLs()
     {
-        List<StoredSessionAttempt> expiredAttempts = tm.begin(() -> {
+        List<StoredSessionAttempt> expiredAttempts = tm.autoCommit(() -> {
             Instant creationDeadline = ssm.getStoreTime().minus(attemptTTL);
             return ssm.findActiveAttemptsCreatedBefore(creationDeadline, (long) 0, 100);
         });
@@ -162,7 +162,7 @@ public class WorkflowExecutionTimeoutEnforcer
 
     private void enforceTaskTTLs()
     {
-        List<TaskAttemptSummary> expiredTasks = tm.begin(() -> {
+        List<TaskAttemptSummary> expiredTasks = tm.autoCommit(() -> {
             Instant startDeadline = ssm.getStoreTime().minus(taskTTL);
             return ssm.findTasksStartedBeforeWithState(TASK_TTL_ENFORCED_STATE_CODES, startDeadline, (long) 0, 100);
         });


### PR DESCRIPTION
Use of transaction increases potential risk of nested transaction or
not-in-transaction issues. autoCommit can avoid it.