### PR TITLE
Digdag push validation on the server side.

### DIFF
--- a/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
@@ -556,23 +556,8 @@ public class ProjectResource
                     if (md5Count.getCount() != contentLength) {
                         throw new IllegalArgumentException("Content-Length header doesn't match with uploaded data size");
                     }
-                    WorkflowDefinitionList defs = meta.getWorkflowList();
-                    for (WorkflowDefinition def : defs.get()) {
-                        Workflow wf = compiler.compile(def.getName(), def.getConfig());
 
-                        // validate workflow and schedule
-                        for (WorkflowTask task : wf.getTasks()) {
-                            // raise an exception if task doesn't valid.
-                            task.getConfig();
-                        }
-                        Revision rev = Revision.builderFromArchive("check", meta, getUserInfo())
-                                .archiveType(ArchiveType.NONE)
-                                .build();
-                        // raise an exception if "schedule:" is invalid.
-                        srm.tryGetScheduler(rev, def);
-
-                    }
-
+                    validateWorkflowAndSchedule(meta);
                 }
 
                 ArchiveManager.Location location =
@@ -702,6 +687,26 @@ public class ProjectResource
             throw new IllegalArgumentException(String.format(ENGLISH,
                         "Size of a file in the archive exceeds limit (%d > %d bytes): %s",
                         entry.getSize(), MAX_ARCHIVE_FILE_SIZE_LIMIT, entry.getName()));
+        }
+    }
+
+    private void validateWorkflowAndSchedule(ArchiveMetadata meta)
+    {
+        WorkflowDefinitionList defs = meta.getWorkflowList();
+        for (WorkflowDefinition def : defs.get()) {
+            Workflow wf = compiler.compile(def.getName(), def.getConfig());
+
+            // validate workflow and schedule
+            for (WorkflowTask task : wf.getTasks()) {
+                // raise an exception if task doesn't valid.
+                task.getConfig();
+            }
+            Revision rev = Revision.builderFromArchive("check", meta, getUserInfo())
+                    .archiveType(ArchiveType.NONE)
+                    .build();
+            // raise an exception if "schedule:" is invalid.
+            srm.tryGetScheduler(rev, def);
+
         }
     }
 

--- a/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
@@ -1,8 +1,6 @@
 package io.digdag.server.rs;
 
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.net.URI;
 import java.time.Instant;
@@ -91,7 +89,6 @@ import io.digdag.core.workflow.WorkflowCompiler;
 import io.digdag.core.workflow.WorkflowTask;
 import io.digdag.server.GenericJsonExceptionHandler;
 import io.digdag.spi.DirectDownloadHandle;
-import io.digdag.spi.Scheduler;
 import io.digdag.spi.SecretControlStore;
 import io.digdag.spi.SecretControlStoreManager;
 import io.digdag.spi.SecretScopes;

--- a/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
@@ -561,14 +561,9 @@ public class ProjectResource
                         Workflow wf = compiler.compile(def.getName(), def.getConfig());
 
                         // validate workflow and schedule
-//                        Set<String> required = new HashSet<>();
                         for (WorkflowTask task : wf.getTasks()) {
                             // raise an exception if task doesn't valid.
                             task.getConfig();
-//                            String require = config.getOptional("require>", String.class).orNull();
-//                            if (require != null && required.add(require)) {
-//                                f.ln("  -> %s", require);
-//                            }
                         }
                         Revision rev = Revision.builderFromArchive("check", meta, getUserInfo())
                                 .archiveType(ArchiveType.NONE)

--- a/digdag-tests/src/test/java/acceptance/ValidateProjectIT.java
+++ b/digdag-tests/src/test/java/acceptance/ValidateProjectIT.java
@@ -1,0 +1,87 @@
+package acceptance;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import utils.CommandStatus;
+import utils.TemporaryDigdagServer;
+
+import java.nio.file.Path;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static utils.TestUtils.copyResource;
+import static utils.TestUtils.main;
+
+//
+// This file doesn't contain normal case.
+// It defined in another test.
+//
+public class ValidateProjectIT
+{
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Rule
+    public TemporaryDigdagServer server = TemporaryDigdagServer.builder()
+            .build();
+
+    private Path config;
+    private Path projectDir;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        projectDir = folder.getRoot().toPath().resolve("foobar");
+        config = folder.newFile().toPath();
+    }
+
+    @Test
+    public void uploadInvalidTaskProject()
+            throws Exception
+    {
+        // Create new project
+        CommandStatus initStatus = main("init",
+                "-c", config.toString(),
+                projectDir.toString());
+        assertThat(initStatus.code(), is(0));
+
+        copyResource("acceptance/error_task/invalid_at_group.dig", projectDir.resolve("invalid_at_group.dig"));
+
+        // Push the project
+        CommandStatus pushStatus = main(
+                "push",
+                "--project", projectDir.toString(),
+                "foobar",
+                "-c", config.toString(),
+                "-e", server.endpoint());
+        assertThat(pushStatus.code(), is(1));
+        assertThat(pushStatus.errUtf8(), containsString("A task can't have more than one operator"));
+    }
+
+    @Test
+    public void uploadInvalidScheduleProject()
+            throws Exception
+    {
+        // Create new project
+        CommandStatus initStatus = main("init",
+                "-c", config.toString(),
+                projectDir.toString());
+        assertThat(initStatus.code(), is(0));
+
+        copyResource("acceptance/schedule/invalid_schedule.dig", projectDir.resolve("invalid_schedule.dig"));
+
+        // Push the project
+        CommandStatus pushStatus = main(
+                "push",
+                "--project", projectDir.toString(),
+                "foobar",
+                "-c", config.toString(),
+                "-e", server.endpoint());
+        assertThat(pushStatus.code(), is(1));
+        assertThat(pushStatus.errUtf8(), containsString("scheduler requires mm:ss format"));
+    }
+}

--- a/digdag-tests/src/test/resources/acceptance/schedule/invalid_schedule.dig
+++ b/digdag-tests/src/test/resources/acceptance/schedule/invalid_schedule.dig
@@ -1,0 +1,8 @@
+timezone: UTC
+
+schedule:
+  hourly>: "10:11:12" # correct format is "MM:SS"
+
++foo:
+  sh>: "touch foo.out"
+


### PR DESCRIPTION
Hello, @muga , @yoyama 

Could you advise me how to implement a validation?

`digdag push` requires validation on the server side.
It requires two things at least. And this issue will Fix two issues.
* task validation(#859).
* schedule validation(#922).

I implement the first one. Second schedule validation seems to require `SchedulerManager` class.
https://github.com/hiroyuki-sato/digdag/commit/5004fb635e4ec598255f66593c45d7ab7f4ce5e6#diff-84a9dc43263ac1f78fa3b2aca8234f6fR576

I'm not familiar with Google Guice. I'm not sure how to instantiate it. Do you have any idea for that?

This code almost copies of `digdag check` code.
https://github.com/treasure-data/digdag/blob/master/digdag-cli/src/main/java/io/digdag/cli/Check.java

Best regards.
