### PR TITLE
Add required npm version on build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -322,6 +322,7 @@ project(':digdag-ui') {
 
         doFirst {
             exec {
+                // npm ci requires npm version 5.7 or more.
                 commandLine System.env.NPM ?: "npm", "ci"
             }
             exec {


### PR DESCRIPTION
This PR adds one comment in build.gradle. 'npm ci' requires npm vesion 5.7 or more.