### PR TITLE
rb>: operator supports ruby option arguments

### DIFF
--- a/digdag-docs/src/operators/rb.md
+++ b/digdag-docs/src/operators/rb.md
@@ -34,3 +34,27 @@ See [Ruby API documents](../../ruby_api.html) for details including best practic
   ```
   require: task/my_workflow
   ```
+
+* **ruby**: PATH STRING or COMMAND ARGUMENTS LIST
+
+  The ruby defaults to `ruby`. If an alternate ruby and options are desired, use the `ruby` option.
+
+  Examples:
+
+  ```
+  ruby: /usr/local/bin/ruby
+  ```
+
+  ```
+  ruby: ["ruby", "-rbundler/setup"]
+  ```
+
+  It is also possible to configure in `_export` section.
+
+  Examples:
+
+  ```
+  _export:
+    rb:
+      ruby: /usr/local/bin/ruby
+  ```

--- a/digdag-docs/src/operators/rb.md
+++ b/digdag-docs/src/operators/rb.md
@@ -58,3 +58,19 @@ See [Ruby API documents](../../ruby_api.html) for details including best practic
     rb:
       ruby: /usr/local/bin/ruby
   ```
+
+## TIPS: Run ruby with bundler
+
+It is possible to run ruby scripts with [bundler](https://bundler.io/) using `BUNDLE_GEMFILE` environment variable and `-rbundler/setup` option as:
+
+    _export:
+      BUNDLE_GEMFILE: /path/to/Gemfile
+      rb:
+        require: tasks/my_workflow
+        ruby: ["ruby", "-rbundler/setup"]
+
+    +step1:
+      rb>: my_step1_method
+    +step2:
+      rb>: Task::MyWorkflow.step2
+

--- a/digdag-tests/src/test/java/acceptance/RbIT.java
+++ b/digdag-tests/src/test/java/acceptance/RbIT.java
@@ -49,7 +49,7 @@ public class RbIT
             throws Exception
     {
         final Path tempdir = folder.getRoot().toPath().toAbsolutePath();
-        final Path projectDir = tempdir.resolve("echo_params");
+        final Path projectDir = tempdir.resolve("rb");
         final Path scriptsDir = projectDir.resolve("scripts");
 
         // Create new project
@@ -64,7 +64,7 @@ public class RbIT
         // Push the project
         final CommandStatus pushStatus = main("push",
                 "--project", projectDir.toString(),
-                "echo_params",
+                "rb",
                 "-c", config.toString(),
                 "-e", server.endpoint(),
                 "-r", "4711");
@@ -74,7 +74,7 @@ public class RbIT
         final CommandStatus startStatus = main("start",
                 "-c", config.toString(),
                 "-e", server.endpoint(),
-                "echo_params", "echo_rb_params",
+                "rb", "echo_rb_params",
                 "--session", "now");
         assertThat(startStatus.code(), is(0));
         final Id attemptId = getAttemptId(startStatus);
@@ -92,5 +92,56 @@ public class RbIT
 
         final String logs = getAttemptLogs(client, attemptId);
         assertThat(logs, containsString("digdag params"));
+    }
+
+    @Test
+    public void verifyConfigurationRubyOption()
+            throws Exception
+    {
+        final Path tempdir = folder.getRoot().toPath().toAbsolutePath();
+        final Path projectDir = tempdir.resolve("rb");
+        final Path scriptsDir = projectDir.resolve("scripts");
+
+        // Create new project
+        final CommandStatus initStatus = main("init",
+                "-c", config.toString(),
+                projectDir.toString());
+        assertThat(initStatus.code(), is(0));
+        Files.createDirectories(scriptsDir);
+        copyResource("acceptance/rb/config_ruby.dig", projectDir.resolve("config_ruby.dig"));
+        copyResource("acceptance/echo_params/scripts/echo_params.rb", scriptsDir.resolve("echo_params.rb"));
+
+        // Push the project
+        final CommandStatus pushStatus = main("push",
+                "--project", projectDir.toString(),
+                "rb",
+                "-c", config.toString(),
+                "-e", server.endpoint(),
+                "-r", "4711");
+        assertThat(pushStatus.errUtf8(), pushStatus.code(), is(0));
+
+        // Start the workflow
+        final CommandStatus startStatus = main("start",
+                "-c", config.toString(),
+                "-e", server.endpoint(),
+                "rb", "config_ruby",
+                "--session", "now");
+        assertThat(startStatus.code(), is(0));
+        final Id attemptId = getAttemptId(startStatus);
+
+        // Wait for the attempt to complete
+        RestSessionAttempt attempt = null;
+        for (int i = 0; i < 30; i++) {
+            attempt = client.getSessionAttempt(attemptId);
+            if (attempt.getDone()) {
+                break;
+            }
+            Thread.sleep(1000);
+        }
+        assertThat(attempt.getSuccess(), is(true));
+
+        final String logs = getAttemptLogs(client, attemptId);
+        assertThat(logs, containsString("ruby ruby"));
+        assertThat(logs, containsString("ruby [\"ruby\", \"-w\"]"));
     }
 }

--- a/digdag-tests/src/test/java/acceptance/RbIT.java
+++ b/digdag-tests/src/test/java/acceptance/RbIT.java
@@ -1,0 +1,96 @@
+package acceptance;
+
+import io.digdag.client.DigdagClient;
+import io.digdag.client.api.Id;
+import io.digdag.client.api.RestSessionAttempt;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import utils.CommandStatus;
+import utils.TemporaryDigdagServer;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static utils.TestUtils.copyResource;
+import static utils.TestUtils.getAttemptId;
+import static utils.TestUtils.getAttemptLogs;
+import static utils.TestUtils.main;
+
+public class RbIT
+{
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Rule
+    public TemporaryDigdagServer server = TemporaryDigdagServer.of();
+
+    private Path config;
+    private DigdagClient client;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        config = folder.newFile().toPath();
+
+        client = DigdagClient.builder()
+                .host(server.host())
+                .port(server.port())
+                .build();
+    }
+
+    @Test
+    public void verifyConfigurationPararms()
+            throws Exception
+    {
+        final Path tempdir = folder.getRoot().toPath().toAbsolutePath();
+        final Path projectDir = tempdir.resolve("echo_params");
+        final Path scriptsDir = projectDir.resolve("scripts");
+
+        // Create new project
+        final CommandStatus initStatus = main("init",
+                "-c", config.toString(),
+                projectDir.toString());
+        assertThat(initStatus.code(), is(0));
+        Files.createDirectories(scriptsDir);
+        copyResource("acceptance/echo_params/echo_rb_params.dig", projectDir.resolve("echo_rb_params.dig"));
+        copyResource("acceptance/echo_params/scripts/echo_params.rb", scriptsDir.resolve("echo_params.rb"));
+
+        // Push the project
+        final CommandStatus pushStatus = main("push",
+                "--project", projectDir.toString(),
+                "echo_params",
+                "-c", config.toString(),
+                "-e", server.endpoint(),
+                "-r", "4711");
+        assertThat(pushStatus.errUtf8(), pushStatus.code(), is(0));
+
+        // Start the workflow
+        final CommandStatus startStatus = main("start",
+                "-c", config.toString(),
+                "-e", server.endpoint(),
+                "echo_params", "echo_rb_params",
+                "--session", "now");
+        assertThat(startStatus.code(), is(0));
+        final Id attemptId = getAttemptId(startStatus);
+
+        // Wait for the attempt to complete
+        RestSessionAttempt attempt = null;
+        for (int i = 0; i < 30; i++) {
+            attempt = client.getSessionAttempt(attemptId);
+            if (attempt.getDone()) {
+                break;
+            }
+            Thread.sleep(1000);
+        }
+        assertThat(attempt.getSuccess(), is(true));
+
+        final String logs = getAttemptLogs(client, attemptId);
+        assertThat(logs, containsString("digdag params"));
+    }
+}

--- a/digdag-tests/src/test/resources/acceptance/echo_params/echo_rb_params.dig
+++ b/digdag-tests/src/test/resources/acceptance/echo_params/echo_rb_params.dig
@@ -1,0 +1,6 @@
+_export:
+  rb:
+    require: 'scripts/echo_params'
+
++foo:
+  rb>: EchoParams.echo_params

--- a/digdag-tests/src/test/resources/acceptance/echo_params/scripts/echo_params.rb
+++ b/digdag-tests/src/test/resources/acceptance/echo_params/scripts/echo_params.rb
@@ -1,0 +1,9 @@
+
+class EchoParams
+  def echo_params
+    puts 'digdag params'
+    Digdag.env.params.each do |k,v|
+      puts "#{k} #{v}"
+    end
+  end
+end

--- a/digdag-tests/src/test/resources/acceptance/echo_params/scripts/echo_params.rb
+++ b/digdag-tests/src/test/resources/acceptance/echo_params/scripts/echo_params.rb
@@ -1,4 +1,3 @@
-
 class EchoParams
   def echo_params
     puts 'digdag params'

--- a/digdag-tests/src/test/resources/acceptance/rb/config_ruby.dig
+++ b/digdag-tests/src/test/resources/acceptance/rb/config_ruby.dig
@@ -1,0 +1,13 @@
+# For tests of ruby: option
+
+_export:
+  rb:
+    require: 'scripts/echo_params'
+
++ruby_string_option:
+  rb>: EchoParams.echo_params
+  ruby: "ruby"
+
++ruby_array_option:
+  rb>: EchoParams.echo_params
+  ruby: ["ruby", "-w"]


### PR DESCRIPTION
Enhancement of https://github.com/treasure-data/digdag/pull/984. Support ruby custom arguments.

A USE CASE: This allows to support bundler with the way of Idea5 of https://github.com/treasure-data/digdag/issues/318#issuecomment-466014440

```
+task:
  _export:
    docker:
      image: your_image_bundle_installed_inside
  _env:
    BUNDLE_GEMFILE: /path/to/Gemfile/in/docker
  rb>: Workflow.foo
  require: tasks/workflow
  ruby: [ruby, -rbundler/setup]
```

To keep backward compatibility, this PR still supports `ruby: "string"`.

I did not add tests because I could not find any existing tests for ruby operator, but I verified this works manually.