### PR TITLE
[WIP] Fix retry degradtion #1131

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/agent/CallOperatorFactory.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/CallOperatorFactory.java
@@ -78,6 +78,7 @@ public class CallOperatorFactory
 
             return TaskResult.defaultBuilder(request)
                 .subtaskConfig(def)
+                .callSubTask(true)
                 .build();
         }
     }

--- a/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
@@ -191,7 +191,6 @@ public class OperatorManager
             all.merge(request.getConfig());  // export / carry params (TaskRequest.config sent by WorkflowExecutor doesn't include config of this task)
             Config evalParams = all.deepCopy();
             all.merge(request.getLocalConfig());
-
             config = evalEngine.eval(all, evalParams);
         }
         catch (TemplateException ex) {

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
@@ -905,6 +905,12 @@ public class DatabaseSessionStoreManager
         }
 
         @Override
+        public void clearInitailTaskStateFlags(long taskId)
+        {
+            dao.clearTaskStateFlags(taskId, TaskStateFlags.INITIAL_TASK);
+        }
+
+        @Override
         public void addDependencies(long downstream, List<Long> upstreams)
         {
             for (long upstream : upstreams) {
@@ -1933,6 +1939,13 @@ public class DatabaseSessionStoreManager
                 " where id = :id" +
                 " and state = :oldState")
         long setDoneState(@Bind("id") long taskId, @Bind("oldState") short oldState, @Bind("newState") short newState);
+
+        @SqlUpdate("update tasks" +
+                " set updated_at = now(), state_flags = state_flags - :stateFlags" +
+                " where id = :id"
+                )
+        long clearTaskStateFlags(@Bind("id") long taskId, @Bind("stateFlags") int stateFlags);
+
 
         @SqlUpdate("update task_state_details" +
                 " set error = :error" +

--- a/digdag-core/src/main/java/io/digdag/core/session/TaskControlStore.java
+++ b/digdag-core/src/main/java/io/digdag/core/session/TaskControlStore.java
@@ -23,6 +23,8 @@ public interface TaskControlStore
 
     boolean copyInitialTasksForRetry(List<Long> recursiveChildrenIdList);
 
+    void clearInitailTaskStateFlags(long taskId);
+
     void addDependencies(long downstream, List<Long> upstreams);
 
     // return true if one or more child task is progressible.

--- a/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java
+++ b/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java
@@ -1185,7 +1185,7 @@ public class WorkflowExecutor
         // task successfully finished. add ^sub and ^check tasks
         boolean subtaskAdded = false;
         try {
-            Optional<Long> rootSubtaskId = addSubtasksIfNotEmpty(lockedTask, result.getSubtaskConfig());
+            Optional<Long> rootSubtaskId = addSubtasksIfNotEmpty(lockedTask, result.getSubtaskConfig(), result.getCallSubTask());
             Optional<Long> checkTaskId = addCheckTasksIfAny(lockedTask, rootSubtaskId);
             subtaskAdded = rootSubtaskId.isPresent() || checkTaskId.isPresent();
         }
@@ -1274,12 +1274,13 @@ public class WorkflowExecutor
         params.merge(task.getConfig().getExport());
     }
 
-    private Optional<Long> addSubtasksIfNotEmpty(TaskControl lockedTask, Config subtaskConfig)
+    private Optional<Long> addSubtasksIfNotEmpty(TaskControl lockedTask, Config subtaskConfig, boolean isCallOpSubTask)
         throws TaskLimitExceededException
     {
         if (subtaskConfig.isEmpty()) {
             return Optional.absent();
         }
+
 
         WorkflowTaskList tasks = compiler.compileTasks(lockedTask.get().getFullName(), "^sub", subtaskConfig);
         if (tasks.isEmpty()) {
@@ -1287,7 +1288,7 @@ public class WorkflowExecutor
         }
 
         logger.trace("Adding sub tasks: {}", tasks);
-        long rootTaskId = lockedTask.addGeneratedSubtasks(tasks, ImmutableList.of(), true, true);
+        long rootTaskId = lockedTask.addGeneratedSubtasks(tasks, ImmutableList.of(), true, false, isCallOpSubTask);
         return Optional.of(rootTaskId);
     }
 

--- a/digdag-spi/src/main/java/io/digdag/spi/TaskResult.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/TaskResult.java
@@ -16,6 +16,12 @@ public interface TaskResult
 {
     Config getSubtaskConfig();
 
+    @Value.Default
+    default boolean getCallSubTask()
+    {
+        return false;
+    }
+
     Config getExportParams();
 
     List<ConfigKey> getResetStoreParams();


### PR DESCRIPTION
The cause is PR #928 which fixed the retry issue in callee by call operator.
In that PR, INITIAL_TASK state flag is always set to generated sub tasks.
As result, generated sub tasks by operators such as for_each, if and other operator run twice.

ex) consider about operator A which  generates task subA.
If retry happens,  both A and subA are target of the retry because INITIAL_TASK state_flags.
The task A generate subA' again and executed.  subA is also retried.
So one retry generates two subA task.

This is cause of the issue.

To fix it, INITIAL_TASK is only added to the sub task of call operator.
In other operators, INITIAL_TASK is not set. (Same as revert #928)
Call operator's sub tasks still require INITIAL_TAKS because of the retry in the callee.
But same duplicate tasks also happen in call operator.
So for call operator, additional process are added.
For call operator task, after generated sub tasks are added, INITIAL_TASK of the call> task are removed
to avoid retry. 
And the parent task of generated sub tasks are changed from call> task to its parent task.
As result the call> task are eliminated from task chain and remove from retry process.

