### PR TITLE
Update README.md to add how to use Swagger to check Digdag REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,18 @@ $ brew install node
   * sphinx_rtd_theme
   * recommonmark
 
+### Check Digdag REST API
+
+Use `--enable-swagger` option to check the current Digdag REST API.
+
+```
+$ ./gradlew cli
+$ ./pkg/digdag-<current version>.jar server --memory --enable-swagger # Run server with --enable-swagger option
+
+$ docker run -dp 8080:8080 swaggerapi/swagger-ui # Run Swagger-UI on different console
+$ open http://localhost:8080/?url=http://localhost:65432/api/swagger.json # Open api/swagger.json on Swagger-UI
+```
+
 ### Running tests
 
 ```


### PR DESCRIPTION
follow-up of https://github.com/treasure-data/digdag/pull/577. This PR updates README.md to add how to use Swagger for Digdag REST API at least. digdag.io update is out of scope in this PR. 