### PR TITLE
UI: Show attempt params to attempt/session views

### DIFF
--- a/digdag-ui/console.jsx
+++ b/digdag-ui/console.jsx
@@ -1160,6 +1160,10 @@ class AttemptView extends React.Component {
               <td>Status</td>
               <td><AttemptStatusView attempt={attempt} /></td>
             </tr>
+            <tr>
+              <td>Params</td>
+              <td><ParamsView params={attempt.params} /></td>
+            </tr>
           </tbody>
         </table>
         <ReactInterval timeout={refreshIntervalMillis} enabled={!this.state.done} callback={() => this.fetch()} />
@@ -1254,6 +1258,10 @@ class SessionView extends React.Component {
             <tr>
               <td>Last Attempt Duration:</td>
               <td><DurationView start={lastAttempt && lastAttempt.createdAt} end={lastAttempt && lastAttempt.finishedAt} /></td>
+            </tr>
+            <tr>
+              <td>Last Attempt Params:</td>
+              <td><ParamsView params={lastAttempt && lastAttempt.params} /></td>
             </tr>
           </tbody>
         </table>

--- a/digdag-ui/style.less
+++ b/digdag-ui/style.less
@@ -75,7 +75,6 @@ pre {
 }
 
 .params-view {
-  width: 190px;
   height: 130px;
 }
 


### PR DESCRIPTION
I've made a following change:
 - Show attempt params to attempt/session views.

A lot of sessions are invoked with params (`digdag start ... -p xxx=yyy ...`), I have trouble with figuring out what I want to see, so make it easy to find which param is used.

I think `.params-view`'s width is not needed, so deleted it.