### PR TITLE
Fix documentation of digdag.env.export

### DIFF
--- a/digdag-docs/src/workflow_definition.rst
+++ b/digdag-docs/src/workflow_definition.rst
@@ -167,6 +167,15 @@ You can set variables programmably using language API. For example, Python API p
 
 ``digdag.env.store(dict)`` stores variables so that all following tasks (including tasks which are not children of the task) can use them.
 
+.. code-block:: python
+
+    import digdag
+
+    class MyWorkflow(object):
+      def export_and_call_child(self):
+        digdag.env.export({"my_param": 2})
+        digdag.env.add_subtask({'_type': 'call', '_command': 'child1.dig'})
+
 ``digdag.env.export(dict)`` is same with "_export" directive in YAML file. It defines variables for their children.
 
 See language API documents for details:

--- a/examples/params.dig
+++ b/examples/params.dig
@@ -45,17 +45,8 @@ timezone: UTC
     py>: examples.params.export_params_step3
 
 # To carry parameters to dependent tasks, you can set parameters
-# to "digdag.task.export_params". Those export_params are global
-# parameters that affect all following tasks.
+# to "digdag.env.export". Those parameters are global parameters
+# that affect all child tasks.
 +export_params_2:
-  +set_export:
-    py>: examples.params.set_export
-
-  # dependent tasks use carried parameters
-  +dependent1:
-    py>: examples.params.show_export
-
-# all following dependent tasks also use carried parameters
-+dependent2:
-  py>: examples.params.show_export
-
+  +set_export_and_call_child:
+    py>: examples.params.set_export_and_call_child

--- a/examples/params.py
+++ b/examples/params.py
@@ -18,8 +18,9 @@ def export_params_step3(mysql):
 def export_overwrite(mysql):
     print("export_overwrite: mysql = "+str(mysql))
 
-def set_export():
+def set_export_and_call_child():
     digdag.env.export({"table": "carried information"})
+    digdag.env.add_subtask({'_type': 'call', '_command': 'params_child.dig'})
 
 def show_export(table=None):
     print("show_export: table = " + str(table))

--- a/examples/params_child.dig
+++ b/examples/params_child.dig
@@ -1,0 +1,9 @@
+timezone: UTC
+
+# dependent tasks use carried parameters
++export_params_dependent1:
+  py>: examples.params.show_export
+
+# all dependent tasks also use carried parameters
++export_params_dependent2:
+  py>: examples.params.show_export


### PR DESCRIPTION
Fix https://github.com/treasure-data/digdag/issues/944

* digdag.env.export does not affect following tasks, but affect only child tasks.
* child tasks can be created only via digdag.env.add_subtask currently.
