### PR TITLE
Support `password_override` option on `pg` and `redshift` operators

### DIFF
--- a/digdag-docs/src/operators/pg.md
+++ b/digdag-docs/src/operators/pg.md
@@ -23,9 +23,7 @@ _export:
 +insert_to_summary_table:
   pg>: queries/join_log_with_master.sql
   insert_into: summary_table
-```
 
-```
 +select_members:
   pg>: select_members.sql
   store_last_results: first
@@ -42,7 +40,8 @@ _export:
 ## Secrets
 
 * **pg.password**: NAME
-  Optional user password to use when connecting to the postgres database.
+
+  Optional user password to use when connecting to the Postgres database. If you want to use multiple credentials, use `password_override` option.
 
 ## Options
 
@@ -197,4 +196,14 @@ _export:
 
   ```
   status_table: customized_status_table
+  ```
+
+* **password_override**: NAME
+
+  Secret key name that has a non-default database password as its value. This would be useful whey you want to use multiple database credentials. If it's set, Digdag looks up secrets with this value as a secret key name. If not, the default secret key `pg.password` is used.
+
+  Examples (let's say you've already added a secret key value `pg.another_password=password1234`):
+
+  ```
+  password_override: another_password
   ```

--- a/digdag-docs/src/operators/redshift.md
+++ b/digdag-docs/src/operators/redshift.md
@@ -23,9 +23,7 @@ _export:
 +insert_to_summary_table:
   redshift>: queries/join_log_with_master.sql
   insert_into: summary_table
-```
 
-```
 +select_members:
   redshift>: select_members.sql
   store_last_results: first
@@ -43,7 +41,7 @@ _export:
 
 * **aws.redshift.password**: NAME
 
-  Optional user password to use when connecting to the Redshift database.
+  Optional user password to use when connecting to the Redshift database. If you want to use multiple credentials, use `password_override` option.
 
 ## Options
 
@@ -219,3 +217,14 @@ _export:
   ```
   socket_timeout: 1800s
   ```
+
+* **password_override**: NAME
+
+  Secret key name that has a non-default database password as its value. This would be useful whey you want to use multiple database credentials. If it's set, Digdag looks up secrets with this value as a secret key name. If not, the default secret key `redshift.password` is used.
+
+  Examples (let's say you've already added a secret key value `redshift.another_password=password1234`):
+
+  ```
+  password_override: another_password
+  ```
+

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcConnectionConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcConnectionConfig.java
@@ -17,13 +17,13 @@ public abstract class AbstractJdbcConnectionConfig
     protected static Optional<String> getPassword(SecretProvider secrets, Config params)
     {
         Optional<String> passwordOverrideKey = params.getOptional("password_override", String.class);
-
-        Optional<String> overriddenPassword = Optional.absent();
         if (passwordOverrideKey.isPresent()) {
-            overriddenPassword = secrets.getSecretOptional(passwordOverrideKey.get());
+            // When `password_override` is specified, the key needs to exist
+            return Optional.of(secrets.getSecret(passwordOverrideKey.get()));
         }
-
-        return overriddenPassword.or(secrets.getSecretOptional("password"));
+        else {
+            return secrets.getSecretOptional("password");
+        }
     }
 
     public abstract String host();

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcConnectionConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcConnectionConfig.java
@@ -8,11 +8,24 @@ import java.sql.DriverManager;
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import io.digdag.client.config.Config;
+import io.digdag.spi.SecretProvider;
 import io.digdag.util.DurationParam;
 import static java.util.Locale.ENGLISH;
 
 public abstract class AbstractJdbcConnectionConfig
 {
+    protected static Optional<String> getPassword(SecretProvider secrets, Config params)
+    {
+        Optional<String> passwordOverrideKey = params.getOptional("password_override", String.class);
+
+        Optional<String> overriddenPassword = Optional.absent();
+        if (passwordOverrideKey.isPresent()) {
+            overriddenPassword = secrets.getSecretOptional(passwordOverrideKey.get());
+        }
+
+        return overriddenPassword.or(secrets.getSecretOptional("password"));
+    }
+
     public abstract String host();
 
     public abstract int port();

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/pg/PgConnectionConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/pg/PgConnectionConfig.java
@@ -35,18 +35,6 @@ public abstract class PgConnectionConfig
                 .build();
     }
 
