### PR TITLE
Rename 'SimpleCommandExecutor' for testing with 'MockCommandExecutor'

### DIFF
--- a/digdag-core/src/test/java/io/digdag/core/workflow/MockCommandExecutor.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/MockCommandExecutor.java
@@ -8,11 +8,11 @@ import com.google.common.base.Optional;
 import io.digdag.spi.CommandExecutor;
 import io.digdag.spi.TaskRequest;
 
-public class SimpleCommandExecutor
+public class MockCommandExecutor
     implements CommandExecutor
 {
     @Inject
-    public SimpleCommandExecutor()
+    public MockCommandExecutor()
     { }
 
     public Process start(Path projectPath, TaskRequest request, ProcessBuilder pb)

--- a/digdag-core/src/test/java/io/digdag/core/workflow/OperatorTestingUtils.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/OperatorTestingUtils.java
@@ -1,7 +1,6 @@
 package io.digdag.core.workflow;
 
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -10,7 +9,6 @@ import com.google.inject.Scopes;
 import com.google.inject.TypeLiteral;
 
 import io.digdag.client.config.Config;
-import io.digdag.client.config.ConfigElement;
 import io.digdag.client.config.ConfigFactory;
 import io.digdag.client.config.ConfigUtils;
 import io.digdag.core.Environment;
@@ -45,7 +43,7 @@ public class OperatorTestingUtils
     public static <T extends OperatorFactory> T newOperatorFactory(Class<T> factoryClass)
     {
         Injector initInjector = Guice.createInjector((Module) (binder) -> {
-            binder.bind(CommandExecutor.class).to(SimpleCommandExecutor.class).in(Scopes.SINGLETON);
+            binder.bind(CommandExecutor.class).to(MockCommandExecutor.class).in(Scopes.SINGLETON);
             binder.bind(CommandLogger.class).to(TaskContextCommandLogger.class).in(Scopes.SINGLETON);
             binder.bind(TemplateEngine.class).to(ConfigEvalEngine.class).in(Scopes.SINGLETON);
             binder.bind(ConfigFactory.class).toInstance(ConfigUtils.configFactory);

--- a/digdag-core/src/test/java/io/digdag/core/workflow/WorkflowTestingUtils.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/WorkflowTestingUtils.java
@@ -55,7 +55,7 @@ public class WorkflowTestingUtils
         DigdagEmbed.Bootstrap bootstrap = new DigdagEmbed.Bootstrap()
             .withExtensionLoader(false)
             .addModules((binder) -> {
-                binder.bind(CommandExecutor.class).to(SimpleCommandExecutor.class).in(Scopes.SINGLETON);
+                binder.bind(CommandExecutor.class).to(MockCommandExecutor.class).in(Scopes.SINGLETON);
 
                 binder.bind(SecretCrypto.class).toProvider(SecretCryptoProvider.class).in(Scopes.SINGLETON);
                 binder.bind(SecretStoreManager.class).to(DatabaseSecretStoreManager.class).in(Scopes.SINGLETON);


### PR DESCRIPTION
This PR just renames 'SimpleCommandExecutor' for testing with 'MockCommandExecutor'. 