### PR TITLE
[WIP] jdbc operators (pg>, redshift> ) enable logging 

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcConnection.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcConnection.java
@@ -128,7 +128,7 @@ public abstract class AbstractJdbcConnection
     protected ResultSet executeQuery(String sql)
             throws SQLException
     {
-        try ( Statement stmt = connection.createStatement() ) {
+        try (Statement stmt = connection.createStatement()) {
             loggingExecuteSQL(sql);
             return stmt.executeQuery(sql); // executeQuery throws exception if given query includes multiple statements
         }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcConnection.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcConnection.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
 import static java.util.Locale.ENGLISH;
 
 public abstract class AbstractJdbcConnection
-    implements JdbcConnection
+        implements JdbcConnection
 {
     private static final Logger logger = LoggerFactory.getLogger(JdbcConnection.class);
 
@@ -125,13 +125,11 @@ public abstract class AbstractJdbcConnection
         }
     }
 
-    protected ResultSet executeQuery(String sql)
+    protected ResultSet executeQuery(Statement stmt, String sql)
             throws SQLException
     {
-        try (Statement stmt = connection.createStatement()) {
-            loggingExecuteSQL(sql);
-            return stmt.executeQuery(sql); // executeQuery throws exception if given query includes multiple statements
-        }
+        loggingExecuteSQL(sql);
+        return stmt.executeQuery(sql); // executeQuery throws exception if given query includes multiple statements
     }
 
     @Override
@@ -177,5 +175,4 @@ public abstract class AbstractJdbcConnection
             logger.info(line);
         }
     }
-
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcConnection.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcConnection.java
@@ -169,4 +169,10 @@ public abstract class AbstractJdbcConnection
         }
     }
 
+    protected ResultSet executeQueryWithLogging(String sql) throws SQLException
+    {
+        Statement stmt = connection.createStatement();
+        loggingExecuteSQL(sql);
+        return stmt.executeQuery(sql);  // executeQuery throws exception if given query includes multiple statements
+    }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcConnection.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcConnection.java
@@ -23,7 +23,7 @@ public abstract class AbstractJdbcConnection
 
     private String quoteString;
 
-    private Boolean enableDebug;
+    private boolean enableDebug;
 
     protected AbstractJdbcConnection(Connection connection)
     {
@@ -152,11 +152,11 @@ public abstract class AbstractJdbcConnection
     }
 
     @Override
