### PR TITLE
Add note regarding db permission for empty_databases parameter

### DIFF
--- a/digdag-docs/src/operators/td_ddl.md
+++ b/digdag-docs/src/operators/td_ddl.md
@@ -89,6 +89,10 @@
   empty_databases: [my_database1, my_database2]
   ```
 
+.. note::
+
+   Database permissions for the restricted users are not inherited. You need to grant permission again after ran `empty_databases`.
+
 * **drop_databases**: [ARRAY OF NAMES]
 
   Drop databases if exists.


### PR DESCRIPTION
"empty_databases" parameter for td_ddl> can clear all tables on the listed databases by dropping and creating databases. By this behavior, administrators have to grant permission to the restricted users every time after the workflow finished. It would be better to add annotation regarding permission to the document.