### PR TITLE
[doc] Fix store_last_results description in redshift

### DIFF
--- a/digdag-docs/src/operators/redshift.md
+++ b/digdag-docs/src/operators/redshift.md
@@ -91,7 +91,7 @@ _export:
   download_file: output.csv
   ```
 
-* **store_last_results**: first | all
+* **store_last_results**: false | first | all
 
   Whether to store the query results to ``redshift.last_results`` parameter. *Default:* `false`.
 

--- a/digdag-docs/src/operators/redshift.md
+++ b/digdag-docs/src/operators/redshift.md
@@ -91,7 +91,7 @@ _export:
   download_file: output.csv
   ```
 
-* **store_last_results**: BOOLEAN
+* **store_last_results**: first | all
 
   Whether to store the query results to ``redshift.last_results`` parameter. *Default:* `false`.
 


### PR DESCRIPTION
`store_last_results` in redshift isn't BOOLEAN. 
The valid value is `first`. `all` and `false`.
I copied this fix from pg operator.
Should I add `false`?
