### PR TITLE
Issue #1079: Moved the Authenticator interface to the SPI module.

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/Server.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Server.java
@@ -133,7 +133,7 @@ public class Server
         Properties props = buildServerProperties();
         ConfigElement ce = PropertyUtils.toConfigElement(props);
         ServerConfig serverConfig = ServerConfig.convertFrom(ce);
-        ServerBootstrap.start(new ServerBootstrap(version, serverConfig));
+        ServerBootstrap.start(new ServerBootstrap(version, serverConfig, loadSystemPlugins(props)));
     }
 
     protected Properties buildServerProperties()

--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -343,6 +343,7 @@ In the config file, following parameters are available
 * server.http.enable-http2 (enable HTTP/2. default: false)
 * server.http.headers.KEY = VALUE (HTTP header to set on API responses)
 * server.jmx.port (port to listen JMX in integer. default: JMX is disabled)
+* server.authenticator-class (string) The FQCN of the ``io.digdag.spi.Authenticator`` implementation to use. The implementation is to be provided by a system plugin. The auth plugin configuration is implementation specific. Default: ``io.digdag.standards.auth.jwt.JwtAuthenticator``
 * database.type (enum, "h2" or "postgresql")
 * database.user (string)
 * database.password (string)

--- a/digdag-docs/src/internal.md
+++ b/digdag-docs/src/internal.md
@@ -114,7 +114,7 @@ Extension needs least code to make some extension possible. But it's the hardest
 
 A typical use case is for system integrators to customize digdag for their internal use.
 
