### PR TITLE
Add description about --version option on help

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/Main.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Main.java
@@ -348,6 +348,7 @@ public class Main
         err.println("    -l, --log-level LEVEL            log level (error, warn, info, debug or trace)");
         err.println("    -X KEY=VALUE                     add a performance system config");
         err.println("    -c, --config PATH.properties     Configuration file (default: " + defaultConfigPath(env) + ")");
+        err.println("    --version                        show client version");
         err.println("");
     }
 }


### PR DESCRIPTION
I did not notice that `--version` option was available because `digdag --help` did not show it.

Now, digdag --help shows a help as (the bottom line):

```
$ digdag --help
...
    delete <project-name>              delete a project
    secrets --project <project-name>   manage secrets
    version                            show client and server version

  Options:
    -L, --log PATH                   output log messages to a file (default: -)
    -l, --log-level LEVEL            log level (error, warn, info, debug or trace)
    -X KEY=VALUE                     add a performance system config
    -c, --config PATH.properties     Configuration file (default: /Users/naotoshi.seo/.config/digdag/config)
    --version                        show client version
```