### PR TITLE
py>: operator supports python option arguments

### DIFF
--- a/digdag-docs/src/operators/py.md
+++ b/digdag-docs/src/operators/py.md
@@ -21,11 +21,26 @@ See [Python API documents](../../python_api.html) for details including variable
   py>: tasks.MyWorkflow.my_task
   ```
 
-The python defaults to `python`. If an alternate python such as `/opt/conda/bin/python` is desired, use the `python` option in the `_export` section.
+* **python**: PATH STRING or COMMAND ARGUMENTS LIST
 
-    _export:
-      py:
-        python: /opt/conda/bin/python
+  The python defaults to `python`. If an alternate python and options are desired, use the `python` option.
 
-    +step1:
-      py>: tasks.MyWorkflow.my_task2
+  Examples:
+
+  ```
+  python: /opt/conda/bin/python
+  ```
+
+  ```
+  python: ["python", "-v"]
+  ```
+
+  It is also possible to configure in `_export` section.
+
+  Examples:
+
+  ```
+  _export:
+    py:
+      python: /opt/conda/bin/python
+  ```

--- a/digdag-tests/src/test/java/acceptance/PyIT.java
+++ b/digdag-tests/src/test/java/acceptance/PyIT.java
@@ -49,7 +49,6 @@ public class PyIT
             throws Exception
     {
         Path tempdir = folder.getRoot().toPath().toAbsolutePath();
-        Path configDir = folder.getRoot().toPath().toAbsolutePath();
         Path projectDir = tempdir.resolve("py");
         Path scriptsDir = projectDir.resolve("scripts");
 

--- a/digdag-tests/src/test/java/acceptance/PyIT.java
+++ b/digdag-tests/src/test/java/acceptance/PyIT.java
@@ -1,0 +1,155 @@
+package acceptance;
+
+import io.digdag.client.DigdagClient;
+import io.digdag.client.api.Id;
+import io.digdag.client.api.RestSessionAttempt;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import utils.CommandStatus;
+import utils.TemporaryDigdagServer;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static utils.TestUtils.copyResource;
+import static utils.TestUtils.getAttemptId;
+import static utils.TestUtils.getAttemptLogs;
+import static utils.TestUtils.main;
+
+public class PyIT
+{
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Rule
+    public TemporaryDigdagServer server = TemporaryDigdagServer.of();
+
+    private Path config;
+    private DigdagClient client;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        config = folder.newFile().toPath();
+
+        client = DigdagClient.builder()
+                .host(server.host())
+                .port(server.port())
+                .build();
+    }
+
+    @Test
+    public void verifyDefaultConfigurationParamsAreNotUploadedIfConfigurationFileIsSpecified()
+            throws Exception
+    {
+        Path tempdir = folder.getRoot().toPath().toAbsolutePath();
+        Path configDir = folder.getRoot().toPath().toAbsolutePath();
+        Path projectDir = tempdir.resolve("py");
+        Path scriptsDir = projectDir.resolve("scripts");
+
+        // Create new project
+        CommandStatus initStatus = main("init",
+                "-c", config.toString(),
+                projectDir.toString());
+        assertThat(initStatus.code(), is(0));
+        Files.createDirectories(scriptsDir);
+        copyResource("acceptance/echo_params/echo_params.dig", projectDir.resolve("echo_params.dig"));
+        copyResource("acceptance/echo_params/scripts/__init__.py", scriptsDir.resolve("__init__.py"));
+        copyResource("acceptance/echo_params/scripts/echo_params.py", scriptsDir.resolve("echo_params.py"));
+
+        // Push the project
+        CommandStatus pushStatus = main("push",
+                "--project", projectDir.toString(),
+                "py",
+                "-c", config.toString(),
+                "-e", server.endpoint(),
+                "-r", "4711");
+        assertThat(pushStatus.errUtf8(), pushStatus.code(), is(0));
+
+        // Start the workflow
+        Id attemptId;
+        {
+            CommandStatus startStatus = main("start",
+                    "-c", config.toString(),
+                    "-e", server.endpoint(),
+                    "py", "echo_params",
+                    "--session", "now");
+            assertThat(startStatus.code(), is(0));
+            attemptId = getAttemptId(startStatus);
+        }
+
+        // Wait for the attempt to complete
+        {
+            RestSessionAttempt attempt = null;
+            for (int i = 0; i < 30; i++) {
+                attempt = client.getSessionAttempt(attemptId);
+                if (attempt.getDone()) {
+                    break;
+                }
+                Thread.sleep(1000);
+            }
+            assertThat(attempt.getSuccess(), is(true));
+        }
+
+        String logs = getAttemptLogs(client, attemptId);
+        assertThat(logs, containsString("digdag params"));
+    }
+
+    @Test
+    public void verifyConfigurationPythonOption()
+            throws Exception
+    {
+        final Path tempdir = folder.getRoot().toPath().toAbsolutePath();
+        final Path projectDir = tempdir.resolve("py");
+        final Path scriptsDir = projectDir.resolve("scripts");
+
+        // Create new project
+        final CommandStatus initStatus = main("init",
+                "-c", config.toString(),
+                projectDir.toString());
+        assertThat(initStatus.code(), is(0));
+        Files.createDirectories(scriptsDir);
+        copyResource("acceptance/py/config_python.dig", projectDir.resolve("config_python.dig"));
+        copyResource("acceptance/echo_params/scripts/__init__.py", scriptsDir.resolve("__init__.py"));
+        copyResource("acceptance/echo_params/scripts/echo_params.py", scriptsDir.resolve("echo_params.py"));
+
+        // Push the project
+        final CommandStatus pushStatus = main("push",
+                "--project", projectDir.toString(),
+                "py",
+                "-c", config.toString(),
+                "-e", server.endpoint(),
+                "-r", "4711");
+        assertThat(pushStatus.errUtf8(), pushStatus.code(), is(0));
+
+        // Start the workflow
+        final CommandStatus startStatus = main("start",
+                "-c", config.toString(),
+                "-e", server.endpoint(),
+                "py", "config_python",
+                "--session", "now");
+        assertThat(startStatus.code(), is(0));
+        final Id attemptId = getAttemptId(startStatus);
+
+        // Wait for the attempt to complete
+        RestSessionAttempt attempt = null;
+        for (int i = 0; i < 30; i++) {
+            attempt = client.getSessionAttempt(attemptId);
+            if (attempt.getDone()) {
+                break;
+            }
+            Thread.sleep(1000);
+        }
+        assertThat(attempt.getSuccess(), is(true));
+
+        final String logs = getAttemptLogs(client, attemptId);
+        assertThat(logs, containsString("python python"));
+        assertThat(logs, containsString("python [u'python', u'-v']"));
+    }
+}

--- a/digdag-tests/src/test/resources/acceptance/py/config_python.dig
+++ b/digdag-tests/src/test/resources/acceptance/py/config_python.dig
@@ -1,0 +1,9 @@
+# For tests of python: option
+
++python_string_option:
+  py>: scripts.echo_params.echo_params
+  python: "python"
+
++python_array_option:
+  py>: scripts.echo_params.echo_params
+  python: ["python", "-v"]


### PR DESCRIPTION
Python version of https://github.com/treasure-data/digdag/pull/1022

FYI: It seems that `sh>` operator already supports List.

~I did not add tests because I could not find any existing tests for python operator, but I verified this works manually.~