### PR TITLE
[doc] Add api.max_archive_total_size_limit description

### DIFF
--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -369,6 +369,7 @@ In the config file, following parameters are available
 * executor.attempt_ttl (string. default: 7d. An attempt is killed if it is running longer than this period.)
 * api.max_attempts_page_size (integer. The max number of rows of attempts in api response)
 * api.max_sessions_page_size (integer. The max number of rows of sessions in api response)
+* api.max_archive_total_size_limit (integer. The maximum size of an archived project. i.e. ``digdag push`` size. default: 2MB(2\*1024\*1024))
 
 
 Secret Encryption Key


### PR DESCRIPTION
#994 document.

![2019-02-27 19 08 25](https://user-images.githubusercontent.com/767650/53482702-31337380-3ac3-11e9-994d-64ef5028cac9.png)
