### PR TITLE
Upgrade Guice to 4.2.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,7 +113,7 @@ subprojects {
         jacksonVersion = "2.9.9"
         jacksonDatabindVersion = "2.9.9"
         awsJavaSdkVersion = "1.11.63"
-        guavaVersion = "19.0"
+        guavaVersion = "27.1-jre"
     }
 
     tasks.withType(JavaCompile) {

--- a/digdag-client/build.gradle
+++ b/digdag-client/build.gradle
@@ -12,7 +12,7 @@ dependencies {
         // available version of guava at the moment (e.g. 21.0). This is not good.
         exclude group: 'com.google.guava', module: 'guava'
     }
-    compile "com.google.guava:guava:19.0"
+    compile "com.google.guava:guava:25.1-jre"
 
     compile 'org.jboss.resteasy:resteasy-client:3.0.24.Final'
     compile 'org.apache.commons:commons-compress:1.10'

--- a/digdag-client/build.gradle
+++ b/digdag-client/build.gradle
@@ -13,7 +13,7 @@ dependencies {
         exclude group: 'com.google.guava', module: 'guava'
     }
     compile "com.google.guava:guava:25.1-jre"
-
+    compile "com.google.code.findbugs:jsr305:3.0.2"
     compile 'org.jboss.resteasy:resteasy-client:3.0.24.Final'
     compile 'org.apache.commons:commons-compress:1.10'
     compile 'io.jsonwebtoken:jjwt:0.6.0'

--- a/digdag-client/build.gradle
+++ b/digdag-client/build.gradle
@@ -12,7 +12,7 @@ dependencies {
         // available version of guava at the moment (e.g. 21.0). This is not good.
         exclude group: 'com.google.guava', module: 'guava'
     }
-    compile "com.google.guava:guava:25.1-jre"
+    compile "com.google.guava:guava:${project.ext.guavaVersion}"
     compile "com.google.code.findbugs:jsr305:3.0.2"
     compile 'org.jboss.resteasy:resteasy-client:3.0.24.Final'
     compile 'org.apache.commons:commons-compress:1.10'

--- a/digdag-core/build.gradle
+++ b/digdag-core/build.gradle
@@ -5,10 +5,8 @@ dependencies {
     compile project(':digdag-plugin-utils')
     compile project(':digdag-guice-rs-server')
 
-    // this dependency is here only to override dependency conflict of
-    // jackson-module-guice -> guice 3.0.
-    // https://github.com/FasterXML/jackson-modules-base/pull/22
-    compile 'org.embulk:guice-bootstrap:0.2.1'
+    compile 'com.google.inject:guice:4.2.2'
+    compile 'org.embulk:guice-bootstrap:0.3.2'
 
     compile("com.fasterxml.jackson.module:jackson-module-guice:${project.ext.jacksonVersion}") {
         // Avoid upgrading com.google.guava:guava:19.0 -> 23.6-android
@@ -42,7 +40,7 @@ dependencies {
 
     // Dependency conflict resolution
     compile 'javax.activation:activation:1.1.1'
-    compile 'org.apache.httpcomponents:httpclient:4.5.2'
+    compile 'org.apache.httpcomponents:httpclient:4.5.3'
 
     testCompile project(path: ':digdag-client', configuration: 'testArtifacts')
 }

--- a/digdag-guice-rs/build.gradle
+++ b/digdag-guice-rs/build.gradle
@@ -1,6 +1,6 @@
 
 dependencies {
-    compile 'com.google.inject:guice:4.0'
+    compile 'com.google.inject:guice:4.2.0'
     compile 'javax.servlet:javax.servlet-api:3.1.0'
     compile 'org.jboss.resteasy:resteasy-jaxrs:3.0.13.Final'
     compile 'org.jboss.resteasy:async-http-servlet-3.0:3.0.13.Final'

--- a/digdag-guice-rs/build.gradle
+++ b/digdag-guice-rs/build.gradle
@@ -1,7 +1,6 @@
 
 dependencies {
     compile 'com.google.inject:guice:4.2.2'
-    compile 'com.google.inject:guice:4.2.0'
     compile 'javax.servlet:javax.servlet-api:3.1.0'
     compile 'org.jboss.resteasy:resteasy-jaxrs:3.0.13.Final'
     compile 'org.jboss.resteasy:async-http-servlet-3.0:3.0.13.Final'

--- a/digdag-guice-rs/build.gradle
+++ b/digdag-guice-rs/build.gradle
@@ -1,6 +1,6 @@
 
 dependencies {
-    compile 'com.google.inject:guice:4.2.1'
+    compile 'com.google.inject:guice:4.2.2'
     compile 'javax.servlet:javax.servlet-api:3.1.0'
     compile 'org.jboss.resteasy:resteasy-jaxrs:3.0.13.Final'
     compile 'org.jboss.resteasy:async-http-servlet-3.0:3.0.13.Final'

--- a/digdag-guice-rs/build.gradle
+++ b/digdag-guice-rs/build.gradle
@@ -1,6 +1,6 @@
 
 dependencies {
-    compile 'com.google.inject:guice:4.2.0'
+    compile 'com.google.inject:guice:4.2.1'
     compile 'javax.servlet:javax.servlet-api:3.1.0'
     compile 'org.jboss.resteasy:resteasy-jaxrs:3.0.13.Final'
     compile 'org.jboss.resteasy:async-http-servlet-3.0:3.0.13.Final'

--- a/digdag-guice-rs/build.gradle
+++ b/digdag-guice-rs/build.gradle
@@ -1,6 +1,7 @@
 
 dependencies {
     compile 'com.google.inject:guice:4.2.2'
+    compile 'com.google.inject:guice:4.2.0'
     compile 'javax.servlet:javax.servlet-api:3.1.0'
     compile 'org.jboss.resteasy:resteasy-jaxrs:3.0.13.Final'
     compile 'org.jboss.resteasy:async-http-servlet-3.0:3.0.13.Final'

--- a/digdag-spi/build.gradle
+++ b/digdag-spi/build.gradle
@@ -1,5 +1,5 @@
 
 dependencies {
     compile project(':digdag-client')
-    compile 'com.google.inject.extensions:guice-multibindings:4.0'
+    compile 'com.google.inject.extensions:guice-multibindings:4.2.0'
 }

--- a/digdag-spi/build.gradle
+++ b/digdag-spi/build.gradle
@@ -1,5 +1,5 @@
 
 dependencies {
     compile project(':digdag-client')
-    compile 'com.google.inject.extensions:guice-multibindings:4.2.0'
+    compile 'com.google.inject.extensions:guice-multibindings:4.2.1'
 }

--- a/digdag-spi/build.gradle
+++ b/digdag-spi/build.gradle
@@ -1,5 +1,5 @@
 
 dependencies {
     compile project(':digdag-client')
-    compile 'com.google.inject.extensions:guice-multibindings:4.2.1'
+    compile 'com.google.inject.extensions:guice-multibindings:4.2.2'
 }

--- a/digdag-standards/build.gradle
+++ b/digdag-standards/build.gradle
@@ -43,11 +43,11 @@ dependencies {
 
     compile ('com.google.auth:google-auth-library-credentials:0.4.0') { exclude group: 'com.google.guava', module: 'guava-jdk5' }
     compile ('com.google.auth:google-auth-library-oauth2-http:0.4.0') { exclude group: 'com.google.guava', module: 'guava-jdk5' }
-    compile ('com.google.http-client:google-http-client:1.22.0') { exclude group: 'com.google.guava', module: 'guava-jdk5' }
-    compile ('com.google.http-client:google-http-client-jackson2:1.22.0') { exclude group: 'com.google.guava', module: 'guava-jdk5' }
+    compile ('com.google.http-client:google-http-client:1.24.1') { exclude group: 'com.google.guava', module: 'guava-jdk5' }
+    compile ('com.google.http-client:google-http-client-jackson2:1.24.1') { exclude group: 'com.google.guava', module: 'guava-jdk5' }
     compile ('com.google.oauth-client:google-oauth-client:1.22.0') { exclude group: 'com.google.guava', module: 'guava-jdk5' }
 
-    compile 'com.google.code.findbugs:jsr305:3.0.1'
+    compile 'com.google.code.findbugs:jsr305:3.0.2'
 
     // Newer version of jetty-client with some important bugfixes.
     // jetty-client is used by td-client-java, and ideally we would bump the version there but

--- a/digdag-tests/build.gradle
+++ b/digdag-tests/build.gradle
@@ -2,6 +2,7 @@
 dependencies {
     testCompile project(':digdag-cli')
     testCompile project(':digdag-storage-s3')
+    testCompile "com.google.code.findbugs:jsr305:3.0.2"
     testCompile 'com.google.code.findbugs:annotations:3.0.1'
     testCompile 'org.subethamail:subethasmtp:3.1.7'
     testCompile 'com.squareup.okhttp3:okhttp:3.12.0'

--- a/digdag-tests/build.gradle
+++ b/digdag-tests/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     testCompile 'com.squareup.okhttp3:okhttp:3.12.0'
     testCompile 'com.squareup.okhttp3:okhttp-tls:3.12.0'
     testCompile 'com.squareup.okhttp3:mockwebserver:3.12.0'
-    testCompile('org.littleshoot:littleproxy:1.1.2') {
+    testCompile('xyz.rogfam:littleproxy:2.0.0-beta-4') {
         // littleproxy depends on guava:20 and it conflicts with digdag-client
         exclude group: 'com.google.guava', module: 'guava'
         // littleproxy depends on slf4j-api:1.7.24 and it conflicts with others


### PR DESCRIPTION
Guice 4.0 doesn't work with Java 10. Support to Java 9 and later was
added since Guice 4.2. Changes:

* https://github.com/google/guice/wiki/Guice41
* https://github.com/google/guice/wiki/Guice42