### PR TITLE
Add project_id to spi.ac.ProjectTarget

### DIFF
--- a/digdag-server/src/main/java/io/digdag/server/ac/DefaultAccessController.java
+++ b/digdag-server/src/main/java/io/digdag/server/ac/DefaultAccessController.java
@@ -3,7 +3,9 @@ package io.digdag.server.ac;
 import io.digdag.spi.AuthenticatedUser;
 import io.digdag.spi.ac.AccessControlException;
 import io.digdag.spi.ac.AccessController;
+import io.digdag.spi.ac.AttemptTarget;
 import io.digdag.spi.ac.ProjectTarget;
+import io.digdag.spi.ac.ScheduleTarget;
 import io.digdag.spi.ac.SecretTarget;
 import io.digdag.spi.ac.SiteTarget;
 import io.digdag.spi.ac.WorkflowTarget;
@@ -153,7 +155,7 @@ public class DefaultAccessController
     { }
 
     @Override
-    public void checkKillAttempt(WorkflowTarget target, AuthenticatedUser user)
+    public void checkKillAttempt(AttemptTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
@@ -190,22 +192,22 @@ public class DefaultAccessController
     { }
 
     @Override
-    public void checkSkipSchedule(WorkflowTarget target, AuthenticatedUser user)
+    public void checkSkipSchedule(ScheduleTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public void checkBackfillSchedule(WorkflowTarget target, AuthenticatedUser user)
+    public void checkBackfillSchedule(ScheduleTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public void checkDisableSchedule(WorkflowTarget target, AuthenticatedUser user)
+    public void checkDisableSchedule(ScheduleTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public void checkEnableSchedule(WorkflowTarget target, AuthenticatedUser user)
+    public void checkEnableSchedule(ScheduleTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 }

--- a/digdag-server/src/main/java/io/digdag/server/rs/AttemptResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/AttemptResource.java
@@ -120,7 +120,7 @@ public class AttemptResource
                 else {
                     // of project
 
-                    final ProjectTarget projTarget = ProjectTarget.of(getSiteId(), projName);
+                    final ProjectTarget projTarget = ProjectTarget.of(getSiteId(), projName, proj.getId());
                     ac.checkListSessionsOfProject(projTarget, getAuthenticatedUser()); // AccessControl
                     attempts = ss.getAttemptsOfProject(includeRetried, proj.getId(), validPageSize, Optional.fromNullable(lastId),
                             ac.getListSessionsFilterOfProject(

--- a/digdag-server/src/main/java/io/digdag/server/rs/AttemptResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/AttemptResource.java
@@ -33,6 +33,7 @@ import io.digdag.client.api.*;
 import io.digdag.spi.ac.AccessControlException;
 import io.digdag.spi.ac.AccessController;
 import io.digdag.spi.ScheduleTime;
+import io.digdag.spi.ac.AttemptTarget;
 import io.digdag.spi.ac.ProjectTarget;
 import io.digdag.spi.ac.SiteTarget;
 import io.digdag.spi.ac.WorkflowTarget;
@@ -335,7 +336,7 @@ public class AttemptResource
                     .getProjectById(attempt.getSession().getProjectId()); // to build WorkflowTarget
 
             ac.checkKillAttempt( // AccessControl
-                    WorkflowTarget.of(getSiteId(), proj.getName(), attempt.getSession().getWorkflowName()),
+                    AttemptTarget.of(getSiteId(), proj.getName(), attempt.getSession().getWorkflowName(), attempt.getSessionId(), attempt.getId()),
                     getAuthenticatedUser());
 
             boolean updated = executor.killAttemptById(getSiteId(), id); // should never throw NotFound

--- a/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
@@ -210,7 +210,7 @@ public class ProjectResource
             StoredRevision rev = ps.getLatestRevision(proj.getId()); // check NotFound first
 
             ac.checkGetProject( // AccessControl
-                    ProjectTarget.of(getSiteId(), proj.getName()),
+                    ProjectTarget.of(getSiteId(), proj.getName(), proj.getId()),
                     getAuthenticatedUser());
 
             return RestModels.project(proj, rev);
@@ -231,7 +231,7 @@ public class ProjectResource
                     StoredRevision rev = ps.getLatestRevision(proj.getId()); // check NotFound first
 
                     ac.checkGetProject( // AccessControl
-                            ProjectTarget.of(getSiteId(), proj.getName()),
+                            ProjectTarget.of(getSiteId(), proj.getName(), proj.getId()),
                             getAuthenticatedUser());
 
                     collection = ImmutableList.of(RestModels.project(proj, rev));
@@ -291,7 +291,7 @@ public class ProjectResource
             StoredRevision rev = ps.getLatestRevision(proj.getId()); // check NotFound first
 
             ac.checkGetProject( // AccessControl
-                    ProjectTarget.of(getSiteId(), proj.getName()),
+                    ProjectTarget.of(getSiteId(), proj.getName(), proj.getId()),
                     getAuthenticatedUser());
 
             return RestModels.project(proj, rev);
@@ -309,7 +309,7 @@ public class ProjectResource
             List<StoredRevision> revs = ps.getRevisions(proj.getId(), 100, Optional.fromNullable(lastId));
 
             ac.checkGetProject( // AccessControl
-                    ProjectTarget.of(getSiteId(), proj.getName()),
+                    ProjectTarget.of(getSiteId(), proj.getName(), proj.getId()),
                     getAuthenticatedUser());
 
             return RestModels.revisionCollection(proj, revs);
@@ -391,7 +391,7 @@ public class ProjectResource
             }
             else {
                 // of project
-                final ProjectTarget projTarget = ProjectTarget.of(getSiteId(), proj.getName());
+                final ProjectTarget projTarget = ProjectTarget.of(getSiteId(), proj.getName(), proj.getId());
 
                 try {
                     ac.checkListWorkflowsOfProject( // AccessControl
@@ -450,7 +450,7 @@ public class ProjectResource
             else {
                 // of project
 
-                final ProjectTarget projTarget = ProjectTarget.of(getSiteId(), proj.getName());
+                final ProjectTarget projTarget = ProjectTarget.of(getSiteId(), proj.getName(), proj.getId());
                 ac.checkListSchedulesOfProject( // AccessControl
                         projTarget,
                         getAuthenticatedUser());
@@ -499,7 +499,7 @@ public class ProjectResource
             else {
                 // of project
 
-                final ProjectTarget projTarget = ProjectTarget.of(getSiteId(), proj.getName());
+                final ProjectTarget projTarget = ProjectTarget.of(getSiteId(), proj.getName(), proj.getId());
                 ac.checkListSessionsOfProject( // AccessControl
                         projTarget,
                         getAuthenticatedUser());
@@ -528,7 +528,7 @@ public class ProjectResource
                     archiveManager.getArchive(ps, projId, revName); // check NotFound first
 
             ac.checkGetProjectArchive( // AccessControl
-                    ProjectTarget.of(getSiteId(), proj.getName()),
+                    ProjectTarget.of(getSiteId(), proj.getName(), proj.getId()),
                     getAuthenticatedUser());
 
             if (!archiveOrNone.isPresent()) {
@@ -588,7 +588,7 @@ public class ProjectResource
             StoredProject project = ensureNotDeletedProject(ps.getProjectById(projId)); // check NotFound first
 
             ac.checkDeleteProject( // AccessControl
-                    ProjectTarget.of(getSiteId(), project.getName()),
+                    ProjectTarget.of(getSiteId(), project.getName(), project.getId()),
                     getAuthenticatedUser());
 
             return ProjectControl.deleteProject(ps, projId, (control, proj) -> {
@@ -843,7 +843,7 @@ public class ProjectResource
             ensureNotDeletedProject(project);
 
             ac.checkGetProjectSecretList( // AccessControl
-                    ProjectTarget.of(getSiteId(), project.getName()),
+                    ProjectTarget.of(getSiteId(), project.getName(), project.getId()),
                     getAuthenticatedUser());
 
             SecretControlStore store = scsp.getSecretControlStore(getSiteId());

--- a/digdag-server/src/main/java/io/digdag/server/rs/ScheduleResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/ScheduleResource.java
@@ -22,6 +22,7 @@ import io.digdag.core.schedule.StoredSchedule;
 import io.digdag.core.session.StoredSessionAttemptWithSession;
 import io.digdag.spi.ac.AccessControlException;
 import io.digdag.spi.ac.AccessController;
+import io.digdag.spi.ac.ScheduleTarget;
 import io.digdag.spi.ac.SiteTarget;
 import io.digdag.spi.ac.WorkflowTarget;
 import io.swagger.annotations.Api;
@@ -130,7 +131,7 @@ public class ScheduleResource
             ZoneId timeZone = getTimeZoneOfSchedule(sched);
 
             ac.checkSkipSchedule( // AccessControl
-                    WorkflowTarget.of(getSiteId(), sched.getWorkflowName(), proj.getName()),
+                    ScheduleTarget.of(getSiteId(), proj.getName(), sched.getWorkflowName(), sched.getId()),
                     getAuthenticatedUser());
 
             StoredSchedule updated;
@@ -175,7 +176,7 @@ public class ScheduleResource
                     .getProjectById(sched.getProjectId()); // check NotFound first
 
             ac.checkBackfillSchedule( // AccessControl
-                    WorkflowTarget.of(getSiteId(), sched.getWorkflowName(), proj.getName()),
+                    ScheduleTarget.of(getSiteId(), proj.getName(), sched.getWorkflowName(), sched.getId()),
                     getAuthenticatedUser());
 
             List<StoredSessionAttemptWithSession> attempts =
@@ -204,7 +205,7 @@ public class ScheduleResource
                     .getProjectById(sched.getProjectId()); // check NotFound first
 
             ac.checkDisableSchedule( // AccessControl
-                    WorkflowTarget.of(getSiteId(), sched.getWorkflowName(), proj.getName()),
+                    ScheduleTarget.of(getSiteId(), proj.getName(), sched.getWorkflowName(), sched.getId()),
                     getAuthenticatedUser());
 
             StoredSchedule updated = sm.getScheduleStore(getSiteId()).updateScheduleById(id, (store, storedSchedule) -> { // should never throw NotFound
@@ -231,7 +232,7 @@ public class ScheduleResource
                     .getProjectById(sched.getProjectId()); // check NotFound first
 
             ac.checkEnableSchedule( // AccessControl
-                    WorkflowTarget.of(getSiteId(), sched.getWorkflowName(), proj.getName()),
+                    ScheduleTarget.of(getSiteId(), proj.getName(), sched.getWorkflowName(), sched.getId()),
                     getAuthenticatedUser());
 
             StoredSchedule updated = sm.getScheduleStore(getSiteId()).updateScheduleById(id, (store, storedSchedule) -> { // should never throw NotFound

--- a/digdag-spi/src/main/java/io/digdag/spi/ac/AccessController.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/ac/AccessController.java
@@ -310,7 +310,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkKillAttempt(WorkflowTarget target, AuthenticatedUser user)
+    void checkKillAttempt(AttemptTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     //
@@ -388,7 +388,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkSkipSchedule(WorkflowTarget target, AuthenticatedUser user)
+    void checkSkipSchedule(ScheduleTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     /**
@@ -398,7 +398,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkBackfillSchedule(WorkflowTarget target, AuthenticatedUser user)
+    void checkBackfillSchedule(ScheduleTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     /**
@@ -408,7 +408,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkDisableSchedule(WorkflowTarget target, AuthenticatedUser user)
+    void checkDisableSchedule(ScheduleTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     /**
@@ -418,6 +418,6 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkEnableSchedule(WorkflowTarget target, AuthenticatedUser user)
+    void checkEnableSchedule(ScheduleTarget target, AuthenticatedUser user)
             throws AccessControlException;
 }

--- a/digdag-spi/src/main/java/io/digdag/spi/ac/AttemptTarget.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/ac/AttemptTarget.java
@@ -1,0 +1,28 @@
+package io.digdag.spi.ac;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface AttemptTarget
+{
+    int getSiteId();
+
+    String getProjectName();
+
+    String getWorkflowName();
+
+    long getSessionId();
+
+    long getId();
+
+    static AttemptTarget of(int siteId, String projectName, String workflowName, long sessionId, long id)
+    {
+        return ImmutableAttemptTarget.builder()
+                .siteId(siteId)
+                .projectName(projectName)
+                .workflowName(workflowName)
+                .sessionId(sessionId)
+                .id(id)
+                .build();
+    }
+}

--- a/digdag-spi/src/main/java/io/digdag/spi/ac/ProjectTarget.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/ac/ProjectTarget.java
@@ -1,5 +1,6 @@
 package io.digdag.spi.ac;
 
+import com.google.common.base.Optional;
 import org.immutables.value.Value;
 
 @Value.Immutable
@@ -9,13 +10,26 @@ public interface ProjectTarget
 
     String getName();
 
+    Optional<Integer> getId();
+
     // TODO better to have revision info?
 
     static ProjectTarget of(int siteId, String name)
     {
+        return of(siteId, name, Optional.absent());
+    }
+
+    static ProjectTarget of(int siteId, String name, int id)
+    {
+        return of(siteId, name, Optional.of(id));
+    }
+
+    static ProjectTarget of(int siteId, String name, Optional<Integer> id)
+    {
         return ImmutableProjectTarget.builder()
                 .siteId(siteId)
                 .name(name)
+                .id(id)
                 .build();
     }
 }

--- a/digdag-spi/src/main/java/io/digdag/spi/ac/ScheduleTarget.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/ac/ScheduleTarget.java
@@ -1,0 +1,25 @@
+package io.digdag.spi.ac;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface ScheduleTarget
+{
+    int getSiteId();
+
+    String getProjectName();
+
+    String getWorkflowName();
+
+    int getId();
+
+    static ScheduleTarget of(int siteId, String projectName, String workflowName, int id)
+    {
+        return ImmutableScheduleTarget.builder()
+                .siteId(siteId)
+                .projectName(projectName)
+                .workflowName(workflowName)
+                .id(id)
+                .build();
+    }
+}

--- a/digdag-tests/src/test/java/acceptance/AccessControllerIT.java
+++ b/digdag-tests/src/test/java/acceptance/AccessControllerIT.java
@@ -37,6 +37,7 @@ import io.digdag.server.ac.DefaultAccessController;
 import io.digdag.spi.AuthenticatedUser;
 import io.digdag.spi.ac.AccessControlException;
 import io.digdag.spi.ac.AccessController;
+import io.digdag.spi.ac.AttemptTarget;
 import io.digdag.spi.ac.ProjectTarget;
 import io.digdag.spi.ac.SiteTarget;
 import io.digdag.spi.ac.WorkflowTarget;
@@ -290,7 +291,7 @@ public class AccessControllerIT
         }
 
         @Override
-        public void checkKillAttempt(WorkflowTarget target, AuthenticatedUser user)
+        public void checkKillAttempt(AttemptTarget target, AuthenticatedUser user)
                 throws AccessControlException
         {
             switch (target.getProjectName()) {


### PR DESCRIPTION
This PR adds project_id to spi.ac.ProjectTarget in AccessController SPI introduced by v0.10. The id information would be useful. 