### PR TITLE
Modify sample of bq_load> operator

### DIFF
--- a/digdag-docs/src/operators/bq_load.md
+++ b/digdag-docs/src/operators/bq_load.md
@@ -237,9 +237,10 @@
     bq_load>: gs://<bucket>/path/to_file
     ...
     schema:
-      - name: "name",
-        type: "string"
-      ...
+      fields:
+        - name: "name",
+          type: "string"
+        ...
   ```
 
   Or you can write it as external file.


### PR DESCRIPTION
`fields:` is required in `schema:` parameter.
Reference: https://github.com/treasure-data/digdag/blob/d6d29a7161f69169055ea3b2e83f1d113292fcf7/digdag-tests/src/test/resources/acceptance/bigquery/load.dig