### PR TITLE
Exporting pool_name options for each engine

### DIFF
--- a/digdag-docs/src/operators/td.md
+++ b/digdag-docs/src/operators/td.md
@@ -183,16 +183,28 @@
     path: /endpoint
   ```
 
-* **pool_name**: NAME
+* **presto_pool_name**: NAME
 
   Name of a resource pool to run the query in.
+  Applicable only when ``engine`` is ``presto``.
 
   Examples:
 
   ```
-  pool_name: poc
+  presto_pool_name: poc
   ```
 
+* **hive_pool_name**: NAME
+
+  Name of a resource pool to run the query in.
+  Applicable only when ``engine`` is ``hive``.
+
+  Examples:
+
+  ```
+  engine: hive
+  hive_pool_name: poc
+  ```
 
 ## Output parameters
 

--- a/digdag-docs/src/operators/td_for_each.md
+++ b/digdag-docs/src/operators/td_for_each.md
@@ -70,13 +70,26 @@ For example, if you run a query `select email, name from users` and the query re
 
   Set Priority (From `-2` (VERY LOW) to `2` (VERY HIGH) , default: 0 (NORMAL)).
 
-* **pool_name**: NAME
+* **presto_pool_name**: NAME
 
   Name of a resource pool to run the query in.
+  Applicable only when ``engine`` is ``presto``.
 
   Examples:
 
   ```
+  presto_pool_name: poc
+  ```
+
+* **hive_pool_name**: NAME
+
+  Name of a resource pool to run the query in.
+  Applicable only when ``engine`` is ``hive``.
+
+  Examples:
+
+  ```
+  engine: hive
   pool_name: poc
   ```
 

--- a/digdag-docs/src/operators/td_wait.md
+++ b/digdag-docs/src/operators/td_wait.md
@@ -72,14 +72,27 @@ Example queries:
 
   Set Priority (From `-2` (VERY LOW) to `2` (VERY HIGH) , default: 0 (NORMAL)).
 
-* **pool_name**: NAME
+* **presto_pool_name**: NAME
 
   Name of a resource pool to run the queries in.
+  Applicable only when ``engine`` is ``presto``.
 
   Examples:
 
   ```
-  pool_name: poc
+  presto_pool_name: poc
+  ```
+
+* **hive_pool_name**: NAME
+
+  Name of a resource pool to run the queries in.
+  Applicable only when ``engine`` is ``hive``.
+
+  Examples:
+
+  ```
+  engine: hive
+  hive_pool_name: poc
   ```
 
 ## Output parameters

--- a/digdag-docs/src/operators/td_wait_table.md
+++ b/digdag-docs/src/operators/td_wait_table.md
@@ -76,12 +76,25 @@
 
   Set Priority (From `-2` (VERY LOW) to `2` (VERY HIGH) , default: 0 (NORMAL)).
 
-* **pool_name**: NAME
+* **presto_pool_name**: NAME
 
   Name of a resource pool to run the queries in.
+  Applicable only when ``engine`` is ``presto``.
 
   Examples:
 
   ```
