### PR TITLE
[doc] Use `name` instead of `workflow-name` in cli.

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/client/Backfill.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Backfill.java
@@ -53,7 +53,7 @@ public class Backfill
 
     public SystemExitException usage(String error)
     {
-        err.println("Usage: " + programName + " backfill <project-name> <workflow-name>");
+        err.println("Usage: " + programName + " backfill <project-name> <name>");
         err.println("  Options:");
         err.println("    -f, --from 'yyyy-MM-dd[ HH:mm:ss]'  timestamp to start backfill from (required)");
         err.println("        --name NAME                  retry attempt name");

--- a/digdag-cli/src/main/java/io/digdag/cli/client/ShowSchedule.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/ShowSchedule.java
@@ -56,6 +56,6 @@ public class ShowSchedule
             count++;
         }
         ln("%d entries.", count);
-        err.println("Use `" + programName + " workflows [project-name] [workflow-name]` to show workflow details.");
+        err.println("Use `" + programName + " workflows [project-name] [name]` to show workflow details.");
     }
 }


### PR DESCRIPTION
Follow-up: #775

Use `name` instead of `workflow-name` in `digdag backfill` command line usage.
This change keeps consistency document and commands line usage.
#740 change it in the document. 
https://github.com/treasure-data/digdag/pull/740/files#diff-6da101123e994bcefae83a68f19bda25R558

I also found `workflow-name` in `digdag schedules` command usage.
