### PR TITLE
[wip] Implement td_result_export> operator

### DIFF
--- a/digdag-docs/src/operators/td_result_export.md
+++ b/digdag-docs/src/operators/td_result_export.md
@@ -1,0 +1,43 @@
+# td_result_export>: Treasure Data result exporter
+
+**td_result_export>** operator exports a job result to an output destination.
+
+    _export:
+      td:
+        database: www_access
+
+    +simple_query:
+      td>: queries/simple_query.sql
+
+    +export_query_result:
+      td_result_export>:
+        job_id: 12345
+        result_url: mysql://${secret:user}:${secret:password}@${secret:host}/database/table
+
+## Options
+
+* **job_id**: NUMBER The id of a job that is exported.
+
+  Examples:
+
+  ```
+  job_id: 12345
+  ```
+
+  You can also specify `${td.last_job_id}` as the last executed job id.
+
+  ```
+  job_id: ${td.last_job_id}
+  ```
+
+* **result_url**: NAME Output the job result to the URL.
+
+  Examples:
+
+  ```
+  result_url: mysql://${secret:user}:${secret:password}@${secret:host}/database/table
+  ```
+  
+  For all supported URL-style results in Treasure Data, please see ["Writing Job Results into ***" in Treasure Data support site](https://support.treasuredata.com/hc/en-us/sections/360000245208-Databases).
+
+  We **strongly** recommend using secrets to store all sensitive items (e.g. user, password, etc.) instead of writing down them in YAML files directly.

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/OperatorModule.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/OperatorModule.java
@@ -11,6 +11,7 @@ import io.digdag.standards.operator.pg.PgOperatorFactory;
 import io.digdag.standards.operator.redshift.RedshiftLoadOperatorFactory;
 import io.digdag.standards.operator.redshift.RedshiftOperatorFactory;
 import io.digdag.standards.operator.redshift.RedshiftUnloadOperatorFactory;
+import io.digdag.standards.operator.td.TDResultExportOperatorFactory;
 import io.digdag.standards.operator.td.TdDdlOperatorFactory;
 import io.digdag.standards.operator.td.TdForEachOperatorFactory;
 import io.digdag.standards.operator.td.TdLoadOperatorFactory;
@@ -44,6 +45,7 @@ public class OperatorModule
         addStandardOperatorFactory(binder, TdWaitOperatorFactory.class);
         addStandardOperatorFactory(binder, TdWaitTableOperatorFactory.class);
         addStandardOperatorFactory(binder, TdPartialDeleteOperatorFactory.class);
+        addStandardOperatorFactory(binder, TDResultExportOperatorFactory.class);
         addStandardOperatorFactory(binder, EchoOperatorFactory.class);
         addStandardOperatorFactory(binder, IfOperatorFactory.class);
         addStandardOperatorFactory(binder, FailOperatorFactory.class);

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TDResultExportOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TDResultExportOperatorFactory.java
@@ -1,0 +1,66 @@
+package io.digdag.standards.operator.td;
+
+import com.google.inject.Inject;
+import com.treasuredata.client.model.TDExportResultJobRequest;
+import io.digdag.client.config.Config;
+import io.digdag.core.Environment;
+import io.digdag.spi.Operator;
+import io.digdag.spi.OperatorContext;
+import io.digdag.spi.OperatorFactory;
+import io.digdag.util.UserSecretTemplate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+public class TDResultExportOperatorFactory
+        implements OperatorFactory
+{
+    private final Map<String, String> env;
+    private final Config systemConfig;
+    private static Logger logger = LoggerFactory.getLogger(TdTableExportOperatorFactory.class);
+
+    @Inject
+    public TDResultExportOperatorFactory(@Environment Map<String, String> env, Config systemConfig)
+    {
+        this.env = env;
+        this.systemConfig = systemConfig;
+    }
+
+    @Override
+    public String getType() { return "td_result_export"; }
+
+    @Override
+    public Operator newOperator(OperatorContext context) { return new TDResultExportOperator(context); }
+
+    private class TDResultExportOperator
+            extends BaseTdJobOperator
+    {
+        private final String jobId;
+        private final String resultUrl;
+
+        private TDResultExportOperator(OperatorContext context)
+        {
+            super(context, env, systemConfig);
+            Config params = request.getConfig().mergeDefault(
+                    request.getConfig().getNestedOrGetEmpty("td"));
+            this.jobId = params.get("job_id", String.class);
+            this.resultUrl = UserSecretTemplate.of(params.get("result_url", String.class))
+                    .format(context.getSecrets());
+        }
+
+        @Override
+        protected String startJob(TDOperator op, String domainKey)
+        {
+            TDExportResultJobRequest jobRequest = TDExportResultJobRequest.builder()
+                    .jobId(this.jobId)
+                    .resultOutput(this.resultUrl)
+                    .build();
+
+            String jobId = op.submitNewJobWithRetry(client -> client.submitResultExportJob(jobRequest));
+            logger.info("Started result export job id={}", jobId);
+
+            return jobId;
+        }
+    }
+}

--- a/digdag-tests/src/test/java/acceptance/td/TdResultExportIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/TdResultExportIT.java
@@ -1,0 +1,99 @@
+package acceptance.td;
+
+import com.treasuredata.client.TDClient;
+import com.treasuredata.client.model.TDExportResultJobRequest;
+import com.treasuredata.client.model.TDJob;
+import com.treasuredata.client.model.TDSaveQueryRequest;
+import com.treasuredata.client.model.TDSavedQuery;
+import com.treasuredata.client.model.TDSavedQueryStartRequest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Date;
+import java.util.UUID;
+
+import static acceptance.td.Secrets.TD_API_KEY;
+import static acceptance.td.Secrets.TD_API_ENDPOINT;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assume.assumeThat;
+
+public class TdResultExportIT
+{
+    private TDClient client;
+    private String database;
+    private String table;
+    private String savedQuery;
+    private String jobId;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        assumeThat(TD_API_KEY, not(isEmptyOrNullString()));
+        assumeThat(TD_API_ENDPOINT, not(isEmptyOrNullString()));
+
+        client = TDClient.newBuilder(false)
+                .setApiKey(TD_API_KEY)
+                .setEndpoint(TD_API_ENDPOINT)
+                .build();
+        database = "tmp_" + UUID.randomUUID().toString().replace('-', '_');
+        client.createDatabase(database);
+        String queryName = "test_" + UUID.randomUUID().toString().replace('-', '_');
+        createQuery(queryName);
+        TDSavedQueryStartRequest req = TDSavedQueryStartRequest.builder()
+                .name(queryName)
+                .scheduledTime(new Date())
+                .build();
+        this.jobId = client.startSavedQuery(req);
+        this.table = "test_" + UUID.randomUUID().toString().replace('-', '_');
+        client.createTableIfNotExists(database, table);
+    }
+
+    @Test
+    public void testSubmitResultExportJob()
+    {
+        String resultUrl = "td://@/" + this.database + "/" + this.table;
+        TDExportResultJobRequest req = TDExportResultJobRequest.builder()
+                .jobId(this.jobId)
+                .resultOutput(resultUrl)
+                .build();
+        client.submitResultExportJob(req);
+    }
+
+    @After
+    public void deleteQuery()
+            throws Exception
+    {
+        if (client != null) {
+            client.deleteSavedQuery(savedQuery);
+        }
+    }
+
+    @After
+    public void deleteDatabase()
+            throws Exception
+    {
+        if (client != null && database != null) {
+            client.deleteDatabase(database);
+        }
+    }
+
+    private TDSavedQuery createQuery(String name)
+    {
+        return saveQuery(TDSavedQuery.newBuilder(
+                name,
+                TDJob.Type.PRESTO,
+                database,
+                "select 1",
+                "Asia/Tokyo")
+                .build());
+    }
+
+    private TDSavedQuery saveQuery(TDSaveQueryRequest request)
+    {
+        this.savedQuery = request.getName();
+        return client.saveQuery(request);
+    }
+}


### PR DESCRIPTION
# What is this PR?
- This is re-implement `td_result_export>` operator of #843 

# Sample

```yml
_export:
  td:
    database: www_access

+simple_query:
  td>: queries/simple_query.sql

+export_query_result:
  td_result_export>:
    job_id: 12345
    result_url: mysql://${secret:user}:${secret:password}@${secret:host}/database/table
```