### PR TITLE
UI: Upgrade bootstrap 4.3.1 and bootstrap-sass 3.4.1

### DIFF
--- a/digdag-ui/package-lock.json
+++ b/digdag-ui/package-lock.json
@@ -2194,9 +2194,9 @@
       }
     },
     "bootstrap": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.1.2.tgz",
-      "integrity": "sha512-3bP609EdMc/8EwgGp8KgpN8HwnR4V4lZ9CTi5pImMrXNxpkw7dK1B05aMwQWpG1ZWmTLlBSN/uzkuz5GsmQNFA=="
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.3.1.tgz",
+      "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag=="
     },
     "bootstrap-loader": {
       "version": "3.0.2",
@@ -2282,9 +2282,9 @@
       }
     },
     "bootstrap-sass": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/bootstrap-sass/-/bootstrap-sass-3.4.0.tgz",
-      "integrity": "sha512-qdUyw4KmNNPSIdBadn+eyuuQFH0LsZlRCs6tor1zN8sQas7mnY5JNfemauraOdNPiFQd2gFeeo3gZjZZCuohZg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/bootstrap-sass/-/bootstrap-sass-3.4.1.tgz",
+      "integrity": "sha512-p5rxsK/IyEDQm2CwiHxxUi0MZZtvVFbhWmyMOt4lLkA4bujDA1TGoKT0i1FKIWiugAdP+kK8T5KMDFIKQCLYIA==",
       "dev": true
     },
     "brace": {
@@ -4345,7 +4345,9 @@
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "optional": true
     },
     "extend-shallow": {
       "version": "3.0.2",

--- a/digdag-ui/package.json
+++ b/digdag-ui/package.json
@@ -17,7 +17,7 @@
   "license": "",
   "dependencies": {
     "@babel/runtime": "^7.2.0",
-    "bootstrap": "4.1.2",
+    "bootstrap": "4.3.1",
     "brace": "^0.10.0",
     "buffer": "5.0.5",
     "cryptiles": "4.1.2",
@@ -77,7 +77,7 @@
     "babel-eslint": "^10.0.1",
     "babel-loader": "8.0.5",
     "bootstrap-loader": "3.0.2",
-    "bootstrap-sass": "3.4.0",
+    "bootstrap-sass": "3.4.1",
     "cross-env": "3.2.4",
     "css-loader": "^2.1.0",
     "eslint": "^5.12.1",


### PR DESCRIPTION
This PR upgrades 1) bootstrap 4.3.1 2) bootstrap-sass 3.4.1.