### PR TITLE
[Doc] Fix the description of `log-server.type`

### DIFF
--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -351,7 +351,7 @@ In the config file, following parameters are available
 * archive.s3.credentials.access-key-id (string. default: instance profile)
 * archive.s3.credentials.secret-access-key (string. default: instance profile)
 * archive.s3.path-style-access (boolean. default: false)
-* log-server.type (type of log storage, "local" or "s3". default: "local")
+* log-server.type (type of log storage, "local" , "null", or "s3". default: "null". This parameter will be overwritten with "local" if ``-O, --task-log DIR`` is set.)
 * log-server.s3.endpoint (string, default: "s3.amazonaws.com")
 * log-server.s3.bucket (string)
 * log-server.s3.path (string)


### PR DESCRIPTION
# What is this PR ?
- This pr fixes the wrong description of `log-server.type`.
- The current description of `log-server.type` says `log-server.type (type of log storage, “local” or “s3”. default: “local”)`  [url](http://docs.digdag.io/command_reference.html?highlight=config#server-mode-commands)

![command reference digdag 0 9 5 documentation](https://user-images.githubusercontent.com/681496/44640772-9fa55500-a9fe-11e8-8bcc-ba073fec2331.png)

- But I found that digdag server uses `"null"` as the default value, unless `-O` or `--task-log` argument is set currently.

https://github.com/treasure-data/digdag/blob/6b42b923482a7ba4153eb10faaf8269cf9815658/digdag-core/src/main/java/io/digdag/core/log/LogServerManager.java#L35

 - And if `--task-log` argument is specified, this option will be overwritten.

https://github.com/treasure-data/digdag/blob/d994b00b616cc9807044a411c9d262ce614267f6/digdag-cli/src/main/java/io/digdag/cli/Server.java#L162-L165