### PR TITLE
Upgrade gradle-bintray-plugin from 1.7.3 to 1.8.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'com.github.johnrengelman.shadow' version '2.0.3'
-    id 'com.jfrog.bintray' version '1.7.3'
+    id 'com.jfrog.bintray' version '1.8.1'
     id 'com.github.kt3k.coveralls' version '2.6.3'
     id 'com.github.spotbugs' version '1.6.2'
 }


### PR DESCRIPTION
This PR upgrades gradle-bintray-plugin from 1.7.3 to 1.8.1 to resolve https://github.com/treasure-data/digdag/pull/802. gradle-bintray-plugin could not upload artifacts to Bintray. The cause of the issue is that Gradle 4.8 was generating incompatible file data of artifacts that cannot be handled by bintray plugin. 

ref: https://github.com/bintray/gradle-bintray-plugin/issues/234
