### PR TITLE
Add Cc and Bcc address to mail operator.

### DIFF
--- a/digdag-docs/src/operators/mail.md
+++ b/digdag-docs/src/operators/mail.md
@@ -16,12 +16,14 @@ To use Gmail SMTP server, you need to do either of:
         mail>: body.txt
         subject: workflow started
         to: [me@example.com]
+        cc: [foo@example.com,bar@example.com]
 
       +step2:
         mail>:
           data: this is email body embedded in a .dig file
         subject: workflow started
         to: [me@example.com]
+        bcc: [foo@example.com,bar@example.com]
 
       +step3:
         sh>: this_task_might_fail.sh
@@ -134,6 +136,26 @@ To use Gmail SMTP server, you need to do either of:
 
   ```
   to: [analyst@examile.com]
+  ```
+
+* **cc**: [ADDR1, ADDR2, ...]
+
+  Cc addresses.
+
+  Examples:
+
+  ```
+  cc: [analyst@examile.com]
+  ```
+
+* **bcc**: [ADDR1, ADDR2, ...]
+
+  Bcc addresses.
+
+  Examples:
+
+  ```
+  bcc: [analyst@examile.com]
   ```
 
 * **from**: ADDR

--- a/digdag-standards/build.gradle
+++ b/digdag-standards/build.gradle
@@ -77,4 +77,7 @@ dependencies {
     testCompile 'org.eclipse.jetty:jetty-servlet:9.3.11.v20160721'
     testCompile 'org.eclipse.jetty:jetty-servlets:9.3.11.v20160721'
     testCompile 'org.eclipse.jetty:jetty-webapp:9.3.11.v20160721'
+    // mail test
+    testCompile 'org.subethamail:subethasmtp:3.1.7'
+
 }

--- a/digdag-standards/build.gradle
+++ b/digdag-standards/build.gradle
@@ -78,6 +78,6 @@ dependencies {
     testCompile 'org.eclipse.jetty:jetty-servlets:9.3.11.v20160721'
     testCompile 'org.eclipse.jetty:jetty-webapp:9.3.11.v20160721'
     // mail test
-    testCompile 'org.subethamail:subethasmtp:3.1.7'
+    testCompile 'com.icegreen:greenmail:1.5.8'
 
 }

--- a/digdag-standards/build.gradle
+++ b/digdag-standards/build.gradle
@@ -78,6 +78,8 @@ dependencies {
     testCompile 'org.eclipse.jetty:jetty-servlets:9.3.11.v20160721'
     testCompile 'org.eclipse.jetty:jetty-webapp:9.3.11.v20160721'
     // mail test
-    testCompile 'com.icegreen:greenmail:1.5.8'
+    testCompile ('com.icegreen:greenmail:1.5.8'){
+        exclude group: 'org.slf4j', module: 'slf4j-api'
 
+    }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/MailOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/MailOperatorFactory.java
@@ -123,6 +123,8 @@ public class MailOperatorFactory
             catch (ConfigException ex) {
                 toList = ImmutableList.of(params.get("to", String.class));
             }
+            List<String> bccList = params.getListOrEmpty("bcc", String.class);
+            List<String> ccList = params.getListOrEmpty("cc", String.class);
 
             boolean isHtml = params.get("html", boolean.class, false);
 
@@ -135,6 +137,14 @@ public class MailOperatorFactory
 
                 msg.setRecipients(RecipientType.TO,
                         toList.stream()
+                                .map(it -> newAddress(it))
+                                .toArray(InternetAddress[]::new));
+                msg.setRecipients(RecipientType.BCC,
+                        bccList.stream()
+                                .map(it -> newAddress(it))
+                                .toArray(InternetAddress[]::new));
+                msg.setRecipients(RecipientType.CC,
+                        ccList.stream()
                                 .map(it -> newAddress(it))
                                 .toArray(InternetAddress[]::new));
 

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/MailOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/MailOperatorFactoryTest.java
@@ -15,7 +15,6 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/MailOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/MailOperatorFactoryTest.java
@@ -10,7 +10,6 @@ import com.icegreen.greenmail.util.ServerSetupTest;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigException;
 import io.digdag.spi.Operator;
-import io.digdag.spi.TaskExecutionException;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -21,7 +20,6 @@ import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
 import javax.mail.Message;
-import javax.mail.internet.InternetAddress;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -33,7 +31,6 @@ import static io.digdag.core.workflow.OperatorTestingUtils.newContext;
 import static io.digdag.core.workflow.OperatorTestingUtils.newOperatorFactory;
 import static io.digdag.core.workflow.OperatorTestingUtils.newTaskRequest;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -67,22 +64,22 @@ public class MailOperatorFactoryTest
     }
 
     @Before
