### PR TITLE
Make page_size configurable

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/client/ShowAttempts.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/ShowAttempts.java
@@ -45,7 +45,7 @@ public class ShowAttempts
         err.println("       " + programName + " attempts <session-id>            show attempts for a session");
         err.println("  Options:");
         err.println("    -i, --last-id ID                 shows more session attempts from this id");
-        err.println("    -s, --page-size Number           shows more session attempts of the number of this page size(up to 1000)");
+        err.println("    -s, --page-size Number           shows more session attempts of the number of this page size (in default up to 100)");
         showCommonOptions();
         return systemExit(error);
     }

--- a/digdag-cli/src/main/java/io/digdag/cli/client/ShowAttempts.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/ShowAttempts.java
@@ -19,6 +19,9 @@ public class ShowAttempts
     @Parameter(names = {"-i", "--last-id"})
     Id lastId = null;
 
+    @Parameter(names = {"-s", "--page-size"})
+    Integer pageSize = null;
+
     @Override
     public void mainWithClientException()
             throws Exception
@@ -42,6 +45,7 @@ public class ShowAttempts
         err.println("       " + programName + " attempts <session-id>            show attempts for a session");
         err.println("  Options:");
         err.println("    -i, --last-id ID                 shows more session attempts from this id");
+        err.println("    -s, --page-size Number           shows more session attempts of the number of this page size(up to 1000)");
         showCommonOptions();
         return systemExit(error);
     }
@@ -53,9 +57,9 @@ public class ShowAttempts
         List<RestSessionAttempt> attempts;
 
         if (sessionId == null) {
-            attempts = client.getSessionAttempts(Optional.fromNullable(lastId)).getAttempts();
+            attempts = client.getSessionAttempts(Optional.fromNullable(lastId), Optional.fromNullable(pageSize)).getAttempts();
         } else {
-            attempts = client.getSessionAttempts(sessionId, Optional.fromNullable(lastId)).getAttempts();
+            attempts = client.getSessionAttempts(sessionId, Optional.fromNullable(lastId), Optional.fromNullable(pageSize)).getAttempts();
         }
 
         ln("Session attempts:");

--- a/digdag-cli/src/main/java/io/digdag/cli/client/ShowSession.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/ShowSession.java
@@ -20,6 +20,9 @@ public class ShowSession
     @Parameter(names = {"-i", "--last-id"})
     Id lastId = null;
 
+    @Parameter(names = {"-s", "--page-size"})
+    Integer pageSize = null;
+
     @Override
     public void mainWithClientException()
             throws Exception
@@ -77,6 +80,7 @@ public class ShowSession
         err.println("       " + programName + " session  <session-id>            show a single session");
         err.println("  Options:");
         err.println("    -i, --last-id ID                 shows more session attempts from this id");
+        err.println("    -s, --page-size Number           shows more sessions of the number of this page size(up to 1000)");
         showCommonOptions();
         return systemExit(error);
     }
@@ -92,10 +96,10 @@ public class ShowSession
         } else {
             RestProject project = client.getProject(projName);
             if (workflowName == null) {
-                sessions = client.getSessions(project.getId(), Optional.fromNullable(lastId)).getSessions();
+                sessions = client.getSessions(project.getId(), Optional.fromNullable(lastId), Optional.fromNullable(pageSize)).getSessions();
             }
             else {
-                sessions = client.getSessions(project.getId(), workflowName, Optional.fromNullable(lastId)).getSessions();
+                sessions = client.getSessions(project.getId(), workflowName, Optional.fromNullable(lastId), Optional.fromNullable(pageSize)).getSessions();
             }
         }
 

--- a/digdag-cli/src/main/java/io/digdag/cli/client/ShowSession.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/ShowSession.java
@@ -79,7 +79,7 @@ public class ShowSession
         err.println("       " + programName + " sessions <project-name> <name>   show sessions for a workflow");
         err.println("       " + programName + " session  <session-id>            show a single session");
         err.println("  Options:");
