### PR TITLE
Not recreate DigdagEmbed object for each test method

### DIFF
--- a/digdag-core/src/test/java/io/digdag/core/workflow/StoreParameterTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/StoreParameterTest.java
@@ -9,7 +9,9 @@ import io.digdag.core.session.StoredSessionAttemptWithSession;
 import java.nio.file.Path;
 import java.util.List;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -17,19 +19,33 @@ import org.junit.rules.TemporaryFolder;
 import static io.digdag.client.config.ConfigUtils.newConfig;
 import static io.digdag.core.workflow.WorkflowTestingUtils.loadYamlResource;
 import static io.digdag.core.workflow.WorkflowTestingUtils.runWorkflow;
-import static io.digdag.core.workflow.WorkflowTestingUtils.setupEmbed;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 public class StoreParameterTest
 {
+    private static DigdagEmbed embed;
+
+    @BeforeClass
+    public static void createDigdagEmbed()
+            throws Exception
+    {
+        embed = WorkflowTestingUtils.setupEmbed();
+    }
+
+    @AfterClass
+    public static void destroyDigdagEmbed()
+            throws Exception
+    {
+        embed.close();
+    }
+
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 
-    private DigdagEmbed embed;
     private LocalSite localSite;
     private Path projectPath;
     private TransactionManager tm;
@@ -38,17 +54,9 @@ public class StoreParameterTest
     public void setUp()
         throws Exception
     {
-        this.embed = setupEmbed();
         this.localSite = embed.getLocalSite();
         this.tm = embed.getTransactionManager();
         this.projectPath = folder.newFolder().toPath();
-    }
-
-    @After
-    public void destroy()
-        throws Exception
-    {
-        embed.close();
     }
 
     @Test

--- a/digdag-core/src/test/java/io/digdag/core/workflow/TaskDependenciesTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/TaskDependenciesTest.java
@@ -10,18 +10,33 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 import static io.digdag.core.workflow.WorkflowTestingUtils.loadYamlResource;
 import static io.digdag.core.workflow.WorkflowTestingUtils.runWorkflow;
-import static io.digdag.core.workflow.WorkflowTestingUtils.setupEmbed;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
 public class TaskDependenciesTest {
+
+    private static DigdagEmbed embed;
+
+    @BeforeClass
+    public static void createDigdagEmbed()
+            throws Exception {
+        embed = WorkflowTestingUtils.setupEmbed();
+    }
+
+    @AfterClass
+    public static void destroyDigdagEmbed()
+            throws Exception {
+        embed.close();
+    }
 
     @Rule
     public ExpectedException exception = ExpectedException.none();
@@ -29,7 +44,6 @@ public class TaskDependenciesTest {
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 
-    private DigdagEmbed embed;
     private LocalSite localSite;
     private Path projectPath;
     private TransactionManager tm;
@@ -37,16 +51,9 @@ public class TaskDependenciesTest {
     @Before
     public void setUp()
             throws Exception {
-        this.embed = setupEmbed();
         this.localSite = embed.getLocalSite();
         this.tm = embed.getTransactionManager();
         this.projectPath = folder.newFolder().toPath();
-    }
-
-    @After
-    public void destroy()
-            throws Exception {
-        embed.close();
     }
 
     @Test

--- a/digdag-core/src/test/java/io/digdag/core/workflow/WorkflowCompilerTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/WorkflowCompilerTest.java
@@ -7,38 +7,45 @@ import io.digdag.client.config.ConfigException;
 import io.digdag.client.config.ConfigFactory;
 import io.digdag.core.DigdagEmbed;
 import io.digdag.core.config.YamlConfigLoader;
+import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.After;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 
-import static io.digdag.core.workflow.WorkflowTestingUtils.setupEmbed;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class WorkflowCompilerTest
 {
+    private static DigdagEmbed embed;
+
     @Rule public ExpectedException exception = ExpectedException.none();
 
-    private DigdagEmbed embed;
-
     private WorkflowCompiler compiler;
+
+    @BeforeClass
+    public static void createDigdagEmbed()
+            throws Exception
+    {
+        embed = WorkflowTestingUtils.setupEmbed();
+    }
+
+    @AfterClass
+    public static void destroyDigdagEmbed()
+            throws Exception
+    {
+        embed.close();
+    }
 
     @Before
     public void setUp()
             throws Exception
     {
-        embed = setupEmbed();
         compiler = new WorkflowCompiler();
-    }
-
-    @After
-    public void destroy()
-        throws Exception
-    {
-        embed.close();
     }
 
     private Config loadYamlResource(String name)

--- a/digdag-core/src/test/java/io/digdag/core/workflow/WorkflowExecutorTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/WorkflowExecutorTest.java
@@ -8,7 +8,9 @@ import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigException;
 import io.digdag.core.DigdagEmbed;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -22,13 +24,27 @@ import static org.hamcrest.Matchers.is;
 
 public class WorkflowExecutorTest
 {
+    private static DigdagEmbed embed;
+
+    @BeforeClass
+    public static void createDigdagEmbed()
+    {
+        embed = WorkflowTestingUtils.setupEmbed();
+    }
+
+    @AfterClass
+    public static void destroyDigdagEmbed()
+            throws Exception
+    {
+        embed.close();
+    }
+
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 
-    private DigdagEmbed embed;
     private LocalSite localSite;
     private TransactionManager tm;
 
@@ -36,16 +52,8 @@ public class WorkflowExecutorTest
     public void setUp()
         throws Exception
     {
-        this.embed = setupEmbed();
         this.localSite = embed.getLocalSite();
         this.tm = embed.getTransactionManager();
-    }
-
-    @After
-    public void destroy()
-        throws Exception
-    {
-        embed.close();
     }
 
     @Test

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/ForEachOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/ForEachOperatorFactoryTest.java
@@ -1,7 +1,10 @@
 package io.digdag.standards.operator;
 
 import io.digdag.core.database.TransactionManager;
+import io.digdag.core.workflow.WorkflowTestingUtils;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -25,11 +28,24 @@ import static io.digdag.core.workflow.OperatorTestingUtils.newOperatorFactory;
 import static io.digdag.core.workflow.OperatorTestingUtils.newTaskRequest;
 import static io.digdag.core.workflow.OperatorTestingUtils.newContext;
 import static io.digdag.core.workflow.WorkflowTestingUtils.loadYamlResource;
-import static io.digdag.core.workflow.WorkflowTestingUtils.setupEmbed;
-import static io.digdag.core.workflow.WorkflowTestingUtils.runWorkflow;
 
 public class ForEachOperatorFactoryTest
 {
+    public static DigdagEmbed embed;
+
+    @BeforeClass
+    public static void createDigdagEmbed()
+    {
+        embed = WorkflowTestingUtils.setupEmbed();
+    }
+
+    @AfterClass
+    public static void destroyDigdagEmbed()
+            throws Exception
+    {
+        embed.close();
+    }
+
     @Rule
     public final ExpectedException exception = ExpectedException.none();
 
@@ -55,13 +71,10 @@ public class ForEachOperatorFactoryTest
         Config subtasks = result.getSubtaskConfig();
         assertThat(subtasks, is(loadYamlResource(expectedResource)));
 
-        try (DigdagEmbed embed = setupEmbed()) {
-            assertTrue(
-                    runWorkflow(embed, tempPath, "test", subtasks)
-                            .getStateFlags()
-                            .isSuccess()
-            );
-        }
+        assertTrue(WorkflowTestingUtils.runWorkflow(embed, tempPath, "test", subtasks)
+                .getStateFlags()
+                .isSuccess()
+        );
     }
 
     @Test


### PR DESCRIPTION
To make tests faster, this PR stops recreating `DigdagEmbed` object for each test method.