### PR TITLE
[POC] Add fetch job information operator

### DIFF
--- a/digdag-standards/build.gradle
+++ b/digdag-standards/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     compile 'com.sun.mail:javax.mail:1.5.6'   // 'com.sun.mail:smtp' doesn't work because enabling mail.debug property throws java.lang.NoClassDefFoundError: com/sun/mail/util/MailLogger
 
     // td
-    compile 'com.treasuredata.client:td-client:0.8.5'
+    compile 'com.treasuredata.client:td-client:0.8.6'
     compile 'org.msgpack:msgpack-core:0.8.11'
     compile 'org.yaml:snakeyaml:1.17'
 

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/OperatorModule.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/OperatorModule.java
@@ -14,6 +14,7 @@ import io.digdag.standards.operator.redshift.RedshiftUnloadOperatorFactory;
 import io.digdag.standards.operator.td.TDResultExportOperatorFactory;
 import io.digdag.standards.operator.td.TdDdlOperatorFactory;
 import io.digdag.standards.operator.td.TdForEachOperatorFactory;
+import io.digdag.standards.operator.td.TdJobShowOperatorFactory;
 import io.digdag.standards.operator.td.TdLoadOperatorFactory;
 import io.digdag.standards.operator.td.TdOperatorFactory;
 import io.digdag.standards.operator.td.TdPartialDeleteOperatorFactory;
@@ -46,6 +47,7 @@ public class OperatorModule
         addStandardOperatorFactory(binder, TdWaitTableOperatorFactory.class);
         addStandardOperatorFactory(binder, TdPartialDeleteOperatorFactory.class);
         addStandardOperatorFactory(binder, TDResultExportOperatorFactory.class);
+        addStandardOperatorFactory(binder, TdJobShowOperatorFactory.class);
         addStandardOperatorFactory(binder, EchoOperatorFactory.class);
         addStandardOperatorFactory(binder, IfOperatorFactory.class);
         addStandardOperatorFactory(binder, FailOperatorFactory.class);

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdJobShowOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdJobShowOperatorFactory.java
@@ -1,0 +1,105 @@
+package io.digdag.standards.operator.td;
+
+import com.google.common.base.Optional;
+import com.google.inject.Inject;
+import com.treasuredata.client.TDClientException;
+import com.treasuredata.client.model.TDJob;
+import io.digdag.client.config.Config;
+import io.digdag.core.Environment;
+import io.digdag.spi.Operator;
+import io.digdag.spi.OperatorContext;
+import io.digdag.spi.OperatorFactory;
+import io.digdag.spi.TaskExecutionException;
+import io.digdag.spi.TaskResult;
+import io.digdag.util.BaseOperator;
+
+import java.util.Map;
+
+public class TdJobShowOperatorFactory
+        implements OperatorFactory
+{
+
+    private final Map<String, String> env;
+    private final Config systemConfig;
+
+    @Inject
+    public TdJobShowOperatorFactory(@Environment Map<String, String> env, Config systemConfig)
+    {
+        this.env = env;
+        this.systemConfig = systemConfig;
+    }
+
+    @Override
+    public String getType()
+    {
+        return "td_job_show";
+    }
+
+    @Override
+    public Operator newOperator(OperatorContext context)
+    {
+        return new TdJobShowOperator(context, env, systemConfig);
+    }
+
+    private class TdJobShowOperator
+            extends BaseOperator
+    {
+        private final String jobId;
+        private final Config params;
+        private final Map<String, String> env;
+        private final TDOperator.SystemDefaultConfig systemDefaultConfig;
+        private final Optional<String> storeKey;
+
+        public TdJobShowOperator(OperatorContext context, Map<String, String> env, Config systemConfig)
+        {
+            super(context);
+            this.params = request.getConfig().mergeDefault(
+                    request.getConfig().getNestedOrGetEmpty("td"));
+            this.env = env;
+            this.systemDefaultConfig = TDOperator.systemDefaultConfig(systemConfig);
+            this.jobId = params.get("_command", String.class);
+            this.storeKey = params.getOptional("store_key", String.class);
+        }
+
+        @Override
+        public TaskResult runTask()
+        {
+            try (TDOperator op = TDOperator.fromConfig(systemDefaultConfig, env, params, context.getSecrets().getSecrets("td"))) {
+                TDJobOperator job = op.newJobOperator(jobId);
+                TDJob jobInfo = job.getJobInfo();
+
+                TaskResult taskResult = TaskResult.empty(request);
+                Config storeParams;
+                if (this.storeKey.isPresent()) {
+                    storeParams = taskResult
+                            .getStoreParams()
+                            .getNestedOrSetEmpty(storeKey.get())
+                            .getNestedOrSetEmpty(jobInfo.getJobId());
+                }
+                else {
+                    storeParams = taskResult.getStoreParams()
+                            .getNestedOrSetEmpty("td")
+                            .getNestedOrSetEmpty("stored_jobs")
+                            .getNestedOrSetEmpty(jobInfo.getJobId());
+                }
+
+                storeParams
+                        .set("id", jobInfo.getJobId())
+                        .set("num_records", jobInfo.getNumRecords())
+                        .set("status", jobInfo.getStatus().toString())
+                        .set("type", jobInfo.getType().toString())
+                        .set("query", jobInfo.getQuery())
+                        .set("result_schema", jobInfo.getResultSchema().or(""))
+                        .set("created_at", jobInfo.getCreatedAt())
+                        .set("start_at", jobInfo.getStartAt())
+                        .set("end_at", jobInfo.getEndAt());
+
+                return taskResult;
+            }
+            catch (
+                    TDClientException ex) {
+                throw new TaskExecutionException(ex);
+            }
+        }
+    }
+}