-    protected static Optional<String> getPassword(SecretProvider secrets, Config params)
-    {
-        Optional<String> passwordOverrideKey = params.getOptional("password_override", String.class);
-
-        Optional<String> overriddenPassword = Optional.absent();
-        if (passwordOverrideKey.isPresent()) {
-            overriddenPassword = secrets.getSecretOptional(passwordOverrideKey.get());
-        }
-
-        return overriddenPassword.or(secrets.getSecretOptional("password"));
-    }
-
     @Override
     public String jdbcDriverName()
     {

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/redshift/RedshiftConnectionConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/redshift/RedshiftConnectionConfig.java
@@ -24,7 +24,7 @@ public abstract class RedshiftConnectionConfig
                 .host(secrets.getSecretOptional("host").or(() -> params.get("host", String.class)))
                 .port(secrets.getSecretOptional("port").transform(Integer::parseInt).or(() -> params.get("port", int.class, 5439)))
                 .user(secrets.getSecretOptional("user").or(() -> params.get("user", String.class)))
-                .password(secrets.getSecretOptional("password"))
+                .password(getPassword(secrets, params))
                 .database(secrets.getSecretOptional("database").or(() -> params.get("database", String.class)))
                 .ssl(secrets.getSecretOptional("ssl").transform(Boolean::parseBoolean).or(() -> params.get("ssl", boolean.class, false)))
                 .connectTimeout(params.get("connect_timeout", DurationParam.class, DurationParam.of(Duration.ofSeconds(30))))

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/redshift/RedshiftConnectionConfigTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/redshift/RedshiftConnectionConfigTest.java
@@ -1,6 +1,7 @@
-package io.digdag.standards.operator.pg;
+package io.digdag.standards.operator.redshift;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import io.digdag.standards.operator.jdbc.JdbcOpTestHelper;
@@ -15,38 +16,40 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
-public class PgConnectionConfigTest
+public class RedshiftConnectionConfigTest
 {
     private final JdbcOpTestHelper jdbcOpTestHelper = new JdbcOpTestHelper();
 
-    private PgConnectionConfig connConfigWithDefaultValue;
-    private PgConnectionConfig connConfigWithCustomValue;
-    private PgConnectionConfig connConfigWithDefaultValueFromSecrets;
-    private PgConnectionConfig connConfigWithCustomValueFromSecrets;
-    private PgConnectionConfig connConfigWithOverriddenPassword;
-    private PgConnectionConfig connConfigWithMissingOverriddenPassword;
+    private RedshiftConnectionConfig connConfigWithDefaultValue;
+    private RedshiftConnectionConfig connConfigWithCustomValue;
+    private RedshiftConnectionConfig connConfigWithDefaultValueFromSecrets;
+    private RedshiftConnectionConfig connConfigWithCustomValueFromSecrets;
+    private RedshiftConnectionConfig connConfigWithOverriddenPassword;
+    private RedshiftConnectionConfig connConfigWithMissingOverriddenPassword;
 
     @Before
     public void setUp()
             throws IOException
     {
-        // This map contains only minimum custom values to test default values
-        Map<String, String> defaultConfigValues = ImmutableMap.of(
-                "host", "foobar0.org",
-                "user", "user0",
-                "database", "database0"
-        );
+        {
+            // This map contains only minimum custom values to test default values
+            Map<String, String> defaultConfigValues = ImmutableMap.of(
+                    "host", "foobar0.org",
+                    "user", "user0",
+                    "database", "database0"
+            );
 
-        this.connConfigWithDefaultValue = PgConnectionConfig.configure(
-                key -> Optional.absent(), jdbcOpTestHelper.createConfig(defaultConfigValues)
-        );
+            this.connConfigWithDefaultValue = RedshiftConnectionConfig.configure(
+                    key -> Optional.absent(), jdbcOpTestHelper.createConfig(defaultConfigValues)
+            );
 
-        // This map contains values that are all "ignore" so that we can detect if this value is used unexpectedly
-        Map<String, String> ignoredDefaultConfigValues = Maps.transformValues(defaultConfigValues, key -> "ignore");
+            // This map contains values that are all "ignore" so that we can detect if this value is used unexpectedly
+            Map<String, String> ignoredDefaultConfigValues = Maps.transformValues(defaultConfigValues, key -> "ignore");
 
-        this.connConfigWithDefaultValueFromSecrets = PgConnectionConfig.configure(
-                key -> Optional.fromNullable(defaultConfigValues.get(key)), jdbcOpTestHelper.createConfig(ignoredDefaultConfigValues)
-        );
+            this.connConfigWithDefaultValueFromSecrets = RedshiftConnectionConfig.configure(
+                    key -> Optional.fromNullable(defaultConfigValues.get(key)), jdbcOpTestHelper.createConfig(ignoredDefaultConfigValues)
+            );
+        }
 
         // This map contains whole custom values to test if custom values are used expectedly
         Map<String, String> customConfigValues = ImmutableMap.<String, String>builder().
@@ -60,41 +63,48 @@ public class PgConnectionConfigTest
                 put("socket_timeout", "12 m").
                 put("schema", "myschema").build();
 
-        this.connConfigWithCustomValue = PgConnectionConfig.configure(
-                key -> key.equals("password") ? Optional.of("password1") : Optional.absent(), jdbcOpTestHelper.createConfig(customConfigValues)
-        );
+        {
+            this.connConfigWithCustomValue = RedshiftConnectionConfig.configure(
+                    key -> key.equals("password") ? Optional.of("password1") : Optional.absent(), jdbcOpTestHelper.createConfig(customConfigValues)
+            );
 
-        // This map contains values that are all "ignore" so that we can detect if this value is used unexpectedly
-        Map<String, String> ignoredCustomConfigValues = Maps.transformValues(customConfigValues, key -> "ignore");
+            // This map contains values that are all "ignore" so that we can detect if this value is used unexpectedly
+            ImmutableList<String> itemsFromOnlyConfig = ImmutableList.of("connect_timeout", "socket_timeout");
+            Map<String, String> ignoredCustomConfigValues =
+                    Maps.transformEntries(customConfigValues,
+                            (key, value) -> itemsFromOnlyConfig.contains(key) ? value : "ignore");
 
-        this.connConfigWithCustomValueFromSecrets = PgConnectionConfig.configure(
-                key -> Optional.fromNullable(customConfigValues.get(key)), jdbcOpTestHelper.createConfig(ignoredCustomConfigValues)
-        );
+            this.connConfigWithCustomValueFromSecrets = RedshiftConnectionConfig.configure(
+                    key -> Optional.fromNullable(customConfigValues.get(key)), jdbcOpTestHelper.createConfig(ignoredCustomConfigValues)
+            );
+        }
 
-        Map<String, String> configValuesWithOverriddenPassword = ImmutableMap.<String, String>builder()
-                .putAll(customConfigValues)
-                .put("another_db_password", "password2")
-                .build();
+        {
+            Map<String, String> configValuesWithOverriddenPassword = ImmutableMap.<String, String>builder()
+                    .putAll(customConfigValues)
+                    .put("another_db_password", "password2")
+                    .build();
 
-        Map<String, String> configValuesUsingOverriddenPassword = ImmutableMap.<String, String>builder()
-                .putAll(customConfigValues)
-                .put("password_override", "another_db_password")
-                .build();
+            Map<String, String> configValuesUsingOverriddenPassword = ImmutableMap.<String, String>builder()
+                    .putAll(customConfigValues)
+                    .put("password_override", "another_db_password")
+                    .build();
 
-        this.connConfigWithOverriddenPassword = PgConnectionConfig.configure(
-                key -> Optional.fromNullable(configValuesWithOverriddenPassword.get(key)),
-                jdbcOpTestHelper.createConfig(configValuesUsingOverriddenPassword)
-        );
+            this.connConfigWithOverriddenPassword = RedshiftConnectionConfig.configure(
+                    key -> Optional.fromNullable(configValuesWithOverriddenPassword.get(key)),
+                    jdbcOpTestHelper.createConfig(configValuesUsingOverriddenPassword)
+            );
 
-        Map<String, String> configValuesUsingMissingOverriddenPassword = ImmutableMap.<String, String>builder()
-                .putAll(customConfigValues)
-                .put("password_override", "missing_db_password")
-                .build();
+            Map<String, String> configValuesUsingMissingOverriddenPassword = ImmutableMap.<String, String>builder()
+                    .putAll(customConfigValues)
+                    .put("password_override", "missing_db_password")
+                    .build();
 
-        this.connConfigWithMissingOverriddenPassword = PgConnectionConfig.configure(
-                key -> Optional.fromNullable(configValuesWithOverriddenPassword.get(key)),
-                jdbcOpTestHelper.createConfig(configValuesUsingMissingOverriddenPassword)
-        );
+            this.connConfigWithMissingOverriddenPassword = RedshiftConnectionConfig.configure(
+                    key -> Optional.fromNullable(configValuesWithOverriddenPassword.get(key)),
+                    jdbcOpTestHelper.createConfig(configValuesUsingMissingOverriddenPassword)
+            );
+        }
     }
 
     @Test
@@ -120,8 +130,8 @@ public class PgConnectionConfigTest
     @Test
     public void url()
     {
-        assertThat(connConfigWithDefaultValue.url(), is("jdbc:postgresql://foobar0.org:5432/database0"));
-        assertThat(connConfigWithDefaultValueFromSecrets.url(), is("jdbc:postgresql://foobar0.org:5432/database0"));
+        assertThat(connConfigWithDefaultValue.url(), is("jdbc:postgresql://foobar0.org:5439/database0"));
+        assertThat(connConfigWithDefaultValueFromSecrets.url(), is("jdbc:postgresql://foobar0.org:5439/database0"));
         assertThat(connConfigWithCustomValue.url(), is("jdbc:postgresql://foobar1.org:6543/database1"));
         assertThat(connConfigWithCustomValueFromSecrets.url(), is("jdbc:postgresql://foobar1.org:6543/database1"));
     }

--- a/digdag-tests/src/test/java/acceptance/PgIT.java
+++ b/digdag-tests/src/test/java/acceptance/PgIT.java
@@ -33,7 +33,6 @@ import java.util.Properties;
 import java.util.UUID;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.junit.Assume.assumeTrue;
@@ -58,6 +57,7 @@ public class PgIT
     private String host;
     private String user;
     private String database;
+    private String password;
     private String tempDatabase;
     private String dataSchemaName;
 
@@ -84,6 +84,7 @@ public class PgIT
 
             host = (String) props.get("host");
             user = (String) props.get("user");
+            password = (String) props.get("password");
             database = (String) props.get("database");
         }
         else {
@@ -91,6 +92,7 @@ public class PgIT
             Config config = Config.deserializeFromJackson(objectMapper, objectMapper.readTree(PG_IT_CONFIG));
             host = config.get("host", String.class);
             user = config.get("user", String.class);
+            password = config.get("password", String.class);
             database = config.get("database", String.class);
 
         }
@@ -484,6 +486,7 @@ public class PgIT
         return key -> Optional.fromNullable(ImmutableMap.of(
                 "host", host,
                 "user", user,
+                "password", password,
                 "database", tempDatabase
         ).get(key));
     }
