### PR TITLE
Feature add index to session attempts

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/Main.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Main.java
@@ -152,6 +152,8 @@ public class Main
         jc.addCommand("delete", injector.getInstance(Delete.class));
         jc.addCommand("secrets", injector.getInstance(Secrets.class), "secret");
         jc.addCommand("version", injector.getInstance(Version.class), "version");
+        jc.addCommand("migrate", injector.getInstance(Migrate.class));
+
 
         jc.addCommand("selfupdate", injector.getInstance(SelfUpdate.class));
 
@@ -299,6 +301,7 @@ public class Main
         err.println("    r[un] <workflow.dig>               run a workflow");
         err.println("    c[heck]                            show workflow definitions");
         err.println("    sched[uler]                        run a scheduler server");
+        err.println("    migrate (run|check)                migrate database");
         err.println("    selfupdate                         update cli to the latest version");
         err.println("");
         err.println("  Server-mode commands:");

--- a/digdag-cli/src/main/java/io/digdag/cli/Migrate.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Migrate.java
@@ -1,0 +1,144 @@
+package io.digdag.cli;
+
+import com.beust.jcommander.Parameter;
+import io.digdag.client.DigdagClient;
+import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigFactory;
+import io.digdag.core.config.PropertyUtils;
+import io.digdag.core.database.DataSourceProvider;
+import io.digdag.core.database.DatabaseConfig;
+import io.digdag.core.database.DatabaseMigrator;
+import io.digdag.core.database.migrate.Migration;
+import org.skife.jdbi.v2.DBI;
+
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Properties;
+
+import static io.digdag.cli.SystemExitException.systemExit;
+
+
+public class Migrate
+    extends Command
+{
+    @Parameter(names = {"-o", "--database"})
+    String database = null;
+
+    SubCommand subCommand = null;
+
+    @Override
+    public void main()
+            throws Exception
+    {
+        checkArgs();
+        DatabaseConfig dbConfig = DatabaseConfig.convertFrom(buildConfig());
+        try (DataSourceProvider dsp = new DataSourceProvider(dbConfig)) {
+            DBI dbi = new DBI(dsp.get());
+            DatabaseMigrator migrator = new DatabaseMigrator(dbi, dbConfig);
+            switch (subCommand) {
+                case RUN:
+                    runMigrate(migrator);
+                    break;
+                case CHECK:
+                    checkMigrate(migrator);
+                    break;
+                default:
+                    throw new RuntimeException("No command");
+            }
+        }
+    }
+
+    // migrate run
+    private void runMigrate(DatabaseMigrator migrator)
+            throws Exception
+    {
+        int numApplied = migrator.migrate();
+        if (numApplied == 0) {
+            out.println("No update");
+        }
+        else {
+            out.println("Migrations successfully finished");
+        }
+    }
+
+    // migrate check
+    private void checkMigrate(DatabaseMigrator migrator)
+            throws Exception
+    {
+        if (!migrator.existsSchemaMigrationsTable()) {
+            out.println("No table exist");
+            return;
+        }
+
+        List<Migration> migrations = migrator.getApplicableMigration();
+        for (Migration m : migrations) {
+            out.println(m.getVersion());
+        }
+        if (migrations.size() == 0) {
+            out.println("No update");
+        }
+    }
+
+    // check and validate arguments
+    private void checkArgs()
+        throws Exception
+    {
+        switch (args.size()) {
+            case 1:
+                switch (args.get(0)) {
+                    case "run":
+                        subCommand = SubCommand.RUN;
+                        break;
+                    case "check":
+                        subCommand = SubCommand.CHECK;
+                        break;
+                    default:
+                        throw usage("Invalid command");
+                }
+                break;
+            default:
+                throw usage("Invalid parameters");
+        }
+
+        if (database == null && configPath == null) {
+            throw usage("--database, or --config option is required");
+        }
+    }
+
+    // build Config from arguments and properties
+    private Config buildConfig()
+            throws Exception
+    {
+        Properties props = loadSystemProperties();
+        if (database != null) {
+            props.setProperty("database.type", "h2");
+            props.setProperty("database.path", Paths.get(database).toAbsolutePath().toString());
+        }
+        ConfigFactory cf = new ConfigFactory(DigdagClient.objectMapper());
+        Config config = PropertyUtils.toConfigElement(props).toConfig(cf);
+        return config;
+    }
+
+    @Override
+    public SystemExitException usage(String error)
+    {
+        err.println("Usage: " + programName + " migrate (run|check) run or check database migration");
+        err.println("  Options:");
+        err.println("    -c, --config PATH.properties     configuration file (default: /Users/you.yamagata/.config/digdag/config)");
+        err.println("    -o, --database DIR               path to H2 database");
+        return systemExit(error);
+    }
+
+    private enum SubCommand
+    {
+        RUN("run"),
+        CHECK("check")
+        ;
+        private final String name;
+
+        SubCommand(String name)
+        {
+            this.name = name;
+        }
+    }
+}

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseMigrator.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseMigrator.java
@@ -84,8 +84,8 @@ public class DatabaseMigrator
 
     public void migrateWithRetry()
     {
-        final int max_retry = 3;
-        for (int i = 0; i < max_retry; i++) {
+        final int maxRetry = 3;
+        for (int i = 0; i < maxRetry; i++) {
             try {
                 logger.info("Database migration started");
                 migrate();
@@ -94,7 +94,7 @@ public class DatabaseMigrator
             }
             catch (RuntimeException re) {
                 logger.warn(re.toString());
-                if (i == max_retry - 1) {
+                if (i == maxRetry - 1) {
                     logger.error("Critical error!!. Database migration failed.");
                 }
                 else {
@@ -111,7 +111,7 @@ public class DatabaseMigrator
         logger.error("Database migration aborted.");
     }
 
-    public void migrate()
+    private void migrate()
     {
         MigrationContext context = new MigrationContext(databaseType);
         try (Handle handle = dbi.open()) {
@@ -182,6 +182,7 @@ public class DatabaseMigrator
         handle.insert("insert into schema_migrations (name, created_at) values (?, now())", m.getVersion());
     }
 
+    @VisibleForTesting
     public String getDatabaseType()
     {
         return databaseType;

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseMigrator.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseMigrator.java
@@ -36,6 +36,7 @@ public class DatabaseMigrator
         new Migration_20170116082921_AddAttemptIndexColumn1(),
         new Migration_20170116090744_AddAttemptIndexColumn2(),
         new Migration_20170223220127_AddLastSessionTimeAndFlagsToSessions(),
+        new Migration_20190318175338_AddIndexToSessionAttempts(),
     })
     .sorted(Comparator.comparing(m -> m.getVersion()))
     .collect(Collectors.toList());

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseModule.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseModule.java
@@ -50,7 +50,7 @@ public class DatabaseModule
         public void migrate()
         {
             if (migrator != null) {
-                migrator.migrate();
+                migrator.migrateWithRetry();
                 migrator = null;
             }
         }

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration.java
@@ -22,7 +22,7 @@ public interface Migration
      * This is introduced because 'create index concurrently' cannot run in transaction.
      * @return
      */
-    default public boolean noTransaction() { return false; }
+    default boolean noTransaction() { return false; }
 
     void migrate(Handle handle, MigrationContext context);
 }

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration.java
@@ -17,5 +17,12 @@ public interface Migration
         return m.group(1);
     }
 
+    /**
+     * If true, this Migration apply without transaction.
+     * This is introduced because 'create index concurrently' cannot run in transaction.
+     * @return
+     */
+    default public boolean noTransaction() { return false; }
+
     void migrate(Handle handle, MigrationContext context);
 }

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20190318175338_AddIndexToSessionAttempts.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20190318175338_AddIndexToSessionAttempts.java
@@ -10,11 +10,14 @@ public class Migration_20190318175338_AddIndexToSessionAttempts
     {
         // DatabaseSessionStoreManager.getActiveAttemptCount uses this index.
         if (context.isPostgres()) {
-            handle.update("create index session_attempts_on_site_id_and_state_flags_partial_2 on session_attempts"
+            handle.update("create index concurrently session_attempts_on_site_id_and_state_flags_partial_2 on session_attempts"
                     + " using btree(site_id) where state_flags & 2 = 0");
         }
         else {
             // H2 does not support partial index
         }
     }
+
+    @Override
+    public boolean noTransaction() { return true; }
 }

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20190318175338_AddIndexToSessionAttempts.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20190318175338_AddIndexToSessionAttempts.java
@@ -1,0 +1,20 @@
+package io.digdag.core.database.migrate;
+
+import org.skife.jdbi.v2.Handle;
+
+public class Migration_20190318175338_AddIndexToSessionAttempts
+        implements Migration
+{
+    @Override
+    public void migrate(Handle handle, MigrationContext context)
+    {
+        // DatabaseSessionStoreManager.getActiveAttemptCount uses this index.
+        if (context.isPostgres()) {
+            handle.update("create index session_attempts_on_site_id_and_state_flags_partial_2 on session_attempts"
+                    + " using btree(site_id) where state_flags & 2 = 0");
+        }
+        else {
+            // H2 does not support partial index
+        }
+    }
+}

--- a/digdag-core/src/test/java/io/digdag/core/database/DatabaseTestingUtils.java
+++ b/digdag-core/src/test/java/io/digdag/core/database/DatabaseTestingUtils.java
@@ -78,7 +78,7 @@ public class DatabaseTestingUtils
         DBI dbi = new DBI(dsp.get());
         TransactionManager tm = new ThreadLocalTransactionManager(dsp.get(), autoAutoCommit);
         // FIXME
-        new DatabaseMigrator(dbi, config).migrate();
+        new DatabaseMigrator(dbi, config).migrateWithRetry();
 
         cleanDatabase(config.getType(), dbi);
 

--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -357,6 +357,7 @@ In the config file, following parameters are available
 * database.validationTimeout (seconds in integer, default: 5)
 * database.maximumPoolSize (integer, default: available CPU cores * 32)
 * database.leakDetectionThreshold (HikariCP leakDetectionThreshold milliseconds in integer. default: 0. To enable, set to >= 2000.)
+* database.migrate (enable DB migration. default: true)
 * archive.type (type of project archiving, "db" or "s3". default: "db")
 * archive.s3.endpoint (string. default: "s3.amazonaws.com")
 * archive.s3.bucket (string)

--- a/digdag-docs/src/db_migration.md
+++ b/digdag-docs/src/db_migration.md
@@ -1,0 +1,34 @@
+# Upgrade with database migration
+
+## 1. Automatic migration
+
+Digdag supports automatic migration when newer version requires database schema modification.
+When a digdag server start, it check `schema_migrations` table and execute each migration sequentially and automatically.
+This is default enable, but you can enable/disable with system parameter `database.migrate`.
+This parameter is documented from 0.9.36
+
+## 2. Change of migration behavior from 0.9.36
+Each migration is executed with transaction. So if migrations fail, you can fix the cause and then retry it. 
+From 0.9.36, we added non-transactional migration. This is because some DDL cannot run in transaction.
+In such migration, if the migration fail, there is a possibility to be required fix by hand before you retry. 
+So we explain how to recover when a non-transactional migration fails in section 4.
+
+## 3. How to upgrade Digdag safely
+If you are running a Digdag cluster in production, we recommend the following way to avoid trouble.
+
+1. Disable auto migration:  `database.migrate: false`
+1. Stop all Digdag servers.
+1. Upgrade Digdag binary.
+1. Check migrations by `digdag migrate check` and confirm which migrations will be applied.
+1. Run cli `digdag migrate run` in a server.
+1. Start Digdag servers.
+
+## 4. List of non-transactional migrations
+### ver. 0.9.36
+#### 20190318175338
+This migration add an index to session_attempts to avoid performance degrade with large session_attempts.
+If you want to retry this migration because of unexpected errors, please run following sql.
+
+    drop index session_attempts_on_site_id_and_state_flags_partial_2;
+    delete from schema_migrations where name like '20190318175338';
+

--- a/digdag-tests/src/test/java/acceptance/CliMigrateIT.java
+++ b/digdag-tests/src/test/java/acceptance/CliMigrateIT.java
@@ -1,0 +1,106 @@
+package acceptance;
+
+import com.google.common.io.Files;
+import io.digdag.core.database.DatabaseConfig;
+import io.digdag.core.database.RemoteDatabaseConfig;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import utils.CommandStatus;
+import utils.TemporaryDigdagServer;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeFalse;
+import static org.junit.Assume.assumeTrue;
+import static utils.TestUtils.*;
+
+public class CliMigrateIT
+{
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Rule
+    public TemporaryDigdagServer server = TemporaryDigdagServer.builder()
+            .inProcess(false)
+            .build();
+
+    private Path config;
+
+    private void createTestDBConfig(Path path, DatabaseConfig dbConfig)
+            throws IOException
+    {
+
+        StringBuffer sbuf = new StringBuffer();
+        sbuf.append(String.format("database.type = %s%n", dbConfig.getType()));
+        if (dbConfig.getRemoteDatabaseConfig().isPresent()) {
+            RemoteDatabaseConfig rdbConfig = dbConfig.getRemoteDatabaseConfig().get();
+            sbuf.append(String.format("database.user = %s%n", rdbConfig.getUser()));
+            sbuf.append(String.format("database.password = %s%n", rdbConfig.getPassword()));
+            sbuf.append(String.format("database.host = %s%n", rdbConfig.getHost()));
+            sbuf.append(String.format("database.database = %s%n", rdbConfig.getDatabase()));
+        }
+        Files.write(sbuf.toString().getBytes(UTF_8), path.toFile());
+    }
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        config = folder.newFile().toPath();
+        if ( server.isRemoteDatabase()) { // migrate command directly connect to database
+            createTestDBConfig(config, server.getTestDatabaseConfig());
+        }
+    }
+
+    @Test
+    public void migratePostgresql()
+            throws Exception
+    {
+        assumeTrue(server.isRemoteDatabase());
+
+        {   // test 'digdag migrate run'
+            CommandStatus status = main("migrate", "run",
+                    "-c", config.toString());
+            assertThat(status.code(), is(0));
+            // When digdag server boot up, already all migrations should be done.
+            assertThat(status.outUtf8(), containsString("No update"));
+        }
+        {   // test 'digdag migrate check'
+            CommandStatus status = main("migrate", "check",
+                    "-c", config.toString());
+            assertThat(status.code(), is(0));
+            // When digdag server boot up, already all migrations should be done.
+            assertThat(status.outUtf8(), containsString("No update"));
+        }
+    }
+
+
+    // This test ignore TemporaryDigdagServer and test to disk H2 database
+    @Test
+    public void migrateH2()
+            throws Exception
+    {
+        assumeFalse(server.isRemoteDatabase());
+        String dbPath = folder.newFolder().toString();
+        {
+            CommandStatus status = main("migrate", "run",
+                    "-o", dbPath);
+            assertThat(status.code(), is(0));
+            assertThat(status.outUtf8(), containsString("successfully finished"));
+        }
+        {   // test 'digdag migrate check'
+            CommandStatus status = main("migrate", "check",
+                    "-o", dbPath);
+            assertThat(status.code(), is(0));
+            // all migrations should be done above 'migrate run'.
+            assertThat(status.outUtf8(), containsString("No update"));
+        }
+    }
+}

--- a/digdag-tests/src/test/java/acceptance/MigrationIT.java
+++ b/digdag-tests/src/test/java/acceptance/MigrationIT.java
@@ -1,0 +1,86 @@
+package acceptance;
+
+import io.digdag.core.database.DatabaseMigrator;
+import io.digdag.core.database.migrate.Migration;
+import io.digdag.core.database.migrate.MigrationContext;
+import io.digdag.core.database.migrate.Migration_20151204221156_CreateTables;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import utils.TemporaryDigdagServer;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+
+import static org.junit.Assert.fail;
+
+
+public class MigrationIT
+{
+    public TemporaryDigdagServer server = null;
+
+    @Before
+    public void setUp()
+    {
+        server = TemporaryDigdagServer.of();
+    }
+
+    @After
+    public void tearDown()
+    {
+        if (server != null) {
+            server.close();
+            server = null;
+        }
+    }
+
+    /**
+     * Check the behavior for upgrading existing database
+     * @throws Exception
+     */
+    @Test
+    public void checkDatabaseUpgrade()
+    {
+        try {
+            server.setupDatabase();
+            DataSource ds = server.getTestDBDataSource();
+            DBI dbi = new DBI(ds);
+            DatabaseMigrator migrator = new DatabaseMigrator(dbi, server.getRemoteTestDatabaseConfig());
+            MigrationContext context = new MigrationContext(migrator.getDatabaseType());
+
+            //Prepare for tables
+            try (Handle handle = dbi.open()) {
+                migrator.createSchemaMigrationsTable(handle, context);
+                Migration m = new Migration_20151204221156_CreateTables();
+                migrator.applyMigration(m, handle, context);
+            }
+
+            //Apply rest migrations when digdag server start
+            server.start(true);
+        }
+        catch (Exception e) {
+            fail(e.toString());
+        }
+    }
+
+    /**
+     * Check session_attempts_on_site_id_and_state_flags_partial_2 index exists
+     * @throws Exception
+     */
+    @Test
+    public void checkMigration_20190318175338_AddIndexToSessionAttempts()
+    {
+        try {
+            server.start();
+            DataSource ds = server.getTestDBDataSource();
+            Connection con = ds.getConnection();
+            con.createStatement().execute("drop index session_attempts_on_site_id_and_state_flags_partial_2");
+        }
+        catch (Exception e) {
+            fail(e.toString());
+        }
+
+    }
+}

--- a/digdag-tests/src/test/java/acceptance/MigrationIT.java
+++ b/digdag-tests/src/test/java/acceptance/MigrationIT.java
@@ -15,6 +15,7 @@ import javax.sql.DataSource;
 import java.sql.Connection;
 
 import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
 
 
 public class MigrationIT
@@ -43,6 +44,8 @@ public class MigrationIT
     @Test
     public void checkDatabaseUpgrade()
     {
+        assumeTrue(server.isRemoteDatabase());
+
         try {
             server.setupDatabase();
             DataSource ds = server.getTestDBDataSource();
@@ -61,6 +64,7 @@ public class MigrationIT
             server.start(true);
         }
         catch (Exception e) {
+            e.printStackTrace();
             fail(e.toString());
         }
     }
@@ -72,6 +76,8 @@ public class MigrationIT
     @Test
     public void checkMigration_20190318175338_AddIndexToSessionAttempts()
     {
+        assumeTrue(server.isRemoteDatabase());
+
         try {
             server.start();
             DataSource ds = server.getTestDBDataSource();
@@ -81,6 +87,5 @@ public class MigrationIT
         catch (Exception e) {
             fail(e.toString());
         }
-
     }
 }

--- a/digdag-tests/src/test/java/utils/TemporaryDigdagServer.java
+++ b/digdag-tests/src/test/java/utils/TemporaryDigdagServer.java
@@ -192,7 +192,12 @@ public class TemporaryDigdagServer
      */
     public DataSource getTestDBDataSource()
     {
-        return new DataSourceProvider(testDatabaseConfig).get();
+        if (isRemoteDatabase()) {
+            return new DataSourceProvider(testDatabaseConfig).get();
+        }
+        else {
+            return null;
+        }
     }
 
     private static class Trampoline

--- a/digdag-tests/src/test/java/utils/TemporaryDigdagServer.java
+++ b/digdag-tests/src/test/java/utils/TemporaryDigdagServer.java
@@ -186,6 +186,15 @@ public class TemporaryDigdagServer
         adminDataSource = dsp.get();
     }
 
