### PR TITLE
Change workflowName in ifOperatorDelayedEvalElseDo

### DIFF
--- a/digdag-core/src/test/java/io/digdag/core/workflow/WorkflowExecutorTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/WorkflowExecutorTest.java
@@ -139,7 +139,7 @@ public class WorkflowExecutorTest
     public void ifOperatorDelayedEvalElseDo()
             throws Exception
     {
-        runWorkflow("if_operator", loadYamlResource("/io/digdag/core/workflow/if_operator_else_do.dig"));
+        runWorkflow("if_operator_else_do", loadYamlResource("/io/digdag/core/workflow/if_operator_else_do.dig"));
         assertThat(new String(Files.readAllBytes(folder.getRoot().toPath().resolve("out")), UTF_8), is("OK_else_do"));
 
     }


### PR DESCRIPTION
Sometimes ifOperatorDelayedEvalDo failed with the message "Session already exists".
The reason is ifOperatorDelayedEvalElseDo and ifOperatorDelayedEvalDo use same workflowName.
To avoid it workflowName used in ifOperatorDelayedEvalElseDo changed.
