### PR TITLE
Support type hints for Python3 on py> operator

### DIFF
--- a/digdag-standards/src/main/resources/digdag/standards/py/runner.py
+++ b/digdag-standards/src/main/resources/digdag/standards/py/runner.py
@@ -108,10 +108,10 @@ def digdag_inspect_arguments(callable_type, exclude_self, params):
     if callable_type == object.__init__:
         # object.__init__ accepts *varargs and **keywords but it throws exception
         return {}
-    try: # Python3
+    if hasattr(inspect, 'getfullargspec'): # Python3
         spec = inspect.getfullargspec(callable_type)
         keywords_ = spec.varkw
-    except AttributeError as error: # Python 2
+    else: # Python 2
         spec = inspect.getargspec(callable_type)
         keywords_ = spec.keywords
 

--- a/digdag-standards/src/main/resources/digdag/standards/py/runner.py
+++ b/digdag-standards/src/main/resources/digdag/standards/py/runner.py
@@ -108,7 +108,13 @@ def digdag_inspect_arguments(callable_type, exclude_self, params):
     if callable_type == object.__init__:
         # object.__init__ accepts *varargs and **keywords but it throws exception
         return {}
-    spec = inspect.getargspec(callable_type)
+    try: # Python3
+        spec = inspect.getfullargspec(callable_type)
+        keywords_ = spec.varkw
+    except AttributeError as error: # Python 2
+        spec = inspect.getargspec(callable_type)
+        keywords_ = spec.keywords
+
     args = {}
     for idx, key in enumerate(spec.args):
         if exclude_self and idx == 0:
@@ -127,7 +133,7 @@ def digdag_inspect_arguments(callable_type, exclude_self, params):
                 else:
                     name = callable_type.__name__
                 raise TypeError("Method '%s' requires parameter '%s' but not set" % (name, key))
-    if spec.keywords:
+    if keywords_:
         # above code was only for validation
         return params
     else:


### PR DESCRIPTION
This PR will fix #904 

The output of work.py is as follows:

```
(test-py3)➜  test-py3 python --version
Python 3.6.6
(test-py3)➜  test-py3 ~/src/digdag/pkg/digdag-0.9.32-SNAPSHOT.jar run work -a
2018-10-23 11:39:27 +0900: Digdag v0.9.31
2018-10-23 11:39:28 +0900 [WARN] (main): Reusing the last session time 2018-10-23T00:00:00+00:00.
2018-10-23 11:39:28 +0900 [INFO] (main): Using session /Users/ariga/src/test-py3/.digdag/status/20181023T000000+0000.
2018-10-23 11:39:28 +0900 [INFO] (main): Starting a new session project id=1 workflow name=work session_time=2018-10-23T00:00:00+00:00
2018-10-23 11:39:29 +0900 [INFO] (0017@[0:default]+work+work1): py>: work.work1
2018-10-23T00:00:00+00:00
Success. Task state is saved at /Users/ariga/src/test-py3/.digdag/status/20181023T000000+0000 directory.
  * Use --session <daily | hourly | "yyyy-MM-dd[ HH:mm:ss]"> to not reuse the last session time.
  * Use --rerun, --start +NAME, or --goal +NAME argument to rerun skipped tasks.
```