### PR TITLE
EcsCommandExecutor: retry polling command status when TaskSetNotFoundException happens

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -277,6 +277,7 @@ public class EcsCommandExecutor
             task = client.getTask(cluster, taskArn);
         } catch (TaskSetNotFoundException e) {
             // if task is not present, an operator will throw TaskExecutionException to retry polling the status.
+            logger.info("Cannot get the Ecs task status. Will be retried.");
             return EcsCommandStatus.of(false, previousStatus.deepCopy());
         }
 


### PR DESCRIPTION
This PR enables mitigating a failure to get Ecs task status. After an Ecs task is submitted, the status sometimes cannot be found, but eventually can be found. To mitigate such failure, it'd better to retry polling the status.