### PR TITLE
[wip] Not restart DigdagServer for each test method

### DIFF
--- a/digdag-tests/src/test/java/acceptance/AdminIT.java
+++ b/digdag-tests/src/test/java/acceptance/AdminIT.java
@@ -4,7 +4,9 @@ import io.digdag.client.DigdagClient;
 import io.digdag.client.api.Id;
 import io.digdag.client.config.Config;
 import org.hamcrest.Matchers;
+import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -23,13 +25,13 @@ import static org.junit.Assert.assertThat;
 
 public class AdminIT
 {
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
-
-    @Rule
-    public TemporaryDigdagServer server = TemporaryDigdagServer.builder()
+    @ClassRule
+    public static TemporaryDigdagServer server = TemporaryDigdagServer.builder()
             .configuration("server.admin.port = 0")
             .build();
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
 
     private Path config;
     private Path projectDir;
@@ -51,6 +53,24 @@ public class AdminIT
                 .host(server.host())
                 .port(server.adminPort())
                 .build();
+    }
+
+    @After
+    public void tearDown()
+    {
+        if (adminClient != null) {
+            adminClient.close();
+            adminClient = null;
+        }
+
+        if (client != null) {
+            client.close();
+            client = null;
+        }
+
+        if (folder != null) {
+            folder.delete();
+        }
     }
 
     @Test