-    public void createInstance() throws IOException
+    public void createInstance()
+            throws IOException
     {
         this.factory = newOperatorFactory(MailOperatorFactory.class);
         this.tempPath = folder.getRoot().toPath();
 
-        String body = Resources.toString(getClass().getResource("mail_body.txt"),UTF_8);
-        Files.write(Paths.get(this.tempPath.toString(),"mail_body.txt"),body.getBytes());
+        String body = Resources.toString(getClass().getResource("mail_body.txt"), UTF_8);
+        Files.write(Paths.get(this.tempPath.toString(), "mail_body.txt"), body.getBytes());
 
         this.mailConfig = newConfig()
-                .set("host","localhost")
-                .set("port",smtpPort)
-                .set("subject","test")
-                .set("_command","mail_body.txt")
-                .set("timezone","Asia/Tokyo")
-                .set("from","alice@example.com");
-
+                .set("host", "localhost")
+                .set("port", smtpPort)
+                .set("subject", "test")
+                .set("_command", "mail_body.txt")
+                .set("timezone", "Asia/Tokyo")
+                .set("from", "alice@example.com");
     }
 
     @After
@@ -94,76 +91,76 @@ public class MailOperatorFactoryTest
     @Test
     public void sendSingleToEmail()
     {
-        mailConfig.set("to","bob@example.com");
+        mailConfig.set("to", "bob@example.com");
 
         Operator op = factory.newOperator(newContext(
                 tempPath,
                 newTaskRequest().withConfig(mailConfig)));
         op.run();
-        receiveCheck("bob@example.com",1);
+        receiveCheck("bob@example.com", 1);
     }
 
     @Test
     public void sendMultipleToEmail()
     {
-        mailConfig.set("to",ImmutableList.of("bob@example.com","charlie@example.com"));
+        mailConfig.set("to", ImmutableList.of("bob@example.com", "charlie@example.com"));
 
         Operator op = factory.newOperator(newContext(
                 tempPath,
                 newTaskRequest().withConfig(mailConfig)));
         op.run();
-        receiveCheck("bob@example.com",1);
-        receiveCheck("charlie@example.com",1);
-     }
+        receiveCheck("bob@example.com", 1);
+        receiveCheck("charlie@example.com", 1);
+    }
 
     @Test
     public void sendSingleToAndCcBccEmail()
     {
-        mailConfig.set("to","bob@example.com")
+        mailConfig.set("to", "bob@example.com")
                 .set("bcc", ImmutableList.of("charlie@example.com"))
-                .set("cc",ImmutableList.of("david@example.com"));
+                .set("cc", ImmutableList.of("david@example.com"));
 
         Operator op = factory.newOperator(newContext(
                 tempPath,
                 newTaskRequest().withConfig(mailConfig)));
         op.run();
-        greenMail.waitForIncomingEmail(5000,2);
+        greenMail.waitForIncomingEmail(5000, 2);
 
-        receiveCheck("bob@example.com",1);
-        receiveCheck("charlie@example.com",1);
-        receiveCheck("david@example.com",1);
+        receiveCheck("bob@example.com", 1);
+        receiveCheck("charlie@example.com", 1);
+        receiveCheck("david@example.com", 1);
     }
 
     @Test
     public void sendSingleToCcEmail()
     {
-        mailConfig.set("to","bob@example.com")
+        mailConfig.set("to", "bob@example.com")
                 .set("cc", ImmutableList.of("charlie@example.com"));
 
         Operator op = factory.newOperator(newContext(
                 tempPath,
                 newTaskRequest().withConfig(mailConfig)));
         op.run();
-        greenMail.waitForIncomingEmail(5000,2);
+        greenMail.waitForIncomingEmail(5000, 2);
 
-        receiveCheck("bob@example.com",1);
-        receiveCheck("charlie@example.com",1);
+        receiveCheck("bob@example.com", 1);
+        receiveCheck("charlie@example.com", 1);
     }
 
     @Test
     public void sendSingleToBccEmail()
     {
-        mailConfig.set("to","bob@example.com")
+        mailConfig.set("to", "bob@example.com")
                 .set("bcc", ImmutableList.of("charlie@example.com"));
 
         Operator op = factory.newOperator(newContext(
                 tempPath,
                 newTaskRequest().withConfig(mailConfig)));
         op.run();
-        greenMail.waitForIncomingEmail(5000,2);
+        greenMail.waitForIncomingEmail(5000, 2);
 
-        receiveCheck("bob@example.com",1);
-        receiveCheck("charlie@example.com",1);
+        receiveCheck("bob@example.com", 1);
+        receiveCheck("charlie@example.com", 1);
     }
 
     @Test
