### PR TITLE
Fix EcsCommandExecutor to pass environment variables to Ecs tasks

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -4,6 +4,7 @@ import com.amazonaws.services.ecs.model.AssignPublicIp;
 import com.amazonaws.services.ecs.model.AwsVpcConfiguration;
 import com.amazonaws.services.ecs.model.ContainerDefinition;
 import com.amazonaws.services.ecs.model.ContainerOverride;
+import com.amazonaws.services.ecs.model.KeyValuePair;
 import com.amazonaws.services.ecs.model.LaunchType;
 import com.amazonaws.services.ecs.model.LogConfiguration;
 import com.amazonaws.services.ecs.model.NetworkConfiguration;
@@ -494,6 +495,7 @@ public class EcsCommandExecutor
         final ContainerDefinition cd = td.getContainerDefinitions().get(0);
         setEcsContainerOverrideName(commandContext, commandRequest, containerOverride, cd);
         setEcsContainerOverrideCommand(commandContext, commandRequest, containerOverride); // RuntimeException,ConfigException
+        setEcsContainerOverrideEnvironment(commandContext, commandRequest, containerOverride);
         setEcsContainerOverrideResource(commandContext, commandRequest, containerOverride);
 
         final TaskOverride taskOverride = new TaskOverride();
@@ -504,7 +506,6 @@ public class EcsCommandExecutor
         //containerOverride.withName()
         //containerOverride.withCommand()
         //containerOverride.withCpu();
-        //containerOverride.withEnvironment();
         //containerOverride.withMemory();
         //containerOverride.withMemoryReservation();
         //containerOverride.withResourceRequirements();
@@ -630,6 +631,18 @@ public class EcsCommandExecutor
     protected List<String> setEcsContainerOverrideArgumentsAfterCommand()
     {
         return ImmutableList.of();
+    }
+
+    protected void setEcsContainerOverrideEnvironment(
+            final CommandContext commandContext,
+            final CommandRequest commandRequest,
+            final ContainerOverride containerOverride)
+    {
+        final ImmutableList.Builder<KeyValuePair> environments = ImmutableList.builder();
+        for (final Map.Entry<String, String> e : commandRequest.getEnvironments().entrySet()) {
+            environments.add(new KeyValuePair().withName(e.getKey()).withValue(e.getValue()));
+        }
+        containerOverride.withEnvironment(environments.build());
     }
 
     protected void setEcsContainerOverrideResource(

--- a/digdag-tests/src/test/java/acceptance/td/PyIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/PyIT.java
@@ -157,6 +157,7 @@ public class PyIT
 
         String logs = getAttemptLogs(client, attemptId);
         assertThat(logs, containsString("digdag params"));
+        assertThat(logs, containsString("'VAR_A', 'aaa'")); // via _env in echo_params.dig
     }
 
 }

--- a/digdag-tests/src/test/resources/acceptance/td/echo_params/echo_params.dig
+++ b/digdag-tests/src/test/resources/acceptance/td/echo_params/echo_params.dig
@@ -3,3 +3,5 @@ _export:
     image: "python:3.7"
 +foo:
   py>: scripts.echo_params.echo_params
+  _env:
+    VAR_A: aaa


### PR DESCRIPTION
This PR fixes EcsCommandExecutor to pass environment variables to Ecs tasks via `_env` option.