### PR TITLE
Fix digdag.env.add_subtask for python3

### DIFF
--- a/digdag-standards/src/main/resources/digdag/standards/py/runner.py
+++ b/digdag-standards/src/main/resources/digdag/standards/py/runner.py
@@ -53,7 +53,7 @@ class Env(object):
                 command = ".".join([function.im_class.__module__, function.im_class.__name__, function.__name__])
             else:
                 # Python 3
-                command = ".".join([function.__module__, function.__name__])
+                command = ".".join([function.__module__, function.__qualname__])
             config = params
             config["py>"] = command
         else:


### PR DESCRIPTION
Fix https://github.com/treasure-data/digdag/issues/971

With python code:

```
class FooClass(object):
    def foo_method(self):
        pass

function = FooClass().foo_method
```

`function.__qualname__` becomes `FooClass.foo_method` although `function.__name__` is `foo_method`.