@@ -175,35 +172,38 @@ public class MailOperatorFactoryTest
                     newTaskRequest().withConfig(mailConfig)));
             op.run();
             fail("should be thrown Exception.");
-        } catch (ConfigException ignore) {
+        }
+        catch (ConfigException ignore) {
         }
     }
 
     @Test
     public void errorCheckRequireTo()
     {
-        mailConfig.set("cc",ImmutableList.of("bob@example.com"));
+        mailConfig.set("cc", ImmutableList.of("bob@example.com"));
         try {
             Operator op = factory.newOperator(newContext(
                     tempPath,
                     newTaskRequest().withConfig(mailConfig)));
             op.run();
             fail("should be thrown Exception.");
-        } catch (ConfigException ignore) {
+        }
+        catch (ConfigException ignore) {
         }
     }
 
     @Test
     public void errorCheckRequireTo2()
     {
-        mailConfig.set("bcc",ImmutableList.of("bob@example.com"));
+        mailConfig.set("bcc", ImmutableList.of("bob@example.com"));
         try {
             Operator op = factory.newOperator(newContext(
                     tempPath,
                     newTaskRequest().withConfig(mailConfig)));
             op.run();
             fail("should be thrown Exception.");
-        } catch (ConfigException ignore) {
+        }
+        catch (ConfigException ignore) {
         }
     }
 
@@ -212,12 +212,12 @@ public class MailOperatorFactoryTest
     {
         Config config = newConfig()
 //                .set("host","localhost")
-                .set("port",smtpPort)
-                .set("subject","test")
-                .set("_command","mail_body.txt")
-                .set("timezone","Asia/Tokyo")
-                .set("from","alice@example.com")
-                .set("to","bob@example.com");
+                .set("port", smtpPort)
+                .set("subject", "test")
+                .set("_command", "mail_body.txt")
+                .set("timezone", "Asia/Tokyo")
+                .set("from", "alice@example.com")
+                .set("to", "bob@example.com");
 
         try {
             Operator op = factory.newOperator(newContext(
@@ -225,7 +225,8 @@ public class MailOperatorFactoryTest
                     newTaskRequest().withConfig(config)));
             op.run();
             fail("should be thrown Exception.");
-        } catch (ConfigException ignore) {
+        }
+        catch (ConfigException ignore) {
         }
     }
 
@@ -233,13 +234,13 @@ public class MailOperatorFactoryTest
     public void errorCheckNoPort()
     {
         Config config = newConfig()
-                .set("host","localhost")
+                .set("host", "localhost")
 //                .set("port",smtpPort)
-                .set("subject","test")
-                .set("_command","mail_body.txt")
-                .set("timezone","Asia/Tokyo")
-                .set("from","alice@example.com")
-                .set("to","bob@example.com");
+                .set("subject", "test")
+                .set("_command", "mail_body.txt")
+                .set("timezone", "Asia/Tokyo")
+                .set("from", "alice@example.com")
+                .set("to", "bob@example.com");
 
         try {
             Operator op = factory.newOperator(newContext(
@@ -247,7 +248,8 @@ public class MailOperatorFactoryTest
                     newTaskRequest().withConfig(config)));
             op.run();
             fail("should be thrown Exception.");
-        } catch (ConfigException ignore) {
+        }
+        catch (ConfigException ignore) {
         }
     }
 
@@ -255,13 +257,13 @@ public class MailOperatorFactoryTest
     public void errorCheckNoSubject()
     {
         Config config = newConfig()
-                .set("host","localhost")
-                .set("port",smtpPort)
+                .set("host", "localhost")
+                .set("port", smtpPort)
 //                .set("subject","test")
-                .set("_command","mail_body.txt")
-                .set("timezone","Asia/Tokyo")
-                .set("from","alice@example.com")
-                .set("to","bob@example.com");
+                .set("_command", "mail_body.txt")
+                .set("timezone", "Asia/Tokyo")
+                .set("from", "alice@example.com")
+                .set("to", "bob@example.com");
 
         try {
             Operator op = factory.newOperator(newContext(
@@ -269,7 +271,8 @@ public class MailOperatorFactoryTest
                     newTaskRequest().withConfig(config)));
             op.run();
             fail("should be thrown Exception.");
-        } catch (ConfigException ignore) {
+        }
+        catch (ConfigException ignore) {
         }
     }
 