@@ -493,6 +496,7 @@ public class PgIT
         return key -> Optional.fromNullable(ImmutableMap.of(
                 "host", host,
                 "user", user,
+                "password", password,
                 "database", database
         ).get(key));
     }

--- a/digdag-tests/src/test/java/acceptance/PgIT.java
+++ b/digdag-tests/src/test/java/acceptance/PgIT.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.StringReader;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -60,6 +61,8 @@ public class PgIT
     private String password;
     private String tempDatabase;
     private String dataSchemaName;
+    private Path configFile;
+    private Path configFileWithPasswordOverride;
 
     private Path root()
     {
@@ -96,6 +99,15 @@ public class PgIT
             database = config.get("database", String.class);
 
         }
+
+        configFile = folder.newFile().toPath();
+        Files.write(configFile, Arrays.asList("pg.password= " + password));
+
+        configFileWithPasswordOverride = folder.newFile().toPath();
+        Files.write(configFileWithPasswordOverride,
+                Arrays.asList("pg.password= " + UUID.randomUUID().toString(),
+                        "pg.another_password= " + password));
+
         tempDatabase = "pgoptest_" + UUID.randomUUID().toString().replace('-', '_');
 
         createTempDatabase();
@@ -163,7 +175,12 @@ public class PgIT
 
         setupSourceTable();
 
