### PR TITLE
Added 'attempt_id' to the RuntimeParams

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/agent/RuntimeParams.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/RuntimeParams.java
@@ -70,6 +70,7 @@ public class RuntimeParams
         params.set("project_id", request.getProjectId());
 
         params.set("retry_attempt_name", request.getRetryAttemptName().orNull());
+        params.set("attempt_id", request.getAttemptId());
 
         // task_*
         params.set("task_name", request.getTaskName());

--- a/digdag-docs/src/workflow_definition.rst
+++ b/digdag-docs/src/workflow_definition.rst
@@ -64,6 +64,7 @@ Name                            Description                                 Exam
 **session_tz_offset**           Time zone offset part of session_time       -0800
 **session_unixtime**            Seconds since the epoch time                1454140800
 **task_name**                   Name of this task                           +my_workflow+parent_task+child_task0
+**attempt_id**                  Integer ID of this attempt                  7
 =============================== =========================================== ==========================
 
 If `schedule: option is set <scheduling_workflow.html>`_, **last_session_time** and **next_session_time** are also available as following:

--- a/digdag-tests/src/test/java/acceptance/BuiltInVariablesIT.java
+++ b/digdag-tests/src/test/java/acceptance/BuiltInVariablesIT.java
@@ -74,6 +74,7 @@ public class BuiltInVariablesIT
                 .put("next_session_tz_offset", is("+0000"))
                 .put("next_session_unixtime", is("1451779200"))
                 .put("task_name", is("+built_in_variables+get_variables+task_name"))
+                .put("attempt_id", is("1"))
                 .build();
 
         assertThat(values.entrySet().size(), is(expectedOutput.size()));

--- a/digdag-tests/src/test/resources/acceptance/built_in_variables/built_in_variables.dig
+++ b/digdag-tests/src/test/resources/acceptance/built_in_variables/built_in_variables.dig
@@ -52,3 +52,5 @@ schedule:
     sh>: "echo next_session_unixtime: \\'${next_session_unixtime}\\' >> output.yml"
   +task_name:
     sh>: "echo task_name: \\'${task_name}\\' >> output.yml"
+  +attempt_id:
+    sh>: "echo attempt_id: \\'${attempt_id}\\' >> output.yml"


### PR DESCRIPTION
When tracking the state of the sessions/attempts on a distinct system, it's necessary for the task code to have access to the attempt_id.