### PR TITLE
[Doc] Use inline literal

### DIFF
--- a/digdag-docs/src/releases/release-0.9.32.rst
+++ b/digdag-docs/src/releases/release-0.9.32.rst
@@ -4,11 +4,11 @@ Release 0.9.32
 General Changes
 ---------------
 
-* Add CLI option --enable-swagger for REST API document [#577, #906]
+* Add CLI option ``--enable-swagger`` for REST API document [#577, #906]
 
-* Add --task-log option in local mode [#784]
+* Add ``--task-log`` option in local mode [#784]
 
-* Add 'attempt_id' to the RuntimeParams [#900]
+* Add ``attempt_id`` to the RuntimeParams [#900]
 
 * Support type hints for Python3 on py> operator [#905]
 


### PR DESCRIPTION
`--task-log`, `--enable-swagger` and `attempt_id` use inline literal.

![2019-01-30 15 15 23](https://user-images.githubusercontent.com/767650/51962125-5fad3700-24a2-11e9-909a-96a072167dde.png)
