### PR TITLE
Fix the issue which causes infinite task retry.

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
@@ -158,7 +158,7 @@ public class OperatorManager
                                 ex.getError(cf).get());  // TODO is error set?
                     }
                 }
-                catch (RuntimeException | AssertionError ex) {
+                catch (RuntimeException | AssertionError ex) { // Avoid infinite task retry cause of AssertionError by Operators
                     if (ex instanceof ConfigException) {
                         logger.error("Configuration error at task {}: {}", request.getTaskName(), formatExceptionMessage(ex));
                     }
@@ -203,7 +203,7 @@ public class OperatorManager
         catch (RuntimeException ex) {
             throw new RuntimeException("Failed to process variables", ex);
         }
-        catch (AssertionError ex) {
+        catch (AssertionError ex) { // Avoid infinite task retry cause of AssertionError by ConfigEvalEngine(nashorn)
             throw new RuntimeException("Unexpected error happened in ConfigEvalEngine: " + ex.getMessage(), ex);
         }
         logger.debug("evaluated config: {}", config);

--- a/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
@@ -158,7 +158,7 @@ public class OperatorManager
                                 ex.getError(cf).get());  // TODO is error set?
                     }
                 }
-                catch (RuntimeException ex) {
+                catch (RuntimeException | AssertionError ex) {
                     if (ex instanceof ConfigException) {
                         logger.error("Configuration error at task {}: {}", request.getTaskName(), formatExceptionMessage(ex));
                     }
@@ -202,6 +202,9 @@ public class OperatorManager
         }
         catch (RuntimeException ex) {
             throw new RuntimeException("Failed to process variables", ex);
+        }
+        catch (AssertionError ex) {
+            throw new RuntimeException("Unexpected error happened in ConfigEvalEngine: " + ex.getMessage(), ex);
         }
         logger.debug("evaluated config: {}", config);
 

--- a/digdag-tests/src/test/java/acceptance/ConfigEvalEngineIT.java
+++ b/digdag-tests/src/test/java/acceptance/ConfigEvalEngineIT.java
@@ -1,0 +1,80 @@
+package acceptance;
+
+import com.google.common.io.Resources;
+import io.digdag.client.api.Id;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import utils.CommandStatus;
+import utils.TemporaryDigdagServer;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Duration;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static utils.TestUtils.*;
+
+public class ConfigEvalEngineIT
+{
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Rule
+    public TemporaryDigdagServer server = TemporaryDigdagServer.of();
+
+    private Path config;
+    private Path projectDir;
+
+    private Path root()
+    {
+        return folder.getRoot().toPath().toAbsolutePath();
+    }
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        projectDir = folder.getRoot().toPath().resolve("config_eval_engine_test");
+        Files.createDirectories(projectDir);
+        config = folder.newFile().toPath();
+    }
+
+
+    @Test
+    public void invalidConfigShouldNotInfiniteLoop()
+            throws Exception
+    {
+        copyResource("acceptance/config_eval_engine/invalid1.dig", projectDir);
+        // Push the project
+        CommandStatus pushStatus = main("push",
+                "--project", projectDir.toString(),
+                "config_eval_engine_test",
+                "-c", config.toString(),
+                "-e", server.endpoint());
+        assertThat(pushStatus.errUtf8(), pushStatus.code(), is(0));
+
+        // Start the workflow
+        Id attemptId;
+        {
+            CommandStatus startStatus = main("start",
+                    "-c", config.toString(),
+                    "-e", server.endpoint(),
+                    "config_eval_engine_test", "invalid1",
+                    "--session", "now");
+            assertThat(startStatus.code(), is(0));
+            attemptId = getAttemptId(startStatus);
+        }
+
+        // Wait for the attempt to complete
+        expect(Duration.ofMinutes(5), attemptFailure(server.endpoint(), attemptId));
+
+        // Verify that the file created by the child workflow is there
+        //assertThat(Files.exists(root().resolve("call_by_name.out")), is(true));
+
+    }
+}

--- a/digdag-tests/src/test/resources/acceptance/config_eval_engine/invalid1.dig
+++ b/digdag-tests/src/test/resources/acceptance/config_eval_engine/invalid1.dig
@@ -1,0 +1,7 @@
++test:
+  if>: ${td.last_results.cnt => 3}
+  _do:
+    echo>: "A,B,C"
+  _else_do:
+    fail>: "count is ${td.last_results.cnt}!!!"
+


### PR DESCRIPTION
If workflow has generated subtasks with reference to undefined variable, nashorn throw AssertionError.
But digdag cannot catch it correctly and retry infinitely.
In addtion if some Operators also throw AssertionError, same issue will happen.
This PR handles these cases.