### PR TITLE
[v0.10] Not pass system environment variables to command executor implicitly

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/operator/PyOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/PyOperatorFactory.java
@@ -197,7 +197,6 @@ public class PyOperatorFactory
             }
 
             final Map<String, String> environments = Maps.newHashMap();
-            environments.putAll(System.getenv());
             CommandOperators.collectEnvironmentVariables(environments, context.getPrivilegedVariables());
 
             final CommandRequest commandRequest = buildCommandRequest(commandContext, workingDirectory, tempDir, environments, cmdline);

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/RbOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/RbOperatorFactory.java
@@ -200,7 +200,6 @@ public class RbOperatorFactory
             }
 
             final Map<String, String> environments = Maps.newHashMap();
-            environments.putAll(System.getenv());
             CommandOperators.collectEnvironmentVariables(environments, context.getPrivilegedVariables());
 
             final CommandRequest commandRequest = buildCommandRequest(commandContext, workingDirectory, tempDir, environments, cmdline.build());

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/ShOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/ShOperatorFactory.java
@@ -156,7 +156,6 @@ public class ShOperatorFactory
                     .format(context.getSecrets());
 
             final Map<String, String> environments = Maps.newHashMap();
-            environments.putAll(System.getenv());
             params.getKeys()
                 .forEach(key -> {
                     if (CommandOperators.isValidEnvKey(key)) {


### PR DESCRIPTION
In v0.10, we will introduce new command executor SPI and a few implementations of remote command executors, which execute code by scripting operators on remote environment from digdag-server. system environment variable passed from digdag-server don't make sense for code. We'd better not pass them to command executor implicitly. "_env" still enables passing them to the code.

This change may break the backward compatibility of the behavior of DockerCommandExecutor. Because v0.10's DockerCommandExecutor will not pass system envs to code implicitly. Instead SimpleCommandExecutor automatically and implicitly passes them to code. That same behavior as current.