### PR TITLE
Cache opened Storage to reuse S3 threads

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/storage/ArchiveManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/storage/ArchiveManager.java
@@ -86,9 +86,9 @@ public class ArchiveManager
             .build(
                     new CacheLoader<ArchiveType, Storage>()
                     {
-                        public Storage load(ArchiveType key)
+                        public Storage load(ArchiveType type)
                         {
-                            return openStorage(key);
+                            return openStorage(type);
                         }
                     });
         this.systemConfig = systemConfig;


### PR DESCRIPTION
OperatorManager calls ArchiveManager.openArchive through TaskCallbackApi
every time when a task starts. But because ArchiveManager.openArchive
doesn't cache opened Storage, it recreates Storage instance every time.
It ends up instantiating S3Storage every time. This overhead is big
because S3Storage creates ExecutorService for TransferManager.