+    /**
+     * Get DataSource for Test DB. (Not admin DB)
+     * @return
+     */
+    public DataSource getTestDBDataSource()
+    {
+        return new DataSourceProvider(testDatabaseConfig).get();
+    }
+
     private static class Trampoline
     {
         private static final String NAME = ManagementFactory.getRuntimeMXBean().getName();
@@ -254,15 +263,22 @@ public class TemporaryDigdagServer
         }
         start();
     }
-
     public void start()
+            throws Exception
+    {
+        start(false);
+    }
+
+    public void start(boolean skipSetupDatabase)
             throws Exception
     {
         started = true;
 
         temporaryFolder.create();
 
-        setupDatabase();
+        if (!skipSetupDatabase) {
+            setupDatabase();
+        }
 
         Path runtimeInfoPath = temporaryFolder.newFolder().toPath().resolve("runtime-info");
         configuration.add("server.runtime-info.path = " + runtimeInfoPath.toAbsolutePath().normalize());
@@ -514,7 +530,7 @@ public class TemporaryDigdagServer
         return p.getClass().getName().equals("java.lang.UNIXProcess");
     }
 
-    private void setupDatabase()
+    public void setupDatabase()
             throws SQLException
     {
         if (testDatabaseConfig == null) {
@@ -769,4 +785,5 @@ public class TemporaryDigdagServer
                 ", port=" + port +
                 '}';
     }
+
 }

--- a/digdag-tests/src/test/java/utils/TemporaryDigdagServer.java
+++ b/digdag-tests/src/test/java/utils/TemporaryDigdagServer.java
@@ -200,6 +200,10 @@ public class TemporaryDigdagServer
         }
     }
 
+    public DatabaseConfig getTestDatabaseConfig() { return testDatabaseConfig; }
+
+
+
     private static class Trampoline
     {
         private static final String NAME = ManagementFactory.getRuntimeMXBean().getName();


### PR DESCRIPTION
Add an index to resolve performance issue on session_attempts.

To support _create index concurrently_, re-write DatabaseMigrator.migrate() and support no transaction mode in Migration.

Original migrate() support two mode.
(a) Initial mode : all migrations in a transaction
(b) Upgrade mode : each migration run in separate transaction

New migrate() only support (b). Because of support no transaction mode.
In multiple digdag server cluster, if digdag servers boot simultaneously, migrate() may fail.
To avoid it, migrateWithRetry() is implemented.
