### PR TITLE
Add job_retry parameter to td query operators

### DIFF
--- a/digdag-docs/src/operators/td.md
+++ b/digdag-docs/src/operators/td.md
@@ -154,9 +154,8 @@
 
   Set automatic job retry count (default: 0).
 
-.. note::
+  We recommend that you not set retry count over 10. If the job is not succeessful less than 10 times retry, it needs some fix a cause of failure.
 
-    We recommend that you not set retry count over 10. If the job is not succeessful less than 10 times retry, it needs some fix a cause of failure.
 
 * **result_connection**: NAME
 

--- a/digdag-docs/src/operators/td.md
+++ b/digdag-docs/src/operators/td.md
@@ -150,6 +150,10 @@
 
   Set Priority (From `-2` (VERY LOW) to `2` (VERY HIGH) , default: 0 (NORMAL)).
 
+* **job_retry**: 0
+
+  Set automatic job retry count (From `0` to `10` times , default: 0).
+
 * **result_connection**: NAME
 
   Use a connection to write the query results to an external system.

--- a/digdag-docs/src/operators/td.md
+++ b/digdag-docs/src/operators/td.md
@@ -152,7 +152,11 @@
 
 * **job_retry**: 0
 
-  Set automatic job retry count (From `0` to `10` times , default: 0).
+  Set automatic job retry count (default: 0).
+
+.. note::
+
+    We recommend that you not set retry count over 10. If the job is not succeessful less than 10 times retry, it needs some fix a cause of failure.
 
 * **result_connection**: NAME
 

--- a/digdag-docs/src/operators/td.md
+++ b/digdag-docs/src/operators/td.md
@@ -156,7 +156,6 @@
 
   We recommend that you not set retry count over 10. If the job is not succeessful less than 10 times retry, it needs some fix a cause of failure.
 
-
 * **result_connection**: NAME
 
   Use a connection to write the query results to an external system.

--- a/digdag-docs/src/operators/td_for_each.md
+++ b/digdag-docs/src/operators/td_for_each.md
@@ -70,6 +70,10 @@ For example, if you run a query `select email, name from users` and the query re
 
   Set Priority (From `-2` (VERY LOW) to `2` (VERY HIGH) , default: 0 (NORMAL)).
 
+* **job_retry**: 0
+
+  Set automatic job retry count (From `0` to `10` times , default: 0).
+
 * **presto_pool_name**: NAME
 
   Name of a resource pool to run the query in.

--- a/digdag-docs/src/operators/td_for_each.md
+++ b/digdag-docs/src/operators/td_for_each.md
@@ -72,7 +72,11 @@ For example, if you run a query `select email, name from users` and the query re
 
 * **job_retry**: 0
 
-  Set automatic job retry count (From `0` to `10` times , default: 0).
+  Set automatic job retry count (default: 0).
+
+.. note::
+
+    We recommend that you not set retry count over 10. If the job is not succeessful less than 10 times retry, it needs some fix a cause of failure.
 
 * **presto_pool_name**: NAME
 

--- a/digdag-docs/src/operators/td_for_each.md
+++ b/digdag-docs/src/operators/td_for_each.md
@@ -74,9 +74,7 @@ For example, if you run a query `select email, name from users` and the query re
 
   Set automatic job retry count (default: 0).
 
-.. note::
-
-    We recommend that you not set retry count over 10. If the job is not succeessful less than 10 times retry, it needs some fix a cause of failure.
+  We recommend that you not set retry count over 10. If the job is not succeessful less than 10 times retry, it needs some fix a cause of failure.
 
 * **presto_pool_name**: NAME
 

--- a/digdag-docs/src/operators/td_wait.md
+++ b/digdag-docs/src/operators/td_wait.md
@@ -78,7 +78,11 @@ Example queries:
 
 * **job_retry**: 0
 
-  Set automatic job retry count (From `0` to `10` times , default: 0).
+  Set automatic job retry count (default: 0).
+
+.. note::
+
+    We recommend that you not set retry count over 10. If the job is not succeessful less than 10 times retry, it needs some fix a cause of failure.
 
 * **presto_pool_name**: NAME
 

--- a/digdag-docs/src/operators/td_wait.md
+++ b/digdag-docs/src/operators/td_wait.md
@@ -76,6 +76,10 @@ Example queries:
 
   Set Priority (From `-2` (VERY LOW) to `2` (VERY HIGH) , default: 0 (NORMAL)).
 
+* **job_retry**: 0
+
+  Set automatic job retry count (From `0` to `10` times , default: 0).
+
 * **presto_pool_name**: NAME
 
   Name of a resource pool to run the queries in.

--- a/digdag-docs/src/operators/td_wait.md
+++ b/digdag-docs/src/operators/td_wait.md
@@ -80,9 +80,7 @@ Example queries:
 
   Set automatic job retry count (default: 0).
 
-.. note::
-
-    We recommend that you not set retry count over 10. If the job is not succeessful less than 10 times retry, it needs some fix a cause of failure.
+  We recommend that you not set retry count over 10. If the job is not succeessful less than 10 times retry, it needs some fix a cause of failure.
 
 * **presto_pool_name**: NAME
 

--- a/digdag-docs/src/operators/td_wait_table.md
+++ b/digdag-docs/src/operators/td_wait_table.md
@@ -84,9 +84,7 @@
 
   Set automatic job retry count (default: 0).
 
-.. note::
-
-    We recommend that you not set retry count over 10. If the job is not succeessful less than 10 times retry, it needs some fix a cause of failure.
+  We recommend that you not set retry count over 10. If the job is not succeessful less than 10 times retry, it needs some fix a cause of failure.
 
 * **presto_pool_name**: NAME
 

--- a/digdag-docs/src/operators/td_wait_table.md
+++ b/digdag-docs/src/operators/td_wait_table.md
@@ -80,6 +80,10 @@
 
   Set Priority (From `-2` (VERY LOW) to `2` (VERY HIGH) , default: 0 (NORMAL)).
 
+* **job_retry**: 0
+
+  Set automatic job retry count (From `0` to `10` times , default: 0).
+
 * **presto_pool_name**: NAME
 
   Name of a resource pool to run the queries in.

--- a/digdag-docs/src/operators/td_wait_table.md
+++ b/digdag-docs/src/operators/td_wait_table.md
@@ -82,7 +82,11 @@
 
 * **job_retry**: 0
 
-  Set automatic job retry count (From `0` to `10` times , default: 0).
+  Set automatic job retry count (default: 0).
+
+.. note::
+
+    We recommend that you not set retry count over 10. If the job is not succeessful less than 10 times retry, it needs some fix a cause of failure.
 
 * **presto_pool_name**: NAME
 


### PR DESCRIPTION
`td>`, `td_wait>`, `td_wait_table>` and `td_for_each>` operators support `job_retry` parameter which  is used for count of retry upon failure.
https://github.com/treasure-data/digdag/search?q=job_retry&unscoped_q=job_retry

It's better to be explained in documentation.