### PR TITLE
[edit documentation] make wording clearer

### DIFF
--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -555,7 +555,7 @@ backfill
 
 .. code-block:: console
 
-    $ digdag backfill <project-name> <name>
+    $ digdag backfill <project-name> <workflow-name>
 
 Starts sessions of a schedule for past session times.
 


### PR DESCRIPTION
Make wording clearer and match the argument name in the command reference documentation with the one in help file shown in the command line (shown below).
```
Usage: digdag backfill <project-name> <workflow-name>
```