### PR TITLE
Use 'npm ci' instead of 'npm install' to avoid update of package-lock…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -322,7 +322,7 @@ project(':digdag-ui') {
 
         doFirst {
             exec {
-                commandLine System.env.NPM ?: "npm", "install"
+                commandLine System.env.NPM ?: "npm", "ci"
             }
             exec {
                 commandLine System.env.NPM ?: "npm", "run", "build"


### PR DESCRIPTION
Currently when build ui, packge-lock.json is modified and it is inconvenient.
To avoid it, I would like to replace _npm install_ to _npm ci_.

Refer link: https://blog.npmjs.org/post/171556855892/introducing-npm-ci-for-faster-more-reliable


