### PR TITLE
Add new td attribute

### DIFF
--- a/digdag-docs/src/operators/td.md
+++ b/digdag-docs/src/operators/td.md
@@ -209,6 +209,7 @@
 ## Output parameters
 
 * **td.last_job_id**
+* **td.last_job.id**
 
   The job id this task executed.
 
@@ -226,4 +227,14 @@
 
   ```
   {"path":"/index.html","count":1}
+  ```
+
+* **td.last_job.num_records**
+
+  The number of records of this job output.
+ 
+  Examples:
+  
+  ```
+  10
   ```

--- a/digdag-docs/src/operators/td_for_each.md
+++ b/digdag-docs/src/operators/td_for_each.md
@@ -96,6 +96,7 @@ For example, if you run a query `select email, name from users` and the query re
 ## Output parameters
 
 * **td.last_job_id**
+* **td.last_job.id**
 
   The job id this task executed.
 
@@ -103,4 +104,14 @@ For example, if you run a query `select email, name from users` and the query re
 
   ```
   52036074
+  ```
+
+* **td.last_job.num_records**
+
+  The number of records of this job output.
+ 
+  Examples:
+  
+  ```
+  10
   ```

--- a/digdag-docs/src/operators/td_load.md
+++ b/digdag-docs/src/operators/td_load.md
@@ -61,6 +61,7 @@
 ## Output parameters
 
 * **td.last_job_id**
+* **td.last_job.id**
 
   The job id this task executed.
 
@@ -68,4 +69,14 @@
 
   ```
   52036074
+  ```
+
+* **td.last_job.num_records**
+
+  The number of records of this job output.
+ 
+  Examples:
+  
+  ```
+  10
   ```

--- a/digdag-docs/src/operators/td_result_export.md
+++ b/digdag-docs/src/operators/td_result_export.md
@@ -41,3 +41,26 @@
   For all supported URL-style results in Treasure Data, please see ["Writing Job Results into ***" in Treasure Data support site](https://support.treasuredata.com/hc/en-us/sections/360000245208-Databases).
 
   We **strongly** recommend using secrets to store all sensitive items (e.g. user, password, etc.) instead of writing down them in YAML files directly.
+
+## Output parameters
+
+* **td.last_job_id**
+* **td.last_job.id**
+
+  The job id this task executed.
+
+  Examples:
+
+  ```
+  52036074
+  ```
+
+* **td.last_job.num_records**
+
+  The number of records of this job output.
+ 
+  Examples:
+  
+  ```
+  10
+  ```

--- a/digdag-docs/src/operators/td_run.md
+++ b/digdag-docs/src/operators/td_run.md
@@ -82,6 +82,7 @@
 ## Output parameters
 
 * **td.last_job_id**
+* **td.last_job.id**
 
   The job id this task executed.
 
@@ -99,4 +100,14 @@
 
   ```
   {"path":"/index.html","count":1}
+  ```
+
+* **td.last_job.num_records**
+
+  The number of records of this job output.
+ 
+  Examples:
+  
+  ```
+  10
   ```

--- a/digdag-docs/src/operators/td_table_export.md
+++ b/digdag-docs/src/operators/td_table_export.md
@@ -126,6 +126,7 @@ NOTE: We're limiting export capability to only us-east region S3 bucket. In gene
 ## Output parameters
 
 * **td.last_job_id**
+* **td.last_job.id**
 
   The job id this task executed.
 
@@ -133,4 +134,14 @@ NOTE: We're limiting export capability to only us-east region S3 bucket. In gene
 
   ```
   52036074
+  ```
+
+* **td.last_job.num_records**
+
+  The number of records of this job output.
+ 
+  Examples:
+  
+  ```
+  10
   ```

--- a/digdag-docs/src/operators/td_wait.md
+++ b/digdag-docs/src/operators/td_wait.md
@@ -98,6 +98,7 @@ Example queries:
 ## Output parameters
 
 * **td.last_job_id**
+* **td.last_job.id**
 
   The job id this task executed.
 
@@ -105,4 +106,14 @@ Example queries:
 
   ```
   52036074
+  ```
+
+* **td.last_job.num_records**
+
+  The number of records of this job output.
+ 
+  Examples:
+  
+  ```
+  10
   ```

--- a/digdag-standards/build.gradle
+++ b/digdag-standards/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     compile 'com.sun.mail:javax.mail:1.5.6'   // 'com.sun.mail:smtp' doesn't work because enabling mail.debug property throws java.lang.NoClassDefFoundError: com/sun/mail/util/MailLogger
 
     // td
-    compile 'com.treasuredata.client:td-client:0.8.5'
+    compile 'com.treasuredata.client:td-client:0.8.6'
     compile 'org.msgpack:msgpack-core:0.8.11'
     compile 'org.yaml:snakeyaml:1.17'
 

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/BaseTdJobOperator.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/BaseTdJobOperator.java
@@ -61,7 +61,10 @@ abstract class BaseTdJobOperator
             // Set last_job_id param
             taskResult.getStoreParams()
                     .getNestedOrSetEmpty("td")
-                    .set("last_job_id", job.getJobId());
+                    .set("last_job_id", job.getJobId()) // for compatibility with old style
+                    .getNestedOrSetEmpty("last_job")
+                    .set("id", job.getJobId())
+                    .set("num_records", job.getJobInfo().getNumRecords());
 
             return taskResult;
         }

