### PR TITLE
Change temp file prefix used by BufferedRemoteTaskLogger

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/agent/ExtractArchiveWorkspaceManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/ExtractArchiveWorkspaceManager.java
@@ -86,6 +86,6 @@ public class ExtractArchiveWorkspaceManager
     private TempDir createNewWorkspace(TaskRequest request)
         throws IOException
     {
-        return tempFiles.createTempDir("workspace", request.getTaskName());
+        return tempFiles.createTempDir("workspace", request.getWorkflowName());
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/agent/ExtractArchiveWorkspaceManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/ExtractArchiveWorkspaceManager.java
@@ -89,7 +89,7 @@ public class ExtractArchiveWorkspaceManager
         // prefix: {projectId}_{workflowName}_{sessionId}_{attemptId}
         final String workspacePrefix = new StringBuilder()
                 .append(request.getProjectId()).append("_")
-                .append(request.getWorkflowName()).append("_")
+                .append(request.getWorkflowName()).append("_") // workflow name is normalized before it's submitted.
                 .append(request.getSessionId()).append("_")
                 .append(request.getAttemptId())
                 .toString();

--- a/digdag-core/src/main/java/io/digdag/core/agent/ExtractArchiveWorkspaceManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/ExtractArchiveWorkspaceManager.java
@@ -86,6 +86,13 @@ public class ExtractArchiveWorkspaceManager
     private TempDir createNewWorkspace(TaskRequest request)
         throws IOException
     {
-        return tempFiles.createTempDir("workspace", request.getWorkflowName());
+        // prefix: {projectId}_{workflowName}_{sessionId}_{attemptId}
+        final String workspacePrefix = new StringBuilder()
+                .append(request.getProjectId()).append("_")
+                .append(request.getWorkflowName()).append("_")
+                .append(request.getSessionId()).append("_")
+                .append(request.getAttemptId())
+                .toString();
+        return tempFiles.createTempDir("workspace", workspacePrefix);
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/log/LogServerManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/log/LogServerManager.java
@@ -1,5 +1,8 @@
 package io.digdag.core.log;
 
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 import java.util.Set;
 import com.google.inject.Inject;
 import io.digdag.core.session.StoredSessionAttemptWithSession;
@@ -18,6 +21,10 @@ import io.digdag.core.TempFileManager;
 
 public class LogServerManager
 {
+    private static final DateTimeFormatter ISO8601_SHORT = DateTimeFormatter
+            .ofPattern("yyyyMMdd'T'HHmmssX", Locale.ENGLISH)
+            .withZone(ZoneOffset.UTC);
+
     private final LogServer logServer;
     private final TempFileManager tempFiles;
 
@@ -82,7 +89,7 @@ public class LogServerManager
             final String tempFilePrefix = new StringBuilder()
                     .append(prefix.getProjectId()).append("_")
                     .append(prefix.getWorkflowName()).append("_") // workflow name is normalized before it's submitted.
-                    .append(prefix.getSessionTime().toString()) // ISO-8601
+                    .append(ISO8601_SHORT.format(prefix.getSessionTime())) // yyyyMMdd'T'HHmmss'Z'
                     .toString();
             return new BufferedRemoteTaskLogger(tempFiles, tempFilePrefix,
                     (firstLogTime, gzData) -> {

--- a/digdag-core/src/main/java/io/digdag/core/log/LogServerManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/log/LogServerManager.java
@@ -78,7 +78,13 @@ public class LogServerManager
             return ((LocalFileLogServer) logServer).newDirectTaskLogger(prefix, taskName);
         }
         else {
-            return new BufferedRemoteTaskLogger(tempFiles, taskName,
+            // temp file prefix: {projectId}_{workflowName}_{sessionTime}
+            final String tempFilePrefix = new StringBuilder()
+                    .append(prefix.getProjectId()).append("_")
+                    .append(prefix.getWorkflowName()).append("_")
+                    .append(prefix.getSessionTime().toString()) // ISO-8601
+                    .toString();
+            return new BufferedRemoteTaskLogger(tempFiles, tempFilePrefix,
                     (firstLogTime, gzData) -> {
                         logServer.putFile(prefix, taskName, firstLogTime, agentId.toString(), gzData);
                     });

--- a/digdag-core/src/main/java/io/digdag/core/log/LogServerManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/log/LogServerManager.java
@@ -81,7 +81,7 @@ public class LogServerManager
             // temp file prefix: {projectId}_{workflowName}_{sessionTime}
             final String tempFilePrefix = new StringBuilder()
                     .append(prefix.getProjectId()).append("_")
-                    .append(prefix.getWorkflowName()).append("_")
+                    .append(prefix.getWorkflowName()).append("_") // workflow name is normalized before it's submitted.
                     .append(prefix.getSessionTime().toString()) // ISO-8601
                     .toString();
             return new BufferedRemoteTaskLogger(tempFiles, tempFilePrefix,


### PR DESCRIPTION
This PR fixes a bug that `BufferedRemoteTaskLogger` cannot upload log files on S3 correctly. The `BufferedRemoteTaskLogger` writes logs tmp files first before uploading them on S3. The tmp file prefix uses task name, if task name is too long, it cannot create tmp files. 

In this PR, the prefix is changed with combination with projectId, workflowName and sessionTime. sessionTime is formatted by ISO-8601 and used as string.

Reported on https://github.com/treasure-data/digdag/issues/729 and assumes #751.