### PR TITLE
Add client options in usage

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/Main.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Main.java
@@ -336,7 +336,7 @@ public class Main
         err.println("  Options:");
         showCommonOptions(env, err);
         err.println("  Client options:");
-        showClientCommonOptions(env, err);
+        showClientCommonOptions(err);
         if (error == null) {
             err.println("Use `<command> --help` to see detailed usage of a command.");
             return systemExit(null);
@@ -356,7 +356,7 @@ public class Main
         err.println("");
     }
 
-    public static void showClientCommonOptions(Map<String, String> env, PrintStream err)
+    public static void showClientCommonOptions(PrintStream err)
     {
         err.println("    -e, --endpoint URL               Server endpoint (default: http://127.0.0.1:65432)");
         err.println("    -H, --header  KEY=VALUE          Additional headers");

--- a/digdag-cli/src/main/java/io/digdag/cli/Main.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Main.java
@@ -335,6 +335,8 @@ public class Main
         err.println("");
         err.println("  Options:");
         showCommonOptions(env, err);
+        err.println("  Client options:");
+        showClientCommonOptions(env, err);
         if (error == null) {
             err.println("Use `<command> --help` to see detailed usage of a command.");
             return systemExit(null);
@@ -353,4 +355,14 @@ public class Main
         err.println("    --version                        show client version");
         err.println("");
     }
+
+    public static void showClientCommonOptions(Map<String, String> env, PrintStream err)
+    {
+        err.println("    -e, --endpoint URL               Server endpoint (default: http://127.0.0.1:65432)");
+        err.println("    -H, --header  KEY=VALUE          Additional headers");
+        err.println("    --disable-version-check          Disable server version check");
+        err.println("    --disable-cert-validation        Disable certificate verification");
+        err.println("");
+    }
+
 }


### PR DESCRIPTION
Hello, @yoyama, @muga 

What do you think to add this message?
https://github.com/treasure-data/digdag/blob/master/digdag-cli/src/main/java/io/digdag/cli/client/ClientCommand.java#L46-L57

```
  Client options:
    -e, --endpoint URL               Server endpoint (default: http://127.0.0.1:65432)
    -H, --header  KEY=VALUE          Additional headers
    --disable-version-check          Disable server version check
    --disable-cert-validation        Disable certificate verification
```