### PR TITLE
Add License to footer

### DIFF
--- a/digdag-docs/src/_templates/footer.html
+++ b/digdag-docs/src/_templates/footer.html
@@ -2,6 +2,6 @@
 {% block extrafooter %}
     <br/>
     <br/>
-    <p><a href="http://digdag.io/">Digdag</a> is an open source project, invented and sponsored by <a href="https://www.treasuredata.com/">Treasure Data, Inc.</a>.</p>
+    <p><a href="http://digdag.io/">Digdag</a> is an open source project, invented and sponsored by <a href="https://www.treasuredata.com/">Treasure Data, Inc.</a>. All components are available under the Apache 2 License.</p>
     {{ super() }}
 {% endblock %}


### PR DESCRIPTION
I heard there is a company whose lawyer rejected to use the Digdag logo because http://docs.digdag.io/logo.html just says “Feel free to use these logos” and does not specify the exact license to use them (like CC0, or some explicit description that makes sure it does require any fee to use it).