### PR TITLE
Check empty value for setting secrets from CLI

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/client/Secrets.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Secrets.java
@@ -264,7 +264,11 @@ public class Secrets
             int equalsIndex = s.indexOf('=');
             if (equalsIndex != -1) {
                 String key = s.substring(0, equalsIndex);
-                String value = s.substring(equalsIndex + 1, s.length());
+                int sLength = s.length();
+                if(equalsIndex + 1 == sLength) {
+                    throw usage("Empty value for --set secret key: '" + key + "'");
+                }
+                String value = s.substring(equalsIndex + 1, sLength);
                 if (key.isEmpty()) {
                     throw usage(null);
                 }


### PR DESCRIPTION
Fix https://github.com/treasure-data/digdag/issues/910

I assume empty value should not be acceptable for secrets, so feel free to close if this specification isn't suitable.

@muga It would be nice if you have a look on it when you have a spare time.