### PR TITLE
Fix dead logo and favicon link

### DIFF
--- a/digdag-ui/config/config.js
+++ b/digdag-ui/config/config.js
@@ -9,7 +9,7 @@ var DIGDAG_CONFIG = {
   },
   logoutUrl: '/',
   navbar: {
-    logo: 'images/logo.png',
+    logo: '/images/logo.png',
     brand: 'Digdag',
     className: 'navbar-inverse',
     style: {

--- a/digdag-ui/lib/html-template.js
+++ b/digdag-ui/lib/html-template.js
@@ -7,7 +7,7 @@ export default function htmlTemplate ({ htmlWebpackPlugin }) {
     <head>
       <meta charset='utf-8'>
       <meta name='viewport' content='width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no'>
-      <link rel='icon' type='image/png' href='images/digdagfavicon.ico'>
+      <link rel='icon' type='image/png' href='/images/digdagfavicon.ico'>
       <title>${data.title}</title>
     </head>
     <body>


### PR DESCRIPTION
https://github.com/treasure-data/digdag/pull/939 cause this issue 🙇 
When we visit not top pages such as `/sessions` or `/workflows`, digdag logo always becomes dead link because not found.