### PR TITLE
Downgrade okhttp 3.9.0 to 3.4.1

### DIFF
--- a/digdag-standards/build.gradle
+++ b/digdag-standards/build.gradle
@@ -15,7 +15,10 @@ dependencies {
     compile 'com.sun.mail:javax.mail:1.5.6'   // 'com.sun.mail:smtp' doesn't work because enabling mail.debug property throws java.lang.NoClassDefFoundError: com/sun/mail/util/MailLogger
 
     // td
-    compile 'com.treasuredata.client:td-client:0.8.6'
+    compile ('com.treasuredata.client:td-client:0.8.6') {
+        exclude group: 'com.squareup.okhttp3', module: 'okhttp'
+        exclude group: 'com.squareup.okhttp3', module: 'okhttp-urlconnection'
+    }
     compile 'org.msgpack:msgpack-core:0.8.11'
     compile 'org.yaml:snakeyaml:1.17'
 

--- a/digdag-tests/build.gradle
+++ b/digdag-tests/build.gradle
@@ -4,8 +4,8 @@ dependencies {
     testCompile project(':digdag-storage-s3')
     testCompile 'com.google.code.findbugs:annotations:3.0.1'
     testCompile 'org.subethamail:subethasmtp:3.1.7'
-    testCompile 'com.squareup.okhttp3:okhttp:3.9.0'
-    testCompile 'com.squareup.okhttp3:mockwebserver:3.9.0'
+    testCompile 'com.squareup.okhttp3:okhttp:3.4.1'
+    testCompile 'com.squareup.okhttp3:mockwebserver:3.4.1'
     testCompile('org.littleshoot:littleproxy:1.1.1') {
         // littleproxy depends on guava:18 and it conflicts with digdag-client
         exclude group: 'com.google.guava', module: 'guava'


### PR DESCRIPTION
CI build have been failing after okhttp was upgraded. This PR downgrades the version to 3.4.1. We also will investigate why for future okhttp upgrade.