### PR TITLE
Migrate to annotationProcessor feature in gradle 4.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '2.0.3'
     id 'com.jfrog.bintray' version '1.7.3'
     id 'com.github.kt3k.coveralls' version '2.6.3'
-    id 'net.ltgt.apt' version '0.9'
 }
 
 apply plugin: 'com.github.johnrengelman.shadow'
@@ -30,7 +29,6 @@ allprojects {
     apply plugin: 'jacoco'
     apply plugin: 'com.jfrog.bintray'
     apply plugin: 'maven-publish'
-    apply plugin: 'net.ltgt.apt'
 
     repositories {
         mavenCentral()
@@ -99,8 +97,8 @@ subprojects {
 
         compileOnly "org.immutables:value:2.3.9:annotations"
         testCompileOnly "org.immutables:value:2.3.9:annotations"
-        apt "org.immutables:value:2.3.9"
-        testApt "org.immutables:value:2.3.9"
+        annotationProcessor "org.immutables:value:2.3.9"
+        testAnnotationProcessor "org.immutables:value:2.3.9"
 
         testCompile 'junit:junit:4.12'
         testCompile 'org.hamcrest:hamcrest-library:1.3'

--- a/build.gradle
+++ b/build.gradle
@@ -242,7 +242,7 @@ subprojects {
         configurations.runtime.dependencies.each(generateDependency.curry('runtime', xml))
         configurations.testCompile.dependencies.each(generateDependency.curry('test', xml))
         configurations.testRuntime.dependencies.each(generateDependency.curry('test', xml))
-        configurations.apt.dependencies.each(generateDependency.curry('provided', xml))
+        configurations.annotationProcessor.dependencies.each(generateDependency.curry('provided', xml))
     }
 
     // Generate maven manifests for sub-modules


### PR DESCRIPTION
This PR fixes followings.

* rewrite to `annotationProcessor` configuration.
 See: https://docs.gradle.org/4.6/release-notes.html#convenient-declaration-of-annotation-processor-dependencies
* remove unnecessary apt plugin

## Note

~This PR has dependency #793 .~