-        CommandStatus status = TestUtils.main("run", "-o", root().toString(), "--project", root().toString(), "-p", "pg_database=" + tempDatabase, "pg.dig");
+        CommandStatus status = TestUtils.main(
+                "run", "-o", root().toString(),
+                "--project", root().toString(),
+                "-p", "pg_database=" + tempDatabase,
+                "-c", configFile.toString(),
+                "pg.dig");
         assertCommandStatus(status);
 
         List<String> csvLines = new ArrayList<>();
@@ -187,7 +204,12 @@ public class PgIT
 
         setupSourceTable(true);
 
-        CommandStatus status = TestUtils.main("run", "-o", root().toString(), "--project", root().toString(), "-p", "pg_database=" + tempDatabase, "pg.dig");
+        CommandStatus status = TestUtils.main(
+                "run", "-o", root().toString(),
+                "--project", root().toString(),
+                "-p", "pg_database=" + tempDatabase,
+                "-c", configFile.toString(),
+                "pg.dig");
         assertCommandStatus(status);
 
         List<String> csvLines = new ArrayList<>();
@@ -216,6 +238,7 @@ public class PgIT
                 "--project", root().toString(),
                 "-p", "pg_database=" + tempDatabase,
                 "-p", "outfile=out",
+                "-c", configFile.toString(),
                 "pg.dig");
         assertCommandStatus(status);
 
