### PR TITLE
[Experimental] Show logs by task

### DIFF
--- a/digdag-ui/console.jsx
+++ b/digdag-ui/console.jsx
@@ -1778,7 +1778,7 @@ class LogFileView extends React.Component {
       return (
         <div>
           <h3 id={'logs-' + this.props.file.taskName + this.props.order.toString()}
-              style={{display: 'block', paddingTop: '50px', marginTop: '-50px'}}>{this.props.file.taskName}</h3>
+              className='log-view'>{this.props.file.taskName}</h3>
           <pre>{pako.inflate(this.state.data, {to: 'string'})}</pre>
         </div>
       )

--- a/digdag-ui/console.jsx
+++ b/digdag-ui/console.jsx
@@ -1763,9 +1763,16 @@ class LogFileView extends React.Component {
   }
 
   render () {
-    return this.state.data
-      ? <span>{pako.inflate(this.state.data, {to: 'string'})}</span>
-      : null
+    if(this.state.data){
+      return (
+        <div>
+          <h3>{this.props.file.taskName}</h3>
+          <pre>{pako.inflate(this.state.data, {to: 'string'})}</pre>
+        </div>
+      )
+    }else{
+      return null
+    }
   }
 }
 
@@ -1825,7 +1832,7 @@ class AttemptLogsView extends React.Component {
     return (
       <div className='row'>
         <h2>Logs</h2>
-        <pre>{this.logFiles()}</pre>
+        {this.logFiles()}
         <ReactInterval timeout={refreshIntervalMillis} enabled={!done} callback={() => this.fetch()} />
       </div>
     )

--- a/digdag-ui/console.jsx
+++ b/digdag-ui/console.jsx
@@ -1774,15 +1774,15 @@ class LogFileView extends React.Component {
   }
 
   render () {
-    if(this.state.data){
+    if (this.state.data) {
       return (
         <div>
           <h3 id={'logs-' + this.props.file.taskName + this.props.order.toString()}
-              className='log-view'>{this.props.file.taskName}</h3>
+            className='log-view'>{this.props.file.taskName}</h3>
           <pre>{pako.inflate(this.state.data, {to: 'string'})}</pre>
         </div>
       )
-    }else{
+    } else {
       return null
     }
   }
@@ -1817,18 +1817,17 @@ class AttemptLogsView extends React.Component {
 
   logFiles () {
     if (!this.state.files.length) {
-      return <pre/>
+      return <pre />
     }
     const taskOrders: Map<string, Number> = new Map()
     return this.state.files.map(file => {
       if (taskOrders.get(file.taskName) == null) {
         taskOrders.set(file.taskName, 1)
-      }
-      else {
+      } else {
         taskOrders.set(file.taskName, taskOrders.get(file.taskName) + 1)
       }
 
-      return <LogFileView key={file.fileName} file={file} attemptId={this.props.attemptId} order={taskOrders.get(file.taskName)}/>
+      return <LogFileView key={file.fileName} file={file} attemptId={this.props.attemptId} order={taskOrders.get(file.taskName)} />
     })
   }
 

--- a/digdag-ui/console.jsx
+++ b/digdag-ui/console.jsx
@@ -1816,7 +1816,8 @@ class AttemptLogsView extends React.Component {
   }
 
   logFiles () {
-    if (!this.state.files.length) {
+    const {files} = this.state
+    if (!files.length) {
       return <pre />
     }
     const taskOrders: Map<string, Number> = new Map()

--- a/digdag-ui/model.js
+++ b/digdag-ui/model.js
@@ -80,6 +80,7 @@ export type Task = {
   updatedAt: string;
   retryAt: ?string;
   startedAt: ?string;
+  order: ?Number;
 };
 
 export type TaskCollection = {

--- a/digdag-ui/style.less
+++ b/digdag-ui/style.less
@@ -90,3 +90,9 @@ pre {
 .editor .ace_cursor {
   display: block;
 }
+
+.log-view {
+  display: block;
+  padding-top: 50px;
+  margin-top: -50px;
+}


### PR DESCRIPTION
# What is this PR ?
- This PR is POC implementation of digdag-ui
- This PR modifies the format of task log in views so that logs are splitted for each tasks.

# Background of this PR
- Currently all task logs are unified, so it is difficult to distinguish that what task each line is  belongs to.

# e.g.

<img width="1238" alt="screen shot 2018-08-27 at 12 21 05" src="https://user-images.githubusercontent.com/681496/44639264-f78b8e00-a9f5-11e8-9f4b-9f1e4e5addba.png">
