### PR TITLE
Update ac.AccessController SPI and rename checkGetProjectSecrets method with checkGetProjectSecretList

### DIFF
--- a/digdag-server/src/main/java/io/digdag/server/ac/DefaultAccessController.java
+++ b/digdag-server/src/main/java/io/digdag/server/ac/DefaultAccessController.java
@@ -52,7 +52,7 @@ public class DefaultAccessController
     { }
 
     @Override
-    public void checkGetProjectSecrets(ProjectTarget target, AuthenticatedUser user)
+    public void checkGetProjectSecretList(ProjectTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 

--- a/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
@@ -836,7 +836,7 @@ public class ProjectResource
             StoredProject project = projectStore.getProjectById(projectId); // check NotFound first
             ensureNotDeletedProject(project);
 
-            ac.checkGetProjectSecrets( // AccessControl
+            ac.checkGetProjectSecretList( // AccessControl
                     ProjectTarget.of(getSiteId(), project.getName()),
                     getAuthenticatedUser());
 

--- a/digdag-spi/src/main/java/io/digdag/spi/ac/AccessController.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/ac/AccessController.java
@@ -105,7 +105,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkGetProjectSecrets(ProjectTarget target, AuthenticatedUser user)
+    void checkGetProjectSecretList(ProjectTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     //


### PR DESCRIPTION
This PR changes `ac.AccessController` SPI and renames `checkGetProjectSecrets` method with `checkGetProjectSecretList` according to https://github.com/treasure-data/digdag/pull/1040.