### PR TITLE
HikariCP JMX metrics

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/database/DataSourceProvider.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DataSourceProvider.java
@@ -87,6 +87,7 @@ public class DataSourceProvider
         hikari.setMaximumPoolSize(config.getMaximumPoolSize());
         hikari.setMinimumIdle(config.getMinimumPoolSize());
         hikari.setRegisterMbeans(config.getEnableJMX());
+        hikari.setLeakDetectionThreshold(config.getLeakDetectionThreshold());
 
         // Here should not set connectionTestQuery (that overrides isValid) because
         // ThreadLocalTransactionManager.commit assumes that Connection.isValid returns

--- a/digdag-core/src/main/java/io/digdag/core/database/DataSourceProvider.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DataSourceProvider.java
@@ -86,6 +86,7 @@ public class DataSourceProvider
         hikari.setValidationTimeout(config.getValidationTimeout() * 1000);
         hikari.setMaximumPoolSize(config.getMaximumPoolSize());
         hikari.setMinimumIdle(config.getMinimumPoolSize());
+        hikari.setRegisterMbeans(config.getEnableJMX());
 
         // Here should not set connectionTestQuery (that overrides isValid) because
         // ThreadLocalTransactionManager.commit assumes that Connection.isValid returns

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseConfig.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseConfig.java
@@ -105,8 +105,7 @@ public interface DatabaseConfig
         builder.maximumPoolSize(maximumPoolSize);
         builder.minimumPoolSize(
                 config.get(keyPrefix + "." + "minimumPoolSize", int.class, maximumPoolSize));  // HikariCP default: Same as maximumPoolSize
-        builder.enableJMX(
-                config.get(keyPrefix + "." + "enableJMX", boolean.class, false));  // HikariCP default: false
+        builder.enableJMX(isJMXEnable(config));
         // database.opts.* to options
         ImmutableMap.Builder<String, String> options = ImmutableMap.builder();
         for (String key : config.getKeys()) {
@@ -124,6 +123,19 @@ public interface DatabaseConfig
                 config.get(keyPrefix + "." + "queue.expireLockInterval", int.class, 10));
 
         return builder.build();
+    }
+
+    /**
+     * If server.jmx.port > 0 then JMX is enable
+     * TODO this method should move to proper class?
+     * @param config
+     * @return
+     */
+    static boolean isJMXEnable(Config config)
+    {
+        return config.getOptional("server.jmx.port", Integer.class)
+                .transform((port) -> port > 0)
+                .or(false);
     }
 
     static Config toConfig(DatabaseConfig databaseConfig, ConfigFactory cf) {

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseConfig.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseConfig.java
@@ -132,7 +132,7 @@ public interface DatabaseConfig
     }
 
     /**
-     * If server.jmx.port > 0 then JMX is enable
+     * If server.jmx.port exists, then JMX is enable
      * TODO this method should move to proper class?
      * @param config
      * @return
@@ -140,7 +140,7 @@ public interface DatabaseConfig
     static boolean isJMXEnable(Config config)
     {
         return config.getOptional("server.jmx.port", Integer.class)
-                .transform((port) -> port > 0)
+                .transform((port) -> true)
                 .or(false);
     }
 

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseConfig.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseConfig.java
@@ -47,6 +47,8 @@ public interface DatabaseConfig
 
     boolean getEnableJMX();
 
+    long getLeakDetectionThreshold();  // milliseconds
+
     static ImmutableDatabaseConfig.Builder builder()
     {
         return ImmutableDatabaseConfig.builder();
@@ -105,7 +107,11 @@ public interface DatabaseConfig
         builder.maximumPoolSize(maximumPoolSize);
         builder.minimumPoolSize(
                 config.get(keyPrefix + "." + "minimumPoolSize", int.class, maximumPoolSize));  // HikariCP default: Same as maximumPoolSize
+
         builder.enableJMX(isJMXEnable(config));
+        builder.leakDetectionThreshold(
+                config.get(keyPrefix + "." + "leakDetectionThreshold", long.class, 0L));  // HikariCP default: 0
+
         // database.opts.* to options
         ImmutableMap.Builder<String, String> options = ImmutableMap.builder();
         for (String key : config.getKeys()) {

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseConfig.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseConfig.java
@@ -45,6 +45,8 @@ public interface DatabaseConfig
 
     int getValidationTimeout();  // seconds
 
+    boolean getEnableJMX();
+
     static ImmutableDatabaseConfig.Builder builder()
     {
         return ImmutableDatabaseConfig.builder();
@@ -103,7 +105,8 @@ public interface DatabaseConfig
         builder.maximumPoolSize(maximumPoolSize);
         builder.minimumPoolSize(
                 config.get(keyPrefix + "." + "minimumPoolSize", int.class, maximumPoolSize));  // HikariCP default: Same as maximumPoolSize
-
+        builder.enableJMX(
+                config.get(keyPrefix + "." + "enableJMX", boolean.class, false));  // HikariCP default: false
         // database.opts.* to options
         ImmutableMap.Builder<String, String> options = ImmutableMap.builder();
         for (String key : config.getKeys()) {
@@ -158,6 +161,7 @@ public interface DatabaseConfig
         config.set(keyPrefix + "." + "validationTimeout", databaseConfig.getValidationTimeout());
         config.set(keyPrefix + "." + "maximumPoolSize", databaseConfig.getMaximumPoolSize());
         config.set(keyPrefix + "." + "minimumPoolSize", databaseConfig.getMinimumPoolSize());
+        config.set(keyPrefix + "." + "enableJMX", databaseConfig.getEnableJMX());
 
         // database.opts.*
         Map<String, String> options = databaseConfig.getOptions();

--- a/digdag-core/src/test/java/io/digdag/core/database/DatabaseTestingUtils.java
+++ b/digdag-core/src/test/java/io/digdag/core/database/DatabaseTestingUtils.java
@@ -59,6 +59,8 @@ public class DatabaseTestingUtils
                 .validationTimeout(5)
                 .minimumPoolSize(0)
                 .maximumPoolSize(10)
+                .enableJMX(false)
+                .leakDetectionThreshold(0)
                 .build();
         }
     }

--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -356,7 +356,7 @@ In the config file, following parameters are available
 * database.idleTimeout (seconds in integer, default: 600)
 * database.validationTimeout (seconds in integer, default: 5)
 * database.maximumPoolSize (integer, default: available CPU cores * 32)
-* database.leakDetectionThreshold (HikariCP leakDetectionThreshold in integer. default: 0. To enable, set to >= 2000.)
+* database.leakDetectionThreshold (HikariCP leakDetectionThreshold milliseconds in integer. default: 0. To enable, set to >= 2000.)
 * archive.type (type of project archiving, "db" or "s3". default: "db")
 * archive.s3.endpoint (string. default: "s3.amazonaws.com")
 * archive.s3.bucket (string)

--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -356,6 +356,7 @@ In the config file, following parameters are available
 * database.idleTimeout (seconds in integer, default: 600)
 * database.validationTimeout (seconds in integer, default: 5)
 * database.maximumPoolSize (integer, default: available CPU cores * 32)
+* database.leakDetectionThreshold (HikariCP leakDetectionThreshold in integer. default: 0. To enable, set to >= 2000.)
 * archive.type (type of project archiving, "db" or "s3". default: "db")
 * archive.s3.endpoint (string. default: "s3.amazonaws.com")
 * archive.s3.bucket (string)


### PR DESCRIPTION
I would like to introduce following to improve DB related monitoring.

1. Enable HikariCP JMX metrics when JMX is enabled
2. Introduce database.leakDetectionThreshold.
