### PR TITLE
Apply circleci jobs to v0_10 branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,3 +77,4 @@ workflows:
             branches:
               only:
                 - master
+                - v0_10


### PR DESCRIPTION
This PR enables applying CircleCI jobs to v0_10 branch. one of release preparation for v0.10