### PR TITLE
Stop document deployment on CI for v0_10 branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,12 +69,16 @@ jobs:
 workflows:
   version: 2
 
-  test:
+  test_and_docs_deployment:
     jobs:
-      - test
-      - docs_deployment:
+      - test: # master and v0_10 branches only
           filters:
             branches:
               only:
                 - master
                 - v0_10
+      - docs_deployment: # master branch only
+          filters:
+            branches:
+              only:
+                - master


### PR DESCRIPTION
follow-up of https://github.com/treasure-data/digdag/pull/982. document deployment should be executed on CI for master branch only. 