-Many of customization points in digdag are assuming Extension to override (e.g. `io.digdag.server.Authenticator`) because it needs less code. But for ease of use, they should also accept system plugins, eventually.
+Many of customization points in digdag are assuming Extension to override (i.e. most of what's bound using guice) because it needs less code. But for ease of use, they should also accept system plugins, eventually.
 
 
 ### System plugins

--- a/digdag-server/src/main/java/io/digdag/server/AuthRequestFilter.java
+++ b/digdag-server/src/main/java/io/digdag/server/AuthRequestFilter.java
@@ -4,6 +4,7 @@ import com.google.common.base.Suppliers;
 import com.google.common.collect.ImmutableMap;
 import com.google.inject.Inject;
 import io.digdag.client.config.ConfigFactory;
+import io.digdag.spi.Authenticator;
 
 import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.container.ContainerRequestContext;

--- a/digdag-server/src/main/java/io/digdag/server/ServerBootstrap.java
+++ b/digdag-server/src/main/java/io/digdag/server/ServerBootstrap.java
@@ -10,6 +10,7 @@ import io.digdag.client.Version;
 import io.digdag.client.config.Config;
 import io.digdag.core.agent.ExtractArchiveWorkspaceManager;
 import io.digdag.core.agent.WorkspaceManager;
+import io.digdag.core.plugin.PluginSet;
 import io.digdag.guice.rs.GuiceRsServerControl;
 import io.digdag.guice.rs.server.undertow.UndertowServer;
 import io.digdag.guice.rs.server.undertow.UndertowServerControl;
@@ -30,11 +31,18 @@ public class ServerBootstrap
 
     protected final Version version;
     protected final ServerConfig serverConfig;
+    private final PluginSet systemPlugins;
 
-    public ServerBootstrap(Version version, ServerConfig serverConfig)
+    public ServerBootstrap(Version version, ServerConfig serverConfig, PluginSet systemPlugins)
     {
         this.version = version;
         this.serverConfig = serverConfig;
+        this.systemPlugins = systemPlugins;
+    }
+
+    public ServerBootstrap(Version version, ServerConfig serverConfig)
+    {
+        this(version, serverConfig, PluginSet.empty());
     }
 
     @Override
@@ -49,7 +57,7 @@ public class ServerBootstrap
         return new DigdagEmbed.Bootstrap()
             .setEnvironment(serverConfig.getEnvironment())
             .setSystemConfig(serverConfig.getSystemConfig())
-            //.setSystemPlugins(loadSystemPlugins(serverConfig.getSystemConfig()))
+            .setSystemPlugins(systemPlugins)
             .overrideModulesWith((binder) -> {
                 binder.bind(WorkspaceManager.class).to(ExtractArchiveWorkspaceManager.class).in(Scopes.SINGLETON);
                 binder.bind(Version.class).toInstance(version);

--- a/digdag-server/src/main/java/io/digdag/server/ServerConfig.java
+++ b/digdag-server/src/main/java/io/digdag/server/ServerConfig.java
@@ -29,6 +29,7 @@ public interface ServerConfig
     public static final int DEFAULT_PORT = 65432;
     public static final String DEFAULT_BIND = "127.0.0.1";
     public static final String DEFAULT_ACCESS_LOG_PATTERN = "json";
+    public static final String DEFAULT_AUTHENTICATOR_CLASS = "io.digdag.standards.auth.jwt.JwtAuthenticator";
 
     public Optional<String> getServerRuntimeInfoPath();
 
@@ -50,12 +51,15 @@ public interface ServerConfig
 
     public Map<String,String> getEnvironment();
 
+    public String getAuthenticatorClass();
+
     public static ImmutableServerConfig.Builder defaultBuilder()
     {
         return ImmutableServerConfig.builder()
             .port(DEFAULT_PORT)
             .bind(DEFAULT_BIND)
             .accessLogPattern(DEFAULT_ACCESS_LOG_PATTERN)
+            .authenticatorClass(DEFAULT_AUTHENTICATOR_CLASS)
             .executorEnabled(true);
     }
 
@@ -91,6 +95,7 @@ public interface ServerConfig
             .headers(readPrefixed.apply("server.http.headers."))
             .systemConfig(ConfigElement.copyOf(config))  // systemConfig needs to include other keys such as server.port so that ServerBootstrap.initialize can recover ServerConfig from this systemConfig
             .environment(readPrefixed.apply("server.environment."))
+            .authenticatorClass(config.get("server.authenticator-class", String.class, DEFAULT_AUTHENTICATOR_CLASS))
             .build();
     }
 

--- a/digdag-server/src/test/java/io/digdag/server/AuthRequestFilterTest.java
+++ b/digdag-server/src/test/java/io/digdag/server/AuthRequestFilterTest.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableMap;
 import io.digdag.client.DigdagClient;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigFactory;
+import io.digdag.spi.Authenticator;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/digdag-server/src/test/java/io/digdag/server/AuthenticatorTest.java
+++ b/digdag-server/src/test/java/io/digdag/server/AuthenticatorTest.java
@@ -4,6 +4,7 @@ import com.google.common.base.Optional;
 import io.digdag.client.DigdagClient;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigFactory;
+import io.digdag.spi.Authenticator;
 import org.junit.Test;
 
 import static org.hamcrest.Matchers.is;

--- a/digdag-spi/src/main/java/io/digdag/spi/Authenticator.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/Authenticator.java
@@ -1,4 +1,4 @@
-package io.digdag.server;
+package io.digdag.spi;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;

--- a/digdag-standards/src/main/java/io/digdag/standards/auth/jwt/JwtAuthenticatorConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/auth/jwt/JwtAuthenticatorConfig.java
@@ -1,0 +1,21 @@
+package io.digdag.standards.auth.jwt;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.immutables.value.Value;
+
+import java.util.Map;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableJwtAuthenticatorConfig.class)
+@JsonDeserialize(as = ImmutableJwtAuthenticatorConfig.class)
+public abstract class JwtAuthenticatorConfig
+{
+    public abstract Map<String, UserConfig> getUserMap();
+
+    public abstract boolean isAllowPublicAccess();
+
+    public static ImmutableJwtAuthenticatorConfig.Builder builder() {
+        return ImmutableJwtAuthenticatorConfig.builder();
+    }
+}

--- a/digdag-standards/src/main/java/io/digdag/standards/auth/jwt/JwtAuthenticatorConfigProvider.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/auth/jwt/JwtAuthenticatorConfigProvider.java
@@ -1,0 +1,48 @@
+package io.digdag.standards.auth.jwt;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import io.digdag.client.api.RestApiKey;
+import io.digdag.client.config.Config;
+
+public class JwtAuthenticatorConfigProvider
+        implements Provider<JwtAuthenticatorConfig>
+{
+
+    private final Config systemConfig;
+
+    @Inject
+    public JwtAuthenticatorConfigProvider(Config systemConfig)
+    {
+        this.systemConfig = systemConfig;
+    }
+
+    @Override
+    public JwtAuthenticatorConfig get()
+    {
+        ImmutableJwtAuthenticatorConfig.Builder builder = JwtAuthenticatorConfig.builder();
+
+        Optional<RestApiKey> apiKey = systemConfig.getOptional("server.apikey", RestApiKey.class);
+
+        if (apiKey.isPresent()) {
+            UserConfig user = UserConfig.builder()
+                    .siteId(0)
+                    .isAdmin(true)
+                    .apiKey(apiKey.get())
+                    .build();
+
+            builder
+                    .userMap(ImmutableMap.of(user.getApiKey().getIdString(), user))
+                    .isAllowPublicAccess(false);
+        }
+        else {
+            builder
+                    .userMap(ImmutableMap.of())
+                    .isAllowPublicAccess(true);
+        }
+
+        return builder.build();
+    }
+}

--- a/digdag-standards/src/main/java/io/digdag/standards/auth/jwt/JwtAuthenticatorPlugin.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/auth/jwt/JwtAuthenticatorPlugin.java
@@ -1,0 +1,26 @@
+package io.digdag.standards.auth.jwt;
+
+import com.google.inject.Binder;
+import io.digdag.spi.Authenticator;
+import io.digdag.spi.Plugin;
+
+public class JwtAuthenticatorPlugin
+        implements Plugin
+{
+    @Override
+    public <T> Class<? extends T> getServiceProvider(Class<T> type)
+    {
+        if (type == Authenticator.class) {
+            return JwtAuthenticator.class.asSubclass(type);
+        }
+        else {
+            return null;
+        }
+    }
+
+    @Override
+    public <T> void configureBinder(Class<T> type, Binder binder)
+    {
+        binder.bind(JwtAuthenticatorConfig.class).toProvider(JwtAuthenticatorConfigProvider.class).asEagerSingleton();
+    }
+}

--- a/digdag-standards/src/main/java/io/digdag/standards/auth/jwt/UserConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/auth/jwt/UserConfig.java
@@ -1,4 +1,4 @@
-package io.digdag.server;
+package io.digdag.standards.auth.jwt;
 
 import io.digdag.client.api.RestApiKey;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;

--- a/digdag-standards/src/main/resources/META-INF/services/io.digdag.spi.Plugin
+++ b/digdag-standards/src/main/resources/META-INF/services/io.digdag.spi.Plugin
@@ -1,1 +1,2 @@
 io.digdag.standards.td.TdDigdagClientConfigurationPlugin
+io.digdag.standards.auth.jwt.JwtAuthenticatorPlugin


### PR DESCRIPTION
Content:
- Moved the Authenticator interface to the SPI module.
- Made the Authenticator implementations to be provided as system plugins.
- Refactored the JwtAuthenticator into a plugin and made it the default one to keep everything backward compatible.


Notes:
- Didn't move `io.digdag.server.AuthenticatorTest` to the SPI module as there's no tests in there. Is it worth creating a test directory in SPI for that test class?

- It's currently impossible to load only a specific implementation of a system plugin if there's more than one implemention of the same interface. To get an instance of a specific implementation, `io.digdag.core.plugin.PluginSet` requires to load them all first. While not a big deal for auth at the moment, that's not ideal. Ideally we'd only load the plugin the user wants based on the configuration.
This would require its own refactor (for example `io.digdag.core.plugin.PluginSet` not to getInstance() on the plugins as the only option).
This has at least 2 drawbacks:
  * Wasting memory.
  * The additional code required by the plugins to expect a missing configuration: a user will configure one plugin and not the other one, but more than one plugin might be in the classpath and will be loaded anyway.
