### PR TITLE
fix can't refer to directories outside the project

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/DockerCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/DockerCommandExecutor.java
@@ -87,6 +87,13 @@ public class DockerCommandExecutor
             command.add("-v").add(String.format(ENGLISH,
                         "%s:%s:rw", projectPath, projectPath));  // use projectPath to keep pb.directory() valid
 
+            if (dockerConfig.has("volume_host") && dockerConfig.has("volume_guest")) {
+                // mount Linking folders between host and guest
+                command.add("-v").add(String.format(ENGLISH,
+                        "%s:%s:rw", dockerConfig.get("volume_host", String.class),
+                        dockerConfig.get("volume_guest", String.class)));
+            }
+
             // workdir
             Path workdir = (pb.directory() == null) ? Paths.get("") : pb.directory().toPath();
             command.add("-w").add(workdir.normalize().toAbsolutePath().toString());


### PR DESCRIPTION
Hello
I am using digdag in own project.
I use the docker function, it can't see the folder of hostOS from the docker container, so I fixed it. I added volume_host and volume_guest tags to the same layer of the image tag. 


usage
```
+ step_create_nantoka:
  _export:
    docker:
      image: $ {docker_python_image_name}
      volume_host: /Users/hisashi/IdeaProjects/sftp_data
      volume_guest: /home/alpine/x_folder/
  py>: tasks.test_yogo1.xyz
```