@@ -277,13 +280,13 @@ public class MailOperatorFactoryTest
     public void errorCheckNoCommand()
     {
         Config config = newConfig()
-                .set("host","localhost")
-                .set("port",smtpPort)
-                .set("subject","test")
+                .set("host", "localhost")
+                .set("port", smtpPort)
+                .set("subject", "test")
 //                .set("_command","mail_body.txt")
-                .set("timezone","Asia/Tokyo")
-                .set("from","alice@example.com")
-                .set("to","bob@example.com");
+                .set("timezone", "Asia/Tokyo")
+                .set("from", "alice@example.com")
+                .set("to", "bob@example.com");
 
         try {
             Operator op = factory.newOperator(newContext(
@@ -291,7 +294,8 @@ public class MailOperatorFactoryTest
                     newTaskRequest().withConfig(config)));
             op.run();
             fail("should be thrown Exception.");
-        } catch (ConfigException ignore) {
+        }
+        catch (ConfigException ignore) {
         }
     }
 
@@ -299,13 +303,13 @@ public class MailOperatorFactoryTest
     public void errorCheckNoFrom()
     {
         Config config = newConfig()
-                .set("host","localhost")
-                .set("port",smtpPort)
-                .set("subject","test")
-                .set("_command","mail_body.txt")
-                .set("timezone","Asia/Tokyo")
+                .set("host", "localhost")
+                .set("port", smtpPort)
+                .set("subject", "test")
+                .set("_command", "mail_body.txt")
+                .set("timezone", "Asia/Tokyo")
 //                .set("from","alice@example.com")
-                .set("to","bob@example.com");
+                .set("to", "bob@example.com");
 
         try {
             Operator op = factory.newOperator(newContext(
@@ -313,37 +317,40 @@ public class MailOperatorFactoryTest
                     newTaskRequest().withConfig(config)));
             op.run();
             fail("should be thrown Exception.");
-        } catch (ConfigException ignore) {
+        }
+        catch (ConfigException ignore) {
         }
     }
 
     @Test
     public void errorCheckStringCc()
     {
-        mailConfig.set("to","bob@example.com")
-                .set("cc","charlie@example.com");
+        mailConfig.set("to", "bob@example.com")
+                .set("cc", "charlie@example.com");
         try {
             Operator op = factory.newOperator(newContext(
                     tempPath,
                     newTaskRequest().withConfig(mailConfig)));
             op.run();
             fail("should be thrown Exception.");
-        } catch (ConfigException ignore) {
+        }
+        catch (ConfigException ignore) {
         }
     }
 
     @Test
     public void errorCheckStringBcc()
     {
-        mailConfig.set("to","bob@example.com")
-                .set("bcc","charlie@example.com");
+        mailConfig.set("to", "bob@example.com")
+                .set("bcc", "charlie@example.com");
         try {
             Operator op = factory.newOperator(newContext(
                     tempPath,
                     newTaskRequest().withConfig(mailConfig)));
             op.run();
             fail("should be thrown Exception.");
-        } catch (ConfigException ignore) {
+        }
+        catch (ConfigException ignore) {
         }
     }
 
@@ -353,6 +360,6 @@ public class MailOperatorFactoryTest
         Retriever retriever = new Retriever(server);
 
         Message[] messages = retriever.getMessages(user);
