### PR TITLE
Upgrade to Jackson 2.9.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,8 +110,8 @@ subprojects {
     }
 
     ext {
-        jacksonVersion = "2.8.11"
-        jacksonDatabindVersion = "2.8.11.1"
+        jacksonVersion = "2.9.9"
+        jacksonDatabindVersion = "2.9.9"
         awsJavaSdkVersion = "1.11.63"
         guavaVersion = "19.0"
     }

--- a/digdag-core/build.gradle
+++ b/digdag-core/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     compile 'com.zaxxer:HikariCP:2.4.7'
     compile 'com.h2database:h2:1.4.192'
     compile 'org.postgresql:postgresql:9.4.1211'
-    compile 'org.yaml:snakeyaml:1.17'
+    compile 'org.yaml:snakeyaml:1.23'
     compile 'com.google.code.findbugs:annotations:3.0.1'
     compile 'org.weakref:jmxutils:1.19'
 

--- a/digdag-standards/build.gradle
+++ b/digdag-standards/build.gradle
@@ -20,7 +20,7 @@ dependencies {
         exclude group: 'com.google.guava', module: 'guava'
     }
     compile 'org.msgpack:msgpack-core:0.8.11'
-    compile 'org.yaml:snakeyaml:1.17'
+    compile 'org.yaml:snakeyaml:1.23'
 
     // postgresql
     compile 'org.postgresql:postgresql:9.4.1211'


### PR DESCRIPTION
This address [CVE-2019-12086](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-12086).