### PR TITLE
Improve message shown by version command when it cannot get server version

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/client/Version.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Version.java
@@ -13,10 +13,16 @@ public class Version extends ClientCommand
     public void mainWithClientException()
             throws Exception
     {
-        DigdagClient client = buildClient(false);
-        Map<String, Object> remoteVersion = client.getVersion();
         ln("Client version: " + version);
-        ln("Server version: " + remoteVersion.getOrDefault("version", ""));
+        try {
+            DigdagClient client = buildClient(false);
+            Map<String, Object> remoteVersion = client.getVersion();
+            ln("Server version: " + remoteVersion.getOrDefault("version", ""));
+        }
+        catch (Exception e) {
+            ln("An error happened during getting Server version.");
+            throw e;
+        }
     }
 
     @Override


### PR DESCRIPTION
This PR improves messages that version command shows if it could not get server version. follow-up of https://github.com/treasure-data/digdag/issues/781