### PR TITLE
[Doc] Fix dead links within http_call.md

### DIFF
--- a/digdag-docs/src/operators/http_call.md
+++ b/digdag-docs/src/operators/http_call.md
@@ -19,7 +19,7 @@ This operator parses response body based on returned Content-Type header. Conten
   http_call>: https://api.example.com/foobar
   ```
 
-Same parameters with **http>** operator are also supported except the parameters listed bellow. The name of the operator is similar to [http> operator](../http.html). But the role is different. See also [http> operator document](../http.html).
+Same parameters with **http>** operator are also supported except the parameters listed bellow. The name of the operator is similar to [http> operator](http.html). But the role is different. See also [http> operator document](http.html).
 
 * store_content
 


### PR DESCRIPTION
follow-up of https://github.com/treasure-data/digdag/pull/1125. This PR adds more fix.