### PR TITLE
Introduce py> operator error message and stacktrace on error

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/operator/PyOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/PyOperatorFactory.java
@@ -12,12 +12,14 @@ import java.nio.file.Path;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Map;
+import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.CharStreams;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.google.inject.Inject;
 import io.digdag.spi.OperatorContext;
 import org.slf4j.Logger;
@@ -172,7 +174,30 @@ public class PyOperatorFactory
             int ecode = p.waitFor();
 
             if (ecode != 0) {
-                throw new RuntimeException("Python command failed with code " + ecode);
+                StringBuilder reason = new StringBuilder();
+                reason.append("Python command failed with code ").append(ecode);
+
+                try {
+                    Config out = mapper.readValue(workspace.getFile(outFile), Config.class);
+                    Config err = out.getNestedOrGetEmpty("error");
+                    Optional<String> errClass = err.getOptional("class", String.class);
+                    Optional<String> errMessage = err.getOptional("message", String.class);
+                    List<String> errBacktrace = err.getListOrEmpty("backtrace", String.class);
+                    if (errClass.isPresent()) {
+                        reason.append(": from ").append(errClass.get());
+                    }
+                    if (errMessage.isPresent()) {
+                        reason.append(": ").append(errMessage.get());
+                    }
+                    if (!errBacktrace.isEmpty()) {
+                        reason.append("\n\tfrom ");
+                        reason.append(String.join("\n", errBacktrace));
+                    }
+                }
+                catch (JsonMappingException ex) {
+                    // comes here if runner.py fails before writing outFile.
+                }
+                throw new RuntimeException(reason.toString());
             }
 
             return mapper.readValue(workspace.getFile(outFile), Config.class);

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/PyOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/PyOperatorFactory.java
@@ -190,8 +190,8 @@ public class PyOperatorFactory
                         reason.append(": ").append(errMessage.get());
                     }
                     if (!errBacktrace.isEmpty()) {
-                        reason.append("\n\tfrom ");
-                        reason.append(String.join("\n", errBacktrace));
+                        reason.append("\n    ");
+                        reason.append(String.join("    ", errBacktrace));
                     }
                 }
                 catch (JsonMappingException ex) {

--- a/digdag-standards/src/main/resources/digdag/standards/py/runner.py
+++ b/digdag-standards/src/main/resources/digdag/standards/py/runner.py
@@ -4,6 +4,7 @@ import json
 import imp
 import inspect
 import collections
+import traceback
 
 command = sys.argv[1]
 in_file = sys.argv[2]
@@ -140,6 +141,9 @@ def digdag_inspect_arguments(callable_type, exclude_self, params):
         return args
 
 callable_type, method_name = digdag_inspect_command(command)
+error = None
+error_value = None
+error_traceback = None
 
 if method_name:
     init_args = digdag_inspect_arguments(callable_type.__init__, True, params)
@@ -147,11 +151,21 @@ if method_name:
 
     method = getattr(instance, method_name)
     method_args = digdag_inspect_arguments(method, True, params)
-    result = method(**method_args)
+    try:
+        result = method(**method_args)
+    except Exception as e:
+        error = e
+        error_type, error_value, _tb = sys.exc_info()
+        error_traceback = traceback.format_exception(error_type, error_value, _tb)
 
 else:
     args = digdag_inspect_arguments(callable_type, False, params)
-    result = callable_type(**args)
+    try:
+        result = callable_type(**args)
+    except Exception as e:
+        error = e
+        error_type, error_value, _tb = sys.exc_info()
+        error_traceback = traceback.format_exception(error_type, error_value, _tb)
 
 out = {
     'subtask_config': digdag_env.subtask_config,
@@ -160,6 +174,15 @@ out = {
     #'state_params': digdag_env.state_params,  # only for retrying
 }
 
+if error:
+    out['error'] = {
+        'class': error_value.__class__.__name__,
+        'message': str(error_value),
+        'backtrace': error_traceback
+    }
+
 with open(out_file, 'w') as f:
     json.dump(out, f)
 
+if error:
+    raise error

--- a/digdag-tests/src/test/java/acceptance/PyIT.java
+++ b/digdag-tests/src/test/java/acceptance/PyIT.java
@@ -151,4 +151,56 @@ public class PyIT
         assertThat(logs, containsString("python python"));
         assertThat(logs, containsString("python [u'python', u'-v']"));
     }
+
+    @Test
+    public void testPythonErrorMessageAndStacktrace()
+            throws Exception
+    {
+        final Path tempdir = folder.getRoot().toPath().toAbsolutePath();
+        final Path projectDir = tempdir.resolve("py");
+        final Path scriptsDir = projectDir.resolve("scripts");
+
+        // Create new project
+        final CommandStatus initStatus = main("init",
+                "-c", config.toString(),
+                projectDir.toString());
+        assertThat(initStatus.code(), is(0));
+        Files.createDirectories(scriptsDir);
+        copyResource("acceptance/py/stacktrace_python.dig", projectDir.resolve("stacktrace_python.dig"));
+        copyResource("acceptance/py/scripts/stacktrace.py", scriptsDir.resolve("stacktrace.py"));
+        copyResource("acceptance/py/scripts/__init__.py", scriptsDir.resolve("__init__.py"));
+
+        // Push the project
+        final CommandStatus pushStatus = main("push",
+                "--project", projectDir.toString(),
+                "py",
+                "-c", config.toString(),
+                "-e", server.endpoint(),
+                "-r", "4711");
+        assertThat(pushStatus.errUtf8(), pushStatus.code(), is(0));
+
+        // Start the workflow
+        final CommandStatus startStatus = main("start",
+                "-c", config.toString(),
+                "-e", server.endpoint(),
+                "py", "stacktrace_python",
+                "--session", "now");
+        assertThat(startStatus.code(), is(0));
+        final Id attemptId = getAttemptId(startStatus);
+
+        // Wait for the attempt to complete
+        RestSessionAttempt attempt = null;
+        for (int i = 0; i < 30; i++) {
+            attempt = client.getSessionAttempt(attemptId);
+            if (attempt.getDone()) {
+                break;
+            }
+            Thread.sleep(1000);
+        }
+
+        final String logs = getAttemptLogs(client, attemptId);
+        assertThat(logs, containsString("Task failed with unexpected error: Python command failed with code 1: from MyError: my error message"));
+        assertThat(logs, containsString(", in run"));
+        assertThat(logs, containsString("ERROR_MESSAGE_BEGIN Python command failed with code 1: from MyError: my error message"));
+    }
 }

