### PR TITLE
Add max_interval to exponential retrying option

### DIFF
--- a/digdag-core/src/test/resources/io/digdag/core/workflow/retry_exponential.dig
+++ b/digdag-core/src/test/resources/io/digdag/core/workflow/retry_exponential.dig
@@ -1,0 +1,8 @@
++retrying:
+  _retry:
+    interval_type: exponential
+    limit: 6
+    interval: 1
+    max_interval: 2
+  +fail:
+    fail>: task failed expectedly at ${moment().valueOf() / 1000}

--- a/digdag-plugin-utils/src/main/java/io/digdag/util/RetryControl.java
+++ b/digdag-plugin-utils/src/main/java/io/digdag/util/RetryControl.java
@@ -1,9 +1,9 @@
 package io.digdag.util;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Optional;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigException;
-//import io.digdag.core.workflow.TaskConfig;
 
 public class RetryControl
 {
@@ -12,13 +12,19 @@ public class RetryControl
         return new RetryControl(config, stateParams, enableByDefault);
     }
 
-    private enum RetryIntervalType {
+    private enum RetryIntervalType
+    {
         CONSTATNT("constant"), EXPONENTIAL("exponential");
+
         String type;
-        private RetryIntervalType(final String type) {
+
+        private RetryIntervalType(final String type)
+        {
             this.type = type;
         }
-        public static RetryIntervalType find(String value) {
+
+        public static RetryIntervalType find(String value)
+        {
             for (RetryIntervalType r : RetryIntervalType.values()) {
                 if (r.type.equalsIgnoreCase(value)) {
                     return r;
@@ -32,16 +38,8 @@ public class RetryControl
     private final int retryLimit;
     private final int retryCount;
     private final int retryInterval;
+    private final Optional<Integer> maxRetryInterval;
     private final RetryIntervalType retryIntervalType;
-
-    private int intValueTextual(JsonNode node){
-        if(node.isTextual()){
-            return Integer.parseInt(node.asText());
-        }
-        else {
-            return node.intValue();
-        }
-    }
 
     private RetryControl(Config config, Config stateParams, boolean enableByDefault)
     {
@@ -49,36 +47,33 @@ public class RetryControl
         this.stateParams = stateParams;
         this.retryCount = stateParams.get("retry_count", int.class, 0);
 
-        final JsonNode retry = config.getInternalObjectNode().get("_retry");
+        final JsonNode retryNode = config.getInternalObjectNode().get("_retry");
         try {
-            if (retry == null) {  // No _retry description. default.
+            if (retryNode == null) {  // No _retry description. default.
                 this.retryLimit = enableByDefault ? 3 : 0;
                 this.retryInterval = 0;
+                this.maxRetryInterval = Optional.absent();
                 this.retryIntervalType = RetryIntervalType.CONSTATNT;
             }
-            else if (retry.isNumber() || retry.isTextual()) {  // Only limit is set.
-                //If set as variable ${..}, the value become text. So text data is also accepted.
-                this.retryLimit = intValueTextual(retry);
+            else if (retryNode.isNumber() || retryNode.isTextual()) {  // Only limit is set.
+                // If set as variable ${..}, the value become text. Here uses Config.get(type, key)
+                // to get retryLimit so that text is also accepted.
+                this.retryLimit = config.get("_retry", int.class);
                 this.retryInterval = 0;
+                this.maxRetryInterval = Optional.absent();
                 this.retryIntervalType = RetryIntervalType.CONSTATNT;
             }
-            else if (retry.isObject()) {  // json format
-                this.retryLimit = intValueTextual(retry.get("limit"));
-                if (retry.has("interval")) {
-                    this.retryInterval = intValueTextual(retry.get("interval"));
-                }
-                else {
-                    this.retryInterval = 0;
-                }
-                if (retry.has("interval_type")) {
-                    this.retryIntervalType = RetryIntervalType.find(retry.get("interval_type").textValue());
-                }
-                else {
-                    this.retryIntervalType = RetryIntervalType.CONSTATNT;
-                }
+            else if (retryNode.isObject()) {  // json format
+                Config retry = config.getNested("_retry");
+                this.retryLimit = retry.get("limit", int.class);
+                this.retryInterval = retry.getOptional("interval", int.class).or(0).intValue();
+                this.maxRetryInterval = retry.getOptional("max_interval", int.class);
+                this.retryIntervalType = retry.getOptional("interval_type", String.class)
+                    .transform(RetryIntervalType::find)
+                    .or(RetryIntervalType.CONSTATNT);
             }
             else {  // Unknown format
-                throw new ConfigException(String.format("Invalid _retry format:%s", retry.toString()));
+                throw new ConfigException(String.format("Invalid _retry format:%s", retryNode.toString()));
             }
         }
         catch(NumberFormatException nfe) {
@@ -98,7 +93,10 @@ public class RetryControl
                 interval = retryInterval;
                 break;
             case EXPONENTIAL:
-                interval = retryInterval * (int)Math.pow(2, retryCount);
+                interval = retryInterval * (int) Math.pow(2, retryCount);
+                if (maxRetryInterval.isPresent()) {
+                    interval = Math.min(interval, maxRetryInterval.get());
+                }
                 break;
         }
         return interval;


### PR DESCRIPTION
With exponential back-off, retry interval grows rapidly. It leads too
long interval. New max_interval option solves it by capping the interval
by a given duration.