### PR TITLE
Fix logic to look up ECS task definition by tags in DefaultEcsClient

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -636,10 +636,7 @@ public class EcsCommandExecutor
             final CommandContext commandContext,
             final CommandRequest commandRequest,
             final ContainerOverride containerOverride)
-    {
-        containerOverride.withCpu(128); // TODO
-        containerOverride.withMemory(256); // TODO
-    }
+    { }
 
     private static void log(final String message, final CommandLogger to)
             throws IOException

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/DefaultEcsClient.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/DefaultEcsClient.java
@@ -38,6 +38,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class DefaultEcsClient
         implements EcsClient
@@ -123,9 +124,7 @@ public class DefaultEcsClient
                 final ListTagsForResourceRequest tagsRequest = new ListTagsForResourceRequest()
                         .withResourceArn(taskDefinitionArn);
                 final ListTagsForResourceResult tagsResult = client.listTagsForResource(tagsRequest);
-                ImmutableMap.Builder<String, String> tagMapBuilder = ImmutableMap.builder();
-                tagsResult.getTags().stream().map(tag -> tagMapBuilder.put(tag.getKey(), tag.getValue()));
-                final Map<String, String> tagMap = tagMapBuilder.build();
+                final Map<String, String> tagMap = tagsResult.getTags().stream().collect(Collectors.toMap(Tag::getKey, Tag::getValue));
 
                 boolean tagsMatched = false;
                 for (final Tag expectedTag : expectedTags) {


### PR DESCRIPTION
This PR fixes a logic to look up ECS task definition by tags in DefaultEcsClient. 