### PR TITLE
Fix some doc typos, explain group retry/vs task retry more

### DIFF
--- a/digdag-docs/src/workflow_definition.rst
+++ b/digdag-docs/src/workflow_definition.rst
@@ -261,7 +261,7 @@ If ``_background: true`` parameter is set to a task or group, the task or group 
 Retrying failed tasks automatically
 -----------------------------------
 
-If ``_retry: N`` (N is an integer: 1, 2, 3, ...) parameter is set to a group, it retires the group from the beginning when one or more children failed.
+If ``_retry: N`` (N is an integer: 1, 2, 3, ...) parameter is set to a group, it retries the group from the beginning when one or more children failed.
 
 .. code-block:: yaml
 
@@ -283,7 +283,7 @@ If ``_retry: N`` (N is an integer: 1, 2, 3, ...) parameter is set to a group, it
       sh>: tasks/analyze_prepared_data_sets.sh
 
 
-Tasks also support ``_retry: N`` parameter to retry the specific task. Note that some operators don't support the generic ``_retry`` option but has its own options to control retrying behavior.
+Tasks also support ``_retry: N`` parameter to retry the specific task. Note that some operators don't support the generic ``_retry`` option but have their own options to control retrying behavior. Some operators do support the generic ``_retry`` option but implement their own logic for retrying, and may conditionally avoid it. In this case, you may use retry at the group level to unconditionally retry, if required.
 
 You can set interval to _retry as follows.
 

--- a/digdag-docs/src/workflow_definition.rst
+++ b/digdag-docs/src/workflow_definition.rst
@@ -283,7 +283,7 @@ If ``_retry: N`` (N is an integer: 1, 2, 3, ...) parameter is set to a group, it
       sh>: tasks/analyze_prepared_data_sets.sh
 
 
-Tasks also support ``_retry: N`` parameter to retry the specific task. Note that some operators don't support the generic ``_retry`` option but have their own options to control retrying behavior. Some operators do support the generic ``_retry`` option but implement their own logic for retrying, and may conditionally avoid it. In this case, you may use retry at the group level to unconditionally retry, if required.
+Tasks also support ``_retry: N`` parameter to retry the specific task. Note that some operators don't support the generic ``_retry`` option but have their own options to control retrying behavior. Operators that involve external systems may reuse previous results. To ensure an external task is repeated, you may use retry at the group level.
 
 You can set interval to _retry as follows.
 

--- a/digdag-docs/src/workflow_definition.rst
+++ b/digdag-docs/src/workflow_definition.rst
@@ -283,7 +283,7 @@ If ``_retry: N`` (N is an integer: 1, 2, 3, ...) parameter is set to a group, it
       sh>: tasks/analyze_prepared_data_sets.sh
 
 
-Tasks also support ``_retry: N`` parameter to retry the specific task. Note that some operators don't support the generic ``_retry`` option but have their own options to control retrying behavior. Operators that involve external systems may reuse previous results. To ensure an external task is repeated, you may use retry at the group level.
+Tasks also support ``_retry: N`` parameter to retry the specific task. Note that some operators don't support the generic ``_retry`` option but have their own options to control retrying behavior. Operators that involve external systems may reuse previous results. To ensure an external task is repeated, you may use ``_retry`` at the group level.
 
 You can set interval to _retry as follows.
 


### PR DESCRIPTION
Some operators will add additional logic to retry, e.g. [TD](https://github.com/treasure-data/digdag/blob/master/digdag-standards/src/main/java/io/digdag/standards/operator/td/TDOperator.java#L70) and
[BQ](https://github.com/treasure-data/digdag/blob/master/digdag-standards/src/main/java/io/digdag/standards/operator/gcp/BqJobRunner.java#L69).

In this case a retry may be avoided if the original error is
considered deterministic, according to the predicate given.

If you want to avoid any conditional logic, it seems you can use group
retry instead. This docs change makes that a bit clearer.