### PR TITLE
Introduce http_call.max_response_content_size system config for http_call> operator

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/operator/HttpCallOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/HttpCallOperatorFactory.java
@@ -44,6 +44,7 @@ public class HttpCallOperatorFactory
     private final ObjectMapper mapper;
     private final YAMLFactory yaml;
     private final ProjectArchiveLoader projectLoader;
+    private final int maxResponseContentSize;
 
     @Inject
     public HttpCallOperatorFactory(ConfigFactory cf,
@@ -58,6 +59,7 @@ public class HttpCallOperatorFactory
                 new ConfigLoaderManager(
                     cf,
                     new YamlConfigLoader()));
+        this.maxResponseContentSize = systemConfig.get("config.http_call.max_response_content_size", int.class, 64 * 1024);
     }
 
     @Override
@@ -102,8 +104,8 @@ public class HttpCallOperatorFactory
             String content = response.getContentAsString();
 
             // validate response length
-            if (content.length() > maxStoredResponseContentSize) {
-                throw new TaskExecutionException("Response content too large: " + content.length() + " > " + maxStoredResponseContentSize);
+            if (content.length() > maxResponseContentSize) {
+                throw new TaskExecutionException("Response content too large: " + content.length() + " > " + maxResponseContentSize);
             }
 
             // parse content based on response media type

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/HttpOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/HttpOperatorFactory.java
@@ -71,7 +71,7 @@ public class HttpOperatorFactory
     private final boolean allowUserProxy;
     private final int maxRedirects;
     private final String userAgent;
-    final int maxStoredResponseContentSize;
+    private final int maxStoredResponseContentSize;
 
     @Inject
     public HttpOperatorFactory(Config systemConfig, @Environment Map<String, String> env)


### PR DESCRIPTION
follow-up of https://github.com/treasure-data/digdag/pull/1082.

The size limit should be separated each other. Because those operators make different resource usage. For example, "http>" uses store param to store response content. but "http_call>" not uses store param. The limit for "http_call>" could be relaxed. For now, as the limitation of http response content size, "http_call>" follows and uses maxStoredResponseContentSize in "http>". This is not good idea. 