-        assertEquals(size,messages.length);
+        assertEquals(size, messages.length);
     }
 }

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/MailOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/MailOperatorFactoryTest.java
@@ -1,0 +1,93 @@
+package io.digdag.standards.operator;
+
+import com.google.common.io.Resources;
+import io.digdag.client.config.Config;
+import io.digdag.spi.Operator;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.subethamail.wiser.Wiser;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import static io.digdag.client.config.ConfigUtils.newConfig;
+import static io.digdag.core.workflow.OperatorTestingUtils.newOperatorFactory;
+import static io.digdag.core.workflow.OperatorTestingUtils.newTaskRequest;
+import static io.digdag.core.workflow.OperatorTestingUtils.newContext;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+
+public class MailOperatorFactoryTest
+{
+
+    private static Wiser wiser;
+
+    final static String hostName = "localhost";
+    final static int port = 2500;
+
+    private MailOperatorFactory factory;
+    private Path tempPath;
+    private Config config;
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @BeforeClass
+    public static void smtpSetup()
+    {
+        wiser = new Wiser();
+        wiser.setPort(port);
+        wiser.setHostname(hostName);
+        wiser.start();
+    }
+
+    @AfterClass
+    public static void shutdownSmtp()
+    {
+        wiser.stop();
+    }
+
+    @Before
+    public void createInstance() throws IOException
+    {
+        this.factory = newOperatorFactory(MailOperatorFactory.class);
+        this.tempPath = folder.getRoot().toPath();
+
+        String body = Resources.toString(getClass().getResource("mail_body.txt"),UTF_8);
+        Files.write(Paths.get(this.tempPath.toString(),"mail_body.txt"),body.getBytes());
+    }
+
+    @Test
+    public void sendEmail()
+    {
+        Config config = newConfig()
+                .set("host","localhost")
+                .set("port",2500)
+                .set("subject","test")
+                .set("_command","mail_body.txt")
+                .set("timezone","Asia/Tokyo")
+                .set("to","bob@example.com")
+                .set("from","alice@example.com");
+        try {
+            String hoge = Resources.toString(getClass().getResource("mail_body.txt"),UTF_8);
+            System.out.println(hoge);
+        }
+        catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        System.out.println(tempPath);
+        Operator op = factory.newOperator(newContext(
+                tempPath,
+                newTaskRequest().withConfig(config)));
+        op.run();
+        assertEquals(true,false);
+    }
+}

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/MailOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/MailOperatorFactoryTest.java
@@ -10,6 +10,7 @@ import com.icegreen.greenmail.util.ServerSetupTest;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigException;
 import io.digdag.spi.Operator;
+import io.digdag.spi.TaskExecutionException;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -207,7 +208,7 @@ public class MailOperatorFactoryTest
         }
     }
 
-    @Ignore
+    @Test
     public void errorCheckNoHost()
     {
         Config config = newConfig()
@@ -226,7 +227,7 @@ public class MailOperatorFactoryTest
             op.run();
             fail("should be thrown Exception.");
         }
-        catch (ConfigException ignore) {
+        catch (TaskExecutionException ignore) {
         }
     }
 

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/MailOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/MailOperatorFactoryTest.java
@@ -1,6 +1,9 @@
 package io.digdag.standards.operator;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.io.Resources;
+import com.icegreen.greenmail.util.GreenMail;
+import com.icegreen.greenmail.util.ServerSetupTest;
 import io.digdag.client.config.Config;
 import io.digdag.spi.Operator;
 import org.junit.After;
@@ -10,7 +13,8 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.subethamail.wiser.Wiser;
+
+import javax.mail.internet.InternetAddress;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -18,23 +22,21 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import static io.digdag.client.config.ConfigUtils.newConfig;
+import static io.digdag.core.workflow.OperatorTestingUtils.newContext;
 import static io.digdag.core.workflow.OperatorTestingUtils.newOperatorFactory;
 import static io.digdag.core.workflow.OperatorTestingUtils.newTaskRequest;
-import static io.digdag.core.workflow.OperatorTestingUtils.newContext;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
 
 public class MailOperatorFactoryTest
 {
 
-    private static Wiser wiser;
-
-    final static String hostName = "localhost";
-    final static int port = 2500;
+    private static GreenMail greenMail;
+    private static int smtpPort;
 
     private MailOperatorFactory factory;
     private Path tempPath;
-    private Config config;
 
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
@@ -42,16 +44,15 @@ public class MailOperatorFactoryTest
     @BeforeClass
     public static void smtpSetup()
     {
-        wiser = new Wiser();
-        wiser.setPort(port);
-        wiser.setHostname(hostName);
-        wiser.start();
+        greenMail = new GreenMail(ServerSetupTest.SMTP);
+        greenMail.start();
+        smtpPort = greenMail.getSmtp().getPort();
     }
 
     @AfterClass
     public static void shutdownSmtp()
     {
-        wiser.stop();
+        greenMail.stop();
     }
 
     @Before
@@ -64,30 +65,51 @@ public class MailOperatorFactoryTest
         Files.write(Paths.get(this.tempPath.toString(),"mail_body.txt"),body.getBytes());
     }
 
