### PR TITLE
Stop using imp module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 */build/
 */out/
 *.pyc
+venv*
+.venv*
 /dist/*.tar.gz
 /config/test_postgresql.properties
 MANIFEST

--- a/digdag-standards/src/main/resources/digdag/standards/py/runner.py
+++ b/digdag-standards/src/main/resources/digdag/standards/py/runner.py
@@ -1,7 +1,7 @@
 import sys
 import os
 import json
-import imp
+import types
 import inspect
 import collections
 import traceback
@@ -15,7 +15,7 @@ with open(in_file) as f:
     params = in_data['params']
 
 # fake digdag_env module already imported
-digdag_env_mod = sys.modules['digdag_env'] = imp.new_module('digdag_env')
+digdag_env_mod = sys.modules['digdag_env'] = types.ModuleType('digdag_env')
 digdag_env_mod.params = params
 digdag_env_mod.subtask_config = collections.OrderedDict()
 digdag_env_mod.export_params = {}
@@ -24,7 +24,7 @@ digdag_env_mod.state_params = {}
 import digdag_env
 
 # fake digdag module already imported
-digdag_mod = sys.modules['digdag'] = imp.new_module('digdag')
+digdag_mod = sys.modules['digdag'] = types.ModuleType('digdag')
 
 class Env(object):
     def __init__(self, digdag_env_mod):
@@ -73,7 +73,7 @@ class Env(object):
 digdag_mod.env = Env(digdag_env_mod)
 import digdag
 
-# add the archive path to improt path
+# add the archive path to import path
 sys.path.append(os.path.abspath(os.getcwd()))
 
 def digdag_inspect_command(command):


### PR DESCRIPTION
imp module [has been deprecated since Python 3.4](https://docs.python.org/3/library/imp.html), it should be replaced with other methods. While importlib.util.module_from_spec is preferred over types.ModuleType, module_from_spec requires dramatic change so this change uses types.ModuleType.

This PR removes the following warning:


```
.digdag/tmp/digdag-py-10-1406823779138478784/runner.py:4: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
  import imp
```
