### PR TITLE
Update LittleProxy 1.1.2 from 1.1.1

### DIFF
--- a/digdag-tests/build.gradle
+++ b/digdag-tests/build.gradle
@@ -6,8 +6,8 @@ dependencies {
     testCompile 'org.subethamail:subethasmtp:3.1.7'
     testCompile 'com.squareup.okhttp3:okhttp:3.9.0'
     testCompile 'com.squareup.okhttp3:mockwebserver:3.9.0'
-    testCompile('org.littleshoot:littleproxy:1.1.1') {
-        // littleproxy depends on guava:18 and it conflicts with digdag-client
+    testCompile('org.littleshoot:littleproxy:1.1.2') {
+        // littleproxy depends on guava:20 and it conflicts with digdag-client
         exclude group: 'com.google.guava', module: 'guava'
     }
     testCompile "com.amazonaws:aws-java-sdk-dynamodb:${project.ext.awsJavaSdkVersion}"

--- a/digdag-tests/build.gradle
+++ b/digdag-tests/build.gradle
@@ -9,6 +9,8 @@ dependencies {
     testCompile('org.littleshoot:littleproxy:1.1.2') {
         // littleproxy depends on guava:20 and it conflicts with digdag-client
         exclude group: 'com.google.guava', module: 'guava'
+        // littleproxy depends on slf4j-api:1.7.24 and it conflicts with others
+        exclude group: 'org.slf4j', module: 'slf4j-api'
     }
     testCompile "com.amazonaws:aws-java-sdk-dynamodb:${project.ext.awsJavaSdkVersion}"
     testCompile('org.apache.avro:avro:1.8.1') {


### PR DESCRIPTION
This PR updates LittleProxy. that requires https://github.com/treasure-data/digdag/pull/791. 
