### PR TITLE
Add support for pool_name to td job operators

### DIFF
--- a/digdag-docs/src/operators/td.md
+++ b/digdag-docs/src/operators/td.md
@@ -183,6 +183,16 @@
     path: /endpoint
   ```
 
+* **pool_name**: NAME
+
+  Name of a resource pool to run the query in.
+
+  Examples:
+
+  ```
+  engine: poc
+  ```
+
 
 ## Output parameters
 

--- a/digdag-docs/src/operators/td.md
+++ b/digdag-docs/src/operators/td.md
@@ -190,7 +190,7 @@
   Examples:
 
   ```
-  engine: poc
+  pool_name: poc
   ```
 
 

--- a/digdag-docs/src/operators/td_for_each.md
+++ b/digdag-docs/src/operators/td_for_each.md
@@ -77,7 +77,7 @@ For example, if you run a query `select email, name from users` and the query re
   Examples:
 
   ```
-  engine: poc
+  pool_name: poc
   ```
 
 ## Output parameters

--- a/digdag-docs/src/operators/td_for_each.md
+++ b/digdag-docs/src/operators/td_for_each.md
@@ -70,6 +70,16 @@ For example, if you run a query `select email, name from users` and the query re
 
   Set Priority (From `-2` (VERY LOW) to `2` (VERY HIGH) , default: 0 (NORMAL)).
 
+* **pool_name**: NAME
+
+  Name of a resource pool to run the query in.
+
+  Examples:
+
+  ```
+  engine: poc
+  ```
+
 ## Output parameters
 
 * **td.last_job_id**

--- a/digdag-docs/src/operators/td_wait.md
+++ b/digdag-docs/src/operators/td_wait.md
@@ -72,6 +72,16 @@ Example queries:
 
   Set Priority (From `-2` (VERY LOW) to `2` (VERY HIGH) , default: 0 (NORMAL)).
 
+* **pool_name**: NAME
+
+  Name of a resource pool to run the queries in.
+
+  Examples:
+
+  ```
+  engine: poc
+  ```
+
 ## Output parameters
 
 * **td.last_job_id**

--- a/digdag-docs/src/operators/td_wait.md
+++ b/digdag-docs/src/operators/td_wait.md
@@ -79,7 +79,7 @@ Example queries:
   Examples:
 
   ```
-  engine: poc
+  pool_name: poc
   ```
 
 ## Output parameters

--- a/digdag-docs/src/operators/td_wait_table.md
+++ b/digdag-docs/src/operators/td_wait_table.md
@@ -83,5 +83,5 @@
   Examples:
 
   ```
