### PR TITLE
PowerShell needs to set TLS1.2 explicitly for connecting to Bintray

### DIFF
--- a/digdag-docs/src/getting_started.md
+++ b/digdag-docs/src/getting_started.md
@@ -21,7 +21,7 @@ If `digdag --help` command works, Digdag is installed successfully.
 On Windows, please open cmd.exe or PowerShell.exe and type following command exactly:
 
 ```
-PowerShell -Command "& {mkdir -Force $env:USERPROFILE\bin; Invoke-WebRequest http://dl.digdag.io/digdag-latest.jar -OutFile $env:USERPROFILE\bin\digdag.bat}"
+PowerShell -Command "& {[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::TLS12; mkdir -Force $env:USERPROFILE\bin; Invoke-WebRequest http://dl.digdag.io/digdag-latest.jar -OutFile $env:USERPROFILE\bin\digdag.bat}"
 ```
 
 Above command downloads a file named `digdag.bat` to a folder named `bin` at your home folder (`C:\Users\YOUR_NAME\bin`).


### PR DESCRIPTION
Lately, Bintray must use TLS 1.2 protocol.
But PowerShell doesn't use it by default. (use TLS 1.1)

This PR update the document to use TLS 1.2 protocol explicitly for downloading Digdag.

I got the following exception when I execute the command.

```
PowerShell -Command "& {mkdir -Force $env:USERPROFILE\bin; Invoke-WebRequest http://dl.digdag.io/digdag-latest.jar -OutFile $env:USERPROFILE\bin\digdag.bat}"

Invoke-WebRequest : 接続が切断されました: 送信時に、予期しないエラーが発生しました。。
At line:1 char:37
+ ... \admin\bin; Invoke-WebRequest http://dl.digdag.io/digdag-latest.jar - ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (System.Net.HttpWebRequest:HttpWebRequest) [Invoke-WebRequest], WebException
    + FullyQualifiedErrorId : WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand
```

Ref1: [Add support for TLS 1.2 (Invoke-WebRequest, Invoke-RestMethod)](https://windowsserver.uservoice.com/forums/301869-powershell/suggestions/15150051-add-support-for-tls-1-2-invoke-webrequest-invoke)
Ref2: [Twitter](https://twitter.com/dmikurube/status/1019387999384027138) (Japanese text)
