### PR TITLE
[doc] Modify from Job Name to Unique ID

### DIFF
--- a/digdag-docs/src/operators/td.md
+++ b/digdag-docs/src/operators/td.md
@@ -208,8 +208,7 @@
 
 ## Output parameters
 
-* **td.last_job_id**
-* **td.last_job.id**
+* **td.last_job_id** or **td.last_job.id**
 
   The job id this task executed.
 

--- a/digdag-docs/src/operators/td_for_each.md
+++ b/digdag-docs/src/operators/td_for_each.md
@@ -95,8 +95,7 @@ For example, if you run a query `select email, name from users` and the query re
 
 ## Output parameters
 
-* **td.last_job_id**
-* **td.last_job.id**
+* **td.last_job_id** or **td.last_job.id**
 
   The job id this task executed.
 

--- a/digdag-docs/src/operators/td_load.md
+++ b/digdag-docs/src/operators/td_load.md
@@ -64,7 +64,7 @@
 
 ## Output parameters
 
-* **td.last_job.id**
+* **td.last_job_id** or **td.last_job.id**
 
   The job id this task executed.
 

--- a/digdag-docs/src/operators/td_load.md
+++ b/digdag-docs/src/operators/td_load.md
@@ -21,12 +21,16 @@
 
 * **td_load>**: FILE.yml
 
-  Path to a YAML template file. This configuration needs to be guessed using td command. If you saved DataConnector job on Treasure Data, you can use job name instead of YAML path.
+  Path to a YAML template file. This configuration needs to be guessed using td command. If you saved DataConnector job on Treasure Data, you can use [Unique ID](https://support.treasuredata.com/hc/en-us/articles/360001474328-Reference-an-Input-Data-Transfer#Configuring%20your%20Unique%20ID%20Incremental%20Data%20Transfer) instead of YAML path.
 
   Examples:
 
   ```
   td_load>: imports/load.yml
+  ```
+
+  ```
+  td_load>: unique_id
   ```
 
 * **database**: NAME
@@ -60,7 +64,6 @@
 
 ## Output parameters
 
-* **td.last_job_id**
 * **td.last_job.id**
 
   The job id this task executed.

--- a/digdag-docs/src/operators/td_run.md
+++ b/digdag-docs/src/operators/td_run.md
@@ -81,8 +81,7 @@
 
 ## Output parameters
 
-* **td.last_job_id**
-* **td.last_job.id**
+* **td.last_job_id** or **td.last_job.id**
 
   The job id this task executed.
 

--- a/digdag-docs/src/operators/td_table_export.md
+++ b/digdag-docs/src/operators/td_table_export.md
@@ -125,8 +125,7 @@ NOTE: We're limiting export capability to only us-east region S3 bucket. In gene
 
 ## Output parameters
 
-* **td.last_job_id**
-* **td.last_job.id**
+* **td.last_job_id** or **td.last_job.id**
 
   The job id this task executed.
 

--- a/digdag-docs/src/operators/td_wait.md
+++ b/digdag-docs/src/operators/td_wait.md
@@ -97,8 +97,7 @@ Example queries:
 
 ## Output parameters
 
-* **td.last_job_id**
-* **td.last_job.id**
+* **td.last_job_id** or **td.last_job.id**
 
   The job id this task executed.
 


### PR DESCRIPTION
Document says `td_load>` can use "Job name" instead of yml. However, "Job name" is not understandable and make a confuse. It would be said "Unique ID".
Refer: https://support.treasuredata.com/hc/en-us/articles/360001474328-Reference-an-Input-Data-Transfer#Configuring%20your%20Unique%20ID%20Incremental%20Data%20Transfer

And remove duplicated "td.last_job_id" item.