### PR TITLE
[poc] Implement td_result_export> operator with specifying a result_connection version

### DIFF
--- a/digdag-docs/src/operators/td_result_export.md
+++ b/digdag-docs/src/operators/td_result_export.md
@@ -1,0 +1,67 @@
+# td_result_export>: Treasure Data result exporter
+
+**td_result_export>** operator exports a job result to an output destination.
+
+    _export:
+      td:
+        database: www_access
+
+    +simple_query:
+      td>: queries/simple_query.sql
+
+    +export_query_result:
+      td_result_export>:
+        job_id: 12345
+        result_connection: my_s3_connection
+        result_settings:
+          bucket: my_bucket
+          path: /logs/
+
+## Options
+
+* **job_id**: NUMBER The id of a job that is exported.
+
+  Examples:
+
+  ```
+  job_id: 12345
+  ```
+
+  You can also specify `${td.last_job_id}` as the last executed job id.
+
+  ```
+  job_id: ${td.last_job_id}
+  ```
+
+* **result_connection**: NAME
+
+  Use a connection to write the query results to an external system.
+
+  You can create a connection using the web console.
+
+  Examples:
+
+  ```
+  result_connection: my_s3_connection
+  ```
+
+* **result_settings**: MAP
+
+  Add additional settings to the result connection.
+
+  Examples:
+
+  ```
+  result_connection: my_s3_connection
+  result_settings:
+    bucket: my_s3_bucket
+    path: /logs/
+  ```
+
+  ```
+  result_connection: my_http
+  result_settings:
+    path: /endpoint
+  ```
+
+  We **strongly** recommend using secrets to store all sensitive items (e.g. user, password, etc.) instead of writing down them in YAML files directly.

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/OperatorModule.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/OperatorModule.java
@@ -11,6 +11,7 @@ import io.digdag.standards.operator.pg.PgOperatorFactory;
 import io.digdag.standards.operator.redshift.RedshiftLoadOperatorFactory;
 import io.digdag.standards.operator.redshift.RedshiftOperatorFactory;
 import io.digdag.standards.operator.redshift.RedshiftUnloadOperatorFactory;
+import io.digdag.standards.operator.td.TDResultExportOperatorFactory;
 import io.digdag.standards.operator.td.TdDdlOperatorFactory;
 import io.digdag.standards.operator.td.TdForEachOperatorFactory;
 import io.digdag.standards.operator.td.TdLoadOperatorFactory;
@@ -44,6 +45,7 @@ public class OperatorModule
         addStandardOperatorFactory(binder, TdWaitOperatorFactory.class);
         addStandardOperatorFactory(binder, TdWaitTableOperatorFactory.class);
         addStandardOperatorFactory(binder, TdPartialDeleteOperatorFactory.class);
+        addStandardOperatorFactory(binder, TDResultExportOperatorFactory.class);
         addStandardOperatorFactory(binder, EchoOperatorFactory.class);
         addStandardOperatorFactory(binder, IfOperatorFactory.class);
         addStandardOperatorFactory(binder, FailOperatorFactory.class);

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TDResultExportOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TDResultExportOperatorFactory.java
@@ -1,0 +1,69 @@
+package io.digdag.standards.operator.td;
+
+import com.google.inject.Inject;
+import com.treasuredata.client.model.TDExportResultJobRequest;
+import io.digdag.client.config.Config;
+import io.digdag.core.Environment;
+import io.digdag.spi.Operator;
+import io.digdag.spi.OperatorContext;
+import io.digdag.spi.OperatorFactory;
+import io.digdag.util.UserSecretTemplate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+public class TDResultExportOperatorFactory
+        implements OperatorFactory
+{
+    private final Map<String, String> env;
+    private final Config systemConfig;
+    private static Logger logger = LoggerFactory.getLogger(TdTableExportOperatorFactory.class);
+
+    @Inject
+    public TDResultExportOperatorFactory(@Environment Map<String, String> env, Config systemConfig)
+    {
+        this.env = env;
+        this.systemConfig = systemConfig;
+    }
+
+    @Override
+    public String getType() { return "td_result_export"; }
+
+    @Override
+    public Operator newOperator(OperatorContext context) { return new TDResultExportOperator(context); }
+
+    private class TDResultExportOperator
+            extends BaseTdJobOperator
+    {
+        private final String jobId;
+        private final String resultSettings;
+        private final String resultConnection;
+
+        private TDResultExportOperator(OperatorContext context)
+        {
+        super(context, env, systemConfig);
+        Config params = request.getConfig();
+        this.jobId = params.get("job_id", String.class);
+        this.resultConnection = params.get("result_connection", String.class);
+
+        UserSecretTemplate template = UserSecretTemplate.of(params.parseNested("result_settings").toString());
+        this.resultSettings = template.format(context.getSecrets());
+    }
+
+        @Override
+        protected String startJob(TDOperator op, String domainKey)
+        {
+            TDExportResultJobRequest jobRequest = TDExportResultJobRequest.builder()
+                    .jobId(this.jobId)
+                    .resultConnectionId(String.valueOf(op.lookupConnection(this.resultConnection)))
+                    .resultConnectionSettings(this.resultSettings)
+                    .build();
+
+            String jobId = op.submitNewJobWithRetry(client -> client.submitResultExportJob(jobRequest));
+            logger.info("Started result export job id={}", jobId);
+
+            return jobId;
+        }
+    }
+}

