### PR TITLE
[doc] Modify wrong argument of attempts command

### DIFF
--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -633,15 +633,14 @@ attempts
 
 .. code-block:: console
 
-    $ digdag attempts [project-name] [+name]
+    $ digdag attempts [session-id]
 
 Shows list of attempts. This command shows all attempts including attempts retried by another attempt. Examples:
 
 .. code-block:: console
 
     $ digdag attempts
-    $ digdag attempts myproj
-    $ digdag attempts myproj +main
+    $ digdag attempts <session-id>
 
 :command:`-i, --last-id ID`
   Shows more attempts older than this id.


### PR DESCRIPTION
Document says `attempts` command can specify <project name>, but command help says supported only session-id.

```
    attempts                           show attempts for all sessions
    attempts <session-id>              show attempts for a session
```

Actually, `attempts <project name>` fails.

```
$ td wf attempts test_workflow
2019-02-21 12:46:32 +0900: Digdag v0.9.33
Usage: td workflow attempts                         show attempts for all sessions
       td workflow attempts <session-id>            show attempts for a session
  Options:
    -i, --last-id ID                 shows more session attempts from this id
    -s, --page-size Number           shows more session attempts of the number of this page size (in default up to 100)
    -e, --endpoint HOST[:PORT]       HTTP endpoint (default: http://127.0.0.1:65432)
    -L, --log PATH                   output log messages to a file (default: -)
    -l, --log-level LEVEL            log level (error, warn, info, debug or trace)
    -X KEY=VALUE                     add a performance system config
    -c, --config PATH.properties     Configuration file (default: /Users/kamikaseda/.config/digdag/config)

error: For input string: "test_workflow"
```