--- a/digdag-tests/src/test/resources/acceptance/py/scripts/stacktrace.py
+++ b/digdag-tests/src/test/resources/acceptance/py/scripts/stacktrace.py
@@ -1,0 +1,5 @@
+class MyError(Exception):
+    pass
+
+def run():
+    raise MyError('my error message')

--- a/digdag-tests/src/test/resources/acceptance/py/stacktrace_python.dig
+++ b/digdag-tests/src/test/resources/acceptance/py/stacktrace_python.dig
@@ -1,0 +1,5 @@
++stacktrace_python:
+  py>: scripts.stacktrace.run
+
+_error:
+  echo>: ERROR_MESSAGE_BEGIN ${error.message} ERROR_MESSAGE_END


### PR DESCRIPTION
Introduce the same function with #1024 for py> operator.

Note that the format of the first line of the error message is slightly different from Ruby, but I'm open to aligning them.

Python: `Python command failed with code 1: from MyError: my error message`
Ruby: `Ruby command failed with code 1: my error message (StacktraceRuby::MyErrorClass) `

Here is the example output:

```
2019-06-11 17:56:06 +0900 [ERROR] (0017@[0:default]+stacktrace_python+stacktrace_python): Task failed with unexpected error: Python command failed with code 1: from MyError: my error message
    Traceback (most recent call last):
      File "<stdin>", line 164, in <module>
      File "scripts/stacktrace.py", line 5, in run
    raise MyError('my error message')
    MyError: my error message

java.lang.RuntimeException: Python command failed with code 1: from MyError: my error message
    Traceback (most recent call last):
      File "<stdin>", line 164, in <module>
      File "scripts/stacktrace.py", line 5, in run
    raise MyError('my error message')
    MyError: my error message

	at io.digdag.standards.operator.PyOperatorFactory$PyOperator.runCode(PyOperatorFactory.java:200)
	at io.digdag.standards.operator.PyOperatorFactory$PyOperator.runTask(PyOperatorFactory.java:97)
	at io.digdag.util.BaseOperator.run(BaseOperator.java:35)
	at io.digdag.core.agent.OperatorManager.callExecutor(OperatorManager.java:315)
	at io.digdag.cli.Run$OperatorManagerWithSkip.callExecutor(Run.java:705)
	at io.digdag.core.agent.OperatorManager.runWithWorkspace(OperatorManager.java:257)
	at io.digdag.core.agent.OperatorManager.lambda$runWithHeartbeat$2(OperatorManager.java:137)
	at io.digdag.core.agent.LocalWorkspaceManager.withExtractedArchive(LocalWorkspaceManager.java:25)
	at io.digdag.core.agent.OperatorManager.runWithHeartbeat(OperatorManager.java:135)
	at io.digdag.core.agent.OperatorManager.run(OperatorManager.java:119)
	at io.digdag.cli.Run$OperatorManagerWithSkip.run(Run.java:687)
	at io.digdag.core.agent.MultiThreadAgent.lambda$null$0(MultiThreadAgent.java:127)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
2019-06-11 17:56:06 +0900 [WARN] (0017@[0:default]+stacktrace_python^failure-alert): Skipped
2019-06-11 17:56:06 +0900 [WARN] (0019@[0:default]+stacktrace_python^error): Skipped
error:
  * +stacktrace_python+stacktrace_python:
    Python command failed with code 1: from MyError: my error message
    Traceback (most recent call last):
      File "<stdin>", line 164, in <module>
      File "scripts/stacktrace.py", line 5, in run
    raise MyError('my error message')
    MyError: my error message
 (runtime)
```