### PR TITLE
Add doc timeout parameters to Redshift operator

### DIFF
--- a/digdag-docs/src/operators/redshift.md
+++ b/digdag-docs/src/operators/redshift.md
@@ -199,3 +199,23 @@ _export:
   ```
   status_table: customized_status_table
   ```
+
+* **connect_timeout**: NAME
+
+  The timeout value used for socket connect operations. If connecting to the server takes longer than this value, the connection is broken. *Default*: `30`.
+
+  Examples:
+
+  ```
+  connect_timeout: 30
+  ```
+  
+* **socket_timeout**: NAME
+
+  The timeout value used for socket read operations. If reading from the server takes longer than this value, the connection is closed. *Default*: `1800`.
+
+  Examples:
+
+  ```
+  socket_timeout: 1800
+  ```


### PR DESCRIPTION
The parameters are defined as below.
https://github.com/treasure-data/digdag/blob/ffdc96fbace271c38b67734f4e3dfdd0f2401582/digdag-standards/src/main/java/io/digdag/standards/operator/redshift/RedshiftConnectionConfig.java#L31-L32