-        err.println("    -i, --last-id ID                 shows more session attempts from this id");
+        err.println("    -i, --last-id ID                 shows more sessions from this id");
         err.println("    -s, --page-size Number           shows more sessions of the number of this page size(up to 1000)");
         showCommonOptions();
         return systemExit(error);

--- a/digdag-cli/src/main/java/io/digdag/cli/client/ShowSession.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/ShowSession.java
@@ -80,7 +80,7 @@ public class ShowSession
         err.println("       " + programName + " session  <session-id>            show a single session");
         err.println("  Options:");
         err.println("    -i, --last-id ID                 shows more sessions from this id");
-        err.println("    -s, --page-size Number           shows more sessions of the number of this page size(up to 1000)");
+        err.println("    -s, --page-size Number           shows more sessions of the number of this page size(in default up to 100)");
         showCommonOptions();
         return systemExit(error);
     }

--- a/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
+++ b/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
@@ -548,28 +548,30 @@ public class DigdagClient implements AutoCloseable
     }
 
     public RestSessionCollection getSessions(Id projectId) {
-        return getSessions(projectId, Optional.absent());
+        return getSessions(projectId, Optional.absent(), Optional.absent());
     }
 
-    public RestSessionCollection getSessions(Id projectId, Optional<Id> lastId)
+    public RestSessionCollection getSessions(Id projectId, Optional<Id> lastId, Optional<Integer> pageSize)
     {
         return doGet(RestSessionCollection.class,
                 target("/api/projects/{projectId}/sessions")
                         .resolveTemplate("projectId", projectId)
-                        .queryParam("last_id", lastId.orNull()));
+                        .queryParam("last_id", lastId.orNull())
+                        .queryParam("page_size", pageSize.orNull()));
     }
 
     public RestSessionCollection getSessions(Id projectId, String workflowName) {
-        return getSessions(projectId, workflowName, Optional.absent());
+        return getSessions(projectId, workflowName, Optional.absent(), Optional.absent());
     }
 
-    public RestSessionCollection getSessions(Id projectId, String workflowName, Optional<Id> lastId)
+    public RestSessionCollection getSessions(Id projectId, String workflowName, Optional<Id> lastId, Optional<Integer> pageSize)
     {
         return doGet(RestSessionCollection.class,
                 target("/api/projects/{projectId}/sessions")
                         .resolveTemplate("projectId", projectId)
                         .queryParam("workflow", workflowName)
-                        .queryParam("last_id", lastId.orNull()));
+                        .queryParam("last_id", lastId.orNull())
+                        .queryParam("page_size", pageSize.orNull()));
     }
 
     public RestSession getSession(Id sessionId)
@@ -579,19 +581,21 @@ public class DigdagClient implements AutoCloseable
                         .resolveTemplate("id", sessionId));
     }
 
-    public RestSessionAttemptCollection getSessionAttempts(Id sessionId, Optional<Id> lastId)
+    public RestSessionAttemptCollection getSessionAttempts(Id sessionId, Optional<Id> lastId, Optional<Integer> pageSize)
     {
         return doGet(RestSessionAttemptCollection.class,
                 target("/api/sessions/{sessionId}/attempts")
                         .resolveTemplate("sessionId", sessionId)
-                        .queryParam("last_id", lastId.orNull()));
+                        .queryParam("last_id", lastId.orNull())
+                        .queryParam("page_size", pageSize.orNull()));
     }
 
-    public RestSessionAttemptCollection getSessionAttempts(Optional<Id> lastId)
+    public RestSessionAttemptCollection getSessionAttempts(Optional<Id> lastId, Optional<Integer> pageSize)
     {
         return doGet(RestSessionAttemptCollection.class,
                 target("/api/attempts")
-                .queryParam("last_id", lastId.orNull()));
+                .queryParam("last_id", lastId.orNull())
+                .queryParam("page_size", pageSize.orNull()));
     }
 
     public RestSessionAttemptCollection getSessionAttempts(String projName, Optional<Id> lastId)

