### PR TITLE
update redshift.md

### DIFF
--- a/digdag-docs/src/operators/redshift.md
+++ b/digdag-docs/src/operators/redshift.md
@@ -171,6 +171,7 @@ _export:
 
   Whether this operator uses a strict transaction to prevent generating unexpected duplicated records just in case. *Default*: `true`.
   This operator creates and uses a status table in the database to make an operation idempotent. But if creating a table isn't allowed, this option should be false.
+  If the query that created the status table completed 24 hours ago, this operator drop the table in the cleanup step.
 
   Examples:
 


### PR DESCRIPTION
I added the explanation about the timing of status table being dropped.
In my understanding, cleanup method do this and the condition is defined as Duration.ofHours(24).

If this is not correct, please point out.