@@ -245,6 +268,7 @@ public class PgIT
                 "--project", root().toString(),
                 "-p", "pg_database=" + tempDatabase,
                 "-p", "outfile=out",
+                "-c", configFile.toString(),
                 "pg.dig");
         assertCommandStatus(status);
 
@@ -273,6 +297,7 @@ public class PgIT
                 "-p", "pg_database=" + tempDatabase,
                 "-p", "outfile=out",
                 "-X", "config.pg.max_store_last_results_rows=2",
+                "-c", configFile.toString(),
                 "pg.dig");
         assertCommandStatus(status, Optional.of("The number of result rows exceeded the limit"));
     }
@@ -292,6 +317,7 @@ public class PgIT
                 "-p", "pg_database=" + tempDatabase,
                 "-p", "outfile=out",
                 "-X", "config.jdbc.max_store_last_results_value_size=2",
+                "-c", configFile.toString(),
                 "pg.dig");
         assertCommandStatus(status, Optional.of("The size of result value exceeded the limit"));
     }
@@ -306,7 +332,12 @@ public class PgIT
         setupSourceTable();
         setupDestTable();
 
-        CommandStatus status = TestUtils.main("run", "-o", root().toString(), "--project", root().toString(), "-p", "pg_database=" + tempDatabase, "pg.dig");
+        CommandStatus status = TestUtils.main(
+                "run", "-o", root().toString(),
+                "--project", root().toString(),
+                "-p", "pg_database=" + tempDatabase,
+                "-c", configFile.toString(),
+                "pg.dig");
         assertCommandStatus(status);
 
         assertTableContents(DEST_TABLE, Arrays.asList(
@@ -326,7 +357,12 @@ public class PgIT
         setupSourceTable();
         setupDestTable();
 
-        CommandStatus status = TestUtils.main("run", "-o", root().toString(), "--project", root().toString(), "-p", "pg_database=" + tempDatabase, "pg.dig");
+        CommandStatus status = TestUtils.main(
+                "run", "-o", root().toString(),
+                "--project", root().toString(),
+                "-p", "pg_database=" + tempDatabase,
+                "-c", configFile.toString(),
+                "pg.dig");
         assertCommandStatus(status);
 
         assertTableContents(DEST_TABLE, Arrays.asList(
@@ -358,6 +394,7 @@ public class PgIT
                 "-p", "user_in_config=" + RESTRICTED_USER,
                 "-p", "schema_in_config=" + dataSchemaName,
                 "-p", "status_table_schema_in_config=" + statusTableSchema,
+                "-c", configFile.toString(),
                 "pg.dig");
         assertCommandStatus(status);
 
@@ -379,7 +416,12 @@ public class PgIT
         setupSourceTable();
         setupDestTable();
 
-        CommandStatus status = TestUtils.main("run", "-o", root().toString(), "--project", root().toString(), "-p", "pg_database=" + tempDatabase, "pg.dig");
+        CommandStatus status = TestUtils.main(
+                "run", "-o", root().toString(),
+                "--project", root().toString(),
+                "-p", "pg_database=" + tempDatabase,
+                "-c", configFile.toString(),
+                "pg.dig");
         assertCommandStatus(status);
 
         assertTableContents(DEST_TABLE, Arrays.asList(

--- a/digdag-tests/src/test/java/acceptance/PgIT.java
+++ b/digdag-tests/src/test/java/acceptance/PgIT.java
@@ -178,6 +178,8 @@ public class PgIT
         CommandStatus status = TestUtils.main(
                 "run", "-o", root().toString(),
                 "--project", root().toString(),
+                "-p", "pg_host=" + host,
+                "-p", "pg_user=" + user,
                 "-p", "pg_database=" + tempDatabase,
                 "-c", configFile.toString(),
                 "pg.dig");
@@ -207,6 +209,8 @@ public class PgIT
         CommandStatus status = TestUtils.main(
                 "run", "-o", root().toString(),
                 "--project", root().toString(),
+                "-p", "pg_host=" + host,
+                "-p", "pg_user=" + user,
                 "-p", "pg_database=" + tempDatabase,
                 "-c", configFile.toString(),
                 "pg.dig");
@@ -236,6 +240,8 @@ public class PgIT
         CommandStatus status = TestUtils.main(
                 "run", "-o", root().toString(),
                 "--project", root().toString(),
+                "-p", "pg_host=" + host,
+                "-p", "pg_user=" + user,
                 "-p", "pg_database=" + tempDatabase,
                 "-p", "outfile=out",
                 "-c", configFile.toString(),
@@ -266,6 +272,8 @@ public class PgIT
         CommandStatus status = TestUtils.main(
                 "run", "-o", root().toString(),
                 "--project", root().toString(),
+                "-p", "pg_host=" + host,
+                "-p", "pg_user=" + user,
                 "-p", "pg_database=" + tempDatabase,
                 "-p", "outfile=out",
                 "-c", configFile.toString(),
@@ -294,6 +302,8 @@ public class PgIT
         CommandStatus status = TestUtils.main(
                 "run", "-o", root().toString(),
                 "--project", root().toString(),
+                "-p", "pg_host=" + host,
+                "-p", "pg_user=" + user,
                 "-p", "pg_database=" + tempDatabase,
                 "-p", "outfile=out",
                 "-X", "config.pg.max_store_last_results_rows=2",
@@ -314,6 +324,8 @@ public class PgIT
         CommandStatus status = TestUtils.main(
                 "run", "-o", root().toString(),
                 "--project", root().toString(),
+                "-p", "pg_host=" + host,
+                "-p", "pg_user=" + user,
                 "-p", "pg_database=" + tempDatabase,
                 "-p", "outfile=out",
                 "-X", "config.jdbc.max_store_last_results_value_size=2",
@@ -335,6 +347,8 @@ public class PgIT
         CommandStatus status = TestUtils.main(
                 "run", "-o", root().toString(),
                 "--project", root().toString(),
+                "-p", "pg_host=" + host,
+                "-p", "pg_user=" + user,
                 "-p", "pg_database=" + tempDatabase,
                 "-c", configFile.toString(),
                 "pg.dig");
@@ -360,6 +374,8 @@ public class PgIT
         CommandStatus status = TestUtils.main(
                 "run", "-o", root().toString(),
                 "--project", root().toString(),
+                "-p", "pg_host=" + host,
+                "-p", "pg_user=" + user,
                 "-p", "pg_database=" + tempDatabase,
                 "-c", configFile.toString(),
                 "pg.dig");
@@ -390,8 +406,9 @@ public class PgIT
         setupSchema(statusTableSchema, true);
 
         CommandStatus status = TestUtils.main("run", "-o", root().toString(), "--project", root().toString(),
+                "-p", "pg_host=" + host,
+                "-p", "pg_user=" + RESTRICTED_USER,
                 "-p", "pg_database=" + tempDatabase,
-                "-p", "user_in_config=" + RESTRICTED_USER,
                 "-p", "schema_in_config=" + dataSchemaName,
                 "-p", "status_table_schema_in_config=" + statusTableSchema,
                 "-c", configFile.toString(),
@@ -416,9 +433,13 @@ public class PgIT
         setupSourceTable();
         setupDestTable();
 
+        // With "strict_transaction: false", `pg` operator can work
+        // even if the user can't create a new status table
         CommandStatus status = TestUtils.main(
                 "run", "-o", root().toString(),
                 "--project", root().toString(),
+                "-p", "pg_host=" + host,
+                "-p", "pg_user=" + RESTRICTED_USER,
                 "-p", "pg_database=" + tempDatabase,
                 "-c", configFile.toString(),
                 "pg.dig");

--- a/digdag-tests/src/test/java/acceptance/PgIT.java
+++ b/digdag-tests/src/test/java/acceptance/PgIT.java
@@ -179,38 +179,6 @@ public class PgIT
     }
 
     @Test
-    public void selectAndDownloadWithPasswordOverride()
-            throws Exception
-    {
-        copyResource("acceptance/pg/select_download_with_password_override.dig", root().resolve("pg.dig"));
-        copyResource("acceptance/pg/select_table.sql", root().resolve("select_table.sql"));
-
-        setupSourceTable(Optional.of(
-                key -> Optional.fromNullable(ImmutableMap.of(
-                        "host", host,
-                        "user", user,
-                        "password", UUID.randomUUID().toString(),
-                        "another_db_password", password,
-                        "database", tempDatabase
-                ).get(key))
-        ));
-
-        CommandStatus status = TestUtils.main("run", "-o", root().toString(), "--project", root().toString(), "-p", "pg_database=" + tempDatabase, "pg.dig");
-        assertCommandStatus(status);
-
-        List<String> csvLines = new ArrayList<>();
-        try (BufferedReader reader = new BufferedReader(new FileReader(new File(root().toFile(), "pg_test.csv")))) {
-            String line;
-            while ((line = reader.readLine()) != null) {
-                csvLines.add(line);
-            }
-            assertThat(csvLines.toString(), is(stringContainsInOrder(
-                    Arrays.asList("id,name,score", "0,foo,3.14", "1,bar,1.23", "2,baz,5.0")
-            )));
-        }
-    }
-
-    @Test
     public void selectAndDownloadWithNullValues()
             throws Exception
     {
@@ -427,19 +395,9 @@ public class PgIT
         setupSourceTable(false);
     }
 
-    private void setupSourceTable(Optional<SecretProvider> customSecretProvider)
-    {
-        setupSourceTable(false, customSecretProvider);
-    }
-
     private void setupSourceTable(boolean withNulls)
     {
-        setupSourceTable(withNulls, Optional.absent());
-    }
-
-    private void setupSourceTable(boolean withNulls, Optional<SecretProvider> customSecretProvider)
-    {
-        SecretProvider secrets = customSecretProvider.or(getDatabaseSecrets());
+        SecretProvider secrets = getDatabaseSecrets();
 
         try (PgConnection conn = PgConnection.open(PgConnectionConfig.configure(secrets, EMPTY_CONFIG))) {
             switchSearchPath(conn);

--- a/digdag-tests/src/test/java/acceptance/td/RedshiftIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/RedshiftIT.java
@@ -228,7 +228,7 @@ public class RedshiftIT
             throws Exception
     {
         testSelectAndDownload(
-                "acceptance/redshift/select_download.dig_with_password_override",
+                "acceptance/redshift/select_download_with_password_override.dig",
                 configFileWithPasswordOverride);
     }
 

--- a/digdag-tests/src/test/resources/acceptance/pg/create_table.dig
+++ b/digdag-tests/src/test/resources/acceptance/pg/create_table.dig
@@ -2,7 +2,7 @@ timezone: UTC
 
 +run:
   pg>: select_table.sql
-  host: localhost
+  host: ${pg_host}
   database: ${pg_database}
-  user: digdag_test
+  user: ${pg_user}
   create_table: dest_tbl

--- a/digdag-tests/src/test/resources/acceptance/pg/insert_into.dig
+++ b/digdag-tests/src/test/resources/acceptance/pg/insert_into.dig
@@ -2,7 +2,7 @@ timezone: UTC
 
 +run:
   pg>: select_table.sql
-  host: localhost
+  host: ${pg_host}
   database: ${pg_database}
-  user: digdag_test
+  user: ${pg_user}
   insert_into: dest_tbl

--- a/digdag-tests/src/test/resources/acceptance/pg/insert_into_with_schema.dig
+++ b/digdag-tests/src/test/resources/acceptance/pg/insert_into_with_schema.dig
@@ -2,9 +2,9 @@ timezone: UTC
 
 +run:
   pg>: select_table.sql
-  host: localhost
+  host: ${pg_host}
   database: ${pg_database}
-  user: ${user_in_config}
+  user: ${pg_user}
   schema: ${schema_in_config}
   status_table_schema: ${status_table_schema_in_config}
   insert_into: dest_tbl

--- a/digdag-tests/src/test/resources/acceptance/pg/insert_into_wo_st.dig
+++ b/digdag-tests/src/test/resources/acceptance/pg/insert_into_wo_st.dig
@@ -3,7 +3,7 @@ timezone: UTC
 +run:
   pg>: select_table.sql
   strict_transaction: false
-  host: localhost
+  host: ${pg_host}
   database: ${pg_database}
-  user: not_admin
+  user: ${pg_user}
   insert_into: dest_tbl

--- a/digdag-tests/src/test/resources/acceptance/pg/select_download.dig
+++ b/digdag-tests/src/test/resources/acceptance/pg/select_download.dig
@@ -2,7 +2,7 @@ timezone: UTC
 
 +run:
   pg>: select_table.sql
-  host: localhost
+  host: ${pg_host}
   database: ${pg_database}
-  user: digdag_test
+  user: ${pg_user}
   download_file: pg_test.csv

--- a/digdag-tests/src/test/resources/acceptance/pg/select_download_with_password_override.dig
+++ b/digdag-tests/src/test/resources/acceptance/pg/select_download_with_password_override.dig
@@ -2,6 +2,8 @@ timezone: UTC
 
 +run:
   pg>: select_table.sql
+  host: localhost
   database: ${pg_database}
+  user: digdag_test
   password_override: another_db_password
   download_file: pg_test.csv

--- a/digdag-tests/src/test/resources/acceptance/pg/select_download_with_password_override.dig
+++ b/digdag-tests/src/test/resources/acceptance/pg/select_download_with_password_override.dig
@@ -1,7 +1,0 @@
-timezone: UTC
-
-+run:
-  pg>: select_table.sql
-  database: ${pg_database}
-  password_override: another_db_password
-  download_file: pg_test.csv

--- a/digdag-tests/src/test/resources/acceptance/pg/select_download_with_password_override.dig
+++ b/digdag-tests/src/test/resources/acceptance/pg/select_download_with_password_override.dig
@@ -1,0 +1,9 @@
+timezone: UTC
+
++run:
+  pg>: select_table.sql
+  host: ${pg_host}
+  database: ${pg_database}
+  user: ${pg_user}
+  password_override: another_password
+  download_file: pg_test.csv

--- a/digdag-tests/src/test/resources/acceptance/pg/select_download_with_password_override.dig
+++ b/digdag-tests/src/test/resources/acceptance/pg/select_download_with_password_override.dig
@@ -1,0 +1,7 @@
+timezone: UTC
+
++run:
+  pg>: select_table.sql
+  database: ${pg_database}
+  password_override: another_db_password
+  download_file: pg_test.csv

--- a/digdag-tests/src/test/resources/acceptance/pg/select_download_with_password_override.dig
+++ b/digdag-tests/src/test/resources/acceptance/pg/select_download_with_password_override.dig
@@ -2,8 +2,6 @@ timezone: UTC
 
 +run:
   pg>: select_table.sql
-  host: localhost
   database: ${pg_database}
-  user: digdag_test
   password_override: another_db_password
   download_file: pg_test.csv

--- a/digdag-tests/src/test/resources/acceptance/pg/select_store_last_results.dig
+++ b/digdag-tests/src/test/resources/acceptance/pg/select_store_last_results.dig
@@ -2,9 +2,9 @@ timezone: UTC
 
 +run:
   pg>: select_table.sql
-  host: localhost
+  host: ${pg_host}
   database: ${pg_database}
-  user: digdag_test
+  user: ${pg_user}
   store_last_results: all
 
 +process:

--- a/digdag-tests/src/test/resources/acceptance/pg/select_store_last_results_first.dig
+++ b/digdag-tests/src/test/resources/acceptance/pg/select_store_last_results_first.dig
@@ -2,9 +2,9 @@ timezone: UTC
 
 +run:
   pg>: select_table.sql
-  host: localhost
+  host: ${pg_host}
   database: ${pg_database}
-  user: digdag_test
+  user: ${pg_user}
   store_last_results: first
 
 +process:

--- a/digdag-tests/src/test/resources/acceptance/redshift/select_download_with_password_override.dig
+++ b/digdag-tests/src/test/resources/acceptance/redshift/select_download_with_password_override.dig
@@ -1,0 +1,9 @@
+timezone: UTC
+
++run:
+  redshift>: select_table.sql
+  host: ${redshift_host}
+  database: ${redshift_database}
+  user: ${redshift_user}
+  password_override: another_password
+  download_file: ${download_file_in_config}


### PR DESCRIPTION
Fix https://github.com/treasure-data/digdag/issues/836

This pull request introduces a new option `password_override` to `pg` and `redshift` operators like this.

---

* **password_override**: NAME

  Secret key name that has a non-default database password as its value. This would be useful whey you want to use multiple database credentials. If it's set, Digdag looks up secrets with this value as a secret key name. If not, the default secret key `pg.password` is used.

  Examples (let's say you've already added a secret key value `pg.another_password=password1234`):

  ```
  password_override: another_password
  ```

----

Also, I noticed existing tests of `pg` and `redshift` operators had some problems (lack of test cases, hardcoded test database configuration, etc.) So I refactored them as well in order to add new test cases.