--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -618,6 +618,8 @@ Shows list of sessions. This command shows only the latest attempts of sessions 
 :command:`-i, --last-id ID`
   Shows more sessions older than this id.
 
+:command:`-s, --page-size N`
+  Shows more sessions of the number of N (up to 1000).
 
 attempts
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -637,6 +639,8 @@ Shows list of attempts. This command shows shows all attempts including attempts
 :command:`-i, --last-id ID`
   Shows more attempts older than this id.
 
+:command:`-s, --page-size N`
+  Shows more attempts of the number of N (up to 1000).
 
 tasks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -362,6 +362,8 @@ In the config file, following parameters are available
 * digdag.secret-encryption-key = (base64 encoded 128-bit AES encryption key)
 * executor.task_ttl (string. default: 1d. A task is killed if it is running longer than this period.)
 * executor.attempt_ttl (string. default: 7d. An attempt is killed if it is running longer than this period.)
+* api.max_attempts_page_size (integer. The max number of rows of attempts in api response)
+* api.max_sessions_page_size (integer. The max number of rows of sessions in api response)
 
 
 Secret Encryption Key
@@ -619,7 +621,7 @@ Shows list of sessions. This command shows only the latest attempts of sessions 
   Shows more sessions older than this id.
 
 :command:`-s, --page-size N`
-  Shows more sessions of the number of N (up to 1000).
+  Shows more sessions of the number of N (in default up to 100).
 
 attempts
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -640,7 +642,7 @@ Shows list of attempts. This command shows shows all attempts including attempts
   Shows more attempts older than this id.
 
 :command:`-s, --page-size N`
-  Shows more attempts of the number of N (up to 1000).
+  Shows more attempts of the number of N (in default up to 100).
 
 tasks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/digdag-server/src/main/java/io/digdag/server/rs/AttemptResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/AttemptResource.java
@@ -85,10 +85,10 @@ public class AttemptResource
             @QueryParam("workflow") String wfName,
             @QueryParam("include_retried") boolean includeRetried,
             @QueryParam("last_id") Long lastId,