--- a/digdag-tests/src/test/java/acceptance/AuthIT.java
+++ b/digdag-tests/src/test/java/acceptance/AuthIT.java
@@ -9,6 +9,7 @@ import org.eclipse.jetty.client.api.ContentResponse;
 import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -23,13 +24,13 @@ public class AuthIT
 {
     private static final RestApiKey apikey = RestApiKey.randomGenerate();
 
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
-
-    @Rule
-    public TemporaryDigdagServer server = TemporaryDigdagServer.builder()
+    @ClassRule
+    public static TemporaryDigdagServer server = TemporaryDigdagServer.builder()
             .configuration("server.apikey = " + apikey)
             .build();
+
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
 
     private HttpClient httpClient;
 
@@ -47,6 +48,7 @@ public class AuthIT
     {
         if (httpClient != null) {
             httpClient.stop();
+            httpClient = null;
         }
     }
 

--- a/digdag-tests/src/test/java/acceptance/CallIT.java
+++ b/digdag-tests/src/test/java/acceptance/CallIT.java
@@ -2,7 +2,9 @@ package acceptance;
 
 import com.google.common.io.Resources;
 import io.digdag.client.api.Id;
+import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -25,11 +27,11 @@ import static utils.TestUtils.main;
 
 public class CallIT
 {
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+    @ClassRule
+    public static TemporaryDigdagServer server = TemporaryDigdagServer.of();
 
     @Rule
-    public TemporaryDigdagServer server = TemporaryDigdagServer.of();
+    public TemporaryFolder folder = new TemporaryFolder();
 
     private Path config;
     private Path projectDir;
@@ -45,6 +47,14 @@ public class CallIT
     {
         projectDir = folder.getRoot().toPath().resolve("foobar");
         config = folder.newFile().toPath();
+    }
+
+    @After
+    public void tearDown()
+    {
+        if (folder != null) {
+            folder.delete();
+        }
     }
 
     private void initCallProject()

--- a/digdag-tests/src/test/java/acceptance/CustomServerHeadersIT.java
+++ b/digdag-tests/src/test/java/acceptance/CustomServerHeadersIT.java
@@ -3,7 +3,7 @@ package acceptance;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
-import org.junit.Rule;
+import org.junit.ClassRule;
 import org.junit.Test;
 import utils.TemporaryDigdagServer;
 
@@ -12,8 +12,8 @@ import static org.junit.Assert.assertThat;
 
 public class CustomServerHeadersIT
 {
-    @Rule
-    public TemporaryDigdagServer server = TemporaryDigdagServer.builder()
+    @ClassRule
+    public static TemporaryDigdagServer server = TemporaryDigdagServer.builder()
             .configuration(
                     "server.http.headers.Foo-Bar-1 = Baz-1",
                     "server.http.headers.Foo-Bar-2 = Baz-2")

--- a/digdag-tests/src/test/java/acceptance/DeleteProjectIT.java
+++ b/digdag-tests/src/test/java/acceptance/DeleteProjectIT.java
@@ -2,7 +2,9 @@ package acceptance;
 
 import io.digdag.client.DigdagClient;
 import io.digdag.client.api.Id;
+import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -25,11 +27,11 @@ import static org.junit.Assert.assertThat;
 
 public class DeleteProjectIT
 {
-    @Rule
-    public TemporaryFolder folder = new TemporaryFolder();
+    @ClassRule
+    public static TemporaryDigdagServer server = TemporaryDigdagServer.of();
 
     @Rule
-    public TemporaryDigdagServer server = TemporaryDigdagServer.of();
+    public TemporaryFolder folder = new TemporaryFolder();
 
     private Path config;
     private Path projectDir;
@@ -46,6 +48,15 @@ public class DeleteProjectIT
                 .host(server.host())
                 .port(server.port())
                 .build();
+    }
+
+    @After
+    public void tearDown()
+    {
+        if (client != null) {
+            client.close();
+            client = null;
+        }
     }
 
     @Test

--- a/digdag-tests/src/test/java/acceptance/ErrorServerMailIT.java
+++ b/digdag-tests/src/test/java/acceptance/ErrorServerMailIT.java
@@ -4,7 +4,9 @@ import io.digdag.client.DigdagClient;
 import io.digdag.client.api.Id;
 import io.digdag.client.api.RestSessionAttempt;
 import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -33,13 +35,13 @@ public class ErrorServerMailIT
     private static final String SMTP_USER = "mail-user";
     private static final String SMTP_PASS = "mail-pass";
 
-    private final Wiser mailServer = startMailServer(HOSTNAME, SMTP_USER, SMTP_PASS);
+    private static final Wiser mailServer = startMailServer(HOSTNAME, SMTP_USER, SMTP_PASS);
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 
-    @Rule
-    public TemporaryDigdagServer server = TemporaryDigdagServer.builder()
+    @ClassRule
+    public static TemporaryDigdagServer server = TemporaryDigdagServer.builder()
             .configuration(
                     "config.mail.host=" + HOSTNAME,
                     "config.mail.port=" + mailServer.getServer().getPort(),
@@ -67,8 +69,8 @@ public class ErrorServerMailIT
         copyResource("acceptance/error_server_mail/alert.txt", projectDir.resolve("alert.txt"));
     }
 
-    @After
-    public void tearDown()
+    @AfterClass
+    public static void tearDown()
             throws Exception
     {
         mailServer.stop();

--- a/digdag-tests/src/test/java/utils/TemporaryDigdagServer.java
+++ b/digdag-tests/src/test/java/utils/TemporaryDigdagServer.java
@@ -81,8 +81,6 @@ public class TemporaryDigdagServer
 
     private static final ThreadFactory DAEMON_THREAD_FACTORY = new ThreadFactoryBuilder().setDaemon(true).build();
 
-    private final TemporaryFolder temporaryFolder = new TemporaryFolder();
-
     private final Optional<Version> version;
 
     private final String host;
@@ -91,15 +89,15 @@ public class TemporaryDigdagServer
     private final ExecutorService executor;
     private final List<String> configuration;
 
-    private final ByteArrayOutputStream out = new ByteArrayOutputStream();
-    private final ByteArrayOutputStream err = new ByteArrayOutputStream();
-
     private final boolean inProcess;
     private final Map<String, String> environment;
     private final Properties properties;
 
     private Path workdir;
     private Process serverProcess;
+    private TemporaryFolder temporaryFolder;
+    private ByteArrayOutputStream out;
+    private ByteArrayOutputStream err;
 
     private Path configDirectory;
     private Path config;
@@ -259,8 +257,12 @@ public class TemporaryDigdagServer
             throws Exception
     {
         started = true;
+        closed = false;
 
+        temporaryFolder = new TemporaryFolder();
         temporaryFolder.create();
+        out = new ByteArrayOutputStream();
+        err = new ByteArrayOutputStream();
 
         setupDatabase();
 
@@ -566,9 +568,11 @@ public class TemporaryDigdagServer
     public void close()
     {
         closed = true;
+        started = false;
 
         if (serverProcess != null) {
             kill(serverProcess);
+            serverProcess = null;
         }
 
         executor.shutdownNow();


### PR DESCRIPTION
To make CI tests faster, this PR makes change not to restart DigdagServer for each test method.