### PR TITLE
Fix database.ThreadLocalTransactionManager to add instanceof for 4th exception handling

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/database/ThreadLocalTransactionManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/ThreadLocalTransactionManager.java
@@ -268,6 +268,7 @@ public class ThreadLocalTransactionManager
             Throwables.propagateIfInstanceOf(e, e1);
             Throwables.propagateIfInstanceOf(e, e2);
             Throwables.propagateIfInstanceOf(e, e3);
+            Throwables.propagateIfInstanceOf(e, e4);
             throw Throwables.propagate(e);
         }
         finally {


### PR DESCRIPTION
follow-up of https://github.com/treasure-data/digdag/pull/936.

On https://github.com/treasure-data/digdag/pull/936, we made change of begin method in database.ThreadLocalTransactionManager. But we also needed to fix and add 4th exception handling. 
