### PR TITLE
Introduce spi.ac.{Attempt,Schedule}Target as AccessController SPI

### DIFF
--- a/digdag-server/src/main/java/io/digdag/server/ac/DefaultAccessController.java
+++ b/digdag-server/src/main/java/io/digdag/server/ac/DefaultAccessController.java
@@ -3,6 +3,7 @@ package io.digdag.server.ac;
 import io.digdag.spi.AuthenticatedUser;
 import io.digdag.spi.ac.AccessControlException;
 import io.digdag.spi.ac.AccessController;
+import io.digdag.spi.ac.AttemptTarget;
 import io.digdag.spi.ac.ProjectTarget;
 import io.digdag.spi.ac.SecretTarget;
 import io.digdag.spi.ac.SiteTarget;
@@ -153,7 +154,7 @@ public class DefaultAccessController
     { }
 
     @Override
-    public void checkKillAttempt(WorkflowTarget target, AuthenticatedUser user)
+    public void checkKillAttempt(AttemptTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 

--- a/digdag-server/src/main/java/io/digdag/server/ac/DefaultAccessController.java
+++ b/digdag-server/src/main/java/io/digdag/server/ac/DefaultAccessController.java
@@ -5,6 +5,7 @@ import io.digdag.spi.ac.AccessControlException;
 import io.digdag.spi.ac.AccessController;
 import io.digdag.spi.ac.AttemptTarget;
 import io.digdag.spi.ac.ProjectTarget;
+import io.digdag.spi.ac.ScheduleTarget;
 import io.digdag.spi.ac.SecretTarget;
 import io.digdag.spi.ac.SiteTarget;
 import io.digdag.spi.ac.WorkflowTarget;
@@ -191,22 +192,22 @@ public class DefaultAccessController
     { }
 
     @Override
-    public void checkSkipSchedule(WorkflowTarget target, AuthenticatedUser user)
+    public void checkSkipSchedule(ScheduleTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public void checkBackfillSchedule(WorkflowTarget target, AuthenticatedUser user)
+    public void checkBackfillSchedule(ScheduleTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public void checkDisableSchedule(WorkflowTarget target, AuthenticatedUser user)
+    public void checkDisableSchedule(ScheduleTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 
     @Override
-    public void checkEnableSchedule(WorkflowTarget target, AuthenticatedUser user)
+    public void checkEnableSchedule(ScheduleTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 }

--- a/digdag-server/src/main/java/io/digdag/server/rs/AttemptResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/AttemptResource.java
@@ -33,6 +33,7 @@ import io.digdag.client.api.*;
 import io.digdag.spi.ac.AccessControlException;
 import io.digdag.spi.ac.AccessController;
 import io.digdag.spi.ScheduleTime;
+import io.digdag.spi.ac.AttemptTarget;
 import io.digdag.spi.ac.ProjectTarget;
 import io.digdag.spi.ac.SiteTarget;
 import io.digdag.spi.ac.WorkflowTarget;
@@ -335,7 +336,7 @@ public class AttemptResource
                     .getProjectById(attempt.getSession().getProjectId()); // to build WorkflowTarget
 
             ac.checkKillAttempt( // AccessControl
-                    WorkflowTarget.of(getSiteId(), proj.getName(), attempt.getSession().getWorkflowName()),
+                    AttemptTarget.of(getSiteId(), proj.getName(), attempt.getSession().getWorkflowName(), attempt.getSessionId(), attempt.getId()),
                     getAuthenticatedUser());
 
             boolean updated = executor.killAttemptById(getSiteId(), id); // should never throw NotFound

--- a/digdag-server/src/main/java/io/digdag/server/rs/ScheduleResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/ScheduleResource.java
@@ -22,6 +22,7 @@ import io.digdag.core.schedule.StoredSchedule;
 import io.digdag.core.session.StoredSessionAttemptWithSession;
 import io.digdag.spi.ac.AccessControlException;
 import io.digdag.spi.ac.AccessController;
+import io.digdag.spi.ac.ScheduleTarget;
 import io.digdag.spi.ac.SiteTarget;
 import io.digdag.spi.ac.WorkflowTarget;
 import io.swagger.annotations.Api;
@@ -130,7 +131,7 @@ public class ScheduleResource
             ZoneId timeZone = getTimeZoneOfSchedule(sched);
 
             ac.checkSkipSchedule( // AccessControl
-                    WorkflowTarget.of(getSiteId(), sched.getWorkflowName(), proj.getName()),
+                    ScheduleTarget.of(getSiteId(), proj.getName(), sched.getWorkflowName(), sched.getId()),
                     getAuthenticatedUser());
 
             StoredSchedule updated;
@@ -175,7 +176,7 @@ public class ScheduleResource
                     .getProjectById(sched.getProjectId()); // check NotFound first
 
             ac.checkBackfillSchedule( // AccessControl
-                    WorkflowTarget.of(getSiteId(), sched.getWorkflowName(), proj.getName()),
+                    ScheduleTarget.of(getSiteId(), proj.getName(), sched.getWorkflowName(), sched.getId()),
                     getAuthenticatedUser());
 
             List<StoredSessionAttemptWithSession> attempts =
@@ -204,7 +205,7 @@ public class ScheduleResource
                     .getProjectById(sched.getProjectId()); // check NotFound first
 
             ac.checkDisableSchedule( // AccessControl
-                    WorkflowTarget.of(getSiteId(), sched.getWorkflowName(), proj.getName()),
+                    ScheduleTarget.of(getSiteId(), proj.getName(), sched.getWorkflowName(), sched.getId()),
                     getAuthenticatedUser());
 
             StoredSchedule updated = sm.getScheduleStore(getSiteId()).updateScheduleById(id, (store, storedSchedule) -> { // should never throw NotFound
@@ -231,7 +232,7 @@ public class ScheduleResource
                     .getProjectById(sched.getProjectId()); // check NotFound first
 
             ac.checkEnableSchedule( // AccessControl
-                    WorkflowTarget.of(getSiteId(), sched.getWorkflowName(), proj.getName()),
+                    ScheduleTarget.of(getSiteId(), proj.getName(), sched.getWorkflowName(), sched.getId()),
                     getAuthenticatedUser());
 
             StoredSchedule updated = sm.getScheduleStore(getSiteId()).updateScheduleById(id, (store, storedSchedule) -> { // should never throw NotFound

--- a/digdag-spi/src/main/java/io/digdag/spi/ac/AccessController.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/ac/AccessController.java
@@ -310,7 +310,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkKillAttempt(WorkflowTarget target, AuthenticatedUser user)
+    void checkKillAttempt(AttemptTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     //

--- a/digdag-spi/src/main/java/io/digdag/spi/ac/AccessController.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/ac/AccessController.java
@@ -388,7 +388,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkSkipSchedule(WorkflowTarget target, AuthenticatedUser user)
+    void checkSkipSchedule(ScheduleTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     /**
@@ -398,7 +398,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkBackfillSchedule(WorkflowTarget target, AuthenticatedUser user)
+    void checkBackfillSchedule(ScheduleTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     /**
@@ -408,7 +408,7 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkDisableSchedule(WorkflowTarget target, AuthenticatedUser user)
+    void checkDisableSchedule(ScheduleTarget target, AuthenticatedUser user)
             throws AccessControlException;
 
     /**
@@ -418,6 +418,6 @@ public interface AccessController
      * @param user
      * @throws AccessControlException
      */
-    void checkEnableSchedule(WorkflowTarget target, AuthenticatedUser user)
+    void checkEnableSchedule(ScheduleTarget target, AuthenticatedUser user)
             throws AccessControlException;
 }

--- a/digdag-spi/src/main/java/io/digdag/spi/ac/AttemptTarget.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/ac/AttemptTarget.java
@@ -11,11 +11,11 @@ public interface AttemptTarget
 
     String getWorkflowName();
 
-    int getSessionId();
+    long getSessionId();
 
-    int getId();
+    long getId();
 
-    static AttemptTarget of(int siteId, String projectName, String workflowName, int sessionId, int id)
+    static AttemptTarget of(int siteId, String projectName, String workflowName, long sessionId, long id)
     {
         return ImmutableAttemptTarget.builder()
                 .siteId(siteId)

--- a/digdag-spi/src/main/java/io/digdag/spi/ac/AttemptTarget.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/ac/AttemptTarget.java
@@ -1,0 +1,28 @@
+package io.digdag.spi.ac;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface AttemptTarget
+{
+    int getSiteId();
+
+    String getProjectName();
+
+    String getWorkflowName();
+
+    int getSessionId();
+
+    int getId();
+
+    static AttemptTarget of(int siteId, String projectName, String workflowName, int sessionId, int id)
+    {
+        return ImmutableAttemptTarget.builder()
+                .siteId(siteId)
+                .projectName(projectName)
+                .workflowName(workflowName)
+                .sessionId(sessionId)
+                .id(id)
+                .build();
+    }
+}

--- a/digdag-spi/src/main/java/io/digdag/spi/ac/ScheduleTarget.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/ac/ScheduleTarget.java
@@ -1,0 +1,25 @@
+package io.digdag.spi.ac;
+
+import org.immutables.value.Value;
+
+@Value.Immutable
+public interface ScheduleTarget
+{
+    int getSiteId();
+
+    String getProjectName();
+
+    String getWorkflowName();
+
+    int getId();
+
+    static ScheduleTarget of(int siteId, String projectName, String workflowName, int id)
+    {
+        return ImmutableScheduleTarget.builder()
+                .siteId(siteId)
+                .projectName(projectName)
+                .workflowName(workflowName)
+                .id(id)
+                .build();
+    }
+}

--- a/digdag-tests/src/test/java/acceptance/AccessControllerIT.java
+++ b/digdag-tests/src/test/java/acceptance/AccessControllerIT.java
@@ -37,6 +37,7 @@ import io.digdag.server.ac.DefaultAccessController;
 import io.digdag.spi.AuthenticatedUser;
 import io.digdag.spi.ac.AccessControlException;
 import io.digdag.spi.ac.AccessController;
+import io.digdag.spi.ac.AttemptTarget;
 import io.digdag.spi.ac.ProjectTarget;
 import io.digdag.spi.ac.SiteTarget;
 import io.digdag.spi.ac.WorkflowTarget;
@@ -290,7 +291,7 @@ public class AccessControllerIT
         }
 
         @Override
-        public void checkKillAttempt(WorkflowTarget target, AuthenticatedUser user)
+        public void checkKillAttempt(AttemptTarget target, AuthenticatedUser user)
                 throws AccessControlException
         {
             switch (target.getProjectName()) {


### PR DESCRIPTION
This PR introduces "spi.ac.AttemptTarget" and "ScheduleTarget" in AccessController SPI. "WorkflowTarget" is used on the attempt kill endpoint to check the kill permission check. But fine-grain information like session_id and attempt_id would be helpful for the permission check for example.

It assumes https://github.com/treasure-data/digdag/pull/1112.