### PR TITLE
[wip] Upgrade okhttp from 3.4.1 to 3.9.0

### DIFF
--- a/digdag-client/build.gradle
+++ b/digdag-client/build.gradle
@@ -22,6 +22,6 @@ dependencies {
     // which conflicts with undertow 1.4.0.Final -> jboss-logging 3.2.1.Final
     compile 'org.jboss.logging:jboss-logging:3.3.0.Final'
 
-    testCompile 'com.squareup.okhttp3:okhttp:3.11.0'
-    testCompile 'com.squareup.okhttp3:mockwebserver:3.11.0'
+    testCompile 'com.squareup.okhttp3:okhttp:3.9.0'
+    testCompile 'com.squareup.okhttp3:mockwebserver:3.9.0'
 }

--- a/digdag-client/build.gradle
+++ b/digdag-client/build.gradle
@@ -22,6 +22,6 @@ dependencies {
     // which conflicts with undertow 1.4.0.Final -> jboss-logging 3.2.1.Final
     compile 'org.jboss.logging:jboss-logging:3.3.0.Final'
 
-    testCompile 'com.squareup.okhttp3:okhttp:3.4.1'
-    testCompile 'com.squareup.okhttp3:mockwebserver:3.4.1'
+    testCompile 'com.squareup.okhttp3:okhttp:3.11.0'
+    testCompile 'com.squareup.okhttp3:mockwebserver:3.11.0'
 }

--- a/digdag-standards/build.gradle
+++ b/digdag-standards/build.gradle
@@ -16,6 +16,11 @@ dependencies {
 
     // td
     compile ('com.treasuredata.client:td-client:0.8.6') {
+        // digdag-tests depends on okhtttp3 3.11.0,
+        // but td-client:0.8.6 depends on okhttp3 3.9.0 for now.
+        // To avoid affecting to digdat-tests, I excluded okhttp3 here.
+        exclude group: 'com.squareup.okhttp3', module: 'okhttp'
+        exclude group: 'com.squareup.okhttp3', module: 'okhttp-urlconnection'
         // digdag depends on guava 0.19.0
         exclude group: 'com.google.guava', module: 'guava'
     }

--- a/digdag-standards/build.gradle
+++ b/digdag-standards/build.gradle
@@ -16,8 +16,7 @@ dependencies {
 
     // td
     compile ('com.treasuredata.client:td-client:0.8.6') {
-        // digdag-tests depends on okhtttp3 3.11.0,
-        // but td-client:0.8.6 depends on okhttp3 3.9.0 for now.
+        // digdag-tests and td-client depend on okhtttp3.
         // To avoid affecting to digdat-tests, I excluded okhttp3 here.
         exclude group: 'com.squareup.okhttp3', module: 'okhttp'
         exclude group: 'com.squareup.okhttp3', module: 'okhttp-urlconnection'

--- a/digdag-tests/build.gradle
+++ b/digdag-tests/build.gradle
@@ -4,8 +4,8 @@ dependencies {
     testCompile project(':digdag-storage-s3')
     testCompile 'com.google.code.findbugs:annotations:3.0.1'
     testCompile 'org.subethamail:subethasmtp:3.1.7'
-    testCompile 'com.squareup.okhttp3:okhttp:3.9.0'
-    testCompile 'com.squareup.okhttp3:mockwebserver:3.9.0'
+    testCompile 'com.squareup.okhttp3:okhttp:3.11.0'
+    testCompile 'com.squareup.okhttp3:mockwebserver:3.11.0'
     testCompile('org.littleshoot:littleproxy:1.1.2') {
         // littleproxy depends on guava:20 and it conflicts with digdag-client
         exclude group: 'com.google.guava', module: 'guava'

--- a/digdag-tests/build.gradle
+++ b/digdag-tests/build.gradle
@@ -4,8 +4,8 @@ dependencies {
     testCompile project(':digdag-storage-s3')
     testCompile 'com.google.code.findbugs:annotations:3.0.1'
     testCompile 'org.subethamail:subethasmtp:3.1.7'
-    testCompile 'com.squareup.okhttp3:okhttp:3.11.0'
-    testCompile 'com.squareup.okhttp3:mockwebserver:3.11.0'
+    testCompile 'com.squareup.okhttp3:okhttp:3.9.0'
+    testCompile 'com.squareup.okhttp3:mockwebserver:3.9.0'
     testCompile('org.littleshoot:littleproxy:1.1.2') {
         // littleproxy depends on guava:20 and it conflicts with digdag-client
         exclude group: 'com.google.guava', module: 'guava'


### PR DESCRIPTION
This PR upgrades okhttp from 3.4.1 to 3.9.0. 
https://github.com/square/okhttp/compare/parent-3.4.1...parent-3.9.0