### PR TITLE
Stop some cli commands call migrate to h2 memory db.

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/client/Archive.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Archive.java
@@ -11,6 +11,7 @@ import io.digdag.cli.StdOut;
 import io.digdag.cli.SystemExitException;
 import io.digdag.cli.YamlMapper;
 import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigElement;
 import io.digdag.client.config.ConfigFactory;
 import io.digdag.core.DigdagEmbed;
 import io.digdag.core.config.ConfigLoaderManager;
@@ -58,7 +59,10 @@ public class Archive
     private void archive()
             throws Exception
     {
+        ConfigElement systemConfig = ConfigElement.fromJson("{ \"database.migrate\" : false } }");
+
         try (DigdagEmbed digdag = new DigdagEmbed.Bootstrap()
+                .setSystemConfig(systemConfig)
                 .withWorkflowExecutor(false)
                 .withScheduleExecutor(false)
                 .withLocalAgent(false)

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Push.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Push.java
@@ -14,6 +14,7 @@ import io.digdag.cli.YamlMapper;
 import io.digdag.client.DigdagClient;
 import io.digdag.client.api.RestProject;
 import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigElement;
 import io.digdag.client.config.ConfigFactory;
 import io.digdag.core.DigdagEmbed;
 import io.digdag.core.config.ConfigLoaderManager;
@@ -76,7 +77,10 @@ public class Push
         Path archivePath = Files.createTempFile(dir, "archive-", ".tar.gz");
         archivePath.toFile().deleteOnExit();
 
+        ConfigElement systemConfig = ConfigElement.fromJson("{ \"database.migrate\" : false } }");
+
         Injector injector = new DigdagEmbed.Bootstrap()
+                .setSystemConfig(systemConfig)
                 .withWorkflowExecutor(false)
                 .withScheduleExecutor(false)
                 .withLocalAgent(false)

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Start.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Start.java
@@ -16,6 +16,7 @@ import io.digdag.client.api.RestWorkflowDefinition;
 import io.digdag.client.api.RestWorkflowSessionTime;
 import io.digdag.client.api.SessionTimeTruncate;
 import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigElement;
 import io.digdag.client.config.ConfigFactory;
 import io.digdag.core.DigdagEmbed;
 import io.digdag.core.config.ConfigLoaderManager;
@@ -91,7 +92,10 @@ public class Start
     private void start(String projName, String workflowName)
         throws Exception
     {
+        ConfigElement systemConfig = ConfigElement.fromJson("{ \"database.migrate\" : false } }");
+
         Injector injector = new DigdagEmbed.Bootstrap()
+            .setSystemConfig(systemConfig)
             .withWorkflowExecutor(false)
             .withScheduleExecutor(false)
             .withLocalAgent(false)

--- a/digdag-tests/src/test/java/acceptance/CliArchiveIT.java
+++ b/digdag-tests/src/test/java/acceptance/CliArchiveIT.java
@@ -1,0 +1,71 @@
+package acceptance;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import utils.CommandStatus;
+import utils.TemporaryDigdagServer;
+
+import java.nio.file.Path;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static utils.TestUtils.copyResource;
+import static utils.TestUtils.main;
+
+public class CliArchiveIT
+{
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Rule
+    public TemporaryDigdagServer server = TemporaryDigdagServer.of();
+
+    private Path config;
+    private Path projectDir;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        projectDir = folder.getRoot().toPath().resolve("foobar");
+        config = folder.newFile().toPath();
+    }
+
+    @Test
+    public void archiveProject()
+            throws Exception
+    {
+
+        // Create new project
+        CommandStatus initStatus = main("init",
+                "-c", config.toString(),
+                projectDir.toString());
+        assertThat(initStatus.code(), is(0));
+
+        copyResource("acceptance/basic.dig", projectDir.resolve("basic.dig"));
+
+        // 1. archive project
+        {
+            CommandStatus archiveStatus = main(
+                    "archive",
+                    "--project", projectDir.toString(),
+                    "--output", "test_archive.tar.gz",
+                    "-c", config.toString()
+            );
+            assertThat(archiveStatus.errUtf8(), archiveStatus.code(), is(0));
+        }
+
+        // 2. then upload it.
+        {
+            CommandStatus uploadStatus = main(
+                    "upload",
+                    "test_archive.tar.gz",
+                    "test_archive_proj",
+                    "-c", config.toString(),
+                    "-e", server.endpoint());
+            assertThat(uploadStatus.errUtf8(), uploadStatus.code(), is(0));
+        }
+    }
+}

--- a/digdag-tests/src/test/java/acceptance/CliStartIT.java
+++ b/digdag-tests/src/test/java/acceptance/CliStartIT.java
@@ -1,0 +1,72 @@
+package acceptance;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import utils.CommandStatus;
+import utils.TemporaryDigdagServer;
+
+import java.nio.file.Path;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static utils.TestUtils.copyResource;
+import static utils.TestUtils.main;
+
+public class CliStartIT
+{
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Rule
+    public TemporaryDigdagServer server = TemporaryDigdagServer.of();
+
+    private Path config;
+    private Path projectDir;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        projectDir = folder.getRoot().toPath().resolve("foobar");
+        config = folder.newFile().toPath();
+    }
+
+    @Test
+    public void startProject()
+            throws Exception
+    {
+
+        // Create new project
+        CommandStatus initStatus = main("init",
+                "-c", config.toString(),
+                projectDir.toString());
+        assertThat(initStatus.code(), is(0));
+
+        copyResource("acceptance/basic.dig", projectDir.resolve("basic.dig"));
+
+        // 1. archive project
+        {
+            CommandStatus pushStatus = main(
+                    "push",
+                    "--project", projectDir.toString(),
+                    "test_proj",
+                    "-c", config.toString(),
+                    "-e", server.endpoint()
+            );
+            assertThat(pushStatus.errUtf8(), pushStatus.code(), is(0));
+        }
+
+        // 2. then start it.
+        {
+            CommandStatus uploadStatus = main(
+                    "start",
+                    "test_proj",
+                    "--session", "now",
+                    "-c", config.toString(),
+                    "-e", server.endpoint());
+            assertThat(uploadStatus.errUtf8(), uploadStatus.code(), is(0));
+        }
+    }
+}


### PR DESCRIPTION
This PR stop useless migrate execution when some cli commands are executed.

archive, push, start cli commands use DigdagEmbed.
In this case database migration is called and applied to empty h2 memory database.

This is no impact to Digdag server because migrate command requires the access to digdag database but no info is provided to these commands.
But after introducing migrate command, migrate info is displayed in console and it may be confused to users.
In addition we should not run useless migrate execution.
So in this PR, "database.migrate : false" set to DigdagEmbed and disable migration.
