### PR TITLE
Fix error when schema_update_options given

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/operator/gcp/BqLoadOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/gcp/BqLoadOperatorFactory.java
@@ -96,9 +96,9 @@ class BqLoadOperatorFactory
             params.getOptional("allow_quoted_newlines", boolean.class).transform(cfg::setAllowQuotedNewlines);
             params.getOptional("allow_jagged_rows", boolean.class).transform(cfg::setAllowJaggedRows);
             params.getOptional("ignore_unknown_values", boolean.class).transform(cfg::setIgnoreUnknownValues);
-            params.getOptional("projection_fields", new TypeReference<List<String>>() {}).transform(cfg::setProjectionFields);
+            Optional.of(params.getListOrEmpty("projection_fields", String.class)).transform(cfg::setProjectionFields);
             params.getOptional("autodetect", boolean.class).transform(cfg::setAutodetect);
-            params.getOptional("schema_update_options", new TypeReference<List<String>>() {}).transform(cfg::setSchemaUpdateOptions);
+            Optional.of(params.getListOrEmpty("schema_update_options", String.class)).transform(cfg::setSchemaUpdateOptions);
 
             return new JobConfiguration()
                     .setLoad(cfg);


### PR DESCRIPTION
I  encountered a bug when a option `schema_update_options` with `bq_load` is given to digdag, it will be dead immediately. I investigated the problem and might find  the root cause. But I don't have enough knowledge about digdag, I will be very pleased if you give me advice.

### Repro

Declare `bq_load` command with `schema_update_options` option.

```
    +load:
      bq_load>: ${ bucket_path }/*.gz
      dataset: ${ dataset_name }
      destination_table: ${ table_name }
      source_format: NEWLINE_DELIMITED_JSON
      schema_update_options: 
        - ALLOW_FIELD_ADDITION
        - ALLOW_FIELD_RELAXATION
```

### Expected

Workflow is executed without an error.

### Actual

`bq_load` failed with `java.lang.ClassCastException`.

