### PR TITLE
Add project_id parameter to require operator doc

### DIFF
--- a/digdag-docs/src/operators/require.md
+++ b/digdag-docs/src/operators/require.md
@@ -1,6 +1,6 @@
 # require>: Depends on another workflow
 
-**require>** operator requires completion of another workflow. This operator is similar to [call> operator](call.html), but this operator doesn't start the other workflow if it's already running or has done for the same session time of this workflow. If the workflow is running or newly started, this operator waits until it completes.
+**require>** operator requires completion of another workflow. This operator is similar to [call> operator](call.html), but this operator doesn't start the other workflow if it's already running or has done for the same session time of this workflow. If the workflow is running or newly started, this operator waits until it completes. In  addition, require operator can kick the another project's workflow.
 
 ```
 # workflow1.dig
@@ -47,6 +47,17 @@
     _do:
       require>: daily_workflow
       session_time: ${moment(last_session_time).add(i, 'day')}
+  ```
+
+* **project_id**: project_id
+
+  Id of another project. You can kick another project's workflow by setting this parameter.
+
+  Examples:
+
+  ```
+  require>: another_project_wf
+  project_id: 12345
   ```
 
 * **ignore_failure**: BOOLEAN


### PR DESCRIPTION
`require>` operator can kick another project's workflow.
https://github.com/treasure-data/digdag/blob/master/digdag-core/src/main/java/io/digdag/core/agent/RequireOperatorFactory.java#L69

It have to be written in document.