### PR TITLE
[doc] Add interval parameter to td_wait and td_wait_table

### DIFF
--- a/digdag-docs/src/operators/td_wait.md
+++ b/digdag-docs/src/operators/td_wait.md
@@ -68,6 +68,10 @@ Example queries:
   engine: presto
   ```
 
+* **interval**: 30s
+
+  Set Interval (default: 30s (30 second)).
+
 * **priority**: 0
 
   Set Priority (From `-2` (VERY LOW) to `2` (VERY HIGH) , default: 0 (NORMAL)).

--- a/digdag-docs/src/operators/td_wait_table.md
+++ b/digdag-docs/src/operators/td_wait_table.md
@@ -72,6 +72,10 @@
   engine: presto
   ```
 
+* **interval**: 30s
+
+  Set Interval (default: 30s (30 second)).
+
 * **priority**: 0
 
   Set Priority (From `-2` (VERY LOW) to `2` (VERY HIGH) , default: 0 (NORMAL)).


### PR DESCRIPTION
`interval` parameter works on `td_wait>` and `td_wait_table>` operators.