### PR TITLE
Fix #582

### DIFF
--- a/digdag-ui/console.jsx
+++ b/digdag-ui/console.jsx
@@ -919,7 +919,14 @@ function task (node:Object) {
 function resolveTaskFile (taskType:string, command:string, task:Object, projectArchive:ProjectArchive):?TaskFile {
   // TODO: resolve paths relative from the workflow file
   // TODO: make operators provide information about files used in a structured way instead of this hack
-  const filename = path.normalize(command)
+  let filename = ''
+  const cmd = path.normalize(command)
+  _.forEach(projectArchive.files, function (p) {
+    // check the cmd contains filename
+    if (cmd.indexOf(p.name) !== -1) {
+      filename = p.name
+    }
+  })
   if (!projectArchive.hasFile(filename)) {
     return null
   }


### PR DESCRIPTION
This PR will fix #582.

This issue always happens if the command contains non-related to filename such as arguments.
https://github.com/treasure-data/digdag/blob/master/digdag-ui/console.jsx#L922 
In the above, `command` includes args the cause why can't display file(s).

So I will add some fix to check the command contains the specific file in archives exists or not.

If the changes are merged, we can show the files as follows: 

![localhost_9000_projects_2_workflows_main ipad](https://user-images.githubusercontent.com/4961885/51786949-c97dc600-21ae-11e9-8548-b76ec73b5e45.png)