-  pool_name: poc
+  presto_pool_name: poc
+  ```
+
+* **hive_pool_name**: NAME
+
+  Name of a resource pool to run the queries in.
+  Applicable only when ``engine`` is ``presto``.
+
+  Examples:
+
+  ```
+  engine: hive
+  hive_pool_name: poc
   ```

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/BaseTdJobOperator.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/BaseTdJobOperator.java
@@ -70,6 +70,11 @@ abstract class BaseTdJobOperator
         }
     }
 
+    protected static Optional<String> poolNameOfEngine(Config params, String engine)
+    {
+        return params.getOptional(engine + "_pool_name", String.class);
+    }
+
     protected static TaskExecutionException propagateTDClientException(TDClientException ex)
     {
         return new TaskExecutionException(ex);

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdForEachOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdForEachOperatorFactory.java
@@ -82,7 +82,7 @@ public class TdForEachOperatorFactory
             this.priority = params.get("priority", int.class, 0);  // TODO this should accept string (VERY_LOW, LOW, NORMAL, HIGH VERY_HIGH)
             this.jobRetry = params.get("job_retry", int.class, 0);
             this.engine = params.get("engine", String.class, "presto");
-            this.poolName = params.getOptional("pool_name", String.class);
+            this.poolName = poolNameOfEngine(params, engine);
             this.doConfig = request.getConfig().getNested("_do");
         }
 

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdOperatorFactory.java
@@ -123,7 +123,7 @@ public class TdOperatorFactory
             this.jobRetry = params.get("job_retry", int.class, 0);
 
             this.engine = params.get("engine", String.class, "presto");
-            this.poolName = params.getOptional("pool_name", String.class);
+            this.poolName = poolNameOfEngine(params, engine);
 
             this.downloadFile = params.getOptional("download_file", String.class);
             if (downloadFile.isPresent() && (insertInto.isPresent() || createTable.isPresent())) {

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdTableExportOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdTableExportOperatorFactory.java
@@ -88,7 +88,7 @@ public class TdTableExportOperatorFactory
                     .secretAccessKey(s3Secrets.getSecretOptional("secret_access_key").or(() -> awsSecrets.getSecret("secret_access_key")))
                     .bucketName(params.get("s3_bucket", String.class))
                     .filePrefix(params.get("s3_path_prefix", String.class))
-                    .poolName(params.getOptional("pool_name", String.class))
+                    .poolName(poolNameOfEngine(params, "hive"))
                     .build();
 
             String jobId = op.submitNewJobWithRetry(client -> client.submitExportJob(req));

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdWaitOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdWaitOperatorFactory.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 import java.util.Map;
 
 import static io.digdag.standards.operator.state.PollingRetryExecutor.pollingRetryExecutor;
+import static io.digdag.standards.operator.td.BaseTdJobOperator.poolNameOfEngine;
 import static io.digdag.standards.operator.td.BaseTdJobOperator.propagateTDClientException;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -91,7 +92,7 @@ public class TdWaitOperatorFactory
                 throw new ConfigException("Unknown 'engine:' option (available options are: hive and presto): " + engine);
             }
             this.priority = params.get("priority", int.class, 0);  // TODO this should accept string (VERY_LOW, LOW, NORMAL, HIGH VERY_HIGH)
-            this.poolName = params.getOptional("pool_name", String.class);
+            this.poolName = poolNameOfEngine(params, engine);
             this.jobRetry = params.get("job_retry", int.class, 0);
             this.state = TaskState.of(request);
         }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdWaitTableOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdWaitTableOperatorFactory.java
@@ -28,6 +28,7 @@ import java.math.BigInteger;
 import java.util.Map;
 
 import static io.digdag.standards.operator.state.PollingRetryExecutor.pollingRetryExecutor;
+import static io.digdag.standards.operator.td.BaseTdJobOperator.poolNameOfEngine;
 import static io.digdag.standards.operator.td.BaseTdJobOperator.propagateTDClientException;
 
 public class TdWaitTableOperatorFactory
@@ -97,7 +98,7 @@ public class TdWaitTableOperatorFactory
                 throw new ConfigException("Unknown 'engine:' option (available options are: hive and presto): " + engine);
             }
             this.priority = params.get("priority", int.class, 0);  // TODO this should accept string (VERY_LOW, LOW, NORMAL, HIGH VERY_HIGH)
-            this.poolName = params.getOptional("pool_name", String.class);
+            this.poolName = poolNameOfEngine(params, engine);
             this.jobRetry = params.get("job_retry", int.class, 0);
             this.state = TaskState.of(request);
         }

--- a/digdag-tests/src/test/resources/acceptance/td/td/td_hive.dig
+++ b/digdag-tests/src/test/resources/acceptance/td/td/td_hive.dig
@@ -3,7 +3,7 @@ timezone: UTC
 +run:
   td>: query.sql
   engine: hive
-  pool_name: hadoop2
+  hive_pool_name: hadoop2
   database: sample_datasets
 
 +post:


### PR DESCRIPTION
Treasure Data jobs can have pool_name option. Resource pools for Hive
and Presto are two isolated resources. So following example may not
work:

```
_export:
  td:
    database: abc
    pool_name: my_poc_presto_pool

+task1:
  td>: query1.sql
  engine: presto

+task2:
  td>: query2.sql
  engine: hive
```

This works:

```
_export:
  td:
    database: abc
    presto_pool_name: my_poc_presto_pool
    hive_pool_name: my_poc_hive_pool

+task1:
  td>: query1.sql
  engine: presto

+task2:
  td>: query2.sql
  engine: hive
```