### PR TITLE
Remove setPosixFilePermissions method call for Windows

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/archive/ProjectArchives.java
+++ b/digdag-core/src/main/java/io/digdag/core/archive/ProjectArchives.java
@@ -10,6 +10,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Set;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
@@ -79,10 +80,19 @@ public class ProjectArchives
                     ByteStreams.copy(archive, out);
                 }
             }
-            if (!Files.isSymbolicLink(path)) {
+            if (!Files.isSymbolicLink(path) && isPosixCompliant()) {
                 Files.setPosixFilePermissions(path, getPosixFilePermissions(entry));
             }
         }
+    }
+
+    private static boolean isPosixCompliant()
+    {
+        final String osName = System.getProperty("os.name");
+        if (osName != null) {
+            return !osName.toLowerCase(Locale.ENGLISH).contains("windows");
+        }
+        return true;
     }
 
     private static Set<PosixFilePermission> getPosixFilePermissions(TarArchiveEntry entry)


### PR DESCRIPTION
This PR removes `Files.setPosixFilePermissions` method call for Windows. "digdag download" command doesn't work on Windows because Windows doesn't support POSIX pretty much. It fails when it calls `Files.setPosixFilePermissions` method.