### PR TITLE
Sort workflows and projects

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
@@ -534,7 +534,7 @@ public class DatabaseProjectStoreManager
                 " join projects proj on a.project_id = proj.id" +
                 " join workflow_configs wc on wc.id = wd.config_id" +
                 " where wd.id > :lastId" +
-                " order by wd.id" +
+                " order by proj.name, wd.name" +
                 " limit :limit")
         List<StoredWorkflowDefinitionWithProject> getLatestActiveWorkflowDefinitions(@Bind("siteId") int siteId, @Bind("limit") int limit, @Bind("lastId") long lastId);
     }
@@ -574,7 +574,7 @@ public class DatabaseProjectStoreManager
                 " join revisions rev on rev.id = wd.revision_id" +
                 " join projects proj on proj.id = rev.project_id" +
                 " join workflow_configs wc on wc.id = wd.config_id" +
-                " order by wd.id")
+                " order by proj.name, wd.name")
         List<StoredWorkflowDefinitionWithProject> getLatestActiveWorkflowDefinitions(@Bind("siteId") int siteId, @Bind("limit") int limit, @Bind("lastId") long lastId);
     }
 
@@ -584,7 +584,7 @@ public class DatabaseProjectStoreManager
                 " where site_id = :siteId" +
                 " and name is not null" +
                 " and id > :lastId" +
-                " order by id asc" +
+                " order by name asc" +
                 " limit :limit")
         List<StoredProject> getProjects(@Bind("siteId") int siteId, @Bind("limit") int limit, @Bind("lastId") int lastId);
 
@@ -741,7 +741,7 @@ public class DatabaseProjectStoreManager
                 " where wd.revision_id = :revId" +
                 " and wd.id > :lastId" +
                 " and proj.site_id = :siteId" +
-                " order by wd.id asc" +
+                " order by wd.name asc" +
                 " limit :limit")
         List<StoredWorkflowDefinition> getWorkflowDefinitions(@Bind("siteId") int siteId, @Bind("revId") int revId, @Bind("limit") int limit, @Bind("lastId") long lastId);
 


### PR DESCRIPTION
### Overview
Digdag workflows and projects are sorted by workflow id or project id.
But in web console or cli, it's very hard to see.

So, I sort by workflow name and projects name.

And, I check expected impact.

Fixed functions are called from theses. I think it doesn't impact other things.

```
getLatestActiveWorkflowDefinitions -> WorkflowResource.java(GET "/api/workflows")
getProjects -> ProjectResource.java(GET "/api/projects")
getWorkflowDefinitions -> ProjectRecource.java(GET "/api/projects/{id}/workflows")
```

About index, `workflow_definitions` and `projects` tables have these index. And I think `workflow_definitions` and `projects` tables column will not increase so much. So, there is no impact on performance.

```
 workflow_definitions     | CREATE UNIQUE INDEX workflow_definitions_on_revision_id_and_name ON public.workflow_definitions USING btree (revision_id, name)
 projects                 | CREATE UNIQUE INDEX projects_on_site_id_and_name ON public.projects USING btree (site_id, name)
```

### The result of the correction is here.
- `/`

![Digdag](https://user-images.githubusercontent.com/13991035/59923309-14ee8480-946e-11e9-9334-7db4fd36e426.png)


↓

![Digdag-4](https://user-images.githubusercontent.com/13991035/59923326-233ca080-946e-11e9-98be-f0dc7b207ca3.png)


- `/projects`

![Digdag-2](https://user-images.githubusercontent.com/13991035/59923331-2899eb00-946e-11e9-8929-f9ffc76608e2.png)


↓

![Digdag-5](https://user-images.githubusercontent.com/13991035/59923339-2c2d7200-946e-11e9-88b5-67dfd193d931.png)


- `/projects/1`

![Digdag-3](https://user-images.githubusercontent.com/13991035/59923341-2f286280-946e-11e9-9da5-eb85da7ce433.png)


↓

![Digdag-6](https://user-images.githubusercontent.com/13991035/59923354-32235300-946e-11e9-8bd9-2e09c31892d4.png)

- cli
```
$ java -jar pkg/digdag-0.9.38-SNAPSHOT.jar workflows
2019-06-21 21:51:27 +0900: Digdag v0.9.36
  aaa
    def
    abc
    bcd
  ccc
    def
    abc
    bcd
  bbb
    def
    abc
    bcd

Use `digdag workflows <project-name> <name>` to show details.

```


↓

```
$ java -jar pkg/digdag-0.9.38-SNAPSHOT.jar workflows
2019-06-21 21:48:39 +0900: Digdag v0.9.36
  aaa
    abc
    bcd
    def
  bbb
    abc
    bcd
    def
  ccc
    abc
    bcd
    def

Use `digdag workflows <project-name> <name>` to show details.

```


### The reproduction procedure is here
```
$ ls
abc.dig bcd.dig def.dig

$ java -jar ~/src/github.com/katsuyan/digdag/pkg/digdag-0.9.38-SNAPSHOT.jar push aaa
2019-06-21 21:34:21 +0900: Digdag v0.9.38-SNAPSHOT
Creating .digdag/tmp/archive-4728853173767840533.tar.gz...
  Archiving def.dig
  Archiving abc.dig
  Archiving bcd.dig
Workflows:
  def.dig
  abc.dig
  bcd.dig
Uploaded:
  id: 1
  name: aaa
  revision: a0514723-17a1-4708-9902-0955653d6fc9
  archive type: db
  project created at: 2019-06-21T12:34:23Z
  revision updated at: 2019-06-21T12:34:23Z

Use `digdag workflows` to show all workflows.

$ java -jar ~/src/github.com/katsuyan/digdag/pkg/digdag-0.9.38-SNAPSHOT.jar push ccc
2019-06-21 21:34:25 +0900: Digdag v0.9.38-SNAPSHOT
Creating .digdag/tmp/archive-3055637018388013950.tar.gz...
  Archiving def.dig
  Archiving abc.dig
  Archiving bcd.dig
Workflows:
  def.dig
  abc.dig
  bcd.dig
Uploaded:
  id: 2
  name: ccc
  revision: 92604ca9-6f70-455c-9543-17e9826e2f26
  archive type: db
  project created at: 2019-06-21T12:34:27Z
  revision updated at: 2019-06-21T12:34:27Z

Use `digdag workflows` to show all workflows.

$ java -jar ~/src/github.com/katsuyan/digdag/pkg/digdag-0.9.38-SNAPSHOT.jar push ddd
2019-06-21 21:34:30 +0900: Digdag v0.9.38-SNAPSHOT
Creating .digdag/tmp/archive-5831196262785445958.tar.gz...
  Archiving def.dig
  Archiving abc.dig
  Archiving bcd.dig
Workflows:
  def.dig
  abc.dig
  bcd.dig
Uploaded:
  id: 3
  name: ddd
  revision: 570b31da-3696-43e3-8ba9-3909fd5708c5
  archive type: db
  project created at: 2019-06-21T12:34:31Z
  revision updated at: 2019-06-21T12:34:31Z

Use `digdag workflows` to show all workflows.
```