--- a/digdag-tests/src/test/java/acceptance/td/TdResultExportIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/TdResultExportIT.java
@@ -1,0 +1,148 @@
+package acceptance.td;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Optional;
+import com.treasuredata.client.TDApiRequest;
+import com.treasuredata.client.TDClient;
+import com.treasuredata.client.TDClientConfig;
+import com.treasuredata.client.model.TDExportResultJobRequest;
+import com.treasuredata.client.model.TDJob;
+import com.treasuredata.client.model.TDSaveQueryRequest;
+import com.treasuredata.client.model.TDSavedQuery;
+import com.treasuredata.client.model.TDSavedQueryStartRequest;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import static acceptance.td.Secrets.TD_API_KEY;
+import static acceptance.td.Secrets.TD_API_ENDPOINT;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assume.assumeThat;
+
+public class TdResultExportIT
+{
+    private TDClient client;
+    private String database;
+    private String table;
+    private String savedQuery;
+    private String jobId;
+    private String connectionId;
+    private static final MediaType JSON = MediaType.parse("application/json; charset=utf-8");
+    private OkHttpClient httpClient;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        assumeThat(TD_API_KEY, not(isEmptyOrNullString()));
+        assumeThat(TD_API_ENDPOINT, not(isEmptyOrNullString()));
+
+        client = TDClient.newBuilder(false)
+                .setApiKey(TD_API_KEY)
+                .setEndpoint(TD_API_ENDPOINT)
+                .build();
+        database = "tmp_" + UUID.randomUUID().toString().replace('-', '_');
+        client.createDatabase(database);
+        String queryName = "test_" + UUID.randomUUID().toString().replace('-', '_');
+        createQuery(queryName);
+        TDSavedQueryStartRequest req = TDSavedQueryStartRequest.builder()
+                .name(queryName)
+                .scheduledTime(new Date())
+                .build();
+        this.jobId = client.startSavedQuery(req);
+        this.table = "test_" + UUID.randomUUID().toString().replace('-', '_');
+        client.createTableIfNotExists(database, table);
+        this.httpClient = new OkHttpClient();
+    }
+
+    @Test
+    public void testSubmitResultExportJob()
+            throws IOException
+    {
+        String testConnectorName =  "test_" + UUID.randomUUID().toString().replace('-', '_');
+        String json = "{\"description\":null,\"name\":\"" + testConnectorName + "\"," +
+                "\"settings\":{\"api_key\":\"\",\"api_hostname\":\"\"}," +
+                "\"shared\":false,\"type\":\"treasure_data\"}";
+
+        RequestBody body = RequestBody.create(JSON, json);
+        Request request = new Request.Builder()
+                .url("https://" + TD_API_ENDPOINT + "/v4/connections")
+                .header("authorization", "TD1 " + TD_API_KEY)
+                .post(body)
+                .build();
+        Response response = httpClient.newCall(request).execute();
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode jsonNode = objectMapper.readTree(response.body().string());
+        connectionId = jsonNode.get("id").asText();
+
+        String resultConnectionSettings = "{\"user_database_name\":\"" + this.database + "\"," +
+                "\"user_table_name\":\"" + this.table + "\"}";
+
+        TDExportResultJobRequest req = TDExportResultJobRequest.builder()
+                .jobId(this.jobId)
+                .resultConnectionId(connectionId)
+                .resultConnectionSettings(resultConnectionSettings)
+                .build();
+        client.submitResultExportJob(req);
+    }
+
+    @After
+    public void deleteQuery()
+    {
+        if (client != null) {
+            client.deleteSavedQuery(savedQuery);
+        }
+    }
+
+    @After
+    public void deleteConnection()
+            throws IOException
+    {
+        if(connectionId != null){
+            Request request = new Request.Builder()
+                    .url("https://" + TD_API_ENDPOINT + "/v4/connections/" + connectionId)
+                    .header("authorization", "TD1 " + TD_API_KEY)
+                    .delete()
+                    .build();
+            httpClient.newCall(request).execute();
+        }
+    }
+
+    @After
+    public void deleteDatabase()
+    {
+        if (client != null && database != null) {
+            client.deleteDatabase(database);
+        }
+    }
+
+    private TDSavedQuery createQuery(String name)
+    {
+        return saveQuery(TDSavedQuery.newBuilder(
+                name,
+                TDJob.Type.PRESTO,
+                database,
+                "select 1",
+                "Asia/Tokyo")
+                .build());
+    }
+
+    private TDSavedQuery saveQuery(TDSaveQueryRequest request)
+    {
+        this.savedQuery = request.getName();
+        return client.saveQuery(request);
+    }
+}


### PR DESCRIPTION
# What is this PR ?
- This is yet another implementation of `td_result_export>` operator
- This status of this implementation is **POC**
- original implementation: #883 

# What is the difference from original implementation ?
- In this version, user can specify the output destination with connection like `td>` operator
- But this implementation depends on the behavior of the endpoint which is not supported officially for now

```yml
result_connection: my_query_result
result_settings:
  user_database_name: my_database
  user_table_name: my_table
```

# Sample

```yml
timezone: UTC

_export:
  td:
    database: my_database

+execute_query:
  td_run>: my_query

+execute_result_export:
  td_result_export>: 
  job_id: ${td.last_job.id}
  result_connection: my_query_result
  result_settings:
    user_database_name: my_database
    user_table_name: my_table
```