### PR TITLE
Fix the several typos detected by github.com/client9/misspell

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
@@ -173,7 +173,7 @@ public class OperatorManager
             });
         }
         catch (RuntimeException | IOException ex) {
-            // exception happend in workspaceManager
+            // exception happened in workspaceManager
             logger.error("Task failed with unexpected error: {}", ex.getMessage(), ex);
             callback.taskFailed(request.getSiteId(),
                     request.getTaskId(), request.getLockId(), agentId,

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
@@ -376,7 +376,7 @@ public class DatabaseProjectStoreManager
          * Create or overwrite a revision.
          *
          * This method doesn't check site id because ProjectControl
-         * interface is avaiable only if site is is valid.
+         * interface is available only if site is is valid.
          */
         @Override
         public StoredRevision insertRevision(int projId, Revision revision)

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20151204221156_CreateTables.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20151204221156_CreateTables.java
@@ -9,7 +9,7 @@ public class Migration_20151204221156_CreateTables
     public void migrate(Handle handle, MigrationContext context)
     {
         if (context.isPostgres()) {
-            // check existance of extension first because CREATE EXTENSION is allowed only for superuser
+            // check the existence of extension first because CREATE EXTENSION is allowed only for superuser
             String ver = handle.createQuery("select installed_version from pg_catalog.pg_available_extensions where name = 'uuid-ossp'")
                 .mapTo(String.class)
                 .first();

--- a/digdag-core/src/test/java/io/digdag/core/database/DatabaseSecretStoreTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/database/DatabaseSecretStoreTest.java
@@ -102,7 +102,7 @@ public class DatabaseSecretStoreTest
         factory.begin(() -> secretControlStore.setProjectSecret(projectId, SecretScopes.PROJECT, KEY1, VALUE1));
 
         AtomicReference<Optional<String>> blockedGetValue = new AtomicReference<>(null);
-        AtomicBoolean comitting = new AtomicBoolean(false);
+        AtomicBoolean committing = new AtomicBoolean(false);
         AtomicBoolean blockedCheckComitting = new AtomicBoolean(false);
 
         Thread thread = factory.begin(() -> secretControlStore.lockProjectSecret(projectId, SecretScopes.PROJECT, KEY1, (control, value) -> {
@@ -118,7 +118,7 @@ public class DatabaseSecretStoreTest
                     catch (Exception ex) {
                         throw new RuntimeException(ex);
                     }
-                    blockedCheckComitting.set(comitting.get());
+                    blockedCheckComitting.set(committing.get());
                 });
                 t.setDaemon(true);
                 t.start();
@@ -132,7 +132,7 @@ public class DatabaseSecretStoreTest
 
                 control.setProjectSecret(projectId, SecretScopes.PROJECT, KEY1, VALUE1 + ".changed");
 
-                comitting.set(true);
+                committing.set(true);
                 return t;
             }
             catch (InterruptedException ex) {

--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -90,7 +90,7 @@ Options:
     * hourly: uses current hour's 00:00 as the session time (update session time every hour).
     * schedule: calculates time based on ``schedule`` configuration of the workflow. Error if ``schedule`` is not set.
     * last: reuses the last session time of the last execution. If it's not available, tries to calculate based on ``schedule``, or uses today's 00:00:00.
-    * timestmap in *yyyy-MM-dd* or *yyyy-MM-dd HH:mm:ss* format: uses the specified time as the session time.
+    * timestamp in *yyyy-MM-dd* or *yyyy-MM-dd HH:mm:ss* format: uses the specified time as the session time.
 
   Default is "last".
 
@@ -107,7 +107,7 @@ Options:
   Example: ``--max-task-threads 5``
 
 :command:`-p, --param KEY=VALUE`
-  Add a session parameter (use multiple times to set many parameters) in KEY=VALUE syntax. This parameter is availabe using ``${...}`` syntax in the YAML file, or using language API.
+  Add a session parameter (use multiple times to set many parameters) in KEY=VALUE syntax. This parameter is available using ``${...}`` syntax in the YAML file, or using language API.
 
   Example: ``-p environment=staging``
 
@@ -148,7 +148,7 @@ Shows workflow definitions and schedules. "c" is alias of check command. Example
   Example: ``--project workflow/``
 
 :command:`-p, --param KEY=VALUE`
-  Overwrite a parameter (use multiple times to set many parameters) in KEY=VALUE syntax. This parameter is availabe using ``${...}`` syntax in the YAML file, or using language API.
+  Overwrite a parameter (use multiple times to set many parameters) in KEY=VALUE syntax. This parameter is available using ``${...}`` syntax in the YAML file, or using language API.
 
   Example: ``-p environment=staging``
 
@@ -204,7 +204,7 @@ Runs a workflow scheduler that runs schedules periodically. This picks up all wo
   Example: ``--max-task-threads 5``
 
 :command:`-p, --param KEY=VALUE`
-  Add a session parameter (use multiple times to set many parameters) in KEY=VALUE syntax. This parameter is availabe using ``${...}`` syntax in the YAML file, or using language API.
+  Add a session parameter (use multiple times to set many parameters) in KEY=VALUE syntax. This parameter is available using ``${...}`` syntax in the YAML file, or using language API.
 
   Example: ``-p environment=staging``
 
@@ -300,7 +300,7 @@ Runs a digdag server. --memory or --database option is required. Examples:
   Example: ``--disable-executor-loop``
 
 :command:`-p, --param KEY=VALUE`
-  Add a session parameter (use multiple times to set many parameters) in KEY=VALUE syntax. This parameter is availabe using ``${...}`` syntax in the YAML file, or using language API.
+  Add a session parameter (use multiple times to set many parameters) in KEY=VALUE syntax. This parameter is available using ``${...}`` syntax in the YAML file, or using language API.
 
   Example: ``-p environment=staging``
 
@@ -434,7 +434,7 @@ Starts a new session. This command requires project name, workflow name, and ses
   Tries to start a new session attempt and validates the results but does nothing.
 
 :command:`-p, --param KEY=VALUE`
-  Add a session parameter (use multiple times to set many parameters) in KEY=VALUE syntax. This parameter is availabe using ``${...}`` syntax in the YAML file, or using language API.
+  Add a session parameter (use multiple times to set many parameters) in KEY=VALUE syntax. This parameter is available using ``${...}`` syntax in the YAML file, or using language API.
 
   Example: ``-p environment=staging``
 

--- a/digdag-docs/src/operators/redshift_load.md
+++ b/digdag-docs/src/operators/redshift_load.md
@@ -248,7 +248,7 @@
 * **csv**: CHARACTER
 
   Parameter mapped to `CSV` parameter of Redshift's `COPY` statement.
-  If you want to just use default quote charactor of `CSV` parameter, set empty string like `csv: ''`
+  If you want to just use default quote character of `CSV` parameter, set empty string like `csv: ''`
 
   Examples:
 

--- a/digdag-docs/src/releases/release-0.2.8.rst
+++ b/digdag-docs/src/releases/release-0.2.8.rst
@@ -9,7 +9,7 @@ Command-line Changes
 General Changes
 ------------------
 
-* Added ``loop`` operator. To support it, ``${...}`` varaibles in ``_do`` key will not be evaluated.
+* Added ``loop`` operator. To support it, ``${...}`` variables in ``_do`` key will not be evaluated.
 
 Release Date
 ------------------

--- a/digdag-docs/src/releases/release-0.4.3.rst
+++ b/digdag-docs/src/releases/release-0.4.3.rst
@@ -34,7 +34,7 @@ Server-mode changes
 
 * Fixed putAndLockRepository on PostgreSQL.
 
-* insertAttempt validates existance of associated workflow definition and using foreign key validation.
+* insertAttempt validates existence of associated workflow definition and using foreign key validation.
 
 
 Release Date

--- a/digdag-docs/src/releases/release-0.8.19.rst
+++ b/digdag-docs/src/releases/release-0.8.19.rst
@@ -4,7 +4,7 @@ Release 0.8.19
 Server Changes
 --------------
 
-* Added an ``isAdmin`` flag to the ``Authenticator.Result`` interface that can be used to grant users adminstrator rights.
+* Added an ``isAdmin`` flag to the ``Authenticator.Result`` interface that can be used to grant users administrator rights.
 * Added an administration API with an endpoint that can be used by administrators to get ``userinfo`` metadata for a session attempt.
 
 UI Changes

--- a/digdag-docs/src/releases/release-0.8.22.rst
+++ b/digdag-docs/src/releases/release-0.8.22.rst
@@ -4,7 +4,7 @@ Release 0.8.22
 General Changes
 ---------------
 
-* Task and Attempt execution time limits are now enforced. The attempt is canceled and a notificaiton sent if either limit is exceeded. The limits can be configured using the
+* Task and Attempt execution time limits are now enforced. The attempt is canceled and a notification sent if either limit is exceeded. The limits can be configured using the
   ``executor.attempt_ttl`` and ``executor.task_ttl`` settings. The default limits are 7 days and 1 day, respectively.
 
 Workflow Changes

--- a/digdag-docs/src/releases/release-0.8.5.rst
+++ b/digdag-docs/src/releases/release-0.8.5.rst
@@ -4,7 +4,7 @@ Release 0.8.5
 General changes
 ---------------
 
-* Fixed ``file name ... is too long ( > 100 bytes)`` error that happend when ``digdag push`` command archives file names longer than 100 bytes. Now digdag client and server use PAX extension to handle long file names.
+* Fixed ``file name ... is too long ( > 100 bytes)`` error that happened when ``digdag push`` command archives file names longer than 100 bytes. Now digdag client and server use PAX extension to handle long file names.
 
 
 Server mode changes

--- a/digdag-docs/src/scheduling_workflow.rst
+++ b/digdag-docs/src/scheduling_workflow.rst
@@ -47,7 +47,7 @@ cron>: ``CRON``                 Use cron format for complex scheduling      cron
 
 .. note::
 
-    When a field is starting with ``*`` , enclosing in quotes is neccessary by a limitasion to be a vaild YAML.
+    When a field is starting with ``*`` , enclosing in quotes is necessary by a limitasion to be a vaild YAML.
 
 
 Running scheduler

--- a/digdag-guice-rs-server/src/main/java/io/digdag/guice/rs/server/ServerLifeCycleManager.java
+++ b/digdag-guice-rs-server/src/main/java/io/digdag/guice/rs/server/ServerLifeCycleManager.java
@@ -82,7 +82,7 @@ public class ServerLifeCycleManager
         }
 
         if (currentState.isSameOrAfter(State.STARTED)) {
-            // Not stopping but already has started (this.postStart() is allready done).
+            // Not stopping but already has started (this.postStart() is already done).
             // Need to call PostStart here. PreStop will be called alter.
             invokeMethods(obj, postStartMethods);
             postStartMethods = ImmutableList.of();

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/state/PollingRetryExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/state/PollingRetryExecutor.java
@@ -23,7 +23,7 @@ public class PollingRetryExecutor
 
     private static final String DEFAULT_ERROR_MESSAGE = "Operation failed";
     private static final Object[] DEFAULT_ERROR_MESSAGE_PARAMETERS = {};
-    private static final List<Predicate<Exception>> DEAFULT_RETRY_PREDICATES = ImmutableList.of();
+    private static final List<Predicate<Exception>> DEFAULT_RETRY_PREDICATES = ImmutableList.of();
 
     private static final String RESULT = "result";
     private static final String DONE = "done";
@@ -62,7 +62,7 @@ public class PollingRetryExecutor
                 state,
                 stateKey,
                 DEFAULT_RETRY_INTERVAL,
-                DEAFULT_RETRY_PREDICATES,
+                DEFAULT_RETRY_PREDICATES,
                 DEFAULT_ERROR_MESSAGE,
                 DEFAULT_ERROR_MESSAGE_PARAMETERS);
     }

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/aws/S3WaitOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/aws/S3WaitOperatorFactoryTest.java
@@ -71,7 +71,7 @@ public class S3WaitOperatorFactoryTest
 
     private static final String SSE_C_KEY = Base64.getEncoder().encodeToString("test-sse-c-key".getBytes(UTF_8));
     private static final String SSE_C_KEY_MD5 = Base64.getEncoder().encodeToString("test-sse-c-key-md5".getBytes(UTF_8));
-    private static final String SSE_C_KEY_ALGORITM = Base64.getEncoder().encodeToString("test-sse-c-key-algorithm".getBytes(UTF_8));
+    private static final String SSE_C_KEY_ALGORITHM = Base64.getEncoder().encodeToString("test-sse-c-key-algorithm".getBytes(UTF_8));
     private static final String VERSION_ID = "test-version-id";
 
     static {
@@ -312,7 +312,7 @@ public class S3WaitOperatorFactoryTest
         when(taskRequest.getConfig()).thenReturn(config);
 
         when(s3Secrets.getSecretOptional("sse_c_key")).thenReturn(Optional.of(SSE_C_KEY));
-        when(s3Secrets.getSecretOptional("sse_c_key_algorithm")).thenReturn(Optional.of(SSE_C_KEY_ALGORITM));
+        when(s3Secrets.getSecretOptional("sse_c_key_algorithm")).thenReturn(Optional.of(SSE_C_KEY_ALGORITHM));
         when(s3Secrets.getSecretOptional("sse_c_key_md5")).thenReturn(Optional.of(SSE_C_KEY_MD5));
 
         when(s3Client.getObjectMetadata(objectMetadataRequestCaptor.capture())).thenThrow(NOT_FOUND_EXCEPTION);
@@ -328,7 +328,7 @@ public class S3WaitOperatorFactoryTest
 
         GetObjectMetadataRequest objectMetadataRequest = objectMetadataRequestCaptor.getValue();
         assertThat(objectMetadataRequest.getSSECustomerKey().getKey(), is(SSE_C_KEY));
-        assertThat(objectMetadataRequest.getSSECustomerKey().getAlgorithm(), is(SSE_C_KEY_ALGORITM));
+        assertThat(objectMetadataRequest.getSSECustomerKey().getAlgorithm(), is(SSE_C_KEY_ALGORITHM));
         assertThat(objectMetadataRequest.getSSECustomerKey().getMd5(), is(SSE_C_KEY_MD5));
     }
 

--- a/digdag-storage-s3/src/main/java/io/digdag/storage/s3/S3Storage.java
+++ b/digdag-storage-s3/src/main/java/io/digdag/storage/s3/S3Storage.java
@@ -60,7 +60,7 @@ public class S3Storage
                     .setNameFormat("storage-s3-upload-transfer-%d")
                     .build());
         this.transferManager = new TransferManager(client, uploadExecutor);
-        // TODO check existance of the bucket so that following
+        // TODO check the existence of the bucket so that following
         //      any GET or PUT don't get 404 Not Found error.
     }
 
@@ -89,7 +89,7 @@ public class S3Storage
 
         // override close to call abort instead because close skips all remaining bytes so that
         // s3 client can reuse the TCP connection. but close of a fully opened file is occasionally
-        // used to skip remaing work (e.g. finally block when exception is thrown). Unlike openRange,
+        // used to skip remaining work (e.g. finally block when exception is thrown). Unlike openRange,
         // performance impact could be significantly large.
         InputStream stream = overrideCloseToAbort(obj.getObjectContent());
 


### PR DESCRIPTION
This pull request fixes minor typos detected by [misspell](https://github.com/client9/misspell). I've skipped a portion of them because they're false positives.

## before

```
$ misspell .
digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java:176:25: "happend" is a misspelling of "happened"
digdag-core/src/main/java/io/digdag/core/config/YamlTagResolver.java:45:81: "alse" is a misspelling of "else"
digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java:379:24: "avaiable" is a misspelling of "available"
digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20151204221156_CreateTables.java:12:21: "existance" is a misspelling of "existence"
digdag-core/src/test/java/io/digdag/core/database/DatabaseSecretStoreTest.java:105:22: "comitting" is a misspelling of "committing"
digdag-docs/src/command_reference.rst:93:6: "timestmap" is a misspelling of "timestamp"
digdag-docs/src/command_reference.rst:110:109: "availabe" is a misspelling of "available"
digdag-docs/src/command_reference.rst:151:107: "availabe" is a misspelling of "available"
digdag-docs/src/command_reference.rst:207:109: "availabe" is a misspelling of "available"
digdag-docs/src/command_reference.rst:303:109: "availabe" is a misspelling of "available"
digdag-docs/src/command_reference.rst:437:109: "availabe" is a misspelling of "available"
digdag-docs/src/operators/redshift_load.md:251:40: "charactor" is a misspelling of "character"
digdag-docs/src/releases/release-0.2.8.rst:12:53: "varaibles" is a misspelling of "variables"
digdag-docs/src/releases/release-0.4.3.rst:37:26: "existance" is a misspelling of "existence"
digdag-docs/src/releases/release-0.8.19.rst:7:102: "adminstrator" is a misspelling of "administrator"
digdag-docs/src/releases/release-0.8.22.rst:7:89: "notificaiton" is a misspelling of "notification"
digdag-docs/src/releases/release-0.8.5.rst:7:64: "happend" is a misspelling of "happened"
digdag-docs/src/scheduling_workflow.rst:50:65: "neccessary" is a misspelling of "necessary"
digdag-guice-rs-server/src/main/java/io/digdag/guice/rs/server/ServerLifeCycleManager.java:85:73: "allready" is a misspelling of "already"
digdag-standards/src/main/java/io/digdag/standards/operator/state/PollingRetryExecutor.java:26:52: "DEAFULT" is a misspelling of "DEFAULT"
digdag-standards/src/main/java/io/digdag/standards/operator/state/PollingRetryExecutor.java:65:16: "DEAFULT" is a misspelling of "DEFAULT"
digdag-standards/src/main/java/io/digdag/standards/operator/td/YamlTagResolver.java:45:81: "alse" is a misspelling of "else"
digdag-standards/src/test/java/io/digdag/standards/operator/aws/S3WaitOperatorFactoryTest.java:74:42: "ALGORITM" is a misspelling of "ALGORITHM"
digdag-standards/src/test/java/io/digdag/standards/operator/aws/S3WaitOperatorFactoryTest.java:315:98: "ALGORITM" is a misspelling of "ALGORITHM"
digdag-standards/src/test/java/io/digdag/standards/operator/aws/S3WaitOperatorFactoryTest.java:331:90: "ALGORITM" is a misspelling of "ALGORITHM"
digdag-storage-s3/src/main/java/io/digdag/storage/s3/S3Storage.java:63:22: "existance" is a misspelling of "existence"
digdag-storage-s3/src/main/java/io/digdag/storage/s3/S3Storage.java:92:24: "remaing" is a misspelling of "remaining"
```

## after

```
$ misspell .
digdag-core/src/main/java/io/digdag/core/config/YamlTagResolver.java:45:81: "alse" is a misspelling of "else"
digdag-standards/src/main/java/io/digdag/standards/operator/td/YamlTagResolver.java:45:81: "alse" is a misspelling of "else"
```