### PR TITLE
build.gradle: Clean digdag-ui build in 'clean' task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -404,6 +404,7 @@ task classpath(dependsOn: [':digdag-cli:classpath']){
 clean {
     delete 'classpath'
     delete 'pkg'
+    delete 'digdag-ui/public'
 }
 
 task release() {


### PR DESCRIPTION
This PR makes minor change to remove digdag-ui build when 'clean' task is executed.