### PR TITLE
Adding http_call operator

### DIFF
--- a/digdag-docs/src/operators/http_call.md
+++ b/digdag-docs/src/operators/http_call.md
@@ -1,0 +1,25 @@
+# http_call>: Call workflow fetched by HTTP
+
+**http_call>** operator makes a HTTP request, parse response body, and embeds it as a subtask.
+
+This operator parses response body based on returned Content-Type header. Content-Type must be set and following values are supported:
+
+* **application/json**: Parse the response as JSON.
+* **application/x-yaml**: Use the returned body as-is.
+
+## Options
+
+* **http_call>**: URI
+
+  The URI of the HTTP request.
+
+  Examples:
+
+  ```
+  http_call>: https://api.example.com/foobar
+  ```
+
+Same parameters with **http>** operator are also supported except the parameters listed bellow. See also [http> operator document](../http.html).
+
+* store_content
+

--- a/digdag-docs/src/operators/http_call.md
+++ b/digdag-docs/src/operators/http_call.md
@@ -1,6 +1,6 @@
 # http_call>: Call workflow fetched by HTTP
 
-**http_call>** operator makes a HTTP request, parse response body, and embeds it as a subtask.
+**http_call>** operator makes a HTTP request, parse response body as workflow, and embeds it as a subtask. The operator is similar to [call> operator](../call.html). The difference is that another workflow is fetched from HTTP.
 
 This operator parses response body based on returned Content-Type header. Content-Type must be set and following values are supported:
 
