### PR TITLE
Add --task-log option in local mode

### DIFF
--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -106,6 +106,11 @@ Options:
 
   Example: ``--max-task-threads 5``
 
+:command:`-O, --task-log DIR`
+  Store task logs to this directory.
+
+  Example: ``--task-log digdag.log``
+
 :command:`-p, --param KEY=VALUE`
   Add a session parameter (use multiple times to set many parameters) in KEY=VALUE syntax. This parameter is availabe using ``${...}`` syntax in the YAML file, or using language API.
 

--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -109,7 +109,7 @@ Options:
 :command:`-O, --task-log DIR`
   Store task logs to this directory.
 
-  Example: ``--task-log digdag.log``
+  Example: ``--task-log log/tasks``
 
 :command:`-p, --param KEY=VALUE`
   Add a session parameter (use multiple times to set many parameters) in KEY=VALUE syntax. This parameter is availabe using ``${...}`` syntax in the YAML file, or using language API.


### PR DESCRIPTION
This patch supports --task-log option in local mode. (Issue #783)
I added LogModule to DigdagEmbed in class Run.
