### PR TITLE
[doc] Add attempt command to the document

### DIFF
--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -649,6 +649,19 @@ Shows list of attempts. This command shows all attempts including attempts retri
 :command:`-s, --page-size N`
   Shows more attempts of the number of N (in default up to 100).
 
+attempt
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: console
+
+    $ digdag attempt [attempt-id]
+
+Shows a single attempt. Examples:
+
+.. code-block:: console
+
+    $ digdag attempt <attempt-id>
+
 tasks
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Digdag command supports `attempt`.

Command's help:

```
    attempt  <attempt-id>              show a single attempt
```