### PR TITLE
[WIP] Bump up td-client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /build/
 */build/
 */out/
+*/target/
 *.pyc
 /dist/*.tar.gz
 /config/test_postgresql.properties

--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,7 @@ subprojects {
     ext {
         jacksonVersion = "2.8.11"
         awsJavaSdkVersion = "1.11.63"
-        guavaVersion = "19.0"
+        guavaVersion = "21.0"
     }
 
     tasks.withType(JavaCompile) {

--- a/digdag-client/build.gradle
+++ b/digdag-client/build.gradle
@@ -12,7 +12,7 @@ dependencies {
         // available version of guava at the moment (e.g. 21.0). This is not good.
         exclude group: 'com.google.guava', module: 'guava'
     }
-    compile "com.google.guava:guava:19.0"
+    compile "com.google.guava:guava:21.0"
 
     compile 'org.jboss.resteasy:resteasy-client:3.0.24.Final'
     compile 'org.apache.commons:commons-compress:1.10'

--- a/digdag-standards/build.gradle
+++ b/digdag-standards/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     compile 'com.sun.mail:javax.mail:1.5.6'   // 'com.sun.mail:smtp' doesn't work because enabling mail.debug property throws java.lang.NoClassDefFoundError: com/sun/mail/util/MailLogger
 
     // td
-    compile 'com.treasuredata.client:td-client:0.7.36'
+    compile 'com.treasuredata.client:td-client:0.8.4'
     compile 'org.msgpack:msgpack-core:0.8.11'
     compile 'org.yaml:snakeyaml:1.17'
 

--- a/digdag-standards/build.gradle
+++ b/digdag-standards/build.gradle
@@ -47,8 +47,6 @@ dependencies {
     compile 'com.google.code.findbugs:jsr305:3.0.1'
 
     // Newer version of jetty-client with some important bugfixes.
-    // jetty-client is used by td-client-java, and ideally we would bump the version there but
-    // td-client-java still targets JDK 7 and jetty-client 9.3.x targets JDK 8.
     // https://github.com/treasure-data/td-client-java/pull/68
     // https://bugs.eclipse.org/bugs/show_bug.cgi?id=475546
     // https://github.com/eclipse/jetty.project/issues/416

--- a/digdag-tests/build.gradle
+++ b/digdag-tests/build.gradle
@@ -4,8 +4,8 @@ dependencies {
     testCompile project(':digdag-storage-s3')
     testCompile 'com.google.code.findbugs:annotations:3.0.1'
     testCompile 'org.subethamail:subethasmtp:3.1.7'
-    testCompile 'com.squareup.okhttp3:okhttp:3.4.1'
-    testCompile 'com.squareup.okhttp3:mockwebserver:3.4.1'
+    testCompile 'com.squareup.okhttp3:okhttp:3.9.0'
+    testCompile 'com.squareup.okhttp3:mockwebserver:3.9.0'
     testCompile('org.littleshoot:littleproxy:1.1.1') {
         // littleproxy depends on guava:18 and it conflicts with digdag-client
         exclude group: 'com.google.guava', module: 'guava'


### PR DESCRIPTION
- This PR is for Circle CI test
- This PR is the experiment to use `td-client` 0.8.x

# background
- To implement `td_result_export` operator, we need to upgrade td-client in digdag
- see also: https://github.com/treasure-data/td-client-java/pull/107