### PR TITLE
Start v0.9.26-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ apply plugin: 'maven'
 
 allprojects {
     group = 'io.digdag'
-    version = '0.9.25'
+    version = '0.9.26-SNAPSHOT'
 
     ext {
         isSnapshotRelease = version.endsWith('-SNAPSHOT')


### PR DESCRIPTION
Let's start 0.9.26. 
Same as dcbd14bca54b2347b9cb503dcd8de77cea73698f