-    public void setDebug(Boolean debug){
+    public void setDebug(boolean debug){
         enableDebug = debug;
     }
     @Override
-    public Boolean getDebug(){ return enableDebug; }
+    public boolean getDebug(){ return enableDebug; }
 
     protected void loggingExecuteSQL(String sql)
     {

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcConnection.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcConnection.java
@@ -23,7 +23,7 @@ public abstract class AbstractJdbcConnection
 
     private String quoteString;
 
-    private boolean enableDebug;
+    private boolean showQuery;
 
     protected AbstractJdbcConnection(Connection connection)
     {
@@ -34,7 +34,7 @@ public abstract class AbstractJdbcConnection
         catch (SQLException ex) {
             throw new DatabaseException("Failed to set auto-commit mode to the connection", ex);
         }
-        this.enableDebug = false;
+        this.showQuery = false;
     }
 
     @Override
@@ -152,15 +152,16 @@ public abstract class AbstractJdbcConnection
     }
 
     @Override
-    public void setDebug(boolean debug){
-        enableDebug = debug;
+    public void setShowQuery(boolean query){
+        showQuery = query;
     }
+
     @Override
-    public boolean getDebug(){ return enableDebug; }
+    public boolean getShowQuery(){ return showQuery; }
 
     protected void loggingExecuteSQL(String sql)
     {
-        if( enableDebug == false ) {
+        if( showQuery == false ) {
             return;
         }
         for(String line: sql.split("\r?\n")) {

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcConnection.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcConnection.java
@@ -125,6 +125,15 @@ public abstract class AbstractJdbcConnection
         }
     }
 
+    protected ResultSet executeQuery(String sql)
+            throws SQLException
+    {
+        try ( Statement stmt = connection.createStatement() ) {
+            loggingExecuteSQL(sql);
+            return stmt.executeQuery(sql); // executeQuery throws exception if given query includes multiple statements
+        }
+    }
+
     @Override
     public String escapeIdent(String ident)
     {
@@ -169,10 +178,4 @@ public abstract class AbstractJdbcConnection
         }
     }
 
-    protected ResultSet executeQueryWithLogging(String sql) throws SQLException
-    {
-        Statement stmt = connection.createStatement();
-        loggingExecuteSQL(sql);
-        return stmt.executeQuery(sql);  // executeQuery throws exception if given query includes multiple statements
-    }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcConnection.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcConnection.java
@@ -23,6 +23,8 @@ public abstract class AbstractJdbcConnection
 
     private String quoteString;
 
+    private Boolean enableDebug;
+
     protected AbstractJdbcConnection(Connection connection)
     {
         this.connection = connection;
@@ -32,6 +34,7 @@ public abstract class AbstractJdbcConnection
         catch (SQLException ex) {
             throw new DatabaseException("Failed to set auto-commit mode to the connection", ex);
         }
+        this.enableDebug = false;
     }
 
     @Override
@@ -78,6 +81,7 @@ public abstract class AbstractJdbcConnection
     {
         try {
             try (Statement stmt = connection.createStatement()) {
+                loggingExecuteSQL(sql);
                 boolean hasResults = stmt.execute(sql);
                 while (hasResults) {
                     ResultSet rs = stmt.getResultSet();
@@ -103,6 +107,7 @@ public abstract class AbstractJdbcConnection
     public void executeUpdate(String sql)
     {
         try {
+            loggingExecuteSQL(sql);
             execute(sql);
         }
         catch (SQLException ex) {
@@ -115,6 +120,7 @@ public abstract class AbstractJdbcConnection
             throws SQLException
     {
         try (Statement stmt = connection.createStatement()) {
+            loggingExecuteSQL(sql);
             stmt.executeUpdate(sql);
         }
     }
@@ -144,4 +150,22 @@ public abstract class AbstractJdbcConnection
             logger.warn("Failed to close a database connection. Ignoring.", ex);
         }
     }
+
+    @Override
+    public void setDebug(Boolean debug){
+        enableDebug = debug;
+    }
+    @Override
+    public Boolean getDebug(){ return enableDebug; }
+
+    protected void loggingExecuteSQL(String sql)
+    {
+        if( enableDebug == false ) {
+            return;
+        }
+        for(String line: sql.split("\r?\n")) {
+            logger.info(line);
+        }
+    }
+
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcConnection.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcConnection.java
@@ -159,19 +159,20 @@ public abstract class AbstractJdbcConnection
     }
 
     @Override
-    public void setShowQuery(boolean query){
+    public void setShowQuery(boolean query)
+    {
         showQuery = query;
     }
 
     @Override
-    public boolean getShowQuery(){ return showQuery; }
+    public boolean getShowQuery() { return showQuery; }
 
     protected void loggingExecuteSQL(String sql)
     {
-        if( showQuery == false ) {
+        if (showQuery == false) {
             return;
         }
-        for(String line: sql.split("\r?\n")) {
+        for (String line : sql.split("\r?\n")) {
             logger.info(line);
         }
     }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcJobOperator.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcJobOperator.java
@@ -37,6 +37,7 @@ public abstract class AbstractJdbcJobOperator<C>
     private final long maxStoreLastResultsRows;
     private final int maxStoreLastResultsColumns;
     private final int maxStoreLastResultsValueSize;
+    private Boolean isDebug;
 
     private <T> Optional<T> getConfigValue(Config systemConfig, String key, Class<T> clazz)
     {
@@ -56,6 +57,7 @@ public abstract class AbstractJdbcJobOperator<C>
     protected TaskResult run(Config params, Config state, C connectionConfig)
     {
         String query = workspace.templateCommand(templateEngine, params, "query", UTF_8);
+        isDebug = params.get("debug",Boolean.class,false);
 
         Optional<TableReference> insertInto = params.getOptional("insert_into", TableReference.class);
         Optional<TableReference> createTable = params.getOptional("create_table", TableReference.class);
@@ -102,6 +104,7 @@ public abstract class AbstractJdbcJobOperator<C>
         }
 
         try (JdbcConnection connection = connect(connectionConfig)) {
+            connection.setDebug(isDebug);
             Exception statementError = connection.validateStatement(query);
             if (statementError != null) {
                 throw new ConfigException("Given query is invalid", statementError);

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcJobOperator.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcJobOperator.java
@@ -37,7 +37,7 @@ public abstract class AbstractJdbcJobOperator<C>
     private final long maxStoreLastResultsRows;
     private final int maxStoreLastResultsColumns;
     private final int maxStoreLastResultsValueSize;
-    private boolean isDebug;
+    private boolean showQuery;
 
     private <T> Optional<T> getConfigValue(Config systemConfig, String key, Class<T> clazz)
     {
@@ -57,7 +57,7 @@ public abstract class AbstractJdbcJobOperator<C>
     protected TaskResult run(Config params, Config state, C connectionConfig)
     {
         String query = workspace.templateCommand(templateEngine, params, "query", UTF_8);
-        isDebug = params.get("debug",boolean.class,false);
+        showQuery = params.get("show_query",boolean.class,false);
 
         Optional<TableReference> insertInto = params.getOptional("insert_into", TableReference.class);
         Optional<TableReference> createTable = params.getOptional("create_table", TableReference.class);
@@ -104,7 +104,7 @@ public abstract class AbstractJdbcJobOperator<C>
         }
 
         try (JdbcConnection connection = connect(connectionConfig)) {
-            connection.setDebug(isDebug);
+            connection.setShowQuery(showQuery);
             Exception statementError = connection.validateStatement(query);
             if (statementError != null) {
                 throw new ConfigException("Given query is invalid", statementError);

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcJobOperator.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcJobOperator.java
@@ -37,7 +37,7 @@ public abstract class AbstractJdbcJobOperator<C>
     private final long maxStoreLastResultsRows;
     private final int maxStoreLastResultsColumns;
     private final int maxStoreLastResultsValueSize;
-    private Boolean isDebug;
+    private boolean isDebug;
 
     private <T> Optional<T> getConfigValue(Config systemConfig, String key, Class<T> clazz)
     {
@@ -57,7 +57,7 @@ public abstract class AbstractJdbcJobOperator<C>
     protected TaskResult run(Config params, Config state, C connectionConfig)
     {
         String query = workspace.templateCommand(templateEngine, params, "query", UTF_8);
-        isDebug = params.get("debug",Boolean.class,false);
+        isDebug = params.get("debug",boolean.class,false);
 
         Optional<TableReference> insertInto = params.getOptional("insert_into", TableReference.class);
         Optional<TableReference> createTable = params.getOptional("create_table", TableReference.class);

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcOperator.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcOperator.java
@@ -45,7 +45,7 @@ abstract class AbstractJdbcOperator<C>
 
     protected boolean strictTransaction(Config params)
     {
-        return params.get("strict_transaction", Boolean.class, true);
+        return params.get("strict_transaction", boolean.class, true);
     }
 
     protected abstract TaskResult run(Config params, Config state, C connectionConfig);

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcOperator.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/AbstractJdbcOperator.java
@@ -45,7 +45,7 @@ abstract class AbstractJdbcOperator<C>
 
     protected boolean strictTransaction(Config params)
     {
-        return params.get("strict_transaction", boolean.class, true);
+        return params.get("strict_transaction", Boolean.class, true);
     }
 
     protected abstract TaskResult run(Config params, Config state, C connectionConfig);

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/JdbcConnection.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/JdbcConnection.java
@@ -37,8 +37,8 @@ interface JdbcConnection
     // Digdag <= v0.9.34
     // Previous versions doesn't have those methods for backward compatibility.
     //
-    default void setShowQuery(boolean query){ new RuntimeException("Subclass need to implement this method."); };
-    default boolean getShowQuery(){ return false; };
+    default void setShowQuery(boolean query) { new RuntimeException("Subclass need to implement this method."); }
+    default boolean getShowQuery() { return false; }
 
     void close();
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/JdbcConnection.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/JdbcConnection.java
@@ -33,8 +33,8 @@ interface JdbcConnection
 
     String escapeIdent(String ident);
 
-    void setDebug(Boolean debug);
-    Boolean getDebug();
+    void setDebug(boolean debug);
+    boolean getDebug();
 
     void close();
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/JdbcConnection.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/JdbcConnection.java
@@ -33,8 +33,12 @@ interface JdbcConnection
 
     String escapeIdent(String ident);
 
-    void setDebug(boolean debug);
-    boolean getDebug();
+    //
+    // Digdag <= v0.9.34
+    // Previous versions doesn't have those methods for backward compatibility.
+    //
+    default void setShowQuery(boolean query){ new RuntimeException("Subclass need to implement this method."); };
+    default boolean getShowQuery(){ return false; };
 
     void close();
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/JdbcConnection.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/jdbc/JdbcConnection.java
@@ -33,5 +33,8 @@ interface JdbcConnection
 
     String escapeIdent(String ident);
 
+    void setDebug(Boolean debug);
+    Boolean getDebug();
+
     void close();
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/pg/PgConnection.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/pg/PgConnection.java
@@ -38,10 +38,12 @@ public class PgConnection
     public void executeReadOnlyQuery(String sql, Consumer<JdbcResultSet> resultHandler)
         throws NotReadOnlyException
     {
-        try (Statement stmt = connection.createStatement()) {
+        try {
             execute("SET TRANSACTION READ ONLY");
-            ResultSet rs = executeQuery(stmt, sql);
-            resultHandler.accept(new PgResultSet(rs));
+            try (Statement stmt = connection.createStatement()) {
+                ResultSet rs = executeQuery(stmt, sql);
+                resultHandler.accept(new PgResultSet(rs));
+            }
             execute("SET TRANSACTION READ WRITE");
         }
         catch (SQLException ex) {

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/pg/PgConnection.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/pg/PgConnection.java
@@ -40,7 +40,7 @@ public class PgConnection
     {
         try {
             execute("SET TRANSACTION READ ONLY");
-            ResultSet rs = executeQueryWithLogging(sql);
+            ResultSet rs = executeQuery(sql);
             resultHandler.accept(new PgResultSet(rs));
             execute("SET TRANSACTION READ WRITE");
         }
@@ -144,7 +144,7 @@ public class PgConnection
                     "SELECT completed_at FROM %s WHERE query_id = '%s' FOR UPDATE NOWAIT",
                     escapeTableReference(statusTableReference()),
                     queryId.toString());
-            try (ResultSet rs = executeQueryWithLogging(sql)) {
+            try (ResultSet rs = executeQuery(sql)) {
                 if (rs.next()) {
                     // status row exists and locked. get status of it.
                     rs.getTimestamp(1);

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/pg/PgConnection.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/pg/PgConnection.java
@@ -41,6 +41,7 @@ public class PgConnection
         try {
             execute("SET TRANSACTION READ ONLY");
             try (Statement stmt = connection.createStatement()) {
+                loggingExecuteSQL(sql);
                 ResultSet rs = stmt.executeQuery(sql);  // executeQuery throws exception if given query includes multiple statements
                 resultHandler.accept(new PgResultSet(rs));
             }
@@ -143,11 +144,12 @@ public class PgConnection
                 throws LockConflictException
         {
             try (Statement stmt = connection.createStatement()) {
-                ResultSet rs = stmt.executeQuery(String.format(ENGLISH,
-                            "SELECT completed_at FROM %s WHERE query_id = '%s' FOR UPDATE NOWAIT",
-                            escapeTableReference(statusTableReference()),
-                            queryId.toString())
-                        );
+                String sql = String.format(ENGLISH,
+                        "SELECT completed_at FROM %s WHERE query_id = '%s' FOR UPDATE NOWAIT",
+                        escapeTableReference(statusTableReference()),
+                        queryId.toString());
+                loggingExecuteSQL(sql);
+                ResultSet rs = stmt.executeQuery(sql);
                 if (rs.next()) {
                     // status row exists and locked. get status of it.
                     rs.getTimestamp(1);

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/pg/PgConnection.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/pg/PgConnection.java
@@ -40,11 +40,8 @@ public class PgConnection
     {
         try {
             execute("SET TRANSACTION READ ONLY");
-            try (Statement stmt = connection.createStatement()) {
-                loggingExecuteSQL(sql);
-                ResultSet rs = stmt.executeQuery(sql);  // executeQuery throws exception if given query includes multiple statements
-                resultHandler.accept(new PgResultSet(rs));
-            }
+            ResultSet rs = executeQueryWithLogging(sql);
+            resultHandler.accept(new PgResultSet(rs));
             execute("SET TRANSACTION READ WRITE");
         }
         catch (SQLException ex) {
@@ -143,13 +140,11 @@ public class PgConnection
         protected StatusRow lockStatusRow(UUID queryId)
                 throws LockConflictException
         {
-            try (Statement stmt = connection.createStatement()) {
-                String sql = String.format(ENGLISH,
-                        "SELECT completed_at FROM %s WHERE query_id = '%s' FOR UPDATE NOWAIT",
-                        escapeTableReference(statusTableReference()),
-                        queryId.toString());
-                loggingExecuteSQL(sql);
-                ResultSet rs = stmt.executeQuery(sql);
+            String sql = String.format(ENGLISH,
+                    "SELECT completed_at FROM %s WHERE query_id = '%s' FOR UPDATE NOWAIT",
+                    escapeTableReference(statusTableReference()),
+                    queryId.toString());
+            try (ResultSet rs = executeQueryWithLogging(sql)) {
                 if (rs.next()) {
                     // status row exists and locked. get status of it.
                     rs.getTimestamp(1);

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/redshift/RedshiftConnection.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/redshift/RedshiftConnection.java
@@ -355,11 +355,11 @@ public class RedshiftConnection
                 // List up status tables
                 List<TableReference> statusTables = new ArrayList<>();
                 {
-                    ResultSet rs = stmt.executeQuery(
-                            String.format(ENGLISH,
-                                    "SELECT schemaname, tablename FROM pg_tables WHERE tablename LIKE '%s_%%'",
-                                    escapeParam(statusTableNamePrefix))
-                    );
+                    String sql = String.format(ENGLISH,
+                            "SELECT schemaname, tablename FROM pg_tables WHERE tablename LIKE '%s_%%'",
+                            escapeParam(statusTableNamePrefix));
+                    loggingExecuteSQL(sql);
+                    ResultSet rs = stmt.executeQuery(sql);
                     while (rs.next()) {
                         statusTables.add(TableReference.of(rs.getString(1), rs.getString(2)));
                     }
@@ -369,14 +369,15 @@ public class RedshiftConnection
                 statusTables.forEach(
                         statusTable -> {
                             try {
-                                ResultSet rs = stmt.executeQuery(
-                                        String.format(ENGLISH,
-                                                "SELECT query_id FROM %s WHERE completed_at < SYSDATE - INTERVAL '%d SECOND'",
-                                                escapeTableReference(statusTable),
-                                                cleanupDuration.getSeconds())
-                                );
+                                String sql = String.format(ENGLISH,
+                                        "SELECT query_id FROM %s WHERE completed_at < SYSDATE - INTERVAL '%d SECOND'",
+                                        escapeTableReference(statusTable),
+                                        cleanupDuration.getSeconds());
+                                loggingExecuteSQL(sql);
+                                ResultSet rs = stmt.executeQuery(sql);
                                 if (rs.next()) {
-                                    stmt.executeUpdate(String.format("DROP TABLE %s", escapeTableReference(statusTable)));
+                                    sql = String.format("DROP TABLE %s", escapeTableReference(statusTable));
+                                    stmt.executeUpdate(sql);
                                 }
                             }
                             catch (SQLException e) {

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/redshift/RedshiftConnection.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/redshift/RedshiftConnection.java
@@ -351,15 +351,14 @@ public class RedshiftConnection
         @Override
         public void cleanup()
         {
-            try (Statement stmt = connection.createStatement()) {
+            try {
                 // List up status tables
                 List<TableReference> statusTables = new ArrayList<>();
                 {
                     String sql = String.format(ENGLISH,
                             "SELECT schemaname, tablename FROM pg_tables WHERE tablename LIKE '%s_%%'",
                             escapeParam(statusTableNamePrefix));
-                    loggingExecuteSQL(sql);
-                    ResultSet rs = stmt.executeQuery(sql);
+                    ResultSet rs = executeQuery(sql);
                     while (rs.next()) {
                         statusTables.add(TableReference.of(rs.getString(1), rs.getString(2)));
                     }
@@ -373,11 +372,10 @@ public class RedshiftConnection
                                         "SELECT query_id FROM %s WHERE completed_at < SYSDATE - INTERVAL '%d SECOND'",
                                         escapeTableReference(statusTable),
                                         cleanupDuration.getSeconds());
-                                loggingExecuteSQL(sql);
-                                ResultSet rs = stmt.executeQuery(sql);
+                                ResultSet rs = executeQuery(sql);
                                 if (rs.next()) {
                                     sql = String.format("DROP TABLE %s", escapeTableReference(statusTable));
-                                    stmt.executeUpdate(sql);
+                                    executeUpdate(sql);
                                 }
                             }
                             catch (SQLException e) {

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/redshift/RedshiftConnection.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/redshift/RedshiftConnection.java
@@ -351,14 +351,14 @@ public class RedshiftConnection
         @Override
         public void cleanup()
         {
-            try {
+            try (Statement stmt = connection.createStatement()) {
                 // List up status tables
                 List<TableReference> statusTables = new ArrayList<>();
                 {
                     String sql = String.format(ENGLISH,
                             "SELECT schemaname, tablename FROM pg_tables WHERE tablename LIKE '%s_%%'",
                             escapeParam(statusTableNamePrefix));
-                    ResultSet rs = executeQuery(sql);
+                    ResultSet rs = executeQuery(stmt,sql);
                     while (rs.next()) {
                         statusTables.add(TableReference.of(rs.getString(1), rs.getString(2)));
                     }
@@ -372,7 +372,7 @@ public class RedshiftConnection
                                         "SELECT query_id FROM %s WHERE completed_at < SYSDATE - INTERVAL '%d SECOND'",
                                         escapeTableReference(statusTable),
                                         cleanupDuration.getSeconds());
-                                ResultSet rs = executeQuery(sql);
+                                ResultSet rs = executeQuery(stmt,sql);
                                 if (rs.next()) {
                                     sql = String.format("DROP TABLE %s", escapeTableReference(statusTable));
                                     executeUpdate(sql);


### PR DESCRIPTION
Follow-up #629 

This PR introduce logging option to JDBC operators(`pg>` and `redshift>`).

@yoyama Please take a look when you have time.
`AbstractJdbcConnection` need to `debug` option for this feature.
I'm worrying how to enable the debug option. 

This option output logs like the below.

```
2019-02-27 20:34:55 +0900 [INFO] (0017@[0:default]+test+task^sub+for-0=id=0=1): pg>: select.sql
2019-02-27 20:34:55 +0900 [INFO] (0017@[0:default]+test+task^sub+for-0=id=0=1): SET TRANSACTION READ ONLY
2019-02-27 20:34:55 +0900 [INFO] (0017@[0:default]+test+task^sub+for-0=id=0=1): select *
2019-02-27 20:34:55 +0900 [INFO] (0017@[0:default]+test+task^sub+for-0=id=0=1):  from users
2019-02-27 20:34:55 +0900 [INFO] (0017@[0:default]+test+task^sub+for-0=id=0=1): -- where id = 1
2019-02-27 20:34:55 +0900 [INFO] (0017@[0:default]+test+task^sub+for-0=id=0=1): SET TRANSACTION READ WRITE
2019-02-27 20:34:55 +0900 [INFO] (0017@[0:default]+test+task^sub+for-0=id=1=2): pg>: select.sql
2019-02-27 20:34:56 +0900 [INFO] (0017@[0:default]+test+task^sub+for-0=id=1=2): SET TRANSACTION READ ONLY
2019-02-27 20:34:56 +0900 [INFO] (0017@[0:default]+test+task^sub+for-0=id=1=2): select *
2019-02-27 20:34:56 +0900 [INFO] (0017@[0:default]+test+task^sub+for-0=id=1=2):  from users
2019-02-27 20:34:56 +0900 [INFO] (0017@[0:default]+test+task^sub+for-0=id=1=2): -- where id = 2
2019-02-27 20:34:56 +0900 [INFO] (0017@[0:default]+test+task^sub+for-0=id=1=2): SET TRANSACTION READ WRITE
2019-02-27 20:34:56 +0900 [INFO] (0017@[0:default]+test+task^sub+for-0=id=2=3): pg>: select.sql
2019-02-27 20:34:56 +0900 [INFO] (0017@[0:default]+test+task^sub+for-0=id=2=3): SET TRANSACTION READ ONLY
2019-02-27 20:34:56 +0900 [INFO] (0017@[0:default]+test+task^sub+for-0=id=2=3): select *
2019-02-27 20:34:56 +0900 [INFO] (0017@[0:default]+test+task^sub+for-0=id=2=3):  from users
2019-02-27 20:34:56 +0900 [INFO] (0017@[0:default]+test+task^sub+for-0=id=2=3): -- where id = 3
2019-02-27 20:34:56 +0900 [INFO] (0017@[0:default]+test+task^sub+for-0=id=2=3): SET TRANSACTION READ WRITE
```