--- a/digdag-tests/src/test/java/acceptance/td/TdIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/TdIT.java
@@ -50,6 +50,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import static acceptance.td.Secrets.ENCRYPTION_KEY;
+import static acceptance.td.Secrets.TD_API_ENDPOINT;
 import static acceptance.td.Secrets.TD_API_KEY;
 import static acceptance.td.Secrets.TD_SECRETS_ENABLED_PROP_KEY;
 import static io.netty.handler.codec.http.HttpHeaders.Names.CONNECTION;
@@ -111,6 +112,7 @@ public class TdIT
         env.put("TD_CONFIG_PATH", noTdConf);
 
         client = TDClient.newBuilder(false)
+                .setEndpoint(TD_API_ENDPOINT)
                 .setApiKey(TD_API_KEY)
                 .build();
         database = "tmp_" + UUID.randomUUID().toString().replace('-', '_');
@@ -172,6 +174,8 @@ public class TdIT
         assertWorkflowRunsSuccessfully();
         JsonNode result = objectMapper().readTree(outfile.toFile());
         assertThat(result.get("last_job_id").asInt(), is(not(0)));
+        assertThat(result.get("last_job").get("id").asInt(), is(not(0)));
+        assertThat(result.get("last_job").get("num_records").asInt(), is(1));
         assertThat(result.get("last_results").isObject(), is(true));
         assertThat(result.get("last_results").isEmpty(objectMapper().getSerializerProvider()), is(false));
         assertThat(result.get("last_results").get("a").asInt(), is(1));
@@ -186,6 +190,8 @@ public class TdIT
         assertWorkflowRunsSuccessfully();
         JsonNode result = objectMapper().readTree(outfile.toFile());
         assertThat(result.get("last_job_id").asInt(), is(not(0)));
+        assertThat(result.get("last_job").get("id").asInt(), is(not(0)));
+        assertThat(result.get("last_job").get("num_records").asInt(), is(0));
         assertThat(result.get("last_results").isObject(), is(true));
         assertThat(result.get("last_results").isEmpty(objectMapper().getSerializerProvider()), is(true));
     }


### PR DESCRIPTION
# What is this PR?
- This PR add new attributes `num_records` on StoreParams as `${td.last_job.num_records}` 

# Background
- Currently `${td.last_job_id}` is set to StoreParams at `BaseTdJobOperator.runTask` 

https://github.com/treasure-data/digdag/blob/c67fcb263094fec45f12b054434e08cce985c97a/digdag-standards/src/main/java/io/digdag/standards/operator/td/BaseTdJobOperator.java#L61-L64

- In some use-cases, it is helpful if more job attributes is set to StoreParams in the same timing
- But `TDJob` object, which has the job information, may become very large size in total because of `query` or `result_schema`, and consume much memory.
- So we decided to add only `num_records` which is thought to be the most useful for now