### PR TITLE
Add `num_records` to ${td.last_job} object

### DIFF
--- a/digdag-docs/src/operators/td.md
+++ b/digdag-docs/src/operators/td.md
@@ -209,6 +209,7 @@
 ## Output parameters
 
 * **td.last_job_id**
+* **td.last_job.id**
 
   The job id this task executed.
 
@@ -226,4 +227,14 @@
 
   ```
   {"path":"/index.html","count":1}
+  ```
+
+* **td.last_job.num_records**
+
+  The number of records of this job output.
+ 
+  Examples:
+  
+  ```
+  10
   ```

--- a/digdag-docs/src/operators/td_for_each.md
+++ b/digdag-docs/src/operators/td_for_each.md
@@ -96,6 +96,7 @@ For example, if you run a query `select email, name from users` and the query re
 ## Output parameters
 
 * **td.last_job_id**
+* **td.last_job.id**
 
   The job id this task executed.
 
@@ -103,4 +104,14 @@ For example, if you run a query `select email, name from users` and the query re
 
   ```
   52036074
+  ```
+
+* **td.last_job.num_records**
+
+  The number of records of this job output.
+ 
+  Examples:
+  
+  ```
+  10
   ```

--- a/digdag-docs/src/operators/td_load.md
+++ b/digdag-docs/src/operators/td_load.md
@@ -61,6 +61,7 @@
 ## Output parameters
 
 * **td.last_job_id**
+* **td.last_job.id**
 
   The job id this task executed.
 
@@ -68,4 +69,14 @@
 
   ```
   52036074
+  ```
+
+* **td.last_job.num_records**
+
+  The number of records of this job output.
+ 
+  Examples:
+  
+  ```
+  10
   ```

--- a/digdag-docs/src/operators/td_run.md
+++ b/digdag-docs/src/operators/td_run.md
@@ -82,6 +82,7 @@
 ## Output parameters
 
 * **td.last_job_id**
+* **td.last_job.id**
 
   The job id this task executed.
 
@@ -99,4 +100,14 @@
 
   ```
   {"path":"/index.html","count":1}
+  ```
+
+* **td.last_job.num_records**
+
+  The number of records of this job output.
+ 
+  Examples:
+  
+  ```
+  10
   ```

--- a/digdag-docs/src/operators/td_table_export.md
+++ b/digdag-docs/src/operators/td_table_export.md
@@ -126,6 +126,7 @@ NOTE: We're limiting export capability to only us-east region S3 bucket. In gene
 ## Output parameters
 
 * **td.last_job_id**
+* **td.last_job.id**
 
   The job id this task executed.
 
@@ -133,4 +134,14 @@ NOTE: We're limiting export capability to only us-east region S3 bucket. In gene
 
   ```
   52036074
+  ```
+
+* **td.last_job.num_records**
+
+  The number of records of this job output.
+ 
+  Examples:
+  
+  ```
+  10
   ```

--- a/digdag-docs/src/operators/td_wait.md
+++ b/digdag-docs/src/operators/td_wait.md
@@ -98,6 +98,7 @@ Example queries:
 ## Output parameters
 
 * **td.last_job_id**
+* **td.last_job.id**
 
   The job id this task executed.
 
@@ -105,4 +106,14 @@ Example queries:
 
   ```
   52036074
+  ```
+
+* **td.last_job.num_records**
+
+  The number of records of this job output.
+ 
+  Examples:
+  
+  ```
+  10
   ```

--- a/digdag-tests/src/test/java/acceptance/td/Secrets.java
+++ b/digdag-tests/src/test/java/acceptance/td/Secrets.java
@@ -12,11 +12,15 @@ public class Secrets
 
     static final String TD_SECRETS_ENABLED_PROP_KEY = "io.digdag.standards.td.secrets.enabled";
 
+    static final String TD_API_ENDPOINT;
+
     static {
         // Do not pick up apikey from ~/.td/td.conf during local test runs
         System.setProperty(TD_SECRETS_ENABLED_PROP_KEY, "false");
 
         TD_API_KEY = System.getenv().getOrDefault("TD_API_KEY", "");
+
+        TD_API_ENDPOINT = System.getenv().getOrDefault("TD_API_ENDPOINT", "api.treasuredata.com");
     }
 
     static final byte[] ENCRYPTION_KEY_BYTES = new byte[128 / 8];

--- a/digdag-tests/src/test/java/acceptance/td/TdIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/TdIT.java
@@ -50,6 +50,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
 import static acceptance.td.Secrets.ENCRYPTION_KEY;
+import static acceptance.td.Secrets.TD_API_ENDPOINT;
 import static acceptance.td.Secrets.TD_API_KEY;
 import static acceptance.td.Secrets.TD_SECRETS_ENABLED_PROP_KEY;
 import static io.netty.handler.codec.http.HttpHeaders.Names.CONNECTION;
@@ -111,6 +112,7 @@ public class TdIT
         env.put("TD_CONFIG_PATH", noTdConf);
 
         client = TDClient.newBuilder(false)
+                .setEndpoint(TD_API_ENDPOINT)
                 .setApiKey(TD_API_KEY)
                 .build();
         database = "tmp_" + UUID.randomUUID().toString().replace('-', '_');
@@ -172,6 +174,8 @@ public class TdIT
         assertWorkflowRunsSuccessfully();
         JsonNode result = objectMapper().readTree(outfile.toFile());
         assertThat(result.get("last_job_id").asInt(), is(not(0)));
+        assertThat(result.get("last_job").get("id").asInt(), is(not(0)));
+        assertThat(result.get("last_job").get("num_records").asInt(), is(1));
         assertThat(result.get("last_results").isObject(), is(true));
         assertThat(result.get("last_results").isEmpty(objectMapper().getSerializerProvider()), is(false));
         assertThat(result.get("last_results").get("a").asInt(), is(1));
@@ -186,6 +190,8 @@ public class TdIT
         assertWorkflowRunsSuccessfully();
         JsonNode result = objectMapper().readTree(outfile.toFile());
         assertThat(result.get("last_job_id").asInt(), is(not(0)));
+        assertThat(result.get("last_job").get("id").asInt(), is(not(0)));
+        assertThat(result.get("last_job").get("num_records").asInt(), is(0));
         assertThat(result.get("last_results").isObject(), is(true));
         assertThat(result.get("last_results").isEmpty(objectMapper().getSerializerProvider()), is(true));
     }


### PR DESCRIPTION
# What is this PR ?
- This PR is re-created PR of #845

# Difference from #845 
I modified to take care of the error which may be thrown from `DJobOperator.getJobInfo()`

```java
           long numRecords = 0L;
            try {
                // job.getJobInfo() may throw error after having retried 3 times
                numRecords = job.getJobInfo().getNumRecords();
            }
            catch (Exception ex) {
                logger.warn("Setting num_records failed. Ignoring this error.", ex);
            }
```

If TD API responds with not 2xx status, `TDClientHttpException` is thrown. But this process is a post process of Operator, so I decided to ignore if `job.getJobInfo()` throws error.