### PR TITLE
[Fix] Group Task still has error status when Group Retry succeed

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
@@ -949,8 +949,9 @@ public class DatabaseSessionStoreManager
             return handle.createQuery(
                     "select parent_id from tasks" +
                     " where id in (" +
-                      "select max(t.id) from tasks t join task_details td on t.id=td.id" +
-                      " where parent_id = :parentId group by td.full_name" +
+                      "select max(t.id) from tasks t join task_details td on t.id = td.id" +
+                      " where parent_id = :parentId" +
+                      " group by td.full_name" +
                     ") and (" +
                       // a child task is progressing now
                       "state = " + TaskStateCode.ERROR.get() +

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
@@ -948,8 +948,10 @@ public class DatabaseSessionStoreManager
         {
             return handle.createQuery(
                     "select parent_id from tasks" +
-                    " where parent_id = :parentId" +
-                    " and (" +
+                    " where id in (" +
+                      "select max(t.id) from tasks t join task_details td on t.id=td.id" +
+                      " where parent_id = :parentId group by td.full_name" +
+                    ") and (" +
                       // a child task is progressing now
                       "state = " + TaskStateCode.ERROR.get() +
                       " or state = " + TaskStateCode.GROUP_ERROR.get() +


### PR DESCRIPTION
Hello.
We found and fixed the bug of Group Retry. (after merged https://github.com/treasure-data/digdag/pull/738.)
https://github.com/treasure-data/digdag/issues/728  issue is also caused by this bug.
The following are the details.
Thanks.

## issue
Workflow Definition
group_retry.dig
```
+wf:
  _retry: 3

  +t1:
    echo>: foo

  +t2:
    # first failure, second success
    sh>: ./second_success.sh
    
  +t3:
    echo>: bar
```
second_success.sh
```
#!/usr/bin/env bash

if [ -e /tmp/executed ]; then
    echo "Success."
else
    echo "Failed." > /tmp/executed
    exit 1
fi
```
Result
![2018-04-16 15 25 46](https://user-images.githubusercontent.com/34811188/39237917-dcf97ab0-48b7-11e8-865c-b280f3cc6988.png)
Log
```
018-04-16 15:25:21.216 +0900 [INFO] (0050@[0:retry_check]+group_retry+wf+t1) io.digdag.core.agent.OperatorManager: echo>: foo
2018-04-16 15:25:23.454 +0900 [INFO] (0050@[0:retry_check]+group_retry+wf+t2) io.digdag.core.agent.OperatorManager: sh>: ./second_success.sh
2018-04-16 15:25:23.499 +0900 [ERROR] (0050@[0:retry_check]+group_retry+wf+t2) io.digdag.core.agent.OperatorManager: Task failed with unexpected error: Command failed with code 1
java.lang.RuntimeException: Command failed with code 1
	at io.digdag.standards.operator.ShOperatorFactory$ShOperator.runTask(ShOperatorFactory.java:143)
	at io.digdag.util.BaseOperator.run(BaseOperator.java:35)
	at io.digdag.core.agent.OperatorManager.callExecutor(OperatorManager.java:312)
	at io.digdag.core.agent.OperatorManager.runWithWorkspace(OperatorManager.java:254)
	at io.digdag.core.agent.OperatorManager.lambda$runWithHeartbeat$2(OperatorManager.java:137)
	at io.digdag.core.agent.ExtractArchiveWorkspaceManager.withExtractedArchive(ExtractArchiveWorkspaceManager.java:77)
	at io.digdag.core.agent.OperatorManager.runWithHeartbeat(OperatorManager.java:135)
	at io.digdag.core.agent.OperatorManager.run(OperatorManager.java:119)
	at io.digdag.core.agent.MultiThreadAgent.lambda$null$0(MultiThreadAgent.java:127)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
2018-04-16 15:25:25.551 +0900 [INFO] (0050@[0:retry_check]+group_retry+wf+t1) io.digdag.core.agent.OperatorManager: echo>: foo
2018-04-16 15:25:28.549 +0900 [INFO] (0050@[0:retry_check]+group_retry+wf+t2) io.digdag.core.agent.OperatorManager: sh>: ./second_success.sh
Success.
2018-04-16 15:25:30.547 +0900 [INFO] (0050@[0:retry_check]+group_retry+wf+t3) io.digdag.core.agent.OperatorManager: echo>: bar
2018-04-16 15:25:32.731 +0900 [INFO] (0050@[0:retry_check]+group_retry+wf+t1) io.digdag.core.agent.OperatorManager: echo>: foo
2018-04-16 15:25:34.707 +0900 [INFO] (0050@[0:retry_check]+group_retry+wf+t2) io.digdag.core.agent.OperatorManager: sh>: ./second_success.sh
Success.
2018-04-16 15:25:36.596 +0900 [INFO] (0050@[0:retry_check]+group_retry+wf+t3) io.digdag.core.agent.OperatorManager: echo>: bar
2018-04-16 15:25:38.869 +0900 [INFO] (0050@[0:retry_check]+group_retry+wf+t1) io.digdag.core.agent.OperatorManager: echo>: foo
2018-04-16 15:25:40.732 +0900 [INFO] (0050@[0:retry_check]+group_retry+wf+t2) io.digdag.core.agent.OperatorManager: sh>: ./second_success.sh
Success.
2018-04-16 15:25:42.516 +0900 [INFO] (0050@[0:retry_check]+group_retry+wf+t3) io.digdag.core.agent.OperatorManager: echo>: bar
2018-04-16 15:25:44.832 +0900 [INFO] (0050@[0:retry_check]+group_retry^failure-alert) io.digdag.core.agent.OperatorManager: type: notify
```

We expected Group Retry finished in the status of Success when all child tasks were Success.  However, it continued to retry and the workflow execution finished in the status of Failed.

It might be caused by the method "isAnyErrorChild".
The method checks every status of child tasks including one already failed before retrying,
So it bounds to return isError although retrying task is Success.

## Fix
The query implemented in isAnyErrorChild makes a change to select “latest” error child task.

Result (after fixed):
![2018-04-16 15 31 03](https://user-images.githubusercontent.com/34811188/39238171-89b47494-48b8-11e8-9584-a8503d2c298b.png)

Log:
```
2018-04-16 15:30:48.932 +0900 [INFO] (0042@[0:retry_check]+group_retry+wf+t1) io.digdag.core.agent.OperatorManager: echo>: foo
2018-04-16 15:30:51.411 +0900 [INFO] (0042@[0:retry_check]+group_retry+wf+t2) io.digdag.core.agent.OperatorManager: sh>: ./second_success.sh
2018-04-16 15:30:51.441 +0900 [ERROR] (0042@[0:retry_check]+group_retry+wf+t2) io.digdag.core.agent.OperatorManager: Task failed with unexpected error: Command failed with code 1
java.lang.RuntimeException: Command failed with code 1
	at io.digdag.standards.operator.ShOperatorFactory$ShOperator.runTask(ShOperatorFactory.java:143)
	at io.digdag.util.BaseOperator.run(BaseOperator.java:35)
	at io.digdag.core.agent.OperatorManager.callExecutor(OperatorManager.java:312)
	at io.digdag.core.agent.OperatorManager.runWithWorkspace(OperatorManager.java:254)
	at io.digdag.core.agent.OperatorManager.lambda$runWithHeartbeat$2(OperatorManager.java:137)
	at io.digdag.core.agent.ExtractArchiveWorkspaceManager.withExtractedArchive(ExtractArchiveWorkspaceManager.java:36)
	at io.digdag.core.agent.OperatorManager.runWithHeartbeat(OperatorManager.java:135)
	at io.digdag.core.agent.OperatorManager.run(OperatorManager.java:119)
	at io.digdag.core.agent.MultiThreadAgent.lambda$null$0(MultiThreadAgent.java:127)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
2018-04-16 15:30:53.653 +0900 [INFO] (0042@[0:retry_check]+group_retry+wf+t1) io.digdag.core.agent.OperatorManager: echo>: foo
2018-04-16 15:30:55.789 +0900 [INFO] (0042@[0:retry_check]+group_retry+wf+t2) io.digdag.core.agent.OperatorManager: sh>: ./second_success.sh
Success.
2018-04-16 15:30:57.915 +0900 [INFO] (0042@[0:retry_check]+group_retry+wf+t3) io.digdag.core.agent.OperatorManager: echo>: bar
```