### PR TITLE
[Fix] Group Task Retry including nested tasks does not update parent id of copied tasks.

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
@@ -886,6 +886,7 @@ public class DatabaseSessionStoreManager
             for (StoredTask task : tasks) {
                 Task newTask = Task.taskBuilder()
                     .from(task)
+                    .parentId(task.getParentId().transform(it -> oldIdToNewId.containsKey(it) ? oldIdToNewId.get(it) : it))
                     .state(TaskStateCode.BLOCKED)
                     .stateFlags(TaskStateFlags.empty())
                     .build();

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
@@ -886,7 +886,7 @@ public class DatabaseSessionStoreManager
             for (StoredTask task : tasks) {
                 Task newTask = Task.taskBuilder()
                     .from(task)
-                    .parentId(task.getParentId().transform(it -> oldIdToNewId.containsKey(it) ? oldIdToNewId.get(it) : it))
+                    .parentId(task.getParentId().transform(it -> oldIdToNewId.getOrDefault(it, it)))
                     .state(TaskStateCode.BLOCKED)
                     .stateFlags(TaskStateFlags.empty())
                     .build();

--- a/digdag-core/src/test/java/io/digdag/core/workflow/TaskDependenciesTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/TaskDependenciesTest.java
@@ -1,0 +1,208 @@
+package io.digdag.core.workflow;
+
+import com.google.common.base.Optional;
+import io.digdag.core.DigdagEmbed;
+import io.digdag.core.LocalSite;
+import io.digdag.core.database.TransactionManager;
+import io.digdag.core.session.ArchivedTask;
+import io.digdag.core.session.StoredSessionAttemptWithSession;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+import static io.digdag.core.workflow.WorkflowTestingUtils.loadYamlResource;
+import static io.digdag.core.workflow.WorkflowTestingUtils.runWorkflow;
+import static io.digdag.core.workflow.WorkflowTestingUtils.setupEmbed;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class TaskDependenciesTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private DigdagEmbed embed;
+    private LocalSite localSite;
+    private Path projectPath;
+    private TransactionManager tm;
+
+    @Before
+    public void setUp()
+            throws Exception {
+        this.embed = setupEmbed();
+        this.localSite = embed.getLocalSite();
+        this.tm = embed.getTransactionManager();
+        this.projectPath = folder.newFolder().toPath();
+    }
+
+    @After
+    public void destroy()
+            throws Exception {
+        embed.close();
+    }
+
+    @Test
+    public void TaskDependenciesTest()
+            throws Exception {
+        StoredSessionAttemptWithSession attempt =
+                runWorkflow(embed, projectPath, "basic", loadYamlResource("/io/digdag/core/workflow/basic.dig"));
+        // # basic.dig
+        // +step1:
+        //  _type: noop
+        //
+        //+step2:
+        //  _export:
+        //    oval: o
+        //    pval: p
+        //
+        //  +step3:
+        //    _type: n${oval}${oval}${pval}
+        //    _check:
+        //      +step4:
+        //        _type: noop
+        //
+        // id | tasks index  | full_name                   | expected parent_id | expected upstream_id 　
+        // 1  | tasks.get(0) | +basic                      |                    |
+        // 2  | tasks.get(1) | +basic+step1                | 1                  |
+        // 3  | tasks.get(2) | +basic+step2                | 1                  | 2
+        // 4  | tasks.get(3) | +basic+step2+step3          | 3                  |
+        // 5  | tasks.get(4) | +basic+step2+step3+step4    | 4                  |
+
+        tm.begin(() -> {
+            assertThat(attempt.getStateFlags().isSuccess(), is(true));
+            List<ArchivedTask> tasks = localSite.getSessionStore().getTasksOfAttempt(attempt.getId());
+
+            // parent_id test
+            assertThat(tasks.get(0).getParentId(), is(Optional.absent()));
+            assertThat(tasks.get(1).getParentId(), is(Optional.of(tasks.get(0).getId())));
+            assertThat(tasks.get(2).getParentId(), is(Optional.of(tasks.get(0).getId())));
+            assertThat(tasks.get(3).getParentId(), is(Optional.of(tasks.get(2).getId())));
+            assertThat(tasks.get(4).getParentId(), is(Optional.of(tasks.get(3).getId())));
+
+            // upstream_id test
+            assertThat(tasks.get(0).getUpstreams(), is(Collections.emptyList()));
+            assertThat(tasks.get(1).getUpstreams(), is(Collections.emptyList()));
+            assertThat(tasks.get(2).getUpstreams(), is(Collections.singletonList(tasks.get(1).getId())));
+            assertThat(tasks.get(3).getUpstreams(), is(Collections.emptyList()));
+            assertThat(tasks.get(4).getUpstreams(), is(Collections.emptyList()));
+
+            return null;
+        });
+    }
+
+    @Test
+    public void GroupRetryTaskDependenciesTest()
+            throws Exception {
+        StoredSessionAttemptWithSession attempt =
+                runWorkflow(embed, projectPath, "retry_on_group", loadYamlResource("/io/digdag/core/workflow/retry_on_group.dig"));
+        tm.begin(() -> {
+            assertThat(attempt.getStateFlags().isSuccess(), is(false));
+            List<ArchivedTask> tasks = localSite.getSessionStore().getTasksOfAttempt(attempt.getId());
+            // # retry_on_group.dig
+            // +first:
+            //   echo>: ""
+            //   append_file: out
+            // +doit:
+            //   _retry: 3
+            //   +task1:
+            //     echo>: "try1"
+            //     append_file: out
+            //   +task2:
+            //     +task2_nested:
+            //       echo>: "try2"
+            //       append_file: out
+            //   +task3:
+            //     fail>: task failed expectedly
+            //   +task4:
+            //     echo>: "skipped"
+            //     append_file: out
+            //
+            // id | tasks index   | full_name                                | expected parent_id | expected upstream_id 　
+            // 1  | tasks.get(0)  | +retry_on_group                          |                    |
+            // 2  | tasks.get(1)  | +retry_on_group+first                    | 1                  |
+            // 3  | tasks.get(2)  | +retry_on_group+doit                     | 1                  | 2
+            // 4  | tasks.get(3)  | +retry_on_group+doit+task1               | 3                  |
+            // 5  | tasks.get(4)  | +retry_on_group+doit+task2               | 3                  | 4
+            // 6  | tasks.get(5)  | +retry_on_group+doit+task2+task2_nested  | 5                  |
+            // 7  | tasks.get(6)  | +retry_on_group+doit+task3               | 3                  | 5
+            // 8  | tasks.get(7)  | +retry_on_group+doit+task4               | 3                  | 7
+            // 9  | tasks.get(8)  | +retry_on_group+doit+task1               | 3                  |
+            // 10 | tasks.get(9)  | +retry_on_group+doit+task2               | 3                  | 9
+            // 11 | tasks.get(10) | +retry_on_group+doit+task2+task2_nested  | 10                 |
+            // 12 | tasks.get(11) | +retry_on_group+doit+task3               | 3                  | 10
+            // 13 | tasks.get(12) | +retry_on_group+doit+task4               | 3                  | 12
+            // 14 | tasks.get(13) | +retry_on_group+doit+task1               | 3                  |
+            // 15 | tasks.get(14) | +retry_on_group+doit+task2               | 3                  | 14
+            // 16 | tasks.get(15) | +retry_on_group+doit+task2+task2_nested  | 15                 |
+            // 17 | tasks.get(16) | +retry_on_group+doit+task3               | 3                  | 15
+            // 18 | tasks.get(17) | +retry_on_group+doit+task4               | 3                  | 17
+            // 19 | tasks.get(18) | +retry_on_group+doit+task1               | 3                  |
+            // 20 | tasks.get(19) | +retry_on_group+doit+task2               | 3                  | 19
+            // 21 | tasks.get(20) | +retry_on_group+doit+task2+task2_nested  | 20                 |
+            // 22 | tasks.get(21) | +retry_on_group+doit+task3               | 3                  | 20
+            // 23 | tasks.get(22) | +retry_on_group+doit+task4               | 3                  | 22
+            // 24 | tasks.get(23) | +retry_on_group^failure-alert            | 1                  |
+
+            // parent_id test
+            assertThat(tasks.get(0).getParentId(), is(Optional.absent()));
+            assertThat(tasks.get(1).getParentId(), is(Optional.of(tasks.get(0).getId())));
+            assertThat(tasks.get(2).getParentId(), is(Optional.of(tasks.get(0).getId())));
+            assertThat(tasks.get(3).getParentId(), is(Optional.of(tasks.get(2).getId())));
+            assertThat(tasks.get(4).getParentId(), is(Optional.of(tasks.get(2).getId())));
+            assertThat(tasks.get(5).getParentId(), is(Optional.of(tasks.get(4).getId())));
+            assertThat(tasks.get(6).getParentId(), is(Optional.of(tasks.get(2).getId())));
+            assertThat(tasks.get(7).getParentId(), is(Optional.of(tasks.get(2).getId())));
+            assertThat(tasks.get(8).getParentId(), is(Optional.of(tasks.get(2).getId())));
+            assertThat(tasks.get(9).getParentId(), is(Optional.of(tasks.get(2).getId())));
+            assertThat(tasks.get(10).getParentId(), is(Optional.of(tasks.get(9).getId())));
+            assertThat(tasks.get(11).getParentId(), is(Optional.of(tasks.get(2).getId())));
+            assertThat(tasks.get(12).getParentId(), is(Optional.of(tasks.get(2).getId())));
+            assertThat(tasks.get(13).getParentId(), is(Optional.of(tasks.get(2).getId())));
+            assertThat(tasks.get(14).getParentId(), is(Optional.of(tasks.get(2).getId())));
+            assertThat(tasks.get(15).getParentId(), is(Optional.of(tasks.get(14).getId())));
+            assertThat(tasks.get(16).getParentId(), is(Optional.of(tasks.get(2).getId())));
+            assertThat(tasks.get(17).getParentId(), is(Optional.of(tasks.get(2).getId())));
+            assertThat(tasks.get(18).getParentId(), is(Optional.of(tasks.get(2).getId())));
+            assertThat(tasks.get(19).getParentId(), is(Optional.of(tasks.get(2).getId())));
+            assertThat(tasks.get(20).getParentId(), is(Optional.of(tasks.get(19).getId())));
+            assertThat(tasks.get(21).getParentId(), is(Optional.of(tasks.get(2).getId())));
+            assertThat(tasks.get(22).getParentId(), is(Optional.of(tasks.get(2).getId())));
+            assertThat(tasks.get(23).getParentId(), is(Optional.of(tasks.get(0).getId())));
+
+            // upstream_id test
+            assertThat(tasks.get(0).getUpstreams(), is(Collections.emptyList()));
+            assertThat(tasks.get(1).getUpstreams(), is(Collections.emptyList()));
+            assertThat(tasks.get(2).getUpstreams(), is(Collections.singletonList(tasks.get(1).getId())));
+            assertThat(tasks.get(3).getUpstreams(), is(Collections.emptyList()));
+            assertThat(tasks.get(4).getUpstreams(), is(Collections.singletonList(tasks.get(3).getId())));
+            assertThat(tasks.get(5).getUpstreams(), is(Collections.emptyList()));
+            assertThat(tasks.get(6).getUpstreams(), is(Collections.singletonList(tasks.get(4).getId())));
+            assertThat(tasks.get(7).getUpstreams(), is(Collections.singletonList(tasks.get(6).getId())));
+            assertThat(tasks.get(8).getUpstreams(), is(Collections.emptyList()));
+            assertThat(tasks.get(9).getUpstreams(), is(Collections.singletonList(tasks.get(8).getId())));
+            assertThat(tasks.get(10).getUpstreams(), is(Collections.emptyList()));
+            assertThat(tasks.get(11).getUpstreams(), is(Collections.singletonList(tasks.get(9).getId())));
+            assertThat(tasks.get(12).getUpstreams(), is(Collections.singletonList(tasks.get(11).getId())));
+            assertThat(tasks.get(13).getUpstreams(), is(Collections.emptyList()));
+            assertThat(tasks.get(14).getUpstreams(), is(Collections.singletonList(tasks.get(13).getId())));
+            assertThat(tasks.get(15).getUpstreams(), is(Collections.emptyList()));
+            assertThat(tasks.get(16).getUpstreams(), is(Collections.singletonList(tasks.get(14).getId())));
+            assertThat(tasks.get(17).getUpstreams(), is(Collections.singletonList(tasks.get(16).getId())));
+            assertThat(tasks.get(18).getUpstreams(), is(Collections.emptyList()));
+            assertThat(tasks.get(19).getUpstreams(), is(Collections.singletonList(tasks.get(18).getId())));
+            assertThat(tasks.get(20).getUpstreams(), is(Collections.emptyList()));
+            assertThat(tasks.get(21).getUpstreams(), is(Collections.singletonList(tasks.get(19).getId())));
+            assertThat(tasks.get(22).getUpstreams(), is(Collections.singletonList(tasks.get(21).getId())));
+            assertThat(tasks.get(23).getUpstreams(), is(Collections.emptyList()));
+            return null;
+        });
+    }
+}

--- a/digdag-core/src/test/java/io/digdag/core/workflow/WorkflowExecutorTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/WorkflowExecutorTest.java
@@ -71,7 +71,7 @@ public class WorkflowExecutorTest
         throws Exception
     {
         runWorkflow("retry_on_group", loadYamlResource("/io/digdag/core/workflow/retry_on_group.dig"));
-        assertThat(new String(Files.readAllBytes(folder.getRoot().toPath().resolve("out")), UTF_8), is("trytrytrytry"));
+        assertThat(new String(Files.readAllBytes(folder.getRoot().toPath().resolve("out")), UTF_8), is("try1try2try1try2try1try2try1try2"));
     }
 
     private void runWorkflow(String workflowName, Config config)

--- a/digdag-core/src/test/resources/io/digdag/core/workflow/retry_on_group.dig
+++ b/digdag-core/src/test/resources/io/digdag/core/workflow/retry_on_group.dig
@@ -4,10 +4,14 @@
 +doit:
   _retry: 3
   +task1:
-    echo>: "try"
+    echo>: "try1"
     append_file: out
   +task2:
-    fail>: task failed expectedly
+    +task2_nested:
+      echo>: "try2"
+      append_file: out
   +task3:
+    fail>: task failed expectedly
+  +task4:
     echo>: "skipped"
     append_file: out


### PR DESCRIPTION
https://github.com/treasure-data/digdag/pull/738 added dependencies for copied tasks but didn’t do parent id.
So we add the implements that update parent id of copied tasks.
 
Without updating parent id, Group Retry unexpectedly works as follow.
Thanks.

# issue
Workflow Definition
group_retry.dig
```
+wf:
  _retry: 3

  +t1:
    echo>: foo

  +t2:
    +t2_nested:
      echo>: bar

  +t3:
    fail>: failure
```
Result
![2018-04-16 20 03 28](https://user-images.githubusercontent.com/34811188/39240206-214fb958-48be-11e8-90aa-3c3ea3462ad6.png)
![2018-04-16 20 03 40](https://user-images.githubusercontent.com/34811188/39240223-2dcfc04c-48be-11e8-9781-e3932646bfa2.png)
We expect task 384 has task 383 as a parent, but actually, the parent id is 379.
So task 384 belongs to task group that has task 379 as a parent.
As a result, task 384 and task 382 start processing parallelly.

# After Fixed
![2018-04-16 20 15 10](https://user-images.githubusercontent.com/34811188/39240343-723b41f2-48be-11e8-998e-99cc04021fbe.png)
![2018-04-16 20 15 19](https://user-images.githubusercontent.com/34811188/39240398-9c0caab6-48be-11e8-9cc8-cea0d3f609c0.png)