### PR TITLE
digdag reschedule <project-name> <name>

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/Main.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Main.java
@@ -310,6 +310,8 @@ public class Main
         err.println("    kill <attempt-id>                  kill a running session attempt");
         err.println("    backfill <project-name> <name>     start sessions of a schedule for past times");
         err.println("    reschedule <schedule-id>           skip sessions of a schedule to a future time");
+        err.println("    reschedule <project-name>          skip sessions of all schedules in a project to a future time");
+        err.println("    reschedule <project-name> <name>   skip sessions of a schedule to a future time");
         err.println("    log <attempt-id>                   show logs of a session attempt");
         err.println("    workflows [project-name] [name]    show registered workflow definitions");
         err.println("    schedules                          show registered schedules");

--- a/digdag-cli/src/main/java/io/digdag/cli/Main.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Main.java
@@ -310,7 +310,6 @@ public class Main
         err.println("    kill <attempt-id>                  kill a running session attempt");
         err.println("    backfill <project-name> <name>     start sessions of a schedule for past times");
         err.println("    reschedule <schedule-id>           skip sessions of a schedule to a future time");
-        err.println("    reschedule <project-name>          skip sessions of all schedules in a project to a future time");
         err.println("    reschedule <project-name> <name>   skip sessions of a schedule to a future time");
         err.println("    log <attempt-id>                   show logs of a session attempt");
         err.println("    workflows [project-name] [name]    show registered workflow definitions");

