### PR TITLE
Retry if ProjectArchives.extractTarArchive fails in ExtractArchiveWorkspaceManager

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/agent/ExtractArchiveWorkspaceManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/ExtractArchiveWorkspaceManager.java
@@ -68,7 +68,7 @@ public class ExtractArchiveWorkspaceManager
                         });
             }
             catch (RetryExecutor.RetryGiveupException e) {
-                Throwables.propagate(e);
+                throw Throwables.propagate(e.getCause());
             }
             return func.run(workspacePath.get());
         }

--- a/digdag-core/src/main/java/io/digdag/core/agent/ExtractArchiveWorkspaceManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/ExtractArchiveWorkspaceManager.java
@@ -31,7 +31,6 @@ public class ExtractArchiveWorkspaceManager
     public ExtractArchiveWorkspaceManager(TempFileManager tempFiles)
     {
         this.tempFiles = tempFiles;
-
     }
 
     @Override

--- a/digdag-core/src/main/java/io/digdag/core/agent/ExtractArchiveWorkspaceManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/ExtractArchiveWorkspaceManager.java
@@ -40,8 +40,12 @@ public class ExtractArchiveWorkspaceManager
         TempDir workspacePath = null;
         try {
             try {
-                // A temporary workspace should be created for each try
-                // And always close the temporary workspace
+                // Here has retrying because there were some observations that downloading of S3 caused too early EOF.
+                // S3Storage uses ResumableInputStream but it can't rescue from too early end of streams.
+                // Because ProjectResource.putProject validates the file, getting IOException here is always unexpected.
+                //
+                // A temporary workspace should be created for each try.
+                // And the created temporary workspace should be closed finally.
                 workspacePath = RetryExecutor.retryExecutor()
                         .retryIf(exception -> true)
                         .withInitialRetryWait(EXTRACT_MIN_RETRY_WAIT_MS)

--- a/digdag-core/src/main/java/io/digdag/core/agent/ExtractArchiveWorkspaceManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/ExtractArchiveWorkspaceManager.java
@@ -1,6 +1,7 @@
 package io.digdag.core.agent;
 
 import com.google.common.base.Optional;
+import com.google.common.base.Throwables;
 import com.google.inject.Inject;
 import io.digdag.core.TempFileManager.TempDir;
 import io.digdag.core.TempFileManager;
@@ -8,12 +9,20 @@ import io.digdag.core.archive.ProjectArchives;
 import io.digdag.spi.StorageObject;
 import io.digdag.spi.TaskRequest;
 import java.io.IOException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.digdag.util.RetryExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class ExtractArchiveWorkspaceManager
     implements WorkspaceManager
 {
+    private static final int EXTRACT_RETRIES = 10;
+    private static final int EXTRACT_MIN_RETRY_WAIT_MS = 1000;
+    private static final int EXTRACT_MAX_RETRY_WAIT_MS = 30000;
+
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private final TempFileManager tempFiles;
@@ -22,18 +31,52 @@ public class ExtractArchiveWorkspaceManager
     public ExtractArchiveWorkspaceManager(TempFileManager tempFiles)
     {
         this.tempFiles = tempFiles;
+
     }
 
     @Override
     public <T> T withExtractedArchive(TaskRequest request, ArchiveProvider archiveProvider, WithWorkspaceAction<T> func)
             throws IOException
     {
-        try (TempDir workspacePath = createNewWorkspace(request)) {
-            Optional<StorageObject> in = archiveProvider.open();
-            if (in.isPresent()) {
-                ProjectArchives.extractTarArchive(workspacePath.get(), in.get().getContentInputStream());
+        TempDir workspacePath = null;
+        try {
+            try {
+                // A temporary workspace should be created for each try
+                // And always close the temporary workspace
+                workspacePath = RetryExecutor.retryExecutor()
+                        .retryIf(exception -> true)
+                        .withInitialRetryWait(EXTRACT_MIN_RETRY_WAIT_MS)
+                        .withMaxRetryWait(EXTRACT_MAX_RETRY_WAIT_MS)
+                        .onRetry((exception, retryCount, retryLimit, retryWait) ->
+                                logger.warn("Failed to extract archive: retry {} of {}", retryCount, retryLimit, exception))
+                        .withRetryLimit(EXTRACT_RETRIES)
+                        .run(() -> {
+                            TempDir newWorkSpacePath = null;
+                            try {
+                                newWorkSpacePath = createNewWorkspace(request);
+                                Optional<StorageObject> in = archiveProvider.open();
+                                if (in.isPresent()) {
+                                    ProjectArchives.extractTarArchive(newWorkSpacePath.get(), in.get().getContentInputStream());
+                                }
+                                return newWorkSpacePath;
+                            }
+                            catch (Throwable e) {
+                                if (newWorkSpacePath != null) {
+                                    newWorkSpacePath.close();
+                                }
+                                throw e;
+                            }
+                        });
+            }
+            catch (RetryExecutor.RetryGiveupException e) {
+                Throwables.propagate(e);
             }
             return func.run(workspacePath.get());
+        }
+        finally {
+            if (workspacePath != null) {
+                workspacePath.close();
+            }
         }
     }
 

--- a/digdag-core/src/test/java/io/digdag/core/agent/ExtractArchiveWorkspaceManagerTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/agent/ExtractArchiveWorkspaceManagerTest.java
@@ -81,6 +81,7 @@ public class ExtractArchiveWorkspaceManagerTest
 
         AtomicInteger funcCounter = new AtomicInteger();
         extractArchiveWorkspaceManager.withExtractedArchive(taskRequest, archiveProvider, (path) -> funcCounter.incrementAndGet());
+        verify(archiveProvider, times(1)).open();
         assertThat(funcCounter.get(), is(1));
 
         assertEmptyWorkspace();
@@ -99,6 +100,22 @@ public class ExtractArchiveWorkspaceManagerTest
         AtomicInteger funcCounter = new AtomicInteger();
         extractArchiveWorkspaceManager.withExtractedArchive(taskRequest, archiveProvider, (path) -> funcCounter.incrementAndGet());
         verify(archiveProvider, times(3)).open();
+        assertThat(funcCounter.get(), is(1));
+
+        assertEmptyWorkspace();
+    }
+
+    @Test
+    public void withoutExtractedArchive()
+            throws Exception
+    {
+        WorkspaceManager.ArchiveProvider archiveProvider = mock(WorkspaceManager.ArchiveProvider.class);
+
+        when(archiveProvider.open()).thenReturn(Optional.absent());
+
+        AtomicInteger funcCounter = new AtomicInteger();
+        extractArchiveWorkspaceManager.withExtractedArchive(taskRequest, archiveProvider, (path) -> funcCounter.incrementAndGet());
+        verify(archiveProvider, times(1)).open();
         assertThat(funcCounter.get(), is(1));
 
         assertEmptyWorkspace();

--- a/digdag-core/src/test/java/io/digdag/core/agent/ExtractArchiveWorkspaceManagerTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/agent/ExtractArchiveWorkspaceManagerTest.java
@@ -1,0 +1,111 @@
+package io.digdag.core.agent;
+
+import com.google.common.base.Optional;
+import io.digdag.core.TempFileManager;
+import io.digdag.spi.StorageObject;
+import io.digdag.spi.TaskRequest;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.zip.GZIPOutputStream;
+
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ExtractArchiveWorkspaceManagerTest
+{
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+    private ExtractArchiveWorkspaceManager extractArchiveWorkspaceManager;
+    private byte[] archived;
+    private TaskRequest taskRequest;
+    private StorageObject storageObject;
+    private StorageObject wrongStorageObject;
+
+    @Before
+    public void setUp()
+            throws IOException
+    {
+        extractArchiveWorkspaceManager = new ExtractArchiveWorkspaceManager(new TempFileManager(temporaryFolder.getRoot().toPath()));
+
+        File digFile = temporaryFolder.newFile();
+
+        String wf = "+task:\n" +
+                "  echo>: hello\n" +
+                "";
+
+        Files.write(digFile.toPath(), wf.getBytes(), StandardOpenOption.CREATE);
+
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        GZIPOutputStream gzipOutputStream = new GZIPOutputStream(outputStream);
+        TarArchiveOutputStream tarArchiveOutputStream = new TarArchiveOutputStream(gzipOutputStream);
+        tarArchiveOutputStream.createArchiveEntry(digFile, "mydig.dig");
+        tarArchiveOutputStream.close();
+
+        archived = outputStream.toByteArray();
+
+        taskRequest = mock(TaskRequest.class);
+        when(taskRequest.getTaskName()).thenReturn("zzz");
+
+        storageObject = mock(StorageObject.class);
+        when(storageObject.getContentLength()).thenReturn((long) archived.length);
+        when(storageObject.getContentInputStream()).thenReturn(new ByteArrayInputStream(archived));
+
+        byte[] wrongArchive = "This isn't a proper archive content".getBytes();
+        wrongStorageObject = mock(StorageObject.class);
+        when(wrongStorageObject.getContentLength()).thenReturn((long) wrongArchive.length);
+        when(wrongStorageObject.getContentInputStream()).thenReturn(new ByteArrayInputStream(wrongArchive));
+    }
+
+    @Test
+    public void withExtractedArchive()
+            throws Exception
+    {
+        WorkspaceManager.ArchiveProvider archiveProvider = mock(WorkspaceManager.ArchiveProvider.class);
+
+        when(archiveProvider.open()).thenReturn(Optional.of(storageObject));
+
+        AtomicInteger funcCounter = new AtomicInteger();
+        extractArchiveWorkspaceManager.withExtractedArchive(taskRequest, archiveProvider, (path) -> funcCounter.incrementAndGet());
+        assertThat(funcCounter.get(), is(1));
+
+        assertEmptyWorkspace();
+    }
+
+    @Test
+    public void withExtractedArchiveWithRetry()
+            throws Exception
+    {
+        WorkspaceManager.ArchiveProvider archiveProvider = mock(WorkspaceManager.ArchiveProvider.class);
+
+        when(archiveProvider.open()).thenReturn(Optional.of(wrongStorageObject),
+                Optional.of(wrongStorageObject),
+                Optional.of(storageObject));
+
+        AtomicInteger funcCounter = new AtomicInteger();
+        extractArchiveWorkspaceManager.withExtractedArchive(taskRequest, archiveProvider, (path) -> funcCounter.incrementAndGet());
+        verify(archiveProvider, times(3)).open();
+        assertThat(funcCounter.get(), is(1));
+
+        assertEmptyWorkspace();
+    }
+
+    private void assertEmptyWorkspace()
+    {
+        assertThat(temporaryFolder.getRoot().toPath().resolve("workspace").toFile().listFiles().length, is(0));
+    }
+}


### PR DESCRIPTION
We've observed a few cases that ProjectArchives.extractTarArchive failed in ExtractArchiveWorkspaceManager#withExtractedArchive due to unexpected EOF of gzipped archive. This workaround would mitigate that.