### PR TITLE
Fix docker/bootstrap/dependencies.sh to rehash pip command

### DIFF
--- a/docker/bootstrap/dependencies.sh
+++ b/docker/bootstrap/dependencies.sh
@@ -24,7 +24,7 @@ sudo -u postgres createdb -O digdag_test digdag_test
 
 # Python
 apt-get -y install python python-pip python-dev
-pip install pip --upgrade
+pip install pip --upgrade && hash -r pip # rehashed https://github.com/pypa/pip/issues/5240
 # Using sphinx==1.4.9 because sphinx_rtd_theme with sphinx 1.5.x has a problem with search and its fix is not released: https://github.com/snide/sphinx_rtd_theme/pull/346
 pip install sphinx==1.4.9 recommonmark sphinx_rtd_theme
 


### PR DESCRIPTION
This PR fixes docker/bootstrap/dependencies.sh to rehash pip command. It can avoid python runtime error by pip upgrading.
ref: https://github.com/pypa/pip/issues/5240