### PR TITLE
Fix dependencies for td-client 0.8.6

### DIFF
--- a/digdag-standards/build.gradle
+++ b/digdag-standards/build.gradle
@@ -16,11 +16,6 @@ dependencies {
 
     // td
     compile ('com.treasuredata.client:td-client:0.8.6') {
-        // digdag-tests depends on okhtttp3 3.4.1,
-        // but td-client:0.8.6 depends on okhttp3 3.9.0 for now.
-        // To avoid affecting to digdat-tests, I excluded okhttp3 here.
-        exclude group: 'com.squareup.okhttp3', module: 'okhttp'
-        exclude group: 'com.squareup.okhttp3', module: 'okhttp-urlconnection'
         // digdag depends on guava 0.19.0
         exclude group: 'com.google.guava', module: 'guava'
     }

--- a/digdag-tests/build.gradle
+++ b/digdag-tests/build.gradle
@@ -4,8 +4,8 @@ dependencies {
     testCompile project(':digdag-storage-s3')
     testCompile 'com.google.code.findbugs:annotations:3.0.1'
     testCompile 'org.subethamail:subethasmtp:3.1.7'
-    testCompile 'com.squareup.okhttp3:okhttp:3.4.1'
-    testCompile 'com.squareup.okhttp3:mockwebserver:3.4.1'
+    testCompile 'com.squareup.okhttp3:okhttp:3.9.0'
+    testCompile 'com.squareup.okhttp3:mockwebserver:3.9.0'
     testCompile('org.littleshoot:littleproxy:1.1.1') {
         // littleproxy depends on guava:18 and it conflicts with digdag-client
         exclude group: 'com.google.guava', module: 'guava'


### PR DESCRIPTION
# What is this PR ?
- This PR solves library dependencies of td-client 0.8.6
- td-client 0.8.x uses OkHttp3.9.0, but digdag does not use OkHttps except digdag-test