### PR TITLE
Fix td_load> parameter issue.

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdLoadOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdLoadOperatorFactory.java
@@ -85,7 +85,7 @@ public class TdLoadOperatorFactory
             if ( numExistParams > 1) {
                 throw new ConfigException("Only the command or one of the config and name params may be set");
             }
-            else if (numExistParams <= 0) {
+            else if (numExistParams == 0) {
                 throw new ConfigException("No parameter is set");
             }
 
@@ -103,12 +103,9 @@ public class TdLoadOperatorFactory
                 this.embulkConfig = Optional.absent();
                 this.sessionName = name;
             }
-            else if (config.isPresent()) {
+            else (config.isPresent()) {
                 this.embulkConfig = Optional.of(config.get().getInternalObjectNode());
                 this.sessionName = Optional.absent();
-            }
-            else {
-                throw new ConfigException("Unexpected config error");
             }
         }
 

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdLoadOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdLoadOperatorFactory.java
@@ -103,7 +103,7 @@ public class TdLoadOperatorFactory
                 this.embulkConfig = Optional.absent();
                 this.sessionName = name;
             }
-            else (config.isPresent()) {
+            else {
                 this.embulkConfig = Optional.of(config.get().getInternalObjectNode());
                 this.sessionName = Optional.absent();
             }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdLoadOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdLoadOperatorFactory.java
@@ -81,8 +81,12 @@ public class TdLoadOperatorFactory
                 throw new ConfigException("The parameters config and name cannot both be set");
             }
 
-            if (Stream.of(command, name, config).filter(Optional::isPresent).count() > 1) {
+            long numExistParams = Stream.of(command, name, config).filter(Optional::isPresent).count();
+            if ( numExistParams > 1) {
                 throw new ConfigException("Only the command or one of the config and name params may be set");
+            }
+            else if (numExistParams <= 0) {
+                throw new ConfigException("No parameter is set");
             }
 
             if (command.isPresent()) {
@@ -104,7 +108,7 @@ public class TdLoadOperatorFactory
                 this.sessionName = Optional.absent();
             }
             else {
-                throw new AssertionError();
+                throw new ConfigException("Unexpected config error");
             }
         }
 

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/td/TdLoadOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/td/TdLoadOperatorFactoryTest.java
@@ -1,0 +1,72 @@
+package io.digdag.standards.operator.td;
+
+import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigException;
+import io.digdag.spi.Operator;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+import java.nio.file.Path;
+
+import static io.digdag.client.config.ConfigUtils.newConfig;
+import static io.digdag.core.workflow.OperatorTestingUtils.newContext;
+import static io.digdag.core.workflow.OperatorTestingUtils.newOperatorFactory;
+import static io.digdag.core.workflow.OperatorTestingUtils.newTaskRequest;
+
+
+public class TdLoadOperatorFactoryTest {
+    @Rule
+    public ExpectedException expectedException = ExpectedException.none();
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    private Path tempPath;
+    private TdLoadOperatorFactory factory;
+
+    @Before
+    public void createInstance()
+    {
+        this.tempPath = folder.getRoot().toPath();
+        this.factory = newOperatorFactory(TdLoadOperatorFactory.class);
+    }
+
+    private Operator newOperatorWithConfig(Config config)
+    {
+        return factory.newOperator(newContext(tempPath, newTaskRequest().withConfig(config)));
+    }
+
+    @Test
+    public void testConfigNoParam()
+    {
+        expectedException.expect(ConfigException.class);
+        expectedException.expectMessage("No parameter is set");
+        newOperatorWithConfig(newConfig());
+    }
+
+    @Test
+    public void testConfigBothConfigAndName()
+    {
+        expectedException.expect(ConfigException.class);
+        expectedException.expectMessage("The parameters config and name cannot both be set");
+        newOperatorWithConfig(newConfig().set("config", newConfig().set("aa", 1)).set("name", "aaa"));
+    }
+
+    @Test
+    public void testConfigBothCommandAndName()
+    {
+        expectedException.expect(ConfigException.class);
+        expectedException.expectMessage("Only the command or one of the config and name params may be set");
+        newOperatorWithConfig(newConfig().set("_command", "aaa.yml").set("name", "bbb.yml"));
+    }
+
+    @Test
+    public void testConfigCommandOnly()
+    {
+        newOperatorWithConfig(newConfig().set("_command", "aaa"));
+    }
+
+}


### PR DESCRIPTION
If td_load> operator with no parameter, it throws AssertError which not inherit RuntimeException.
As result exception is through OperatorManager and caught by MultiThreadAgent and never finish.

This patch change AssertError to ConfigException and add test for config parameter.