### PR TITLE
Update resteasy-client from 3.0.23.Final to 3.0.24.Final

### DIFF
--- a/digdag-client/build.gradle
+++ b/digdag-client/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     }
     compile "com.google.guava:guava:19.0"
 
-    compile 'org.jboss.resteasy:resteasy-client:3.0.23.Final'
+    compile 'org.jboss.resteasy:resteasy-client:3.0.24.Final'
     compile 'org.apache.commons:commons-compress:1.10'
     compile 'io.jsonwebtoken:jjwt:0.6.0'
 


### PR DESCRIPTION
This PR tries to upgrade resteasy-client from 3.0.23.Final to 3.0.24.Final. The missleading warning (https://github.com/treasure-data/digdag/pull/772) doesn't happen in 3.0.24.Final.

ref: https://issues.jboss.org/browse/RESTEASY-1722
diff: https://github.com/resteasy/Resteasy/compare/3.0.23.Final...3.0.24.Final