### PR TITLE
Fix docker/bootstrap/dependencies.sh to change digdag-build image with Node v8.x

### DIFF
--- a/docker/bootstrap/dependencies.sh
+++ b/docker/bootstrap/dependencies.sh
@@ -8,7 +8,7 @@ apt-get -y install maven
 
 # npm
 apt-get -y install curl
-curl -sL https://deb.nodesource.com/setup_6.x | bash -
+curl -sL https://deb.nodesource.com/setup_8.x | bash -
 apt-get -y install nodejs
 
 # Postgres


### PR DESCRIPTION
This PR fixes docker/bootstrap/dependencies.sh to change digdag-build image with Node v8.x