--- a/digdag-tests/src/test/java/acceptance/td/TdJobShowIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/TdJobShowIT.java
@@ -1,0 +1,140 @@
+package acceptance.td;
+
+import com.treasuredata.client.TDClient;
+import com.treasuredata.client.model.TDJob;
+import com.treasuredata.client.model.TDSaveQueryRequest;
+import com.treasuredata.client.model.TDSavedQuery;
+import com.treasuredata.client.model.TDSavedQueryStartRequest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import utils.CommandStatus;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Date;
+import java.util.UUID;
+
+import static acceptance.td.Secrets.TD_API_ENDPOINT;
+import static acceptance.td.Secrets.TD_API_KEY;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeThat;
+import static utils.TestUtils.addWorkflow;
+import static utils.TestUtils.assertCommandStatus;
+import static utils.TestUtils.main;
+
+public class TdJobShowIT
+{
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+    private Path projectDir;
+
+    private TDClient client;
+    private String database;
+    private String table;
+    private String savedQuery;
+    private String jobId;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        assumeThat(TD_API_KEY, not(isEmptyOrNullString()));
+        assumeThat(TD_API_ENDPOINT, not(isEmptyOrNullString()));
+
+        projectDir = folder.newFolder().toPath().toAbsolutePath().normalize();
+
+        client = TDClient.newBuilder(false)
+                .setApiKey(TD_API_KEY)
+                .setEndpoint(TD_API_ENDPOINT)
+                .build();
+        database = "tmp_" + UUID.randomUUID().toString().replace('-', '_');
+        client.createDatabase(database);
+        String queryName = "test_" + UUID.randomUUID().toString().replace('-', '_');
+        createQuery(queryName);
+        TDSavedQueryStartRequest req = TDSavedQueryStartRequest.builder()
+                .name(queryName)
+                .scheduledTime(new Date())
+                .build();
+        this.jobId = client.startSavedQuery(req);
+        this.table = "test_" + UUID.randomUUID().toString().replace('-', '_');
+        client.createTableIfNotExists(database, table);
+    }
+
+    @Test
+    public void testShowJobWithoutOption()
+            throws IOException
+    {
+        String output = folder.newFolder().getAbsolutePath();
+        addWorkflow(projectDir, "acceptance/td/td_job_show/without_option.dig");
+
+        CommandStatus status = main("run",
+                "-o", output,
+                "--project", projectDir.toString(),
+                "-p", "database=" + database,
+                "-p", "queryName=" + savedQuery,
+                projectDir.resolve("without_option.dig").toString()
+        );
+        assertCommandStatus(status);
+        assertThat(new String(Files.readAllBytes(projectDir.resolve("out"))).trim(), is("1 SUCCESS"));
+    }
+
+    @Test
+    public void testShowJobWithOption()
+            throws IOException
+    {
+        String output = folder.newFolder().getAbsolutePath();
+        addWorkflow(projectDir, "acceptance/td/td_job_show/with_option.dig");
+
+        CommandStatus status = main("run",
+                "-o", output,
+                "--project", projectDir.toString(),
+                "-p", "database=" + database,
+                "-p", "queryName=" + savedQuery,
+                projectDir.resolve("with_option.dig").toString()
+        );
+        assertCommandStatus(status);
+        assertThat(new String(Files.readAllBytes(projectDir.resolve("out"))).trim(), is("1 SUCCESS"));
+    }
+
+    @After
+    public void deleteQuery()
+            throws Exception
+    {
+        if (client != null) {
+            client.deleteSavedQuery(savedQuery);
+        }
+    }
+
+    @After
+    public void deleteDatabase()
+            throws Exception
+    {
+        if (client != null && database != null) {
+            client.deleteDatabase(database);
+        }
+    }
+
+    private TDSavedQuery createQuery(String name)
+    {
+        return saveQuery(TDSavedQuery.newBuilder(
+                name,
+                TDJob.Type.PRESTO,
+                database,
+                "select 1",
+                "Asia/Tokyo")
+                .build());
+    }
+
+    private TDSavedQuery saveQuery(TDSaveQueryRequest request)
+    {
+        this.savedQuery = request.getName();
+        return client.saveQuery(request);
+    }
+}

