### PR TITLE
Update Node.js to 8 (appveyor)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ environment:
   - JAVA_HOME: C:\Program Files (x86)\Java\jdk1.8.0
 
 install:
-  - ps: Install-Product node '6.9.1'
+  - ps: Install-Product node '8'
   - node --version
   - npm --version
 


### PR DESCRIPTION
Appveyor uses Node.js 6.9.1 for now, so I've updated it to 8.

Ref. [Selecting Node.js or io.js version](https://www.appveyor.com/docs/lang/nodejs-iojs/#selecting-nodejs-or-iojs-version)