### PR TITLE
Fix: Changed Redshift's connect_timeout and socket_timeout parameters…

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/operator/redshift/RedshiftConnectionConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/redshift/RedshiftConnectionConfig.java
@@ -27,8 +27,8 @@ public abstract class RedshiftConnectionConfig
                 .password(secrets.getSecretOptional("password"))
                 .database(secrets.getSecretOptional("database").or(() -> params.get("database", String.class)))
                 .ssl(secrets.getSecretOptional("ssl").transform(Boolean::parseBoolean).or(() -> params.get("ssl", boolean.class, false)))
-                .connectTimeout(params.get("connect_timeout", DurationParam.class, DurationParam.of(Duration.ofSeconds(30))))
-                .socketTimeout(params.get("socket_timeout", DurationParam.class, DurationParam.of(Duration.ofSeconds(1800))))
+                .connectTimeout(DurationParam.of(Duration.ofSeconds(params.get("connect_timeout", int.class, 30))))
+                .socketTimeout(DurationParam.of(Duration.ofSeconds(params.get("socket_timeout", int.class, 1800))))
                 .schema(secrets.getSecretOptional("schema").or(params.getOptional("schema", String.class)))
                 .build();
     }


### PR DESCRIPTION
Because connect_timeout and socket_timeout of redshift operator cannot be set from config,
Fix to reflect the value of config.

## sample

```
_export:
  redshift:
    host: 'aaaaa'
    port: 5439
    user: 'aaaa'
    password: 'aaa'
    database: 'aaaa'
    ssl: true
    connect_timeout: 5555
    socket_timeout: 8888

+testest:
  redshift>: sql/hoge.sql
```

<img width="456" alt="2018-04-05 16 20 28" src="https://user-images.githubusercontent.com/42721/38352235-82c0f11a-38ed-11e8-8dc2-6c906b445597.png">
