### PR TITLE
Rename getProjectSecrets method in digdag-server's ProjectResource with getProjectSecretList

### DIFF
--- a/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
@@ -827,7 +827,7 @@ public class ProjectResource
     @GET
     @Path("/api/projects/{id}/secrets")
     @Produces("application/json")
-    public RestSecretList getProjectSecrets(@PathParam("id") int projectId)
+    public RestSecretList getProjectSecretList(@PathParam("id") int projectId)
             throws ResourceNotFoundException, AccessControlException
     {
         return tm.<RestSecretList, ResourceNotFoundException, AccessControlException>begin(() -> {


### PR DESCRIPTION
This PR renames getProjectSecrets method with getProjectSecretList. The method actually returns list of secret keys in the scope of the project. That makes developers confused. 