### PR TITLE
Fix typo

### DIFF
--- a/digdag-docs/src/operators/http.md
+++ b/digdag-docs/src/operators/http.md
@@ -16,7 +16,7 @@
 
 ```
 +notify:
-  http>: https://api.example.com/data/sessions/{$session_uuid}
+  http>: https://api.example.com/data/sessions/${session_uuid}
   method: POST
   content:
     status: RUNNING
@@ -54,7 +54,7 @@
   ```
 
   ```
-  http>: https://api.example.com/data/sessions/{$session_uuid}
+  http>: https://api.example.com/data/sessions/${session_uuid}
   ```
 
 * **method**: STRING


### PR DESCRIPTION
`{$session_uuid}` > `${session_uuid}`