-  engine: poc
+  pool_name: poc
   ```

--- a/digdag-docs/src/operators/td_wait_table.md
+++ b/digdag-docs/src/operators/td_wait_table.md
@@ -76,3 +76,12 @@
 
   Set Priority (From `-2` (VERY LOW) to `2` (VERY HIGH) , default: 0 (NORMAL)).
 
+* **pool_name**: NAME
+
+  Name of a resource pool to run the queries in.
+
+  Examples:
+
+  ```
+  engine: poc
+  ```

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdForEachOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdForEachOperatorFactory.java
@@ -1,5 +1,6 @@
 package io.digdag.standards.operator.td;
 
+import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.treasuredata.client.model.TDJobRequest;
 import com.treasuredata.client.model.TDJobRequestBuilder;
@@ -67,6 +68,7 @@ public class TdForEachOperatorFactory
         private final int priority;
         private final int jobRetry;
         private final String engine;
+        private final Optional<String> poolName;
 
         private final Config doConfig;
 
@@ -80,6 +82,7 @@ public class TdForEachOperatorFactory
             this.priority = params.get("priority", int.class, 0);  // TODO this should accept string (VERY_LOW, LOW, NORMAL, HIGH VERY_HIGH)
             this.jobRetry = params.get("job_retry", int.class, 0);
             this.engine = params.get("engine", String.class, "presto");
+            this.poolName = params.getOptional("pool_name", String.class);
             this.doConfig = request.getConfig().getNested("_do");
         }
 
@@ -121,6 +124,7 @@ public class TdForEachOperatorFactory
                     .setQuery(query)
                     .setRetryLimit(jobRetry)
                     .setPriority(priority)
+                    .setPoolName(poolName.orNull())
                     .setDomainKey(domainkey)
                     .setScheduledTime(request.getSessionTime().getEpochSecond())
                     .createTDJobRequest();

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdOperatorFactory.java
@@ -95,6 +95,7 @@ public class TdOperatorFactory
         private final Optional<UserSecretTemplate> resultUrl;
         private final int jobRetry;
         private final String engine;
+        private final Optional<String> poolName;
         private final Optional<String> downloadFile;
         private final Optional<String> resultConnection;
         private final Optional<Config> resultSettings;
@@ -122,6 +123,7 @@ public class TdOperatorFactory
             this.jobRetry = params.get("job_retry", int.class, 0);
 
             this.engine = params.get("engine", String.class, "presto");
+            this.poolName = params.getOptional("pool_name", String.class);
 
             this.downloadFile = params.getOptional("download_file", String.class);
             if (downloadFile.isPresent() && (insertInto.isPresent() || createTable.isPresent())) {
@@ -217,6 +219,7 @@ public class TdOperatorFactory
                     .setQuery(stmt)
                     .setRetryLimit(jobRetry)
                     .setPriority(priority)
+                    .setPoolName(poolName.orNull())
                     .setScheduledTime(request.getSessionTime().getEpochSecond())
                     .setResultConnectionId(resultConnection.transform(name -> getResultConnectionId(name, op)))
                     .setResultConnectionSettings(resultSettings.transform(Config::toString))

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdWaitOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdWaitOperatorFactory.java
@@ -73,6 +73,7 @@ public class TdWaitOperatorFactory
         private final String query;
         private final int queryPollInterval;
         private final String engine;
+        private final Optional<String> poolName;
         private final int priority;
         private final int jobRetry;
         private final TaskState state;
@@ -90,6 +91,7 @@ public class TdWaitOperatorFactory
                 throw new ConfigException("Unknown 'engine:' option (available options are: hive and presto): " + engine);
             }
             this.priority = params.get("priority", int.class, 0);  // TODO this should accept string (VERY_LOW, LOW, NORMAL, HIGH VERY_HIGH)
+            this.poolName = params.getOptional("pool_name", String.class);
             this.jobRetry = params.get("job_retry", int.class, 0);
             this.state = TaskState.of(request);
         }
@@ -129,6 +131,7 @@ public class TdWaitOperatorFactory
                     .setRetryLimit(jobRetry)
                     .setPriority(priority)
                     .setScheduledTime(request.getSessionTime().getEpochSecond())
+                    .setPoolName(poolName.orNull())
                     .setDomainKey(domainKey)
                     .createTDJobRequest();
 

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdWaitTableOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdWaitTableOperatorFactory.java
@@ -78,6 +78,7 @@ public class TdWaitTableOperatorFactory
         private final int rows;
         private final String engine;
         private final int priority;
+        private final Optional<String> poolName;
         private final int jobRetry;
         private final TaskState state;
 
@@ -96,6 +97,7 @@ public class TdWaitTableOperatorFactory
                 throw new ConfigException("Unknown 'engine:' option (available options are: hive and presto): " + engine);
             }
             this.priority = params.get("priority", int.class, 0);  // TODO this should accept string (VERY_LOW, LOW, NORMAL, HIGH VERY_HIGH)
+            this.poolName = params.getOptional("pool_name", String.class);
             this.jobRetry = params.get("job_retry", int.class, 0);
             this.state = TaskState.of(request);
         }
@@ -193,6 +195,7 @@ public class TdWaitTableOperatorFactory
                     .setQuery(query)
                     .setRetryLimit(jobRetry)
                     .setPriority(priority)
+                    .setPoolName(poolName.orNull())
                     .setDomainKey(domainKey)
                     .createTDJobRequest();
 

--- a/digdag-tests/src/test/java/acceptance/td/TdIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/TdIT.java
@@ -156,6 +156,15 @@ public class TdIT
     }
 
     @Test
+    public void testRunQueryWithHiveAndResourcePool()
+            throws Exception
+    {
+        copyResource("acceptance/td/td/td_hive.dig", projectDir.resolve("workflow.dig"));
+        copyResource("acceptance/td/td/query.sql", projectDir.resolve("query.sql"));
+        assertWorkflowRunsSuccessfully();
+    }
+
+    @Test
     public void testStoreLastResult()
             throws Exception
     {

--- a/digdag-tests/src/test/resources/acceptance/td/td/td_hive.dig
+++ b/digdag-tests/src/test/resources/acceptance/td/td/td_hive.dig
@@ -1,0 +1,10 @@
+timezone: UTC
+
++run:
+  td>: query.sql
+  engine: hive
+  pool_name: hadoop2
+  database: sample_datasets
+
++post:
+  sh>: touch ${outfile}


### PR DESCRIPTION
Treasure Data jobs support pool_name parameter to run queries in an
isolated resource pool.