### PR TITLE
Introduce EcsCommandExecutor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,7 @@ subprojects {
     ext {
         jacksonVersion = "2.8.11"
         jacksonDatabindVersion = "2.8.11.1"
-        awsJavaSdkVersion = "1.11.63"
+        awsJavaSdkVersion = "1.11.545"
         guavaVersion = "19.0"
     }
 

--- a/digdag-core/build.gradle
+++ b/digdag-core/build.gradle
@@ -43,7 +43,7 @@ dependencies {
 
     // Dependency conflict resolution
     compile 'javax.activation:activation:1.1.1'
-    compile 'org.apache.httpcomponents:httpclient:4.5.2'
+    compile 'org.apache.httpcomponents:httpclient:4.5.5' // depends on aws-java-sdk 1.11.545
 
     testCompile project(path: ':digdag-client', configuration: 'testArtifacts')
 }

--- a/digdag-standards/build.gradle
+++ b/digdag-standards/build.gradle
@@ -28,6 +28,8 @@ dependencies {
     // aws
     compile "com.amazonaws:aws-java-sdk-kms:${project.ext.awsJavaSdkVersion}"
     compile "com.amazonaws:aws-java-sdk-sts:${project.ext.awsJavaSdkVersion}"
+    compile "com.amazonaws:aws-java-sdk-ecs:${project.ext.awsJavaSdkVersion}"
+    compile "com.amazonaws:aws-java-sdk-logs:${project.ext.awsJavaSdkVersion}"
     compile "com.amazonaws:aws-java-sdk-s3:${project.ext.awsJavaSdkVersion}"
     compile "com.amazonaws:aws-java-sdk-emr:${project.ext.awsJavaSdkVersion}"
     compile "com.amazonaws:aws-java-sdk-dynamodb:${project.ext.awsJavaSdkVersion}"

--- a/digdag-standards/src/main/java/io/digdag/standards/command/CommandExecutorModule.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/CommandExecutorModule.java
@@ -4,8 +4,8 @@ import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.Scopes;
 import io.digdag.spi.CommandExecutor;
-import io.digdag.standards.command.kubernetes.DefaultKubernetesClientFactory;
-import io.digdag.standards.command.kubernetes.KubernetesClientFactory;
+import io.digdag.standards.command.ecs.DefaultEcsClientFactory;
+import io.digdag.standards.command.ecs.EcsClientFactory;
 
 public class CommandExecutorModule
     implements Module
@@ -13,8 +13,10 @@ public class CommandExecutorModule
     @Override
     public void configure(Binder binder)
     {
-        binder.bind(CommandExecutor.class).to(KubernetesCommandExecutor.class).in(Scopes.SINGLETON);
-        binder.bind(KubernetesClientFactory.class).to(DefaultKubernetesClientFactory.class).in(Scopes.SINGLETON);
+        binder.bind(CommandExecutor.class).to(EcsCommandExecutor.class).in(Scopes.SINGLETON);
+        binder.bind(EcsClientFactory.class).to(DefaultEcsClientFactory.class).in(Scopes.SINGLETON);
+        //binder.bind(CommandExecutor.class).to(KubernetesCommandExecutor.class).in(Scopes.SINGLETON);
+        //binder.bind(KubernetesClientFactory.class).to(DefaultKubernetesClientFactory.class).in(Scopes.SINGLETON);
         binder.bind(SimpleCommandExecutor.class).in(Scopes.SINGLETON);
         binder.bind(DockerCommandExecutor.class).in(Scopes.SINGLETON);
     }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/CommandExecutors.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/CommandExecutors.java
@@ -1,0 +1,162 @@
+package io.digdag.standards.command;
+
+import com.google.common.io.ByteStreams;
+import io.digdag.client.config.Config;
+import io.digdag.core.archive.ProjectArchive;
+import io.digdag.core.archive.ProjectArchiveLoader;
+import io.digdag.core.archive.WorkflowResourceMatcher;
+import io.digdag.spi.TaskRequest;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.archivers.tar.TarConstants;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.Locale;
+
+class CommandExecutors
+{
+    private static final Logger logger = LoggerFactory.getLogger(CommandExecutors.class);
+
+    private CommandExecutors()
+    { }
+
+    /**
+     * return relative path of project archive
+     *
+     * @param projectPath
+     * @param request
+     * @return
+     * @throws IOException
+     */
+    static Path createArchiveFromLocal(
+            final ProjectArchiveLoader projectArchiveLoader,
+            final Path projectPath,
+            final Path ioDirectoryPath,
+            final TaskRequest request)
+            throws IOException
+    {
+        final Path archivePath = Files.createTempFile(projectPath.resolve(".digdag/tmp"), "archive-input-", ".tar.gz"); // throw IOException
+        logger.debug("Creating " + archivePath + "...");
+
+        final Config config = request.getConfig();
+        final WorkflowResourceMatcher workflowResourceMatcher = WorkflowResourceMatcher.defaultMatcher();
+        final ProjectArchive projectArchive = projectArchiveLoader.load(projectPath, workflowResourceMatcher, config); // throw IOException
+        try (final TarArchiveOutputStream tar = new TarArchiveOutputStream(
+                new GzipCompressorOutputStream(Files.newOutputStream(archivePath.toAbsolutePath())))) { // throw IOException
+            // Archive project files
+            tar.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+            projectArchive.listFiles((resourceName, absPath) -> { // throw IOException
+                logger.debug("  Archiving " + resourceName);
+                if (!Files.isDirectory(absPath)) {
+                    final TarArchiveEntry e = buildTarArchiveEntry(projectPath, absPath, resourceName); // throw IOException
+                    tar.putArchiveEntry(e); // throw IOException
+                    if (e.isSymbolicLink()) {
+                        logger.debug("    symlink -> " + e.getLinkName());
+                    }
+                    else {
+                        try (final InputStream in = Files.newInputStream(absPath)) { // throw IOException
+                            ByteStreams.copy(in, tar); // throw IOException
+                        }
+                    }
+                    tar.closeArchiveEntry(); // throw IOExcpetion
+                }
+            });
+
+            // Add .digdag/tmp/ files to the archive
+            final Path absoluteIoDirectoryPath = projectPath.resolve(ioDirectoryPath);
+            try (final DirectoryStream<Path> ds = Files.newDirectoryStream(absoluteIoDirectoryPath)) {
+                for (final Path absPath : ds) {
+                    final String resourceName = ProjectArchive.realPathToResourceName(projectPath, absPath);
+                    final TarArchiveEntry e = buildTarArchiveEntry(projectPath, absPath, resourceName);
+                    tar.putArchiveEntry(e); // throw IOexception
+                    if (!e.isSymbolicLink()) {
+                        try (final InputStream in = Files.newInputStream(absPath)) { // throw IOException
+                            ByteStreams.copy(in, tar); // throw IOException
+                        }
+                    }
+                    tar.closeArchiveEntry(); // throw IOExcpetion
+                }
+            }
+        }
+
+        return archivePath;
+    }
+
+    static TarArchiveEntry buildTarArchiveEntry(final Path projectPath, final Path absPath, final String name)
+            throws IOException
+    {
+        final TarArchiveEntry e;
+        if (Files.isSymbolicLink(absPath)) {
+            e = new TarArchiveEntry(name, TarConstants.LF_SYMLINK);
+            final Path rawDest = Files.readSymbolicLink(absPath);
+            final Path normalizedAbsDest = absPath.getParent().resolve(rawDest).normalize();
+
+            if (!normalizedAbsDest.startsWith(projectPath)) {
+                throw new IllegalArgumentException(String.format(Locale.ENGLISH,
+                        "Invalid symbolic link: Given path '%s' is outside of project directory '%s'", normalizedAbsDest, projectPath));
+            }
+
+            // absolute path will be invalid on a server. convert it to a relative path
+            final Path normalizedRelativeDest = absPath.getParent().relativize(normalizedAbsDest);
+
+            String linkName = normalizedRelativeDest.toString();
+
+            // TarArchiveEntry(File) does this normalization but setLinkName doesn't. So do it here:
+            linkName = linkName.replace(File.separatorChar, '/');
+            e.setLinkName(linkName);
+        }
+        else {
+            e = new TarArchiveEntry(absPath.toFile(), name);
+            try {
+                int mode = 0;
+                for (final PosixFilePermission perm : Files.getPosixFilePermissions(absPath)) {
+                    switch (perm) {
+                        case OWNER_READ:
+                            mode |= 0400;
+                            break;
+                        case OWNER_WRITE:
+                            mode |= 0200;
+                            break;
+                        case OWNER_EXECUTE:
+                            mode |= 0100;
+                            break;
+                        case GROUP_READ:
+                            mode |= 0040;
+                            break;
+                        case GROUP_WRITE:
+                            mode |= 0020;
+                            break;
+                        case GROUP_EXECUTE:
+                            mode |= 0010;
+                            break;
+                        case OTHERS_READ:
+                            mode |= 0004;
+                            break;
+                        case OTHERS_WRITE:
+                            mode |= 0002;
+                            break;
+                        case OTHERS_EXECUTE:
+                            mode |= 0001;
+                            break;
+                        default:
+                            // ignore
+                    }
+                }
+                e.setMode(mode);
+            }
+            catch (UnsupportedOperationException ex) {
+                // ignore custom mode
+            }
+        }
+        return e;
+    }
+}

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -1,0 +1,685 @@
+package io.digdag.standards.command;
+
+import com.amazonaws.services.ecs.model.AssignPublicIp;
+import com.amazonaws.services.ecs.model.AwsVpcConfiguration;
+import com.amazonaws.services.ecs.model.ContainerDefinition;
+import com.amazonaws.services.ecs.model.ContainerOverride;
+import com.amazonaws.services.ecs.model.LaunchType;
+import com.amazonaws.services.ecs.model.LogConfiguration;
+import com.amazonaws.services.ecs.model.NetworkConfiguration;
+import com.amazonaws.services.ecs.model.RunTaskRequest;
+import com.amazonaws.services.ecs.model.RunTaskResult;
+import com.amazonaws.services.ecs.model.Task;
+import com.amazonaws.services.ecs.model.TaskDefinition;
+import com.amazonaws.services.ecs.model.TaskOverride;
+import com.amazonaws.services.logs.model.GetLogEventsResult;
+import com.amazonaws.services.logs.model.OutputLogEvent;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
+import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigException;
+import io.digdag.core.archive.ProjectArchiveLoader;
+import io.digdag.core.archive.ProjectArchives;
+import io.digdag.core.storage.StorageManager;
+import io.digdag.spi.CommandContext;
+import io.digdag.spi.CommandExecutor;
+import io.digdag.spi.CommandLogger;
+import io.digdag.spi.CommandRequest;
+import io.digdag.spi.CommandStatus;
+import io.digdag.spi.TaskExecutionException;
+import io.digdag.spi.TaskRequest;
+import io.digdag.standards.command.ecs.EcsClient;
+import io.digdag.standards.command.ecs.EcsClientConfig;
+import io.digdag.standards.command.ecs.EcsClientFactory;
+import io.digdag.standards.command.ecs.EcsTaskStatus;
+import io.digdag.standards.command.ecs.TemporalProjectArchiveStorage;
+import io.digdag.util.DurationParam;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class EcsCommandExecutor
+        implements CommandExecutor
+{
+    private static Logger logger = LoggerFactory.getLogger(CommandExecutor.class);
+
+    private static final String ECS_COMMAND_EXECUTOR_SYSTEM_CONFIG_PREFIX = "agent.command_executor.ecs.";
+    private static final String DEFAULT_COMMAND_TASK_TTL = ECS_COMMAND_EXECUTOR_SYSTEM_CONFIG_PREFIX + "default_command_task_ttl";
+
+    private final Config systemConfig;
+    private final EcsClientFactory ecsClientFactory;
+    private final DockerCommandExecutor docker;
+    private final StorageManager storageManager;
+    private final ProjectArchiveLoader projectArchiveLoader;
+    private final CommandLogger clog;
+    private final Optional<Duration> defaultCommandTaskTTL;
+
+    @Inject
+    public EcsCommandExecutor(
+            final Config systemConfig,
+            final EcsClientFactory ecsClientFactory,
+            final DockerCommandExecutor docker,
+            final StorageManager storageManager,
+            final ProjectArchiveLoader projectArchiveLoader,
+            final CommandLogger clog)
+    {
+        this.systemConfig = systemConfig;
+        this.ecsClientFactory = ecsClientFactory;
+        this.docker = docker;
+        this.storageManager = storageManager;
+        this.projectArchiveLoader = projectArchiveLoader;
+        this.clog = clog;
+        this.defaultCommandTaskTTL = systemConfig.getOptional(DEFAULT_COMMAND_TASK_TTL, DurationParam.class)
+                .transform(DurationParam::getDuration)
+                .or(Optional.absent());
+    }
+
+    @Override
+    public CommandStatus run(
+            final CommandContext commandContext,
+            final CommandRequest commandRequest)
+            throws IOException
+    {
+        final Config taskConfig = commandContext.getTaskRequest().getConfig();
+        final Optional<String> clusterName = Optional.absent();
+        try {
+            final EcsClientConfig clientConfig = createEcsClientConfig(clusterName, systemConfig, taskConfig); // ConfigException
+            try (final EcsClient client = ecsClientFactory.createClient(clientConfig)) { // ConfigException
+                final TaskDefinition td = findTaskDefinition(commandContext, client, taskConfig); // ConfigException
+                final Optional<ObjectNode> awsLogs = getAwsLogsConfiguration(td); // Nullable, ConfigException
+                // When RuntimeException is thrown by submitTask method, it will be handled and retried by BaseOperator, which is one of base
+                // classes of operator implementation.
+                final Task runTask = submitTask(commandContext, commandRequest, client, td); // ConfigException, RuntimeException
+                final ObjectNode currentStatus = createCurrentStatus(commandContext, commandRequest, clientConfig, runTask, awsLogs);
+                return createNextCommandStatus(commandContext, client, currentStatus);
+            }
+        }
+        catch (ConfigException e) {
+            logger.info("EcsCommandExecutor is not executed.", e);
+            return docker.run(commandContext, commandRequest); // fall back to DockerCommandExecutor
+        }
+    }
+
+    protected Task submitTask(
+            final CommandContext commandContext,
+            final CommandRequest commandRequest,
+            final EcsClient client,
+            final TaskDefinition td)
+            throws ConfigException
+    {
+        final EcsClientConfig clientConfig = client.getConfig();
+        final RunTaskRequest runTaskRequest = buildRunTaskRequest(commandContext, commandRequest, clientConfig, td); // RuntimeException,ConfigException
+        final RunTaskResult runTaskResult = client.submitTask(runTaskRequest); // RuntimeException, ConfigException
+        return findTask(td.getTaskDefinitionArn(), runTaskResult); // RuntimeException
+    }
+
+    protected TaskDefinition findTaskDefinition(
+            final CommandContext commandContext,
+            final EcsClient client,
+            final Config taskConfig)
+            throws ConfigException
+    {
+        TaskDefinition td;
+
+        // find task definition by ecs.task_definition_arn
+        td = findTaskDefinitionByTaskDefinitionArn(commandContext, client, taskConfig); // ConfigException
+        if (td != null) {
+            return td;
+        }
+
+        // find task definition by docker.image
+        td = findTaskDefinitionByDockerImageTag(client, taskConfig); // ConfigException
+        if (td != null) {
+            return td;
+        }
+
+        throw new ConfigException("Parameter ecs.task_definition_arn: or docker.image: is required but not set.");
+    }
+
+    @Nullable
+    protected TaskDefinition findTaskDefinitionByTaskDefinitionArn(
+            final CommandContext commandContext,
+            final EcsClient client,
+            final Config taskConfig)
+            throws ConfigException
+    {
+        if (taskConfig.has("ecs")) {
+            final Config ecsConfig = taskConfig.getNested("ecs");
+            if (ecsConfig.has("task_definition_arn")) {
+                final String taskDefinitionArn = ecsConfig.get("task_definition_arn", String.class);
+                final TaskDefinition td = client.getTaskDefinition(taskDefinitionArn); // ConfigException
+                if (td.getContainerDefinitions().size() > 1) {
+                    throw new ConfigException("Task definition must not have multiple container definitions: " + taskDefinitionArn);
+                }
+                return td;
+            }
+        }
+        return null;
+    }
+
+    @Nullable
+    protected TaskDefinition findTaskDefinitionByDockerImageTag(
+            final EcsClient client,
+            final Config taskConfig)
+            throws ConfigException
+    {
+        if (taskConfig.has("docker")) {
+            final Config dockerConfig = taskConfig.getNested("docker");
+            if (!dockerConfig.has("image")) {
+                throw new ConfigException("Parameter docker.image: is required but not set");
+            }
+
+            final String dockerImageTagValue = dockerConfig.get("image", String.class);
+            final Optional<TaskDefinition> td = client.getTaskDefinitionByTag("digdag.docker.image", dockerImageTagValue);
+            if (!td.isPresent()) {
+                throw new ConfigException("Not found task definition with 'digdag.docker.image' tag: " + dockerImageTagValue);
+            }
+
+            if (td.get().getContainerDefinitions().size() > 1) {
+                throw new ConfigException("Task definition must not have multiple container definitions: " + td.get().getTaskDefinitionArn());
+            }
+
+            return td.get();
+        }
+        return null;
+    }
+
+    protected Optional<ObjectNode> getAwsLogsConfiguration(final TaskDefinition td)
+            throws ConfigException
+    {
+        // Assume that a single container will run in the task.
+        final ContainerDefinition cd = td.getContainerDefinitions().get(0);
+        final LogConfiguration logConfig = cd.getLogConfiguration();
+        final String logDriver = logConfig.getLogDriver();
+        final Optional<ObjectNode> awsLogs;
+        if (logDriver.equals("awslogs")) {
+            final ObjectNode logs = JsonNodeFactory.instance.objectNode();
+            for (final Map.Entry<String, String> e : logConfig.getOptions().entrySet()) {
+                logs.put(e.getKey(), e.getValue());
+            }
+            awsLogs = Optional.of(logs);
+        }
+        else {
+            logger.warn("Not use 'awslogs' as log driver. EcsCommandExecutor doesn't fetch any task logs.");
+            awsLogs = Optional.absent();
+        }
+        return awsLogs;
+    }
+
+    protected ObjectNode createCurrentStatus(
+            final CommandContext commandContext,
+            final CommandRequest commandRequest,
+            final EcsClientConfig clientConfig,
+            final Task runTask,
+            final Optional<ObjectNode> awsLogs)
+    {
+        final Path ioDirectoryPath = commandRequest.getIoDirectory(); // relative
+        final ObjectNode currentStatus = JsonNodeFactory.instance.objectNode();
+        currentStatus.put("cluster_name", clientConfig.getClusterName());
+        currentStatus.put("task_arn", runTask.getTaskArn());
+        currentStatus.put("task_creation_timestamp", runTask.getCreatedAt().getTime() / 1000);
+        currentStatus.put("io_directory", ioDirectoryPath.toString());
+        currentStatus.put("executor_state", JsonNodeFactory.instance.objectNode());
+        currentStatus.put("awslogs", awsLogs.isPresent() ? awsLogs.get() : JsonNodeFactory.instance.nullNode());
+        return currentStatus;
+    }
+
+    @Override
+    public CommandStatus poll(
+            final CommandContext commandContext,
+            final ObjectNode previousStatus)
+            throws IOException
+    {
+        // If executor is falled back in run method, this poll method needs not to be falled back because it's never
+        // used in fall back mode. Please see more details of scripting operators.
+        final Config taskConfig = commandContext.getTaskRequest().getConfig();
+        final String clusterName = previousStatus.get("cluster_name").asText();
+        final EcsClientConfig clientConfig = createEcsClientConfig(Optional.of(clusterName), systemConfig, taskConfig); // ConfigException
+        try (final EcsClient client = ecsClientFactory.createClient(clientConfig)) { // ConfigException
+            return createNextCommandStatus(commandContext, client, previousStatus);
+        }
+    }
+
+    CommandStatus createNextCommandStatus(
+            final CommandContext commandContext,
+            final EcsClient client,
+            final ObjectNode previousStatus)
+            throws IOException
+    {
+        final String cluster = previousStatus.get("cluster_name").asText();
+        final String taskArn = previousStatus.get("task_arn").asText();
+        final Task task = client.getTask(cluster, taskArn);
+
+        if (logger.isDebugEnabled()) {
+            logger.debug("Get task: " + task);
+        }
+
+        final EcsTaskStatus taskStatus = EcsTaskStatus.of(task.getLastStatus());
+        final ObjectNode previousExecutorStatus = (ObjectNode) previousStatus.get("executor_state");
+        final ObjectNode nextExecutorStatus;
+        // If the container doesn't start yet, it cannot extract any log messages from the container.
+        if (taskStatus.isSameOrAfter(EcsTaskStatus.RUNNING)) {
+            // if previous status has 'awslogs' log driver configuration, it tries to fetch log events by that.
+            // Otherwise, it skips fetching logs.
+            if (!previousStatus.get("awslogs").isNull()) { // awslogs?
+                nextExecutorStatus = fetchLogEvents(client, task, previousStatus, previousExecutorStatus);
+            }
+            else {
+                nextExecutorStatus = previousExecutorStatus.deepCopy();
+            }
+        }
+        else { // before running
+            // Write task status to the command logger to avoid users confusing.
+            // It sometimes takes long time to start task running on AWS ECS by several reasons.
+            log(s("Wait running a command task: status %s", taskStatus.getName()), clog);
+            nextExecutorStatus = previousExecutorStatus.deepCopy();
+        }
+
+        final ObjectNode nextStatus = previousStatus.deepCopy();
+        nextStatus.set("executor_state", nextExecutorStatus);
+        final boolean isFinished;
+        if (isFinished = taskStatus.isFinished()) {
+            final String outputArchivePathName = "archive-output.tar.gz";
+            final String outputArchiveKey = createStorageKey(commandContext.getTaskRequest(), outputArchivePathName); // url format
+
+            // Download output config archive
+            final TemporalProjectArchiveStorage temporalStorage = createTemporalProjectArchiveStorage(commandContext.getTaskRequest().getConfig());
+            try (final InputStream in = temporalStorage.getContentInputStream(outputArchiveKey)) {
+                ProjectArchives.extractTarArchive(commandContext.getLocalProjectPath(), in); // IOException
+            }
+
+            // Set exit code of container finished to nextStatus
+            nextStatus.put("status_code", task.getContainers().get(0).getExitCode());
+        }
+        else if (defaultCommandTaskTTL.isPresent() && isRunningLongerThanTTL(previousStatus)) {
+            final TaskRequest request = commandContext.getTaskRequest();
+            final long attemptId = request.getAttemptId();
+            final long taskId = request.getTaskId();
+
+            final String message = s("Command task execution timeout: attempt=%d, task=%d", attemptId, taskId);
+            logger.warn(message);
+
+            logger.info(s("Stop command task %d", task.getTaskArn()));
+            client.stopTask(cluster, taskArn);
+
+            // Throw exception to stop the task as failure
+            throw new TaskExecutionException(message);
+        }
+        return EcsCommandStatus.of(isFinished, nextStatus);
+    }
+
+    ObjectNode fetchLogEvents(final EcsClient client,
+            final Task task,
+            final ObjectNode previousStatus,
+            final ObjectNode previousExecutorStatus)
+            throws IOException
+    {
+        final TaskDefinition td = client.getTaskDefinition(task.getTaskDefinitionArn());
+        final Optional<String> previousToken = !previousExecutorStatus.has("next_token") ?
+                Optional.absent() : Optional.of(previousExecutorStatus.get("next_token").asText());
+        final GetLogEventsResult result = client.getLog(toLogGroupName(previousStatus), toLogStreamName(td, previousStatus), previousToken);
+        final List<OutputLogEvent> logEvents = result.getEvents();
+        final String nextForwardToken = result.getNextForwardToken().substring(2); // trim "f/" prefix of the token
+        final String nextBackwardToken = result.getNextBackwardToken().substring(2); // trim "b/" prefix of the token
+
+        final ObjectNode nextExecutorStatus = previousExecutorStatus.deepCopy();
+        if (!previousToken.isPresent() && nextForwardToken.equals(nextBackwardToken)) {
+            // just in case, we'd better to drop "next_token" key
+            nextExecutorStatus.remove("next_token");
+        }
+        else {
+            for (final OutputLogEvent logEvent : logEvents) {
+                log(logEvent.getMessage() + "\n", clog);
+            }
+            nextExecutorStatus.set("next_token", JsonNodeFactory.instance.textNode(nextForwardToken));
+        }
+        return nextExecutorStatus;
+    }
+
+    private static String toLogGroupName(final ObjectNode previousStatus)
+    {
+        return previousStatus.get("awslogs").get("awslogs-group").asText();
+    }
+
+    private static String toLogStreamName(final TaskDefinition td, final ObjectNode previousStatus)
+    {
+        final JsonNode logConfig = previousStatus.get("awslogs");
+        final String streamPrefix = logConfig.get("awslogs-stream-prefix").asText();
+        final String containerDefinitionName = td.getContainerDefinitions().get(0).getName();
+        final String taskArn = previousStatus.get("task_arn").asText();
+        final String taskArnPostfix = taskArn.substring(taskArn.lastIndexOf('/') + 1);
+        return String.format(Locale.ENGLISH, "%s/%s/%s", streamPrefix, containerDefinitionName, taskArnPostfix);
+    }
+
+    private boolean isRunningLongerThanTTL(final ObjectNode previousStatus)
+    {
+        long creationTimestamp = previousStatus.get("pod_creation_timestamp").asLong();
+        long currentTimestamp = Instant.now().getEpochSecond();
+        return currentTimestamp > creationTimestamp + defaultCommandTaskTTL.get().getSeconds();
+    }
+
+    static class EcsCommandStatus
+            implements CommandStatus
+    {
+        static EcsCommandStatus of(final boolean isFinished, final ObjectNode json)
+        {
+            return new EcsCommandStatus(isFinished, json);
+        }
+
+        private final boolean isFinished;
+        private final ObjectNode json;
+
+        private EcsCommandStatus(final boolean isFinished,
+                final ObjectNode json)
+        {
+            this.isFinished = isFinished;
+            this.json = json;
+        }
+
+        @Override
+        public boolean isFinished()
+        {
+            return isFinished;
+        }
+
+        @Override
+        public int getStatusCode()
+        {
+            return json.get("status_code").intValue();
+        }
+
+        @Override
+        public String getIoDirectory()
+        {
+            return json.get("io_directory").textValue();
+        }
+
+        @Override
+        public ObjectNode toJson()
+        {
+            return json;
+        }
+    }
+
+    protected Task findTask(final String taskDefinitionArn, final RunTaskResult result) {
+        for (final Task t : result.getTasks()) {
+            if (t.getTaskDefinitionArn().equals(taskDefinitionArn)) {
+                return t;
+            }
+        }
+        throw new RuntimeException("Submitted task could not be found"); // TODO the message should be improved more understandably.
+    }
+
+    EcsClientConfig createEcsClientConfig(
+            final Optional<String> clusterName,
+            final Config systemConfig,
+            final Config config)
+    {
+        return EcsClientConfig.of(clusterName, systemConfig, config);
+    }
+
+    RunTaskRequest buildRunTaskRequest(
+            final CommandContext commandContext,
+            final CommandRequest commandRequest,
+            final EcsClientConfig clientConfig,
+            final TaskDefinition td)
+            throws ConfigException
+    {
+        final RunTaskRequest runTaskRequest = new RunTaskRequest();
+        setEcsCluster(clientConfig, runTaskRequest);
+        setEcsGroup(runTaskRequest);
+        setEcsTaskDefinition(commandContext, commandRequest, td, runTaskRequest);
+        setEcsTaskCount(runTaskRequest);
+        setEcsTaskOverride(commandContext, commandRequest, td, runTaskRequest); // RuntimeException,ConfigException
+        setEcsTaskLaunchType(clientConfig, runTaskRequest);
+        setEcsNetworkConfiguration(clientConfig, runTaskRequest);
+        return runTaskRequest;
+    }
+
+    protected void setEcsTaskDefinition(
+            final CommandContext commandContext,
+            final CommandRequest commandRequest,
+            final TaskDefinition td,
+            final RunTaskRequest request)
+    {
+        request.withTaskDefinition(td.getTaskDefinitionArn());
+    }
+
+    protected void setEcsCluster(final EcsClientConfig clientConfig, final RunTaskRequest request)
+    {
+        request.withCluster(clientConfig.getClusterName());
+    }
+
+    protected void setEcsTaskCount(final RunTaskRequest request)
+    {
+        request.withCount(1);
+    }
+
+    protected void setEcsGroup(final RunTaskRequest request)
+    {
+    }
+
+    protected void setEcsTaskOverride(
+            final CommandContext commandContext,
+            final CommandRequest commandRequest,
+            final TaskDefinition td,
+            final RunTaskRequest request)
+            throws ConfigException
+    {
+        final ContainerOverride containerOverride = new ContainerOverride();
+        // Assume that a single container will run in the task.
+        final ContainerDefinition cd = td.getContainerDefinitions().get(0);
+        setEcsContainerOverrideName(commandContext, commandRequest, containerOverride, cd);
+        setEcsContainerOverrideCommand(commandContext, commandRequest, containerOverride); // RuntimeException,ConfigException
+        setEcsContainerOverrideResource(commandContext, commandRequest, containerOverride);
+
+        final TaskOverride taskOverride = new TaskOverride();
+        taskOverride.withContainerOverrides(containerOverride);
+        request.withOverrides(taskOverride);
+
+        //final ContainerOverride containerOverride = new ContainerOverride();
+        //containerOverride.withName()
+        //containerOverride.withCommand()
+        //containerOverride.withCpu();
+        //containerOverride.withEnvironment();
+        //containerOverride.withMemory();
+        //containerOverride.withMemoryReservation();
+        //containerOverride.withResourceRequirements();
+
+        //final TaskOverride taskOverride = new TaskOverride();
+        //taskOverride.withContainerOverrides();
+        //taskOverride.withExecutionRoleArn();
+        //taskOverride.withTaskRoleArn();
+        //request.withOverrides(taskOverride);
+    }
+
+    protected void setEcsContainerOverrideName(
+            final CommandContext commandContext,
+            final CommandRequest commandRequest,
+            final ContainerOverride containerOverride,
+            final ContainerDefinition cd)
+    {
+        containerOverride.withName(cd.getName());
+    }
+
+    TemporalProjectArchiveStorage createTemporalProjectArchiveStorage(final Config taskConfig)
+            throws ConfigException
+    {
+        return TemporalProjectArchiveStorage.of(storageManager, systemConfig);
+    }
+
+    protected void setEcsContainerOverrideCommand(
+            final CommandContext commandContext,
+            final CommandRequest commandRequest,
+            final ContainerOverride containerOverride)
+            throws ConfigException
+    {
+        final Path projectPath = commandContext.getLocalProjectPath();
+        final Path ioDirectoryPath = commandRequest.getIoDirectory(); // relative
+        final Config taskConfig = commandContext.getTaskRequest().getConfig();
+
+        final TemporalProjectArchiveStorage temporalStorage = createTemporalProjectArchiveStorage(taskConfig); // config exception
+
+        // Create project archive on local. Input contents, e.g. input config file and runner script, are included
+        // in the project archive. It will be uploaded on temporal config storage and then, will be downloaded on
+        // the container. The download URL is generated by pre-signed URL.
+        final Path projectArchivePath;
+        try {
+            projectArchivePath = CommandExecutors.createArchiveFromLocal(projectArchiveLoader, projectPath,
+                    commandRequest.getIoDirectory(), commandContext.getTaskRequest()); // IOException
+        }
+        catch (IOException e) {
+            final String message = s("Cannot archive the project archive. It will be retried.");
+            logger.error(message, e);
+            throw new RuntimeException(message, e);
+        }
+
+        final Path relativeProjectArchivePath = projectPath.relativize(projectArchivePath); // relative
+        final Path lastPathElementOfArchivePath = projectPath.resolve(".digdag/tmp").relativize(projectArchivePath);
+        final String projectArchiveStorageKey = createStorageKey(commandContext.getTaskRequest(), lastPathElementOfArchivePath.toString());
+        final String projectArchiveDirectDownloadUrl;
+        try {
+            // Upload the temporal project archive on the temporal storage with the storage key
+            temporalStorage.uploadFile(projectArchiveStorageKey, projectArchivePath); // IOException
+            projectArchiveDirectDownloadUrl = temporalStorage.getDirectDownloadUrl(projectArchiveStorageKey);
+        }
+        catch (IOException e) {
+            final String message = s("Cannot upload a temporal project archive '%s'with storage key '%s'. It will be retried.", projectArchivePath.toString(), projectArchiveStorageKey);
+            logger.error(message, e);
+            throw new RuntimeException(message, e);
+        }
+        finally {
+            try {
+                Files.deleteIfExists(projectArchivePath); // IOException but ignored
+            }
+            catch (IOException e) {
+                // can be ignored because agent will delete project dir once the task will be finished.
+                logger.info(s("Cannot remove a temporal project archive: %s", projectArchivePath.toString()));
+            }
+        }
+
+        // Create output archive path in the container
+        // Upload the archive file to the S3 bucket
+        final String outputProjectArchivePathName = ".digdag/tmp/archive-output.tar.gz"; // relative
+        final String outputProjectArchiveStorageKey = createStorageKey(commandContext.getTaskRequest(), "archive-output.tar.gz");
+        final String outputProjectArchiveDirectUploadUrl = temporalStorage.getDirectUploadUrl(outputProjectArchiveStorageKey);
+
+        // Build command line arguments that will be passed to Kubernetes API here
+        final ImmutableList.Builder<String> bashArguments = ImmutableList.builder();
+        // TODO
+        // Revisit we need it or not for debugging. If the command will be enabled, pods will show commands are executed
+        // by the executor and will include pre-signed URLs in the commands.
+        //bashArguments.add("set -eux");
+        bashArguments.add(s("mkdir -p %s", ioDirectoryPath.toString()));
+        bashArguments.add(s("curl -s \"%s\" --output %s", projectArchiveDirectDownloadUrl, relativeProjectArchivePath.toString()));
+        bashArguments.add(s("tar -zxf %s", relativeProjectArchivePath.toString()));
+        if (!commandRequest.getWorkingDirectory().toString().isEmpty()) {
+            bashArguments.add(s("pushd %s", commandRequest.getWorkingDirectory().toString()));
+        }
+        bashArguments.addAll(setEcsContainerOverrideArgumentsBeforeCommand());
+        // Add command passed from operator
+        bashArguments.add(commandRequest.getCommandLine().stream().map(Object::toString).collect(Collectors.joining(" ")));
+        bashArguments.add(s("exit_code=$?"));
+        bashArguments.addAll(setEcsContainerOverrideArgumentsAfterCommand());
+        if (!commandRequest.getWorkingDirectory().toString().isEmpty()) {
+            bashArguments.add(s("popd"));
+        }
+        bashArguments.add(s("tar -zcf %s  --exclude %s --exclude %s .digdag/tmp/", outputProjectArchivePathName, relativeProjectArchivePath.toString(), outputProjectArchivePathName));
+        bashArguments.add(s("curl -s -X PUT -T %s -L \"%s\"", outputProjectArchivePathName, outputProjectArchiveDirectUploadUrl));
+        bashArguments.add(s("exit $exit_code"));
+
+        final List<String> bashCommand = ImmutableList.<String>builder()
+                .add("/bin/bash")
+                .add("-c")
+                .add(bashArguments.build().stream().map(Object::toString).collect(Collectors.joining("; ")))
+                .build();
+        logger.debug("Submit command line arguments: " + bashCommand);
+
+        containerOverride.withCommand(bashCommand);
+    }
+
+    protected List<String> setEcsContainerOverrideArgumentsBeforeCommand()
+    {
+        return ImmutableList.of();
+    }
+
+
+    protected List<String> setEcsContainerOverrideArgumentsAfterCommand()
+    {
+        return ImmutableList.of();
+    }
+
+    protected void setEcsContainerOverrideResource(
+            final CommandContext commandContext,
+            final CommandRequest commandRequest,
+            final ContainerOverride containerOverride)
+    {
+        containerOverride.withCpu(128); // TODO
+        containerOverride.withMemory(256); // TODO
+    }
+
+    private static void log(final String message, final CommandLogger to)
+            throws IOException
+    {
+        final byte[] bytes = message.getBytes(StandardCharsets.UTF_8);
+        final InputStream in = new ByteArrayInputStream(bytes);
+        to.copy(in, System.out);
+    }
+
+    private static String s(final String format, final Object... args)
+    {
+        return String.format(Locale.ENGLISH, format, args);
+    }
+
+    private static String createStorageKey(final TaskRequest request, final String lastPathElementOfArchiveFile)
+    {
+        // file key: {taskId}/{lastPathElementOfArchiveFile}
+        return new StringBuilder()
+                .append(request.getTaskId()).append("/")
+                .append(lastPathElementOfArchiveFile)
+                .toString();
+    }
+
+    protected void setEcsTaskLaunchType(final EcsClientConfig clientConfig, final RunTaskRequest request)
+    {
+        final String type = clientConfig.getLaunchType();
+        final LaunchType launchType = LaunchType.fromValue(type);
+        request.withLaunchType(launchType);
+    }
+
+    protected void setEcsNetworkConfiguration(final EcsClientConfig clientConfig, final RunTaskRequest request)
+    {
+        request.withNetworkConfiguration(new NetworkConfiguration().withAwsvpcConfiguration(
+                new AwsVpcConfiguration()
+                        .withSubnets(clientConfig.getSubnets())
+                        .withAssignPublicIp(AssignPublicIp.ENABLED) // TODO should be extracted
+                ));
+
+        //final AwsVpcConfiguration awsVpcConfig = new AwsVpcConfiguration();
+        //awsVpcConfig.withAssignPublicIp();
+        //awsVpcConfig.withAssignPublicIp();
+        //awsVpcConfig.withSecurityGroups();
+        //awsVpcConfig.withSubnets();
+        //final NetworkConfiguration config = new NetworkConfiguration();
+        //config.withAwsvpcConfiguration(vpcConfig);
+        //request.withNetworkConfiguration(config);
+    }
+}

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/DefaultEcsClient.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/DefaultEcsClient.java
@@ -1,0 +1,213 @@
+package io.digdag.standards.command.ecs;
+
+import com.amazonaws.services.ecs.AmazonECSClient;
+import com.amazonaws.services.ecs.model.AccessDeniedException;
+import com.amazonaws.services.ecs.model.BlockedException;
+import com.amazonaws.services.ecs.model.ClusterNotFoundException;
+import com.amazonaws.services.ecs.model.DescribeTaskDefinitionRequest;
+import com.amazonaws.services.ecs.model.DescribeTaskDefinitionResult;
+import com.amazonaws.services.ecs.model.DescribeTasksRequest;
+import com.amazonaws.services.ecs.model.DescribeTasksResult;
+import com.amazonaws.services.ecs.model.InvalidParameterException;
+import com.amazonaws.services.ecs.model.ListTagsForResourceRequest;
+import com.amazonaws.services.ecs.model.ListTagsForResourceResult;
+import com.amazonaws.services.ecs.model.ListTaskDefinitionsRequest;
+import com.amazonaws.services.ecs.model.ListTaskDefinitionsResult;
+import com.amazonaws.services.ecs.model.PlatformTaskDefinitionIncompatibilityException;
+import com.amazonaws.services.ecs.model.PlatformUnknownException;
+import com.amazonaws.services.ecs.model.RunTaskRequest;
+import com.amazonaws.services.ecs.model.RunTaskResult;
+import com.amazonaws.services.ecs.model.StopTaskRequest;
+import com.amazonaws.services.ecs.model.Tag;
+import com.amazonaws.services.ecs.model.TagResourceRequest;
+import com.amazonaws.services.ecs.model.TagResourceResult;
+import com.amazonaws.services.ecs.model.Task;
+import com.amazonaws.services.ecs.model.TaskDefinition;
+import com.amazonaws.services.ecs.model.TaskSetNotFoundException;
+import com.amazonaws.services.ecs.model.UnsupportedFeatureException;
+import com.amazonaws.services.logs.AWSLogs;
+import com.amazonaws.services.logs.model.GetLogEventsRequest;
+import com.amazonaws.services.logs.model.GetLogEventsResult;
+import com.google.common.base.Optional;
+import io.digdag.client.config.ConfigException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Locale;
+
+public class DefaultEcsClient
+        implements EcsClient
+{
+    private static Logger logger = LoggerFactory.getLogger(EcsClient.class);
+
+    private final EcsClientConfig config;
+    private final AmazonECSClient client;
+    private final AWSLogs logs;
+
+    protected DefaultEcsClient(
+            final EcsClientConfig config,
+            final AmazonECSClient client,
+            final AWSLogs logs)
+    {
+        this.config = config;
+        this.client = client;
+        this.logs = logs;
+    }
+
+    @Override
+    public EcsClientConfig getConfig()
+    {
+        return config;
+    }
+
+    /**
+     * Run task on AWS ECS.
+     * https://docs.aws.amazon.com/cli/latest/reference/ecs/run-task.html
+     *
+     * @param request
+     * @return
+     */
+    @Override
+    public RunTaskResult submitTask(final RunTaskRequest request)
+            throws ConfigException
+    {
+        try {
+            return client.runTask(request);
+        }
+        catch (InvalidParameterException |
+                ClusterNotFoundException |
+                UnsupportedFeatureException |
+                PlatformUnknownException |
+                PlatformTaskDefinitionIncompatibilityException |
+                AccessDeniedException |
+                BlockedException e) {
+            throw new ConfigException("Task failed during the task submission", e);
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public TaskDefinition getTaskDefinition(final String taskDefinitionArn)
+    {
+        final DescribeTaskDefinitionRequest request = new DescribeTaskDefinitionRequest()
+                .withTaskDefinition(taskDefinitionArn);
+        final DescribeTaskDefinitionResult result;
+        try {
+            result = client.describeTaskDefinition(request);
+        }
+        catch (InvalidParameterException e) {
+            throw new ConfigException("Task definition arn not found: " + taskDefinitionArn, e);
+        }
+        return result.getTaskDefinition();
+    }
+
+    @Override
+    public Optional<TaskDefinition> getTaskDefinitionByTag(final String tagName, final String tagValue)
+    {
+        String nextToken = null;
+        while (true) {
+            final ListTaskDefinitionsRequest listRequest = new ListTaskDefinitionsRequest();
+            if (nextToken != null) {
+                listRequest.withNextToken(nextToken);
+            }
+
+            final ListTaskDefinitionsResult listResult = client.listTaskDefinitions(listRequest);
+            final List<String> taskDefinitionArns = listResult.getTaskDefinitionArns();
+            for (final String taskDefinitionArn : taskDefinitionArns) {
+                final ListTagsForResourceRequest tagsRequest = new ListTagsForResourceRequest()
+                        .withResourceArn(taskDefinitionArn);
+                final ListTagsForResourceResult tagsResult = client.listTagsForResource(tagsRequest);
+                for (final Tag tag : tagsResult.getTags()) {
+                    if (tag.getKey().equals(tagName) && tag.getValue().equals(tagValue)) {
+                        final TaskDefinition td = getTaskDefinition(taskDefinitionArn);
+                        return Optional.of(td);
+                    }
+                }
+            }
+            nextToken = listResult.getNextToken();
+            if (nextToken == null) {
+                return Optional.absent();
+            }
+        }
+    }
+
+    /**
+     * Get task running on AWS ECS.
+     * https://docs.aws.amazon.com/cli/latest/reference/ecs/describe-tasks.html
+     *
+     * @param cluster
+     * @param taskArn
+     * @return
+     */
+    @Override
+    public Task getTask(final String cluster, final String taskArn)
+    {
+        final DescribeTasksRequest request = new DescribeTasksRequest()
+                .withCluster(cluster)
+                .withTasks(taskArn);
+
+        final DescribeTasksResult result;
+        try {
+            result = client.describeTasks(request); // several exceptions
+        }
+        catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        List<Task> tasks = result.getTasks();
+        if (tasks.isEmpty()) {
+            throw new TaskSetNotFoundException(String.format(Locale.ENGLISH, "Task '%s' not found on cluster '%s'", taskArn, cluster));
+        }
+        return tasks.get(0);
+    }
+
+    /**
+     * Stop task.
+     * https://docs.aws.amazon.com/cli/latest/reference/ecs/stop-task.html
+     *
+     * @param cluster
+     * @param taskArn
+     */
+    @Override
+    public void stopTask(final String cluster, final String taskArn)
+    {
+        final StopTaskRequest request = new StopTaskRequest()
+                .withCluster(cluster)
+                .withTask(taskArn);
+        client.stopTask(request);
+    }
+
+    /**
+     * Get log events.
+     * https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_GetLogEvents.html
+     *
+     * @param groupName
+     * @param streamName
+     * @param nextToken
+     * @return
+     */
+    @Override
+    public GetLogEventsResult getLog(
+            final String groupName,
+            final String streamName,
+            final Optional<String> nextToken)
+    {
+        final GetLogEventsRequest request = new GetLogEventsRequest()
+                .withLogGroupName(groupName)
+                .withLogStreamName(streamName);
+        if (nextToken.isPresent()) {
+            request.withNextToken("f/" + nextToken.get());
+        }
+        return logs.getLogEvents(request);
+    }
+
+    @Override
+    public void close()
+            throws IOException
+    {
+        client.shutdown();
+    }
+}

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/DefaultEcsClientFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/DefaultEcsClientFactory.java
@@ -1,0 +1,42 @@
+package io.digdag.standards.command.ecs;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.Protocol;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.ecs.AmazonECSClient;
+import com.amazonaws.services.logs.AWSLogs;
+import com.amazonaws.services.logs.AWSLogsClient;
+import io.digdag.client.config.ConfigException;
+
+import javax.validation.constraints.NotNull;
+
+public class DefaultEcsClientFactory
+        implements EcsClientFactory
+{
+    @Override
+    public EcsClient createClient(final EcsClientConfig ecsClientConfig)
+            throws ConfigException
+    {
+        // TODO improve to enable several types of credentials providers
+        final AWSStaticCredentialsProvider credentials = new AWSStaticCredentialsProvider(
+                new BasicAWSCredentials(ecsClientConfig.getAccessKeyId(), ecsClientConfig.getSecretAccessKey()));
+        // TODO improve to enable more options
+        final ClientConfiguration clientConfig = new ClientConfiguration()
+                .withProtocol(Protocol.HTTPS);
+
+        final AmazonECSClient ecsClient = (AmazonECSClient) AmazonECSClient.builder()
+                .withRegion(ecsClientConfig.getRegion())
+                .withCredentials(credentials)
+                .withClientConfiguration(clientConfig)
+                .build();
+
+        final AWSLogs logsClient = AWSLogsClient.builder()
+                .withRegion(ecsClientConfig.getRegion())
+                .withCredentials(credentials)
+                .withClientConfiguration(clientConfig)
+                .build();
+
+        return new DefaultEcsClient(ecsClientConfig, ecsClient, logsClient);
+    }
+}

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClient.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClient.java
@@ -2,6 +2,7 @@ package io.digdag.standards.command.ecs;
 
 import com.amazonaws.services.ecs.model.RunTaskRequest;
 import com.amazonaws.services.ecs.model.RunTaskResult;
+import com.amazonaws.services.ecs.model.Tag;
 import com.amazonaws.services.ecs.model.Task;
 import com.amazonaws.services.ecs.model.TaskDefinition;
 import com.amazonaws.services.logs.model.GetLogEventsResult;
@@ -9,6 +10,7 @@ import com.google.common.base.Optional;
 import io.digdag.client.config.ConfigException;
 
 import java.io.IOException;
+import java.util.List;
 
 public interface EcsClient
         extends AutoCloseable
@@ -26,7 +28,7 @@ public interface EcsClient
         boolean match(TaskDefinition td);
     }
 
-    Optional<TaskDefinition> getTaskDefinitionByTag(String tagName, String tagValue);
+    Optional<TaskDefinition> getTaskDefinitionByTags(List<Tag> tags);
 
     Task getTask(String cluster, String taskArn);
 

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClient.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClient.java
@@ -1,0 +1,39 @@
+package io.digdag.standards.command.ecs;
+
+import com.amazonaws.services.ecs.model.RunTaskRequest;
+import com.amazonaws.services.ecs.model.RunTaskResult;
+import com.amazonaws.services.ecs.model.Task;
+import com.amazonaws.services.ecs.model.TaskDefinition;
+import com.amazonaws.services.logs.model.GetLogEventsResult;
+import com.google.common.base.Optional;
+import io.digdag.client.config.ConfigException;
+
+import java.io.IOException;
+
+public interface EcsClient
+        extends AutoCloseable
+{
+    EcsClientConfig getConfig();
+
+    RunTaskResult submitTask(RunTaskRequest request)
+            throws ConfigException;
+
+    TaskDefinition getTaskDefinition(String taskDefinitionArn);
+
+    @FunctionalInterface
+    interface FilterFunction
+    {
+        boolean match(TaskDefinition td);
+    }
+
+    Optional<TaskDefinition> getTaskDefinitionByTag(String tagName, String tagValue);
+
+    Task getTask(String cluster, String taskArn);
+
+    void stopTask(String cluster, String taskArn);
+
+    GetLogEventsResult getLog(String groupName, String streamName, Optional<String> nextToken);
+
+    @Override
+    void close() throws IOException;
+}

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
@@ -1,0 +1,110 @@
+package io.digdag.standards.command.ecs;
+
+import com.google.common.base.Optional;
+import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigException;
+import io.digdag.core.storage.StorageManager;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class EcsClientConfig
+{
+    private static final String SYSTEM_CONFIG_PREFIX = "agent.command_executor.ecs.";
+
+    public static EcsClientConfig of(final Optional<String> clusterName, final Config systemConfig, final Config taskConfig)
+    {
+        return EcsClientConfig.createFromSystemConfig(clusterName, systemConfig);
+        /**
+        if (config.has("ecs")) {
+            // from task config
+            return createFromTaskConfig(clusterName, config); // TODO
+        }
+        else {
+            // from system config
+            return EcsClientConfig.createFromSystemConfig(clusterName, systemConfig);
+        }
+         */
+    }
+
+    private static EcsClientConfig createFromTaskConfig(final Optional<String> clusterName, final Config config)
+    {
+        // TODO
+        // We'd better to customize cluster config by task config
+        throw new ConfigException("Not supported yet");
+    }
+
+    private static EcsClientConfig createFromSystemConfig(final Optional<String> clusterName, final Config systemConfig)
+    {
+        final String name;
+        if (!clusterName.isPresent()) {
+            // Throw ConfigException if 'name' doesn't exist in system config.
+            name = systemConfig.get(SYSTEM_CONFIG_PREFIX + "name", String.class); // ConfigException
+        }
+        else {
+            name = clusterName.get();
+        }
+
+        final String extractedPrefix = SYSTEM_CONFIG_PREFIX + name + ".";
+        final Config extracted = StorageManager.extractKeyPrefix(systemConfig, extractedPrefix);
+        return new EcsClientConfig(name,
+                extracted.get("launch_type", String.class),
+                extracted.get("access_key_id", String.class),
+                extracted.get("secret_access_key", String.class),
+                extracted.get("region", String.class),
+                extracted.get("subnets", String.class)
+        );
+    }
+
+    private final String clusterName;
+    private final String launchType;
+    private final String accessKeyId;
+    private final String secretAccessKey;
+    private final String region;
+    private final List<String> subnets;
+
+    private EcsClientConfig(final String clusterName,
+            final String launchType,
+            final String accessKeyId,
+            final String secretAccessKey,
+            final String region,
+            final String subnets)
+    {
+        this.clusterName = clusterName;
+        this.launchType = launchType;
+        this.accessKeyId = accessKeyId;
+        this.secretAccessKey = secretAccessKey;
+        this.region = region;
+        this.subnets = Arrays.asList(subnets.split(",")); // TODO more robust
+    }
+
+    public String getClusterName()
+    {
+        return clusterName;
+    }
+
+    public String getLaunchType()
+    {
+        return launchType;
+    }
+
+    public String getAccessKeyId()
+    {
+        return accessKeyId;
+    }
+
+    public String getSecretAccessKey()
+    {
+        return secretAccessKey;
+    }
+
+    public String getRegion()
+    {
+        return region;
+    }
+
+    public List<String> getSubnets()
+    {
+        return subnets;
+    }
+}

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientFactory.java
@@ -1,0 +1,9 @@
+package io.digdag.standards.command.ecs;
+
+import io.digdag.client.config.ConfigException;
+
+public interface EcsClientFactory
+{
+    EcsClient createClient(EcsClientConfig ecsClientConfig)
+            throws ConfigException;
+}

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsTaskStatus.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsTaskStatus.java
@@ -1,0 +1,55 @@
+package io.digdag.standards.command.ecs;
+
+/**
+ * this class represents task lifecycle status on AWS ECS.
+ * https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-lifecycle.html
+ */
+public enum EcsTaskStatus
+{
+    PROVISIONING(0, "provisioning"),
+    PENDING(1, "pending"),
+    ACTIVATING(2, "activating"),
+    RUNNING(3, "running"),
+    DEACTIVATING(4, "deactivating"),
+    STOPPING(5, "stopping"),
+    DEPROVISIONING(6, "deprovisioning"),
+    STOPPED(7, "stopped");
+
+    private final int index;
+    private final String name;
+
+    EcsTaskStatus(final int index, final String name)
+    {
+        this.index = index;
+        this.name = name;
+    }
+
+    public int getIndex()
+    {
+        return index;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public boolean isFinished()
+    {
+        return isSameOrAfter(EcsTaskStatus.STOPPED);
+    }
+
+    public boolean isSameOrAfter(EcsTaskStatus another)
+    {
+        return another.index <= index;
+    }
+
+    public static EcsTaskStatus of(String value) {
+        for (final EcsTaskStatus s : EcsTaskStatus.values()) {
+            if (s.name.equalsIgnoreCase(value)) {
+                return s;
+            }
+        }
+        throw new IllegalStateException("Unknown task status " + value);
+    }
+}

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/TemporalProjectArchiveStorage.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/TemporalProjectArchiveStorage.java
@@ -1,0 +1,58 @@
+package io.digdag.standards.command.ecs;
+
+import com.google.common.base.Throwables;
+import io.digdag.client.config.Config;
+import io.digdag.core.storage.StorageManager;
+import io.digdag.spi.Storage;
+import io.digdag.spi.StorageFileNotFoundException;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+
+public class TemporalProjectArchiveStorage
+{
+    private static final String PARAMS_PREFIX = "agent.command_executor.ecs.temporal_storage.";
+
+    public static TemporalProjectArchiveStorage of(final StorageManager sm, final Config systemConfig)
+    {
+        final Storage storage = sm.create(systemConfig, PARAMS_PREFIX);
+        return new TemporalProjectArchiveStorage(storage);
+    }
+
+    private final Storage storage;
+
+    private TemporalProjectArchiveStorage(final Storage storage)
+    {
+        this.storage = storage;
+    }
+
+    public void uploadFile(final String key, final Path filePath)
+            throws IOException
+    {
+        final File file = filePath.toFile();
+        storage.put(key, file.length(), () -> new FileInputStream(file));
+    }
+
+    public String getDirectDownloadUrl(final String key)
+    {
+        return storage.getDirectDownloadHandle(key).get().getUrl().toString();
+    }
+
+    public String getDirectUploadUrl(final String key)
+    {
+        return storage.getDirectUploadHandle(key).get().getUrl().toString();
+    }
+
+    public InputStream getContentInputStream(final String key)
+    {
+        try {
+            return storage.open(key).getContentInputStream();
+        }
+        catch (StorageFileNotFoundException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+}

--- a/digdag-tests/src/test/java/acceptance/td/PyIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/PyIT.java
@@ -1,0 +1,162 @@
+package acceptance.td;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.digdag.client.DigdagClient;
+import io.digdag.client.api.Id;
+import io.digdag.client.api.RestSessionAttempt;
+import io.digdag.client.config.Config;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import utils.CommandStatus;
+import utils.TemporaryDigdagServer;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyOrNullString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeThat;
+import static utils.TestUtils.copyResource;
+import static utils.TestUtils.getAttemptId;
+import static utils.TestUtils.getAttemptLogs;
+import static utils.TestUtils.main;
+
+public class PyIT
+{
+    private static final String ECS_CONFIG = System.getenv("ECS_IT_CONFIG");
+
+    private static final Logger logger = LoggerFactory.getLogger(EmrIT.class);
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+    @Rule
+    public TemporaryDigdagServer server = TemporaryDigdagServer.of();
+
+    private String accessKeyId;
+    private String secretAccessKey;
+    // AWS ECS
+    private String ecsCluster;
+    private String ecsLaunchType;
+    private String ecsRegion;
+    private String ecsSubnets;
+    // AWS S3
+    private String s3Bucket;
+    private String s3Endpoint;
+
+    private Config config;
+    private Path configFile;
+    private DigdagClient client;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        assumeThat(ECS_CONFIG, not(isEmptyOrNullString()));
+
+        ObjectMapper objectMapper = DigdagClient.objectMapper();
+        config = Config.deserializeFromJackson(objectMapper, objectMapper.readTree(ECS_CONFIG));
+
+        accessKeyId = config.get("access_key_id", String.class);
+        secretAccessKey = config.get("secret_access_key", String.class);
+
+        ecsCluster = config.get("ecs_cluster", String.class);
+        ecsLaunchType = config.get("ecs_launch_type", String.class);
+        ecsRegion = config.get("ecs_region", String.class);
+        ecsSubnets = config.get("ecs_subnets", String.class);
+
+        s3Bucket = config.get("s3_bucket", String.class);
+        s3Endpoint = config.get("s3_endopint", String.class);
+
+        server = TemporaryDigdagServer.builder()
+                .configuration(
+                        "agent.command_executor.ecs.name=" + ecsCluster,
+                        "agent.command_executor.ecs." + ecsCluster + ".launch_type=" + ecsLaunchType,
+                        "agent.command_executor.ecs." + ecsCluster + ".access_key_id=" + accessKeyId,
+                        "agent.command_executor.ecs." + ecsCluster + ".secret_access_key=" + secretAccessKey,
+                        "agent.command_executor.ecs." + ecsCluster + ".region=" + ecsRegion,
+                        "agent.command_executor.ecs." + ecsCluster + ".subnets=" + ecsSubnets,
+                        "agent.command_executor.ecs.temporal_storage.type=s3",
+                        "agent.command_executor.ecs.temporal_storage.s3.bucket=" + s3Bucket,
+                        "agent.command_executor.ecs.temporal_storage.s3.endpoint=" + s3Endpoint,
+                        "agent.command_executor.ecs.temporal_storage.s3.credentials.access-key-id=" + accessKeyId,
+                        "agent.command_executor.ecs.temporal_storage.s3.credentials.secret-access-key=" + secretAccessKey,
+                        "agent.command_executor.ecs.temporal_storage.s3.direct_download=true",
+                        "agent.command_executor.ecs.temporal_storage.s3.direct_download_expiration=18000",
+                        "agent.command_executor.ecs.temporal_storage.s3.direct_upload=true",
+                        "agent.command_executor.ecs.temporal_storage.s3.direct_upload_expiration=18000"
+                )
+                .build();
+        server.start();
+
+        configFile = folder.newFile().toPath();
+
+        client = DigdagClient.builder()
+                .host(server.host())
+                .port(server.port())
+                .build();
+    }
+
+    @Test
+    public void testRunOnEcs()
+            throws Exception
+    {
+        Path tempdir = folder.getRoot().toPath().toAbsolutePath();
+        Path projectDir = tempdir.resolve("py");
+        Path scriptsDir = projectDir.resolve("scripts");
+
+        // Create new project
+        CommandStatus initStatus = main("init",
+                "-c", configFile.toString(),
+                projectDir.toString());
+        assertThat(initStatus.code(), is(0));
+        Files.createDirectories(scriptsDir);
+        copyResource("acceptance/td/echo_params/echo_params.dig", projectDir.resolve("echo_params.dig"));
+        copyResource("acceptance/echo_params/scripts/__init__.py", scriptsDir.resolve("__init__.py"));
+        copyResource("acceptance/echo_params/scripts/echo_params.py", scriptsDir.resolve("echo_params.py"));
+
+        // Push the project
+        CommandStatus pushStatus = main("push",
+                "--project", projectDir.toString(),
+                "py",
+                "-c", configFile.toString(),
+                "-e", server.endpoint(),
+                "-r", "4711");
+        assertThat(pushStatus.errUtf8(), pushStatus.code(), is(0));
+
+        // Start the workflow
+        Id attemptId;
+        {
+            CommandStatus startStatus = main("start",
+                    "-c", configFile.toString(),
+                    "-e", server.endpoint(),
+                    "py", "echo_params",
+                    "--session", "now");
+            assertThat(startStatus.code(), is(0));
+            attemptId = getAttemptId(startStatus);
+        }
+
+        // Wait for the attempt to complete
+        {
+            RestSessionAttempt attempt = null;
+            for (int i = 0; i < 300; i++) { // TODO heuristics should be removed
+                attempt = client.getSessionAttempt(attemptId);
+                if (attempt.getDone()) {
+                    break;
+                }
+                Thread.sleep(1000);
+            }
+            assertThat(attempt.getSuccess(), is(true));
+        }
+
+        String logs = getAttemptLogs(client, attemptId);
+        assertThat(logs, containsString("digdag params"));
+    }
+
+}

--- a/digdag-tests/src/test/resources/acceptance/td/echo_params/echo_params.dig
+++ b/digdag-tests/src/test/resources/acceptance/td/echo_params/echo_params.dig
@@ -1,0 +1,5 @@
+_export:
+  docker:
+    image: "python:3.7"
++foo:
+  py>: scripts.echo_params.echo_params


### PR DESCRIPTION
This PR introduces EcsCommandExecutor, which enables submitting scripting operators, e.g. "py>", "rb>" and "sh>", and running the script on ECS cluster as ECS tasks. The functionality is based on command executor SPI v2. It will be released in v0.10.