### PR TITLE
Fix that DigdagClient raises JsonParseException

### DIFF
--- a/digdag-client/src/test/java/io/digdag/client/DigdagClientTest.java
+++ b/digdag-client/src/test/java/io/digdag/client/DigdagClientTest.java
@@ -262,7 +262,7 @@ public class DigdagClientTest
 
         RecordedRequest request = mockWebServer.takeRequest();
 
-        assertThat(request.getHeader(ACCEPT_ENCODING), is("gzip"));
+        assertThat(request.getHeader(ACCEPT_ENCODING), is("gzip, deflate"));
     }
 
     @Test


### PR DESCRIPTION
Fix https://github.com/treasure-data/digdag/issues/947

This issue occurs with digdag >= 0.9.26, and it is caused by resteasy-cient >= 3.0.20.Final.

The resteasy-client now works naturally and it seems that the workaround is not needed anymore.