### PR TITLE
Add RestTask#getError method to pass error config to clients from AttemptResource#getTasks

### DIFF
--- a/digdag-client/src/main/java/io/digdag/client/api/RestTask.java
+++ b/digdag-client/src/main/java/io/digdag/client/api/RestTask.java
@@ -46,6 +46,8 @@ public interface RestTask
 
     Optional<Instant> getStartedAt();
 
+    Config getError();
+
     // TODO in out Report
 
     static ImmutableRestTask.Builder builder()

--- a/digdag-server/src/main/java/io/digdag/server/rs/RestModels.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/RestModels.java
@@ -319,6 +319,7 @@ public final class RestModels
             .updatedAt(task.getUpdatedAt())
             .retryAt(task.getRetryAt())
             .startedAt(task.getStartedAt())
+            .error(task.getError())
             .build();
     }
 


### PR DESCRIPTION
Though it's worth for users to check the reason why tasks failed by both of user errors and system errors, AttemptResource#getTasks endpoint doesn't return error configs to users. Users don't have change to see and handle the error except error task.

This PR fixes RestTask that is model class to pass error configs to clients from AttemptResource#getTasks.