### PR TITLE
Change workspace prefix not to use task name to avoid failing workspace creation

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/agent/ExtractArchiveWorkspaceManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/ExtractArchiveWorkspaceManager.java
@@ -86,6 +86,6 @@ public class ExtractArchiveWorkspaceManager
     private TempDir createNewWorkspace(TaskRequest request)
         throws IOException
     {
-        return tempFiles.createTempDir("workspace", request.getTaskName());
+        return tempFiles.createTempDir("workspace", request.getWorkflowName());
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/agent/ExtractArchiveWorkspaceManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/ExtractArchiveWorkspaceManager.java
@@ -89,7 +89,7 @@ public class ExtractArchiveWorkspaceManager
         // prefix: {projectId}_{workflowName}_{sessionId}_{attemptId}
         final String workspacePrefix = new StringBuilder()
                 .append(request.getProjectId()).append("_")
-                .append(request.getWorkflowName()).append("_")
+                .append(request.getWorkflowName()).append("_") // workflow name is normalized before it's submitted.
                 .append(request.getSessionId()).append("_")
                 .append(request.getAttemptId())
                 .toString();

--- a/digdag-core/src/main/java/io/digdag/core/agent/ExtractArchiveWorkspaceManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/ExtractArchiveWorkspaceManager.java
@@ -86,6 +86,13 @@ public class ExtractArchiveWorkspaceManager
     private TempDir createNewWorkspace(TaskRequest request)
         throws IOException
     {
-        return tempFiles.createTempDir("workspace", request.getWorkflowName());
+        // prefix: {projectId}_{workflowName}_{sessionId}_{attemptId}
+        final String workspacePrefix = new StringBuilder()
+                .append(request.getProjectId()).append("_")
+                .append(request.getWorkflowName()).append("_")
+                .append(request.getSessionId()).append("_")
+                .append(request.getAttemptId())
+                .toString();
+        return tempFiles.createTempDir("workspace", workspacePrefix);
     }
 }


### PR DESCRIPTION
This PR changes workspace prefix. The name includes task name. If the task name is long, workspace name is also long. Digdag (0.9.24) server cannot create workspace by "File name too long". This error happens when I tried to reproduce https://github.com/treasure-data/digdag/issues/729.

In this PR, workspace prefix uses ~~workflow name~~ combination with projectId, workflowName, sessionId and attemptId instead of task name. Since the workspace name is internal design so, users might not affect this change directly.

```
2018-04-06 22:24:23.075 +0000 [ERROR] (0142@[1:muga_digdag_issues_729_ng]+muga_digdag_issues_729_ng+repeat^sub+loop-0+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_aaa) io.digdag.core.agent.OperatorManager: Task failed with unexpected error: java.nio.file.FileSystemException: /tmp/digdag-tempdir6619218628117090050/workspace/+muga_digdag_issues_729_ng+repeat^sub+loop-0+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_aaa_7247227962002122889: File name too long
io.digdag.core.TempFileManager$AllocationException: java.nio.file.FileSystemException: /tmp/digdag-tempdir6619218628117090050/workspace/+muga_digdag_issues_729_ng+repeat^sub+loop-0+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_aaa_7247227962002122889: File name too long
        at io.digdag.core.TempFileManager.createTempDir(TempFileManager.java:105)
        at io.digdag.core.agent.ExtractArchiveWorkspaceManager.createNewWorkspace(ExtractArchiveWorkspaceManager.java:89)
        at io.digdag.core.agent.ExtractArchiveWorkspaceManager.lambda$withExtractedArchive$2(ExtractArchiveWorkspaceManager.java:59)
        at io.digdag.util.RetryExecutor.run(RetryExecutor.java:166)
        at io.digdag.util.RetryExecutor.run(RetryExecutor.java:142)
        at io.digdag.core.agent.ExtractArchiveWorkspaceManager.withExtractedArchive(ExtractArchiveWorkspaceManager.java:56)
        at io.digdag.core.agent.OperatorManager.runWithHeartbeat(OperatorManager.java:135)
        at io.digdag.core.agent.OperatorManager.run(OperatorManager.java:119)
        at io.digdag.core.agent.MultiThreadAgent.lambda$null$0(MultiThreadAgent.java:127)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
Caused by: java.nio.file.FileSystemException: /tmp/digdag-tempdir6619218628117090050/workspace/+muga_digdag_issues_729_ng+repeat^sub+loop-0+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa_aaa_7247227962002122889: File name too long
        at sun.nio.fs.UnixException.translateToIOException(UnixException.java:91)
        at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
        at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
        at sun.nio.fs.UnixFileSystemProvider.createDirectory(UnixFileSystemProvider.java:384)
        at java.nio.file.Files.createDirectory(Files.java:674)
        at java.nio.file.TempFileHelper.create(TempFileHelper.java:136)
        at java.nio.file.TempFileHelper.createTempDirectory(TempFileHelper.java:173)
        at java.nio.file.Files.createTempDirectory(Files.java:950)
        at io.digdag.core.TempFileManager.createTempDir(TempFileManager.java:102)
        ... 13 common frames omitted
```