--- a/digdag-cli/src/main/java/io/digdag/cli/client/DisableSchedule.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/DisableSchedule.java
@@ -18,7 +18,7 @@ public class DisableSchedule
     @Override
     public SystemExitException usage(String error)
     {
-        err.println("Usage: " + programName + " disable <id> | <project-name> [name]");
+        err.println("Usage: " + programName + " disable <schedule-id> | <project-name> [name]");
         showCommonOptions();
         err.println("");
         err.println("  Examples:");

--- a/digdag-cli/src/main/java/io/digdag/cli/client/EnableSchedule.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/EnableSchedule.java
@@ -18,7 +18,7 @@ public class EnableSchedule
     @Override
     public SystemExitException usage(String error)
     {
-        err.println("Usage: " + programName + " enable <id> | <project-name> [name]");
+        err.println("Usage: " + programName + " enable <schedule-id> | <project-name> [name]");
         showCommonOptions();
         err.println("");
         err.println("  Examples:");

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Reschedule.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Reschedule.java
@@ -68,8 +68,10 @@ public class Reschedule
         err.println("Usage: " + programName + " reschedule <schedule-id> | <project-name> [name]");
         err.println("  Options:");
         err.println("    -s, --skip N                     skips specified number of schedules from now");
-        err.println("    -t, --skip-to 'yyyy-MM-dd HH:mm:ss Z'  skips schedules until the specified time (exclusive)");
-        err.println("    -a, --run-at 'yyyy-MM-dd HH:mm:ss Z'   set next run time to this time");
+        err.println("    -t, --skip-to 'yyyy-MM-dd HH:mm:ss Z' | 'now'");
+        err.println("                                     skips schedules until the specified time (exclusive)");
+        err.println("    -a, --run-at 'yyyy-MM-dd HH:mm:ss Z'");
+        err.println("                                     set next run time to this time");
         err.println("    -d, --dry-run                    tries to reschedule and validates the results but does nothing");
         showCommonOptions();
         return systemExit(error);
@@ -132,8 +134,11 @@ public class Reschedule
 
         RestScheduleSummary updated;
         if (toTime != null) {
+            Instant time = "now".equals(toTime) ?
+                now :
+                TimeUtil.parseTime(toTime, "-t, --skip-to");
             updated = client.skipSchedulesToTime(schedId,
-                    TimeUtil.parseTime(toTime, "-t, --skip-to"),
+                    time,
                     runAt,
                     dryRun);
         }

--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -637,13 +637,9 @@ reschedule
 .. code-block:: console
 
     $ digdag reschedule <schedule-id>
-    $ digdag reschedule <project-name> [name]
+    $ digdag reschedule <project-name> <name>
 
 Skips a workflow schedule forward to a future time. To run past schedules, use backfill instead.
-
-    $ digdag reschedule <project-name>
-
-Skips all workflow schedules in a project forward to a future time.
 
 :command:`-s, --skip N`
   Skips specified number of schedules from now. This number "N" doesn't mean number of sessions to be skipped. "N" is the number of sessions to be skipped.

--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -637,8 +637,13 @@ reschedule
 .. code-block:: console
 
     $ digdag reschedule <schedule-id>
+    $ digdag reschedule <project-name> [name]
 
-Skips schedule forward to a future time. To run past schedules, use backfill instead.
+Skips a workflow schedule forward to a future time. To run past schedules, use backfill instead.
+
+    $ digdag reschedule <project-name>
+
+Skips all workflow schedules in a project forward to a future time.
 
 :command:`-s, --skip N`
   Skips specified number of schedules from now. This number "N" doesn't mean number of sessions to be skipped. "N" is the number of sessions to be skipped.

--- a/digdag-tests/src/test/java/acceptance/RescheduleIT.java
+++ b/digdag-tests/src/test/java/acceptance/RescheduleIT.java
@@ -1,0 +1,134 @@
+package acceptance;
+
+import io.digdag.client.DigdagClient;
+import io.digdag.client.api.Id;
+import io.digdag.client.api.RestSchedule;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import utils.CommandStatus;
+import utils.TemporaryDigdagServer;
+
+import java.nio.file.Path;
+import java.time.format.DateTimeFormatter;
+import java.time.OffsetDateTime;
+
+import static utils.TestUtils.copyResource;
+import static utils.TestUtils.main;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+public class RescheduleIT
+{
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Rule
+    public TemporaryDigdagServer server = TemporaryDigdagServer.of();
+
+    private Path config;
+    private Path projectDir;
+    private DigdagClient client;
+    private Path outdir;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        projectDir = folder.getRoot().toPath().resolve("foobar");
+        config = folder.newFile().toPath();
+
+        client = DigdagClient.builder()
+                .host(server.host())
+                .port(server.port())
+                .build();
+
+        outdir = projectDir.resolve("outdir");
+    }
+
+    @Test
+    public void initPushRescheduleScheduleId()
+            throws Exception
+    {
+        // Create new project
+        {
+            CommandStatus cmd = main("init",
+                    "-c", config.toString(),
+                    projectDir.toString());
+            assertThat(cmd.code(), is(0));
+        }
+
+        final String projectName = "reschedule-test";
+        copyResource("acceptance/reschedule/reschedule.dig", projectDir.resolve("reschedule.dig"));
+
+        // Push
+        {
+            CommandStatus cmd = main("push",
+                    "-c", config.toString(),
+                    "-e", server.endpoint(),
+                    "--project", projectDir.toString(),
+                    projectName);
+            assertThat(cmd.errUtf8(), cmd.code(), is(0));
+        }
+
+        RestSchedule oldSchedule = client.getSchedule(Id.of("1"));
+        OffsetDateTime skipTo = oldSchedule.getNextScheduleTime().plusDays(1);
+
+        // Reschedule the schedule
+        {
+            CommandStatus cmd = main("reschedule",
+                    "-c", config.toString(),
+                    "-e", server.endpoint(),
+                    "--skip-to", skipTo.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss Z")),
+                    "1");
+            assertThat(cmd.errUtf8(), cmd.code(), is(0));
+        }
+
+        RestSchedule newSchedule = client.getSchedule(Id.of("1"));
+        assertEquals(newSchedule.getNextScheduleTime(), oldSchedule.getNextScheduleTime().plusDays(1));
+    }
+
+    @Test
+    public void initPushRescheduleWorkflow()
+            throws Exception
+    {
+        // Create new project
+        {
+            CommandStatus cmd = main("init",
+                    "-c", config.toString(),
+                    projectDir.toString());
+            assertThat(cmd.code(), is(0));
+        }
+
+        final String projectName = "reschedule-test";
+        copyResource("acceptance/reschedule/reschedule.dig", projectDir.resolve("reschedule.dig"));
+
+        // Push
+        {
+            CommandStatus cmd = main("push",
+                    "-c", config.toString(),
+                    "-e", server.endpoint(),
+                    "--project", projectDir.toString(),
+                    projectName);
+            assertThat(cmd.errUtf8(), cmd.code(), is(0));
+        }
+
+        RestSchedule oldSchedule = client.getSchedule(Id.of("1"));
+        OffsetDateTime skipTo = oldSchedule.getNextScheduleTime().plusDays(1);
+
+        // Reschedule the schedule
+        {
+            CommandStatus cmd = main("reschedule",
+                    "-c", config.toString(),
+                    "-e", server.endpoint(),
+                    "--skip-to", skipTo.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss Z")),
+                    projectName, "reschedule");
+            assertThat(cmd.errUtf8(), cmd.code(), is(0));
+        }
+
+        RestSchedule newSchedule = client.getSchedule(Id.of("1"));
+        assertEquals(newSchedule.getNextScheduleTime(), oldSchedule.getNextScheduleTime().plusDays(1));
+    }
+}

--- a/digdag-tests/src/test/resources/acceptance/reschedule/reschedule.dig
+++ b/digdag-tests/src/test/resources/acceptance/reschedule/reschedule.dig
@@ -1,0 +1,8 @@
+timezone: +09:00
+
+schedule:
+  daily>: 09:00:00
+
++say_ok:
+  echo>: ok
+


### PR DESCRIPTION
Fix https://github.com/treasure-data/digdag/issues/996

Also, supported `digdag reschedule --skip-to now` to make it easy to skip all disabled, but enqueued jobs. ref. https://github.com/treasure-data/digdag/issues/995

Most of implementations are referred from `digdag enable`.

I did not add tests because I could not find any existence tests 😢 

## DISCUSSION

Are there any standard ways to handle errors in a batch command?

I mean that, assume there are schedules with id 1 to 8 in a sample project, and schedules with id 1, 3, 7 result in

```
error: Request conflicted: {"message":"Specified time to skip schedules is already past","status":409}
```

with `digdag reschedule <schedule-id> --skip-to now`.

With the implementation of this PR, `digdag reschedule <project-name> --skip-to now` may stop at the 1st error occurred, and rest of schedules are not rescheduled.

To achieve my demand at https://github.com/treasure-data/digdag/issues/995, I want to apply `--skip-to` all schedules in a project anyway, which should result like

```
error: Request conflicted: {"schedule_id":1, "project": "sample", "message":"Specified time to skip schedules is already past","status":409}
error: Request conflicted: {"schedule_id":3, "project": "sample",  "message":"Specified time to skip schedules is already past","status":409}
error: Request conflicted: {"schedule_id":7,  "project": "sample", "message":"Specified time to skip schedules is already past","status":409}
```

But, I do not know correct ways to merge theses three errors into one error.

If this is difficult by design, I will drop `digdag reschedule <project-name>`. Please let me know.

EDIT: Removed `digdag reschedle <project-name>` batch support for now. Please let me know if there is a good way to handle errors in a batch request.