```
bash-3.2$ digdag run --rerun fluentd-reload.dig -X io.digdag.limits.maxWorkflowTasks=100000
2019-06-11 15:05:56 +0900: Digdag v0.9.37
2019-06-11 15:05:58 +0900 [INFO] (main): Database migration started
2019-06-11 15:05:58 +0900 [INFO] (main): Applying database migration:20151204221156
2019-06-11 15:05:58 +0900 [INFO] (main): Applying database migration:20160602123456
2019-06-11 15:05:58 +0900 [INFO] (main): Applying database migration:20160602184025
2019-06-11 15:05:58 +0900 [INFO] (main): Applying database migration:20160610154832
2019-06-11 15:05:58 +0900 [INFO] (main): Applying database migration:20160623123456
2019-06-11 15:05:58 +0900 [INFO] (main): Applying database migration:20160719172538
2019-06-11 15:05:58 +0900 [INFO] (main): Applying database migration:20160817123456
2019-06-11 15:05:58 +0900 [INFO] (main): Applying database migration:20160818043815
2019-06-11 15:05:58 +0900 [INFO] (main): Applying database migration:20160818220026
2019-06-11 15:05:58 +0900 [INFO] (main): Applying database migration:20160908175551
2019-06-11 15:05:58 +0900 [INFO] (main): Applying database migration:20160926123456
2019-06-11 15:05:58 +0900 [INFO] (main): Applying database migration:20160928203753
2019-06-11 15:05:58 +0900 [INFO] (main): Applying database migration:20161005225356
2019-06-11 15:05:58 +0900 [INFO] (main): Applying database migration:20161028112233
2019-06-11 15:05:58 +0900 [INFO] (main): Applying database migration:20161110112233
2019-06-11 15:05:58 +0900 [INFO] (main): Applying database migration:20161209001857
2019-06-11 15:05:58 +0900 [INFO] (main): Applying database migration:20170116082921
2019-06-11 15:05:58 +0900 [INFO] (main): Applying database migration:20170116090744
2019-06-11 15:05:58 +0900 [INFO] (main): Applying database migration:20170223220127
2019-06-11 15:05:58 +0900 [INFO] (main): Applying database migration:20190318175338
2019-06-11 15:05:58 +0900 [INFO] (main): Database migration successfully finished.
2019-06-11 15:05:58 +0900 [WARN] (main): Reusing the last session time 2019-06-10T00:00:00+09:00.
2019-06-11 15:05:58 +0900 [INFO] (main): Using session /Users/User/test_dag/.digdag/status/20190610T000000+0900.
2019-06-11 15:05:58 +0900 [INFO] (main): Starting a new session project id=1 workflow name=fluentd-reload session_time=2019-06-10T00:00:00+09:00
2019-06-11 15:05:59 +0900 [INFO] (0018@[0:default]+fluentd-reload+full_range_load+load_user_action+load): call>:fluentd-gcs2bq.dig
2019-06-11 15:06:00 +0900 [INFO] (0018@[0:default]+fluentd-reload+full_range_load+load_user_action+load^sub+gcs2bq_loop): loop>: 661
2019-06-11 15:06:01 +0900 [INFO] (0018@[0:default]+fluentd-reload+full_range_load+load_user_action+load^sub+gcs2bq_loop^sub+loop-0+run): echo>: user_action 20170818 test_bulkload.user_action$20170818
user_action 20170818 test_bulkload.user_action$20170818
2019-06-11 15:06:02 +0900 [INFO] (0018@[0:default]+fluentd-reload+full_range_load+load_user_action+load^sub+gcs2bq_loop^sub+loop-0+load): bq_load>: gs://log/user_action/dt=2017-08-18/*.gz
2019-06-11 15:06:02 +0900 [ERROR] (0018@[0:default]+fluentd-reload+full_range_load+load_user_action+load^sub+gcs2bq_loop^sub+loop-0+load): Task failed with unexpected error: java.util.ArrayList cannot be cast to com.google.common.base.Optional
java.lang.ClassCastException: java.util.ArrayList cannot be cast to com.google.common.base.Optional
	at io.digdag.client.config.Config.getOptional(Config.java:294)
	at io.digdag.standards.operator.gcp.BqLoadOperatorFactory$BqLoadOperator.jobConfiguration(BqLoadOperatorFactory.java:101)
	at io.digdag.standards.operator.gcp.BaseBqJobOperator.run(BaseBqJobOperator.java:25)
	at io.digdag.standards.operator.gcp.BaseBqOperator.run(BaseBqOperator.java:28)
	at io.digdag.standards.operator.gcp.BaseGcpOperator.runTask(BaseGcpOperator.java:25)
	at io.digdag.util.BaseOperator.run(BaseOperator.java:35)
	at io.digdag.core.agent.OperatorManager.callExecutor(OperatorManager.java:315)
	at io.digdag.cli.Run$OperatorManagerWithSkip.callExecutor(Run.java:705)
	at io.digdag.core.agent.OperatorManager.runWithWorkspace(OperatorManager.java:257)
	at io.digdag.core.agent.OperatorManager.lambda$runWithHeartbeat$2(OperatorManager.java:137)
	at io.digdag.core.agent.LocalWorkspaceManager.withExtractedArchive(LocalWorkspaceManager.java:25)
	at io.digdag.core.agent.OperatorManager.runWithHeartbeat(OperatorManager.java:135)
	at io.digdag.core.agent.OperatorManager.run(OperatorManager.java:119)
	at io.digdag.cli.Run$OperatorManagerWithSkip.run(Run.java:687)
	at io.digdag.core.agent.MultiThreadAgent.lambda$null$0(MultiThreadAgent.java:127)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```

### Env

```
bash-3.2$ sw_vers
ProductName:	Mac OS X
ProductVersion:	10.13.6
BuildVersion:	17G3025

bash-3.2$ java -version
java version "1.8.0_212"
Java(TM) SE Runtime Environment (build 1.8.0_212-b10)
Java HotSpot(TM) 64-Bit Server VM (build 25.212-b10, mixed mode)

bash-3.2$ digdag --version
0.9.37
```
