### PR TITLE
Fix docker/Makefile to rename docker image for digdag-build with '%ad-%H'

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,5 +1,5 @@
 IMAGE_NAME = digdag/digdag-build
-IMAGE_TAG = $(shell git show --pretty=format:'%H-%ad' --date 'format:%Y%m%dT%H%M%S' | head -n 1)
+IMAGE_TAG = $(shell git show --pretty=format:'%ad-%H' --date 'format:%Y%m%dT%H%M%S' | head -n 1)
 IMAGE = $(IMAGE_NAME):$(IMAGE_TAG)
 
 build:


### PR DESCRIPTION
This PR fixes docker/Makefile and renames docker image for digdag-build