--- a/digdag-tests/src/test/resources/acceptance/td/td_job_show/with_option.dig
+++ b/digdag-tests/src/test/resources/acceptance/td/td_job_show/with_option.dig
@@ -1,0 +1,13 @@
+_export:
+  td:
+    database: ${database}
+
++job_run:
+  td_run>: ${queryName}
+
++job_show:
+  td_job_show>: ${td.last_job_id}
+  store_key: select_job
+
++echo_fetched_job_num_records:
+  sh>: echo "${select_job[td.last_job_id].num_records} ${select_job[td.last_job_id].status}" > ${_project_path}/out

--- a/digdag-tests/src/test/resources/acceptance/td/td_job_show/without_option.dig
+++ b/digdag-tests/src/test/resources/acceptance/td/td_job_show/without_option.dig
@@ -1,0 +1,12 @@
+_export:
+  td:
+    database: ${database}
+
++job_run:
+  td_run>: ${queryName}
+
++job_show:
+  td_job_show>: ${td.last_job_id}
+
++echo_fetched_job_num_records:
+  sh>: echo "${td.stored_jobs[td.last_job_id].num_records} ${td.stored_jobs[td.last_job_id].status}" > ${_project_path}/out


### PR DESCRIPTION
# What is this PR ?
- This pr add `td_job_show>` operator (the name is a temporary name)
- `td_job_show>` operator gets `jobId` as an argument and fetch the job information of the jobId, and stores parameter `${td.stored_jobs[jobId]}` (this is a temporary specification)

# Example

```yaml
_export:
  td:
    database: serizawa_test

+job_show1:
  td_job_show>: 8911629

+echo_fetched_job_num_records:
  echo>: "${td.stored_jobs['8911629'].num_records}"
```

# TODO
- [x] poc implementation
- [ ] fix specification
- [ ] add test
- [ ] add document