+    @After
+    public void resetGreenMail()
+    {
+        greenMail.reset();
+    }
+
     @Test
     public void sendEmail()
     {
         Config config = newConfig()
                 .set("host","localhost")
-                .set("port",2500)
+                .set("port",smtpPort)
                 .set("subject","test")
                 .set("_command","mail_body.txt")
                 .set("timezone","Asia/Tokyo")
                 .set("to","bob@example.com")
                 .set("from","alice@example.com");
-        try {
-            String hoge = Resources.toString(getClass().getResource("mail_body.txt"),UTF_8);
-            System.out.println(hoge);
-        }
-        catch (IOException e) {
-            e.printStackTrace();
-        }
 
-        System.out.println(tempPath);
         Operator op = factory.newOperator(newContext(
                 tempPath,
                 newTaskRequest().withConfig(config)));
         op.run();
-        assertEquals(true,false);
+            assertEquals(1,greenMail.getReceivedMessages().length);
     }
+
+    @Test
+    public void sendEmail2()
+    {
+        Config config = newConfig()
+                .set("host","localhost")
+                .set("port",smtpPort)
+                .set("subject","test")
+                .set("_command","mail_body.txt")
+                .set("timezone","Asia/Tokyo")
+                .set("to","bob@example.com")
+                .set("from","alice@example.com")
+                .set("bcc", ImmutableList.of("charlie@example.com"))
+                .set("cc",ImmutableList.of("david@example.com"));
+
+        Operator op = factory.newOperator(newContext(
+                tempPath,
+                newTaskRequest().withConfig(config)));
+        op.run();
+        greenMail.waitForIncomingEmail(5000,3);
+//        assertEquals(3,greenMail.getReceivedMessages().length);
+    }
+
 }

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/MailOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/MailOperatorFactoryTest.java
@@ -2,18 +2,25 @@ package io.digdag.standards.operator;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Resources;
+import com.icegreen.greenmail.server.AbstractServer;
 import com.icegreen.greenmail.util.GreenMail;
+import com.icegreen.greenmail.util.Retriever;
+import com.icegreen.greenmail.util.ServerSetup;
 import com.icegreen.greenmail.util.ServerSetupTest;
 import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigException;
 import io.digdag.spi.Operator;
+import io.digdag.spi.TaskExecutionException;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
+import javax.mail.Message;
 import javax.mail.internet.InternetAddress;
 
 import java.io.IOException;
@@ -28,6 +35,7 @@ import static io.digdag.core.workflow.OperatorTestingUtils.newTaskRequest;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static junit.framework.TestCase.assertTrue;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 public class MailOperatorFactoryTest
 {
@@ -38,13 +46,16 @@ public class MailOperatorFactoryTest
     private MailOperatorFactory factory;
     private Path tempPath;
 
+    private Config mailConfig;
+
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 
     @BeforeClass
     public static void smtpSetup()
     {
-        greenMail = new GreenMail(ServerSetupTest.SMTP);
+        ServerSetup servers[] = {ServerSetupTest.SMTP, ServerSetupTest.POP3};
+        greenMail = new GreenMail(servers);
         greenMail.start();
         smtpPort = greenMail.getSmtp().getPort();
     }
@@ -63,6 +74,15 @@ public class MailOperatorFactoryTest
 
         String body = Resources.toString(getClass().getResource("mail_body.txt"),UTF_8);
         Files.write(Paths.get(this.tempPath.toString(),"mail_body.txt"),body.getBytes());
+
+        this.mailConfig = newConfig()
+                .set("host","localhost")
+                .set("port",smtpPort)
+                .set("subject","test")
+                .set("_command","mail_body.txt")
+                .set("timezone","Asia/Tokyo")
+                .set("from","alice@example.com");
+
     }
 
     @After
@@ -72,44 +92,267 @@ public class MailOperatorFactoryTest
     }
 
     @Test
-    public void sendEmail()
+    public void sendSingleToEmail()
     {
-        Config config = newConfig()
-                .set("host","localhost")
-                .set("port",smtpPort)
-                .set("subject","test")
-                .set("_command","mail_body.txt")
-                .set("timezone","Asia/Tokyo")
-                .set("to","bob@example.com")
-                .set("from","alice@example.com");
+        mailConfig.set("to","bob@example.com");
 
         Operator op = factory.newOperator(newContext(
                 tempPath,
-                newTaskRequest().withConfig(config)));
+                newTaskRequest().withConfig(mailConfig)));
         op.run();