@@ -19,7 +19,7 @@ This operator parses response body based on returned Content-Type header. Conten
   http_call>: https://api.example.com/foobar
   ```
 
-Same parameters with **http>** operator are also supported except the parameters listed bellow. See also [http> operator document](../http.html).
+Same parameters with **http>** operator are also supported except the parameters listed bellow. The name of the operator is similar to [http> operator](../http.html). But the role is different. See also [http> operator document](../http.html).
 
 * store_content
 

--- a/digdag-docs/src/operators/workflow_control.rst
+++ b/digdag-docs/src/operators/workflow_control.rst
@@ -5,6 +5,7 @@ Workflow control operators
     :maxdepth: 1
 
     call.md
+    http_call.md
     require.md
     loop.md
     for_each.md

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/HttpCallOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/HttpCallOperatorFactory.java
@@ -1,0 +1,191 @@
+package io.digdag.standards.operator;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import com.google.common.base.Strings;
+import com.google.inject.Inject;
+import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigException;
+import io.digdag.client.config.ConfigFactory;
+import io.digdag.core.Environment;
+import io.digdag.core.archive.ProjectArchiveLoader;
+import io.digdag.core.archive.WorkflowFile;
+import io.digdag.core.config.ConfigLoaderManager;
+import io.digdag.core.config.YamlConfigLoader;
+import io.digdag.spi.Operator;
+import io.digdag.spi.OperatorContext;
+import io.digdag.spi.TaskExecutionException;
+import io.digdag.spi.TaskResult;
+import io.digdag.util.UserSecretTemplate;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import javax.ws.rs.core.MediaType;
+import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.api.ContentResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import static io.digdag.util.Workspace.propagateIoException;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class HttpCallOperatorFactory
+        extends HttpOperatorFactory
+{
+    private static final Logger logger = LoggerFactory.getLogger(HttpCallOperatorFactory.class);
+
+    private static final String WORKFLOW_FILE_NAME = "http_call.dig";
+
+    private final ConfigFactory cf;
+    private final ObjectMapper mapper;
+    private final YAMLFactory yaml;
+    private final ProjectArchiveLoader projectLoader;
+
+    @Inject
+    public HttpCallOperatorFactory(ConfigFactory cf,
+            Config systemConfig, @Environment Map<String, String> env)
+    {
+        super(systemConfig, env);
+        this.cf = cf;
+        this.mapper = new ObjectMapper();
+        this.yaml = new YAMLFactory()
+            .configure(YAMLGenerator.Feature.WRITE_DOC_START_MARKER, false);
+        this.projectLoader = new ProjectArchiveLoader(
+                new ConfigLoaderManager(
+                    cf,
+                    new YamlConfigLoader()));
+    }
+
+    @Override
+    public String getType()
+    {
+        return "http_call";
+    }
+
+    @Override
+    public Operator newOperator(OperatorContext context)
+    {
+        return new HttpCallOperator(context);
+    }
+
+    class HttpCallOperator
+            extends HttpOperator
+    {
+        public HttpCallOperator(OperatorContext context)
+        {
+            super(context);
+        }
+
+        @Override
+        public TaskResult runTask()
+        {
+            UserSecretTemplate uriTemplate = UserSecretTemplate.of(params.get("_command", String.class));
+            boolean uriIsSecret = uriTemplate.containsSecrets();
+            URI uri = URI.create(uriTemplate.format(context.getSecrets()));
+
+            ContentResponse response;
+
+            HttpClient httpClient = client();
+            try {
+                response = runHttp(httpClient, uri, uriIsSecret);
+            }
+            finally {
+                stop(httpClient);
+            }
+
+            // This ContentResponse::getContentAsString considers ;charset= parameter
+            // of Content-Type. If not set, it uses UTF-8.
+            String content = response.getContentAsString();
+
+            // validate response length
+            if (content.length() > maxStoredResponseContentSize) {
+                throw new TaskExecutionException("Response content too large: " + content.length() + " > " + maxStoredResponseContentSize);
+            }
+
+            // parse content based on response media type
+            String digFileSource = reformatDigFile(content, response.getMediaType());
+            // write to http_call.dig file
+            Path workflowPath = writeDigFile(digFileSource);
+
+            // following code is almost same with CallOperatorFactory.CallOperator.runTask
+            Config config = request.getConfig();
+
+            WorkflowFile workflowFile;
+            try {
+                workflowFile = projectLoader.loadWorkflowFileFromPath(
+                        workspace.getProjectPath(), workflowPath, config.getFactory().create());
+            }
+            catch (IOException ex) {
+                throw propagateIoException(ex, WORKFLOW_FILE_NAME, ConfigException::new);
+            }
+
+            Config def = workflowFile.toWorkflowDefinition().getConfig();
+
+            return TaskResult.defaultBuilder(request)
+                .subtaskConfig(def)
+                .build();
+        }
+
+        private String reformatDigFile(String content, String mediaTypeString)
+        {
+            if (Strings.isNullOrEmpty(mediaTypeString)) {
+                throw new TaskExecutionException("Content-Type must be set in the HTTP response but not set");
+            }
+            MediaType mediaType = MediaType.valueOf(mediaTypeString);
+
+            String t = mediaType.getType() + "/" + mediaType.getSubtype();  // without ;charset= or other params
+            switch (t) {
+            case MediaType.APPLICATION_JSON:
+                try {
+                    // parse as json
+                    Config sourceConfig = cf.fromJsonString(content);
+                    // reformat as yaml
+                    return formatYaml(sourceConfig);
+                }
+                catch (ConfigException ex) {
+                    throw new RuntimeException("Failed to parse response as JSON: " + ex.getMessage(), ex);
+                }
+
+            case "application/x-yaml":
+                // use as-is; let projectLoader.loadWorkflowFileFromPath handle parse errors
+                return content;
+
+            //case MediaType.TEXT_PLAIN:
+            //case MediaType.APPLICATION_OCTET_STREAM:
+
+            default:
+                throw new TaskExecutionException("Unsupported Content-Type (expected application/json or application/x-yaml): " + mediaTypeString);
+            }
+        }
+
+        private String formatYaml(Config value)
+        {
+            try {
+                StringWriter writer = new StringWriter();
+                try (YAMLGenerator out = yaml.createGenerator(writer)) {
+                    mapper.writeValue(out, value);
+                }
+                return writer.toString();
+            }
+            catch (IOException ex) {
+                throw new RuntimeException(ex);
+            }
+        }
+
+        private Path writeDigFile(String source)
+        {
+            Path workflowPath = workspace.getPath(WORKFLOW_FILE_NAME);
+            try (BufferedWriter writer = Files.newBufferedWriter(workflowPath, UTF_8)) {
+                writer.write(source);
+            }
+            catch (IOException ex) {
+                throw new RuntimeException(ex);
+            }
+            return workflowPath;
+        }
+    }
+}

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/OperatorModule.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/OperatorModule.java
@@ -57,6 +57,7 @@ public class OperatorModule
         addStandardOperatorFactory(binder, S3WaitOperatorFactory.class);
         addStandardOperatorFactory(binder, EmrOperatorFactory.class);
         addStandardOperatorFactory(binder, HttpOperatorFactory.class);
+        addStandardOperatorFactory(binder, HttpCallOperatorFactory.class);
         addStandardOperatorFactory(binder, ParamSetOperatorFactory.class);
         addStandardOperatorFactory(binder, ParamGetOperatorFactory.class);
     }

--- a/digdag-tests/src/test/java/acceptance/HttpCallIT.java
+++ b/digdag-tests/src/test/java/acceptance/HttpCallIT.java
@@ -1,0 +1,283 @@
+package acceptance;
+
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.dataformat.yaml.YAMLGenerator;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Resources;
+import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigFactory;
+import io.digdag.core.config.YamlConfigLoader;
+import io.netty.handler.codec.http.FullHttpRequest;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import okhttp3.Headers;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.QueueDispatcher;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.littleshoot.proxy.HttpProxyServer;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.eclipse.jetty.http.HttpHeader.AUTHORIZATION;
+import static org.eclipse.jetty.http.HttpHeader.CONTENT_TYPE;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static utils.TestUtils.objectMapper;
+import static utils.TestUtils.runWorkflow;
+import static utils.TestUtils.startMockWebServer;
+import utils.TestUtils;
+
+public class HttpCallIT
+{
+    private static final ConfigFactory CF = TestUtils.configFactory();
+    private static final YamlConfigLoader Y = new YamlConfigLoader();
+
+    private MockWebServer httpMockWebServer;
+    private MockWebServer httpsMockWebServer;
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+    private HttpProxyServer proxy;
+    private ConcurrentMap<String, List<FullHttpRequest>> requests;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        httpMockWebServer = startMockWebServer();
+        httpMockWebServer.setDispatcher(new QueueDispatcher());
+        httpsMockWebServer = startMockWebServer(true);
+        requests = new ConcurrentHashMap<>();
+    }
+
+    @After
+    public void tearDownProxy()
+            throws Exception
+    {
+        if (proxy != null) {
+            proxy.stop();
+        }
+    }
+
+    @After
+    public void tearDownHttpServer()
+            throws Exception
+    {
+        if (httpMockWebServer != null) {
+            httpMockWebServer.shutdown();
+        }
+    }
+
+    @After
+    public void tearDownHttpsServer()
+            throws Exception
+    {
+        if (httpsMockWebServer != null) {
+            httpsMockWebServer.shutdown();
+        }
+    }
+
+    private Path root()
+    {
+        return folder.getRoot().toPath().toAbsolutePath();
+    }
+
+    private Config loadYamlResource(String name)
+    {
+        try {
+            String content = Resources.toString(Resources.getResource(name), UTF_8);
+            return Y.loadString(content).toConfig(CF);
+        }
+        catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @Test
+    public void testSubTasksByJson()
+            throws Exception
+    {
+        Config bodyConfig = loadYamlResource("acceptance/http_call/child.dig");
+        httpMockWebServer.enqueue(
+                new MockResponse()
+                .addHeader("Content-Type: application/json")
+                .setBody(bodyConfig.toString()));
+        String uri = "http://localhost:" + httpMockWebServer.getPort() + "/test";
+        runWorkflow(folder, "acceptance/http_call/http_call.dig", ImmutableMap.of(
+                    "test_uri", uri,
+                    "outdir", root().toString(),
+                    "name", "child"));
+        assertThat(httpMockWebServer.getRequestCount(), is(1));
+        assertThat(Files.exists(root().resolve("child.out")), is(true));
+        RecordedRequest request = httpMockWebServer.takeRequest();
+        assertThat(request.getMethod(), is("GET"));
+    }
+
+    @Test
+    public void testSubTasksByYaml()
+            throws Exception
+    {
+        Config bodyConfig = loadYamlResource("acceptance/http_call/child.dig");
+        httpMockWebServer.enqueue(
+                new MockResponse()
+                .addHeader("Content-Type: application/x-yaml")
+                .setBody(formatYaml(bodyConfig)));
+        String uri = "http://localhost:" + httpMockWebServer.getPort() + "/test";
+        runWorkflow(folder, "acceptance/http_call/http_call.dig", ImmutableMap.of(
+                    "test_uri", uri,
+                    "outdir", root().toString(),
+                    "name", "child"));
+        assertThat(httpMockWebServer.getRequestCount(), is(1));
+        assertThat(Files.exists(root().resolve("child.out")), is(true));
+        RecordedRequest request = httpMockWebServer.takeRequest();
+        assertThat(request.getMethod(), is("GET"));
+    }
+
+    private String formatYaml(Config value)
+    {
+        try {
+            StringWriter writer = new StringWriter();
+            try (YAMLGenerator out = new YAMLFactory().createGenerator(writer)) {
+                objectMapper().writeValue(out, value);
+            }
+            return writer.toString();
+        }
+        catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @Test
+    public void testSubTasksByInvalidJson()
+            throws Exception
+    {
+        httpMockWebServer.enqueue(
+                new MockResponse()
+                .addHeader("Content-Type: application/json")
+                .setBody("!invalid!"));
+        String uri = "http://localhost:" + httpMockWebServer.getPort() + "/test";
+        runWorkflow(folder, "acceptance/http_call/http_call.dig", ImmutableMap.of(
+                    "test_uri", uri,
+                    "outdir", root().toString(),
+                    "name", "child"), ImmutableMap.of(), 1);
+    }
+
+    @Test
+    public void testSubTasksByInvalidYaml()
+            throws Exception
+    {
+        httpMockWebServer.enqueue(
+                new MockResponse()
+                .addHeader("Content-Type: application/x-yaml")
+                .setBody("!invalid!"));
+        String uri = "http://localhost:" + httpMockWebServer.getPort() + "/test";
+        runWorkflow(folder, "acceptance/http_call/http_call.dig", ImmutableMap.of(
+                    "test_uri", uri,
+                    "outdir", root().toString(),
+                    "name", "child"), ImmutableMap.of(), 1);
+    }
+
+    @Test
+    public void testSubTasksWithQueryString()
+            throws Exception
+    {
+        Config bodyConfig = loadYamlResource("acceptance/http_call/child.dig");
+        httpMockWebServer.enqueue(
+                new MockResponse()
+                .addHeader("Content-Type: application/json")
+                .setBody(bodyConfig.toString()));
+        String uri = "http://localhost:" + httpMockWebServer.getPort() + "/test";
+        runWorkflow(folder, "acceptance/http_call/http_call_query.dig", ImmutableMap.of(
+                    "test_uri", uri,
+                    "outdir", root().toString(),
+                    "name", "child"));
+        assertThat(httpMockWebServer.getRequestCount(), is(1));
+        assertThat(Files.exists(root().resolve("child.out")), is(true));
+        RecordedRequest request = httpMockWebServer.takeRequest();
+        assertThat(request.getMethod(), is("GET"));
+        assertThat(request.getRequestUrl().queryParameter("k"), is("v"));
+        assertThat(request.getRequestUrl().queryParameter("foo"), is("bar"));
+    }
+
+    @Test
+    public void testSubTasksByPost()
+            throws Exception
+    {
+        Config bodyConfig = loadYamlResource("acceptance/http_call/child.dig");
+        httpMockWebServer.enqueue(
+                new MockResponse()
+                .addHeader("Content-Type: application/json")
+                .setBody(bodyConfig.toString()));
+        String uri = "http://localhost:" + httpMockWebServer.getPort() + "/test";
+        runWorkflow(folder, "acceptance/http_call/http_call_post.dig", ImmutableMap.of(
+                    "test_uri", uri,
+                    "outdir", root().toString(),
+                    "name", "child"));
+        assertThat(httpMockWebServer.getRequestCount(), is(1));
+        assertThat(Files.exists(root().resolve("child.out")), is(true));
+        RecordedRequest request = httpMockWebServer.takeRequest();
+        assertThat(request.getMethod(), is("POST"));
+        assertThat(request.getBody().readUtf8(), is("{\"k\":\"v\",\"foo\":\"bar\"}"));
+    }
+
+    @Test
+    public void testSystemProxy()
+            throws Exception
+    {
+        proxy = TestUtils.startRequestFailingProxy(1, requests);
+        httpMockWebServer.enqueue(
+                new MockResponse()
+                .addHeader("Content-Type: application/json")
+                .setBody("{}"));
+        String uri = "http://localhost:" + httpMockWebServer.getPort() + "/test";
+        runWorkflow(folder, "acceptance/http_call/http_call.dig",
+                ImmutableMap.of(
+                        "test_uri", uri
+                ),
+                ImmutableMap.of(
+                        "config.http.proxy.enabled", "true",
+                        "config.http.proxy.host", "localhost",
+                        "config.http.proxy.port", Integer.toString(proxy.getListenAddress().getPort())
+                ));
+        assertThat(httpMockWebServer.getRequestCount(), is(1));
+        assertThat(requests.get(uri), is(not(empty())));
+    }
+
+    @Test
+    public void testUserProxy()
+            throws Exception
+    {
+        proxy = TestUtils.startRequestFailingProxy(1, requests);
+        httpMockWebServer.enqueue(
+                new MockResponse()
+                .addHeader("Content-Type: application/json")
+                .setBody("{}"));
+        String uri = "http://localhost:" + httpMockWebServer.getPort() + "/test";
+        runWorkflow(folder, "acceptance/http_call/http_call.dig",
+                ImmutableMap.of(
+                        "test_uri", uri,
+                        "http.proxy.enabled", "true",
+                        "http.proxy.host", "localhost",
+                        "http.proxy.port", Integer.toString(proxy.getListenAddress().getPort())
+                ));
+        assertThat(httpMockWebServer.getRequestCount(), is(1));
+        assertThat(requests.get("GET " + uri), is(not(nullValue())));
+        assertThat(requests.get("GET " + uri), is(not(empty())));
+    }
+}

--- a/digdag-tests/src/test/resources/acceptance/http_call/child.dig
+++ b/digdag-tests/src/test/resources/acceptance/http_call/child.dig
@@ -1,0 +1,2 @@
++hello:
+  sh>: pwd > ${outdir}/${name}.out

--- a/digdag-tests/src/test/resources/acceptance/http_call/http_call.dig
+++ b/digdag-tests/src/test/resources/acceptance/http_call/http_call.dig
@@ -1,0 +1,2 @@
++http_call:
+  http_call>: ${test_uri}

--- a/digdag-tests/src/test/resources/acceptance/http_call/http_call_post.dig
+++ b/digdag-tests/src/test/resources/acceptance/http_call/http_call_post.dig
@@ -1,0 +1,6 @@
++http_call:
+  http_call>: ${test_uri}
+  method: POST
+  content:
+    k: v
+    foo: bar

--- a/digdag-tests/src/test/resources/acceptance/http_call/http_call_query.dig
+++ b/digdag-tests/src/test/resources/acceptance/http_call/http_call_query.dig
@@ -1,0 +1,5 @@
++http_call:
+  http_call>: ${test_uri}
+  query:
+    k: v
+    foo: bar


### PR DESCRIPTION
This new `http_call>` operator is useful when a web application wants to
use digdag as its background execution engine and the web application
wants to manage parameters for the execution.

Here is example usage:

1. Workflow calls web app using http_call operator.
2. Web app generates a workflow with some parameters embedded.
3. http_call operator runs the returned workflow as subtasks.
4. Optionally, the web app appends http operator at the end of the
generated workflow so that web app receives a callback.