### PR TITLE
Update tar 2.2.2 for digdag-ui

### DIFF
--- a/digdag-ui/package-lock.json
+++ b/digdag-ui/package-lock.json
@@ -7969,9 +7969,9 @@
           "dev": true
         },
         "tar": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
+          "version": "2.2.2",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.2.tgz",
+          "integrity": "sha512-FCEhQ/4rE1zYv9rYXJw/msRqsnmlje5jHP6huWeBZ704jUTy02c5AZyWujpMR1ax6mVw9NyJMfuK2CMDWVIfgA==",
           "dev": true,
           "requires": {
             "block-stream": "*",


### PR DESCRIPTION
This PR updates "tar" library for digdag-ui to 2.2.2.