### PR TITLE
[doc] Add disable/enable command

### DIFF
--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -557,6 +557,52 @@ schedules
 Shows list of schedules.
 
 
+disable
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: console
+
+    $ digdag disable [project-name]
+
+Disable all workflow schedules in a project.
+
+.. code-block:: console
+
+    $ digdag disable [schedule-id]
+    $ digdag disable [project-name] [name]
+
+Disable a workflow schedule.
+
+.. code-block:: console
+
+    $ digdag disable <schedule-id>
+    $ digdag disable myproj
+    $ digdag disable myproj main
+
+
+enable
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: console
+
+    $ digdag enable [project-name]
+
+Enable all workflow schedules in a project.
+
+.. code-block:: console
+
+    $ digdag enable [schedule-id]
+    $ digdag enable [project-name] [name]
+
+Enable a workflow schedule.
+
+.. code-block:: console
+
+    $ digdag enable <schedule-id>
+    $ digdag enable myproj
+    $ digdag enable myproj main
+
+
 backfill
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Command help explains `disable`/`enable` command. But document doesn't it.

```
    disable <schedule-id>              disable a workflow schedule
    disable <project-name>             disable all workflow schedules in a project
    disable <project-name> <name>      disable a workflow schedule
    enable <schedule-id>               enable a workflow schedule
    enable <project-name>              enable all workflow schedules in a project
    enable <project-name> <name>       enable a workflow schedule
```