### PR TITLE
Bump shadow to 4.0.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.github.johnrengelman.shadow' version '2.0.3'
+    id 'com.github.johnrengelman.shadow' version '4.0.4'
     id 'com.jfrog.bintray' version '1.8.1'
     id 'com.github.kt3k.coveralls' version '2.6.3'
     id 'com.github.spotbugs' version '1.6.9'
@@ -394,7 +394,7 @@ task cli(dependsOn: ':digdag-cli:shadowJar') {
         file('pkg').mkdirs()
         cliBuildFile.write("")
         cliBuildFile.append(file("digdag-cli/src/main/sh/selfrun.sh").readBytes())
-        cliBuildFile.append(file("digdag-cli/build/libs/digdag-cli-${project.version}-all.jar").readBytes())
+        cliBuildFile.append(file("digdag-cli/build/libs/digdag-cli-${project.version}.jar").readBytes())
         cliBuildFile.setExecutable(true)
     }
 }


### PR DESCRIPTION
https://github.com/treasure-data/digdag/pull/981 introduce this issue.
 `gradlew test` looks good, but `gradlew cli` and   `gradlew build` task failed as below:

```bash
$ ./gradlew clean cli

> Configure project :
Publication mavenJava not found in project :.
Publication mavenJava not found in project :digdag-docs.

> Configure project :digdag-cli
Publication mavenJava not found in project :.
Publication mavenJava not found in project :digdag-docs.

> Configure project :digdag-client
Publication mavenJava not found in project :.
Publication mavenJava not found in project :digdag-docs.

> Configure project :digdag-core
Publication mavenJava not found in project :.
Publication mavenJava not found in project :digdag-docs.

> Configure project :digdag-docs
Publication mavenJava not found in project :.
Publication mavenJava not found in project :digdag-docs.

> Configure project :digdag-guice-rs
Publication mavenJava not found in project :.
Publication mavenJava not found in project :digdag-docs.

> Configure project :digdag-guice-rs-server
Publication mavenJava not found in project :.
Publication mavenJava not found in project :digdag-docs.

> Configure project :digdag-guice-rs-server-undertow
Publication mavenJava not found in project :.
Publication mavenJava not found in project :digdag-docs.

> Configure project :digdag-plugin-utils
Publication mavenJava not found in project :.
Publication mavenJava not found in project :digdag-docs.

> Configure project :digdag-server
Publication mavenJava not found in project :.
Publication mavenJava not found in project :digdag-docs.

> Configure project :digdag-spi
Publication mavenJava not found in project :.
Publication mavenJava not found in project :digdag-docs.

> Configure project :digdag-standards
Publication mavenJava not found in project :.
Publication mavenJava not found in project :digdag-docs.

> Configure project :digdag-storage-s3
Publication mavenJava not found in project :.
Publication mavenJava not found in project :digdag-docs.

> Configure project :digdag-tests
Publication mavenJava not found in project :.
Publication mavenJava not found in project :digdag-docs.

> Configure project :digdag-ui
Publication mavenJava not found in project :.
Publication mavenJava not found in project :digdag-docs.

FAILURE: Build failed with an exception.

* What went wrong:
Method com/github/jengelman/gradle/plugins/shadow/internal/DependencyFileCollection.getBuildDependencies()Lorg/gradle/api/tasks/TaskDependency; is abstract

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 6.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/5.2/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 0s
```

We need to upgrade shadow. So, I've upgrade shadow from 2.0.3 to 4.0.4.