-            assertEquals(1,greenMail.getReceivedMessages().length);
+        receiveCheck("bob@example.com",1);
     }
 
     @Test
-    public void sendEmail2()
+    public void sendMultipleToEmail()
     {
-        Config config = newConfig()
-                .set("host","localhost")
-                .set("port",smtpPort)
-                .set("subject","test")
-                .set("_command","mail_body.txt")
-                .set("timezone","Asia/Tokyo")
-                .set("to","bob@example.com")
-                .set("from","alice@example.com")
+        mailConfig.set("to",ImmutableList.of("bob@example.com","charlie@example.com"));
+
+        Operator op = factory.newOperator(newContext(
+                tempPath,
+                newTaskRequest().withConfig(mailConfig)));
+        op.run();
+        receiveCheck("bob@example.com",1);
+        receiveCheck("charlie@example.com",1);
+     }
+
+    @Test
+    public void sendSingleToAndCcBccEmail()
+    {
+        mailConfig.set("to","bob@example.com")
                 .set("bcc", ImmutableList.of("charlie@example.com"))
                 .set("cc",ImmutableList.of("david@example.com"));
 
         Operator op = factory.newOperator(newContext(
                 tempPath,
-                newTaskRequest().withConfig(config)));
+                newTaskRequest().withConfig(mailConfig)));
         op.run();
-        greenMail.waitForIncomingEmail(5000,3);
-//        assertEquals(3,greenMail.getReceivedMessages().length);
+        greenMail.waitForIncomingEmail(5000,2);
+
+        receiveCheck("bob@example.com",1);
+        receiveCheck("charlie@example.com",1);
+        receiveCheck("david@example.com",1);
     }
 
