### PR TITLE
Support ruby: option in rb> operator to customize ruby executable command

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/operator/RbOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/RbOperatorFactory.java
@@ -127,8 +127,9 @@ public class RbOperatorFactory
                 mapper.writeValue(fo, ImmutableMap.of("params", params));
             }
 
+            final String ruby = params.get("ruby", String.class, "ruby");
             ImmutableList.Builder<String> cmdline = ImmutableList.builder();
-            cmdline.add("ruby");
+            cmdline.add(ruby);
             cmdline.add("-I").add(workspace.getPath().toString());
             if (feature.isPresent()) {
                 cmdline.add("-r").add(feature.get());


### PR DESCRIPTION
This PR supports `ruby:` option in `rb>` operator to customize ruby executable command like https://github.com/treasure-data/digdag/pull/890