-            @QueryParam("page_size") int pageSize)
+            @QueryParam("page_size") Integer pageSize)
             throws ResourceNotFoundException
     {
-        int validPageSize = QueryParamValidator.validatePageSize(pageSize, MAX_ATTEMPTS_PAGE_SIZE, DEFAULT_ATTEMPTS_PAGE_SIZE);
+        int validPageSize = QueryParamValidator.validatePageSize(Optional.fromNullable(pageSize), MAX_ATTEMPTS_PAGE_SIZE, DEFAULT_ATTEMPTS_PAGE_SIZE);
 
         return tm.begin(() -> {
             List<StoredSessionAttemptWithSession> attempts;

--- a/digdag-server/src/main/java/io/digdag/server/rs/AttemptResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/AttemptResource.java
@@ -34,7 +34,7 @@ import io.digdag.spi.ScheduleTime;
 @Path("/")
 @Produces("application/json")
 public class AttemptResource
-     extends AuthenticatedResource
+    extends AuthenticatedResource
 {
     // GET  /api/attempts                                    # list attempts from recent to old
     // GET  /api/attempts?include_retried=1                  # list attempts from recent to old
@@ -54,6 +54,7 @@ public class AttemptResource
     private final WorkflowExecutor executor;
     private final ConfigFactory cf;
     private static final int MAX_ATTEMPTS_PAGE_SIZE = 1000;
+    private static final int DEFAULT_ATTEMPTS_PAGE_SIZE = 100;
 
     @Inject
     public AttemptResource(
@@ -84,7 +85,7 @@ public class AttemptResource
             @QueryParam("page_size") int pageSize)
             throws ResourceNotFoundException
     {
-        int validPageSize = QueryParamValidator.validatePageSize(pageSize, MAX_ATTEMPTS_PAGE_SIZE);
+        int validPageSize = QueryParamValidator.validatePageSize(pageSize, MAX_ATTEMPTS_PAGE_SIZE, DEFAULT_ATTEMPTS_PAGE_SIZE);
 
         return tm.begin(() -> {
             List<StoredSessionAttemptWithSession> attempts;

--- a/digdag-server/src/main/java/io/digdag/server/rs/AttemptResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/AttemptResource.java
@@ -17,6 +17,7 @@ import javax.ws.rs.core.Response;
 import com.google.inject.Inject;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
+import io.digdag.client.config.Config;
 import io.digdag.core.database.TransactionManager;
 import io.digdag.core.session.ArchivedTask;
 import io.digdag.core.session.SessionStore;
@@ -53,8 +54,8 @@ public class AttemptResource
     private final AttemptBuilder attemptBuilder;
     private final WorkflowExecutor executor;
     private final ConfigFactory cf;
-    private static final int MAX_ATTEMPTS_PAGE_SIZE = 1000;
     private static final int DEFAULT_ATTEMPTS_PAGE_SIZE = 100;
+    private static int MAX_ATTEMPTS_PAGE_SIZE;
 
     @Inject
     public AttemptResource(
@@ -64,7 +65,8 @@ public class AttemptResource
             TransactionManager tm,
             AttemptBuilder attemptBuilder,
             WorkflowExecutor executor,
-            ConfigFactory cf)
+            ConfigFactory cf,
+            Config systemConfig)
     {
         this.rm = rm;
         this.sm = sm;
@@ -73,6 +75,7 @@ public class AttemptResource
         this.attemptBuilder = attemptBuilder;
         this.executor = executor;
         this.cf = cf;
+        MAX_ATTEMPTS_PAGE_SIZE = systemConfig.get("api.max_attempts_page_size", Integer.class, DEFAULT_ATTEMPTS_PAGE_SIZE);
     }
 
     @GET

--- a/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
@@ -157,7 +157,7 @@ public class ProjectResource
     private static final Logger logger = LoggerFactory.getLogger(ProjectResource.class);
     private static final int ARCHIVE_TOTAL_SIZE_LIMIT = 2 * 1024 * 1024;
     private static final int ARCHIVE_FILE_SIZE_LIMIT = ARCHIVE_TOTAL_SIZE_LIMIT;
-    private static final int MAX_SESSIONS_PAGE_SIZE = 1000;
+    private static int MAX_SESSIONS_PAGE_SIZE;
     private static final int DEFAULT_SESSIONS_PAGE_SIZE = 100;
 
     private final ConfigFactory cf;
@@ -186,7 +186,8 @@ public class ProjectResource
             SessionStoreManager ssm,
             SecretControlStoreManager scsp,
             TransactionManager tm,
-            ProjectArchiveLoader projectArchiveLoader)
+            ProjectArchiveLoader projectArchiveLoader,
+            Config systemConfig)
     {
         this.cf = cf;
         this.rawLoader = rawLoader;
@@ -200,6 +201,7 @@ public class ProjectResource
         this.tm = tm;
         this.scsp = scsp;
         this.projectArchiveLoader = projectArchiveLoader;
+        MAX_SESSIONS_PAGE_SIZE = systemConfig.get("api.max_sessions_page_size", Integer.class, DEFAULT_SESSIONS_PAGE_SIZE);
     }
 
     private static StoredProject ensureNotDeletedProject(StoredProject proj)
@@ -402,10 +404,10 @@ public class ProjectResource
             @PathParam("id") int projectId,
             @QueryParam("workflow") String workflowName,
             @QueryParam("last_id") Long lastId,
-            @QueryParam("page_size") int pageSize)
+            @QueryParam("page_size") Integer pageSize)
             throws ResourceNotFoundException
     {
-        int validPageSize = QueryParamValidator.validatePageSize(pageSize, MAX_SESSIONS_PAGE_SIZE, DEFAULT_SESSIONS_PAGE_SIZE);
+        int validPageSize = QueryParamValidator.validatePageSize(Optional.fromNullable(pageSize), MAX_SESSIONS_PAGE_SIZE, DEFAULT_SESSIONS_PAGE_SIZE);
 
         return tm.begin(() -> {
             ProjectStore ps = rm.getProjectStore(getSiteId());

--- a/digdag-server/src/main/java/io/digdag/server/rs/QueryParamValidator.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/QueryParamValidator.java
@@ -1,0 +1,20 @@
+package io.digdag.server.rs;
+
+public class QueryParamValidator
+{
+    public static int validatePageSize(int pageSize, int maxPageSize)
+            throws IllegalArgumentException
+    {
+        if (pageSize > maxPageSize) {
+            String message = "Your specified page_size is " + pageSize + ", " +
+                    "but it is larger than MAX_PAGE_SIZE: " + maxPageSize + ". " +
+                    "You must specify page_size with a number which is smaller than " + maxPageSize + ".";
+
+            // This error results 400 response
+            throw new IllegalArgumentException(message);
+        }
+        else {
+            return pageSize;
+        }
+    }
+}

--- a/digdag-server/src/main/java/io/digdag/server/rs/QueryParamValidator.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/QueryParamValidator.java
@@ -2,9 +2,11 @@ package io.digdag.server.rs;
 
 public class QueryParamValidator
 {
-    public static int validatePageSize(int pageSize, int maxPageSize)
+    public static int validatePageSize(int pageSize, int maxPageSize, int defaultPageSize)
             throws IllegalArgumentException
     {
+        if (pageSize == 0) { return defaultPageSize; }
+
         if (pageSize > maxPageSize) {
             String message = "Your specified page_size is " + pageSize + ", " +
                     "but it is larger than MAX_PAGE_SIZE: " + maxPageSize + ". " +

--- a/digdag-server/src/main/java/io/digdag/server/rs/QueryParamValidator.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/QueryParamValidator.java
@@ -1,13 +1,16 @@
 package io.digdag.server.rs;
 
+import com.google.common.base.Optional;
+
 public class QueryParamValidator
 {
-    public static int validatePageSize(int pageSize, int maxPageSize, int defaultPageSize)
+    public static int validatePageSize(Optional<Integer> pageSize, int maxPageSize, int defaultPageSize)
             throws IllegalArgumentException
     {
-        if (pageSize == 0) { return defaultPageSize; }
+        if (!pageSize.isPresent()) { return defaultPageSize; }
 
-        if (pageSize > maxPageSize) {
+        int pageSizeValue = pageSize.get().intValue();
+        if (pageSizeValue > maxPageSize) {
             String message = "Your specified page_size is " + pageSize + ", " +
                     "but it is larger than MAX_PAGE_SIZE: " + maxPageSize + ". " +
                     "You must specify page_size with a number which is smaller than " + maxPageSize + ".";
@@ -16,7 +19,7 @@ public class QueryParamValidator
             throw new IllegalArgumentException(message);
         }
         else {
-            return pageSize;
+            return pageSizeValue;
         }
     }
 }

--- a/digdag-server/src/main/java/io/digdag/server/rs/SessionResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/SessionResource.java
@@ -38,6 +38,7 @@ public class SessionResource
     private final ProjectStoreManager rm;
     private final SessionStoreManager sm;
     private final TransactionManager tm;
+    private static final int MAX_SESSION_PAGE_SIZE = 1000;
 
     @Inject
     public SessionResource(
@@ -52,13 +53,17 @@ public class SessionResource
 
     @GET
     @Path("/api/sessions")
-    public RestSessionCollection getSessions(@QueryParam("last_id") Long lastId)
+    public RestSessionCollection getSessions(
+            @QueryParam("last_id") Long lastId,
+            @QueryParam("page_size") int pageSize)
     {
+        int validPageSize = QueryParamValidator.validatePageSize(pageSize, MAX_SESSION_PAGE_SIZE);
+
         return tm.begin(() -> {
             ProjectStore rs = rm.getProjectStore(getSiteId());
             SessionStore ss = sm.getSessionStore(getSiteId());
 
-            List<StoredSessionWithLastAttempt> sessions = ss.getSessions(100, Optional.fromNullable(lastId));
+            List<StoredSessionWithLastAttempt> sessions = ss.getSessions(validPageSize, Optional.fromNullable(lastId));
 
             return RestModels.sessionCollection(rs, sessions);
         });

--- a/digdag-server/src/main/java/io/digdag/server/rs/SessionResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/SessionResource.java
@@ -62,9 +62,9 @@ public class SessionResource
     @Path("/api/sessions")
     public RestSessionCollection getSessions(
             @QueryParam("last_id") Long lastId,
-            @QueryParam("page_size") int pageSize)
+            @QueryParam("page_size") Integer pageSize)
     {
-        int validPageSize = QueryParamValidator.validatePageSize(pageSize, MAX_SESSIONS_PAGE_SIZE, DEFAULT_SESSIONS_PAGE_SIZE);
+        int validPageSize = QueryParamValidator.validatePageSize(Optional.fromNullable(pageSize), MAX_SESSIONS_PAGE_SIZE, DEFAULT_SESSIONS_PAGE_SIZE);
 
         return tm.begin(() -> {
             ProjectStore rs = rm.getProjectStore(getSiteId());
@@ -97,10 +97,10 @@ public class SessionResource
     public RestSessionAttemptCollection getSessionAttempts(
             @PathParam("id") long id,
             @QueryParam("last_id") Long lastId,
-            @QueryParam("page_size") int pageSize)
+            @QueryParam("page_size") Integer pageSize)
             throws ResourceNotFoundException
     {
-        int validPageSize = QueryParamValidator.validatePageSize(pageSize, MAX_ATTEMPTS_PAGE_SIZE, DEFAULT_ATTEMPTS_PAGE_SIZE);
+        int validPageSize = QueryParamValidator.validatePageSize(Optional.fromNullable(pageSize), MAX_ATTEMPTS_PAGE_SIZE, DEFAULT_ATTEMPTS_PAGE_SIZE);
 
         return tm.begin(() -> {
             ProjectStore rs = rm.getProjectStore(getSiteId());

--- a/digdag-server/src/main/java/io/digdag/server/rs/SessionResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/SessionResource.java
@@ -6,6 +6,7 @@ import io.digdag.client.api.RestSession;
 import io.digdag.client.api.RestSessionCollection;
 import io.digdag.client.api.RestSessionAttempt;
 import io.digdag.client.api.RestSessionAttemptCollection;
+import io.digdag.client.config.Config;
 import io.digdag.core.database.TransactionManager;
 import io.digdag.core.repository.ProjectStore;
 import io.digdag.core.repository.ProjectStoreManager;
@@ -38,20 +39,23 @@ public class SessionResource
     private final ProjectStoreManager rm;
     private final SessionStoreManager sm;
     private final TransactionManager tm;
-    private static final int MAX_SESSIONS_PAGE_SIZE = 1000;
+    private static int MAX_SESSIONS_PAGE_SIZE;
     private static final int DEFAULT_SESSIONS_PAGE_SIZE = 100;
-    private static final int MAX_ATTEMPTS_PAGE_SIZE = 1000;
+    private static int MAX_ATTEMPTS_PAGE_SIZE;
     private static final int DEFAULT_ATTEMPTS_PAGE_SIZE = 100;
 
     @Inject
     public SessionResource(
             ProjectStoreManager rm,
             SessionStoreManager sm,
-            TransactionManager tm)
+            TransactionManager tm,
+            Config systemConfig)
     {
         this.rm = rm;
         this.sm = sm;
         this.tm = tm;
+        MAX_SESSIONS_PAGE_SIZE = systemConfig.get("api.max_sessions_page_size", Integer.class, DEFAULT_SESSIONS_PAGE_SIZE);
+        MAX_ATTEMPTS_PAGE_SIZE = systemConfig.get("api.max_attempts_page_size", Integer.class, DEFAULT_ATTEMPTS_PAGE_SIZE);
     }
 
     @GET

--- a/digdag-server/src/main/java/io/digdag/server/rs/SessionResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/SessionResource.java
@@ -38,7 +38,8 @@ public class SessionResource
     private final ProjectStoreManager rm;
     private final SessionStoreManager sm;
     private final TransactionManager tm;
-    private static final int MAX_SESSION_PAGE_SIZE = 1000;
+    private static final int MAX_SESSIONS_PAGE_SIZE = 1000;
+    private static final int DEFAULT_SESSIONS_PAGE_SIZE = 100;
 
     @Inject
     public SessionResource(
@@ -57,7 +58,7 @@ public class SessionResource
             @QueryParam("last_id") Long lastId,
             @QueryParam("page_size") int pageSize)
     {
-        int validPageSize = QueryParamValidator.validatePageSize(pageSize, MAX_SESSION_PAGE_SIZE);
+        int validPageSize = QueryParamValidator.validatePageSize(pageSize, MAX_SESSIONS_PAGE_SIZE, DEFAULT_SESSIONS_PAGE_SIZE);
 
         return tm.begin(() -> {
             ProjectStore rs = rm.getProjectStore(getSiteId());

--- a/digdag-tests/src/test/java/acceptance/AttemptLimitIT.java
+++ b/digdag-tests/src/test/java/acceptance/AttemptLimitIT.java
@@ -127,7 +127,7 @@ public class AttemptLimitIT
         });
 
         // Number of actually submitted sessions should be 3 = maxAttempts
-        assertThat(client.getSessionAttempts(Optional.absent()).getAttempts().size(), is(3));
+        assertThat(client.getSessionAttempts(Optional.absent(), Optional.absent()).getAttempts().size(), is(3));
 
         // Although next run time > now, next schedule time is 3-attempt later than start time
         assertThat(client.getSchedules().getSchedules().get(0).getNextScheduleTime().toInstant(), is(startTime.plus(Duration.ofHours(3))));

--- a/digdag-tests/src/test/java/acceptance/InitPushStartIT.java
+++ b/digdag-tests/src/test/java/acceptance/InitPushStartIT.java
@@ -144,7 +144,7 @@ public class InitPushStartIT
 
         // Fetch attempt using client
         {
-            List<RestSessionAttempt> attempts = client.getSessionAttempts(Optional.absent()).getAttempts();
+            List<RestSessionAttempt> attempts = client.getSessionAttempts(Optional.absent(), Optional.absent()).getAttempts();
             assertThat(attempts.size(), is(1));
             RestSessionAttempt attempt = attempts.get(0);
             assertThat(attempt.getProject().getName(), is("foobar"));

--- a/digdag-tests/src/test/java/acceptance/ServerScheduleIT.java
+++ b/digdag-tests/src/test/java/acceptance/ServerScheduleIT.java
@@ -418,7 +418,7 @@ public class ServerScheduleIT
         assertThat(lastUnixtime2Epoch, is(unixtime2Epoch - 2));
         assertThat(unixtime2Epoch, Matchers.greaterThanOrEqualTo(unixtime1Epoch + 10));
 
-        List<RestSessionAttempt> attempts = client.getSessionAttempts(Optional.absent()).getAttempts();
+        List<RestSessionAttempt> attempts = client.getSessionAttempts(Optional.absent(), Optional.absent()).getAttempts();
 
         RestSessionAttempt attempt1 = attempts.stream()
                 .filter(a -> a.getSessionTime().toEpochSecond() == unixtime1Epoch)


### PR DESCRIPTION
# What is this PR ?
- Make `GET /api/attempts` and `GET /api/sessions` enable to take `page_size` parameter and change the number of records in response
- But this PR does not change the current behavior(if `page_size` is not specified, use `100` as a default value)
- Set internal MAX_PAGE_SIZE(up to 1000)
- This feature is the implementation of #857 

# TODO
- [x] Introduce Validator
- [x] Support `page_size` parameter at `GET /api/attempts`
- [x] Support `page_size` parameter at `GET /api/sessions`
- [x] Support `page_size` option at `digdag` cli