### PR TITLE
Support python: option in py> operator to customize python executable command

### DIFF
--- a/digdag-docs/src/operators/py.md
+++ b/digdag-docs/src/operators/py.md
@@ -20,3 +20,12 @@ See [Python API documents](../../python_api.html) for details including variable
   ```
   py>: tasks.MyWorkflow.my_task
   ```
+
+The python defaults to `python`. If an alternate python such as `/opt/conda/bin/python` is desired, use the `python` option in the `_export` section.
+
+    _export:
+      py:
+        python: ["/opt/conda/bin/python"]
+
+    +step1:
+      py>: tasks.MyWorkflow.my_task2

--- a/digdag-docs/src/operators/py.md
+++ b/digdag-docs/src/operators/py.md
@@ -25,7 +25,7 @@ The python defaults to `python`. If an alternate python such as `/opt/conda/bin/
 
     _export:
       py:
-        python: ["/opt/conda/bin/python"]
+        python: /opt/conda/bin/python
 
     +step1:
       py>: tasks.MyWorkflow.my_task2

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/PyOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/PyOperatorFactory.java
@@ -123,17 +123,10 @@ public class PyOperatorFactory
             try (OutputStream fo = workspace.newOutputStream(inFile)) {
                 mapper.writeValue(fo, ImmutableMap.of("params", params));
             }
-            
-            String pythonExecutable;
-            
-            if(params.has("_pythonexec")) {
-            	pythonExecutable = params.get("_pythonexec", String.class);
-            }else {
-            	pythonExecutable = "python";
-            }
 
+            final String python = params.get("python", String.class, "python");
             List<String> cmdline = ImmutableList.<String>builder()
-                .add(pythonExecutable).add("-")  // script is fed from stdin
+                .add(python).add("-")  // script is fed from stdin
                 .addAll(args)
                 .build();
 


### PR DESCRIPTION
follow-up of https://github.com/treasure-data/digdag/pull/703

This PR supports `python:` option in `py>` operator like `sh>` operator's `shell:` option like the following.

```yaml
_export:
  py:
    python: /opt/conda/bin/python
```