+    @Test
+    public void sendSingleToCcEmail()
+    {
+        mailConfig.set("to","bob@example.com")
+                .set("cc", ImmutableList.of("charlie@example.com"));
+
+        Operator op = factory.newOperator(newContext(
+                tempPath,
+                newTaskRequest().withConfig(mailConfig)));
+        op.run();
+        greenMail.waitForIncomingEmail(5000,2);
+
+        receiveCheck("bob@example.com",1);
+        receiveCheck("charlie@example.com",1);
+    }
+
+    @Test
+    public void sendSingleToBccEmail()
+    {
+        mailConfig.set("to","bob@example.com")
+                .set("bcc", ImmutableList.of("charlie@example.com"));
+
+        Operator op = factory.newOperator(newContext(
+                tempPath,
+                newTaskRequest().withConfig(mailConfig)));
+        op.run();
+        greenMail.waitForIncomingEmail(5000,2);
+
+        receiveCheck("bob@example.com",1);
+        receiveCheck("charlie@example.com",1);
+    }
+
+    @Test
+    public void errorCheckNoDestination()
+    {
+        try {
+            Operator op = factory.newOperator(newContext(
+                    tempPath,
+                    newTaskRequest().withConfig(mailConfig)));
+            op.run();
+            fail("should be thrown Exception.");
+        } catch (ConfigException ignore) {
+        }
+    }
+
+    @Test
+    public void errorCheckRequireTo()
+    {
+        mailConfig.set("cc",ImmutableList.of("bob@example.com"));
+        try {
+            Operator op = factory.newOperator(newContext(
+                    tempPath,
+                    newTaskRequest().withConfig(mailConfig)));
+            op.run();
+            fail("should be thrown Exception.");
+        } catch (ConfigException ignore) {
+        }
+    }
+
+    @Test
+    public void errorCheckRequireTo2()
+    {
+        mailConfig.set("bcc",ImmutableList.of("bob@example.com"));
+        try {
+            Operator op = factory.newOperator(newContext(
+                    tempPath,
+                    newTaskRequest().withConfig(mailConfig)));
+            op.run();
+            fail("should be thrown Exception.");
+        } catch (ConfigException ignore) {
+        }
+    }
+
+    @Ignore
+    public void errorCheckNoHost()
+    {
+        Config config = newConfig()
+//                .set("host","localhost")
+                .set("port",smtpPort)
+                .set("subject","test")
+                .set("_command","mail_body.txt")
+                .set("timezone","Asia/Tokyo")
+                .set("from","alice@example.com")
+                .set("to","bob@example.com");
+
+        try {
+            Operator op = factory.newOperator(newContext(
+                    tempPath,
+                    newTaskRequest().withConfig(config)));
+            op.run();
+            fail("should be thrown Exception.");
+        } catch (ConfigException ignore) {
+        }
+    }
+
+    @Test
+    public void errorCheckNoPort()
+    {
+        Config config = newConfig()
+                .set("host","localhost")
+//                .set("port",smtpPort)
+                .set("subject","test")
+                .set("_command","mail_body.txt")
+                .set("timezone","Asia/Tokyo")
+                .set("from","alice@example.com")
+                .set("to","bob@example.com");
+
+        try {
+            Operator op = factory.newOperator(newContext(
+                    tempPath,
+                    newTaskRequest().withConfig(config)));
+            op.run();
+            fail("should be thrown Exception.");
+        } catch (ConfigException ignore) {
+        }
+    }
+
+    @Test
+    public void errorCheckNoSubject()
+    {
+        Config config = newConfig()
+                .set("host","localhost")
+                .set("port",smtpPort)
+//                .set("subject","test")
+                .set("_command","mail_body.txt")
+                .set("timezone","Asia/Tokyo")
+                .set("from","alice@example.com")
+                .set("to","bob@example.com");
+
+        try {
+            Operator op = factory.newOperator(newContext(
+                    tempPath,
+                    newTaskRequest().withConfig(config)));
+            op.run();
+            fail("should be thrown Exception.");
+        } catch (ConfigException ignore) {
+        }
+    }
+
+    @Test
+    public void errorCheckNoCommand()
+    {
+        Config config = newConfig()
+                .set("host","localhost")
+                .set("port",smtpPort)
+                .set("subject","test")
+//                .set("_command","mail_body.txt")
+                .set("timezone","Asia/Tokyo")
+                .set("from","alice@example.com")
+                .set("to","bob@example.com");
+
+        try {
+            Operator op = factory.newOperator(newContext(
+                    tempPath,
+                    newTaskRequest().withConfig(config)));
+            op.run();
+            fail("should be thrown Exception.");
+        } catch (ConfigException ignore) {
+        }
+    }
+
+    @Test
+    public void errorCheckNoFrom()
+    {
+        Config config = newConfig()
+                .set("host","localhost")
+                .set("port",smtpPort)
+                .set("subject","test")
+                .set("_command","mail_body.txt")
+                .set("timezone","Asia/Tokyo")
+//                .set("from","alice@example.com")
+                .set("to","bob@example.com");
+
+        try {
+            Operator op = factory.newOperator(newContext(
+                    tempPath,
+                    newTaskRequest().withConfig(config)));
+            op.run();
+            fail("should be thrown Exception.");
+        } catch (ConfigException ignore) {
+        }
+    }
+
+    @Test
+    public void errorCheckStringCc()
+    {
+        mailConfig.set("to","bob@example.com")
+                .set("cc","charlie@example.com");
+        try {
+            Operator op = factory.newOperator(newContext(
+                    tempPath,
+                    newTaskRequest().withConfig(mailConfig)));
+            op.run();
+            fail("should be thrown Exception.");
+        } catch (ConfigException ignore) {
+        }
+    }
+
+    @Test
+    public void errorCheckStringBcc()
+    {
+        mailConfig.set("to","bob@example.com")
+                .set("bcc","charlie@example.com");
+        try {
+            Operator op = factory.newOperator(newContext(
+                    tempPath,
+                    newTaskRequest().withConfig(mailConfig)));
+            op.run();
+            fail("should be thrown Exception.");
+        } catch (ConfigException ignore) {
+        }
+    }
+
+    private void receiveCheck(String user, int size)
+    {
+        AbstractServer server = greenMail.getPop3();
+        Retriever retriever = new Retriever(server);
+
+        Message[] messages = retriever.getMessages(user);
+        assertEquals(size,messages.length);
+    }
 }

--- a/digdag-standards/src/test/resources/io/digdag/standards/operator/mail_body.txt
+++ b/digdag-standards/src/test/resources/io/digdag/standards/operator/mail_body.txt
@@ -1,0 +1,1 @@
+This is a test mail.


### PR DESCRIPTION
This PR implement #886.
Add Cc and Bcc address to `mail>` operator.

@muga Can you take a look when you get a chance?
I'll modify a document and write tests if this change policy is good.

