### PR TITLE
Remove duplicates when building resumed tasks map

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/workflow/TaskControl.java
+++ b/digdag-core/src/main/java/io/digdag/core/workflow/TaskControl.java
@@ -140,7 +140,6 @@ public class TaskControl
                 .transform(index -> indexToId.get(index))
                 .or(parentTaskId);
             long id;
-
             if (resumingTaskMap.containsKey(wt.getFullName())) {
                 id = store.addResumedSubtask(attemptId, parentId,
                         wt.getTaskType(),

--- a/digdag-core/src/main/java/io/digdag/core/workflow/TaskControl.java
+++ b/digdag-core/src/main/java/io/digdag/core/workflow/TaskControl.java
@@ -121,7 +121,7 @@ public class TaskControl
 
         Map<String, ResumingTask> resumingTaskMap = resumingTasks
             .stream()
-            .collect(Collectors.toMap(t -> t.getFullName(), t -> t));
+            .collect(Collectors.toMap(t -> t.getFullName(), t -> t, (a, b) -> a));
 
         boolean firstTask = true;
         for (WorkflowTask wt : tasks) {
@@ -140,6 +140,7 @@ public class TaskControl
                 .transform(index -> indexToId.get(index))
                 .or(parentTaskId);
             long id;
+
             if (resumingTaskMap.containsKey(wt.getFullName())) {
                 id = store.addResumedSubtask(attemptId, parentId,
                         wt.getTaskType(),

--- a/digdag-core/src/test/java/io/digdag/core/workflow/TaskControlTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/TaskControlTest.java
@@ -1,0 +1,88 @@
+package io.digdag.core.workflow;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigFactory;
+import io.digdag.core.session.ImmutableResumingTask;
+import io.digdag.core.session.ResumingTask;
+import io.digdag.core.session.TaskControlStore;
+import io.digdag.core.session.TaskStateCode;
+import io.digdag.core.session.TaskStateFlags;
+import io.digdag.core.session.TaskType;
+import io.digdag.spi.TaskReport;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyLong;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doNothing;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TaskControlTest
+{
+    @Mock TaskControlStore store;
+    @Mock ObjectMapper mapper;
+
+    @Test
+    public void addDuplicateResumingTasks() throws Exception
+    {
+        Config config = new ConfigFactory(mapper).create();
+        WorkflowTask task = new WorkflowTask.Builder()
+            .name("+test")
+            .fullName("test task")
+            .index(0)
+            .upstreamIndexes(Collections.emptyList())
+            .taskType(new TaskType.Builder().build())
+            .config(config)
+            .build();
+            
+        ResumingTask resumingTask = ImmutableResumingTask.builder()
+            .sourceTaskId(0L)
+            .fullName("test task")
+            .config(TaskConfig.assumeValidated(config, config))
+            .updatedAt(Instant.now())
+            .subtaskConfig(config)
+            .exportParams(config)
+            .resetStoreParams(Collections.emptyList())
+            .storeParams(config)
+            .report(TaskReport.empty())
+            .error(config)
+            .build();
+
+        when(store.addResumedSubtask(
+                anyLong(),
+                anyLong(),
+                any(TaskType.class),
+                any(TaskStateCode.class),
+                any(TaskStateFlags.class),
+                eq(resumingTask))).thenReturn(0L);
+
+        when(store.getTaskCountOfAttempt(anyLong())).thenReturn(0L);
+
+        TaskControl.addInitialTasksExceptingRootTask(
+            store,
+            0L,
+            0L,
+            WorkflowTaskList.of(Arrays.asList(task, task)),
+            Arrays.asList(resumingTask, resumingTask));
+
+        verify(store, times(1)).getTaskCountOfAttempt(anyLong());
+        verify(store, times(1)).addResumedSubtask(
+                anyLong(),
+                anyLong(),
+                any(TaskType.class),
+                any(TaskStateCode.class),
+                any(TaskStateFlags.class),
+                eq(resumingTask));
+    }
+}


### PR DESCRIPTION
When resuming a failed workflow, many tasks with the same full name
may be added, if many retries of the same task failed. This will throw
an uncaught exception when many tasks are added with the same
key (full name), to the map of tasks to resume.

This fixes the problem by discarding any duplicate tasks at the map
building stage. The assumption is that any tasks with the same name
are retries of the same task, so we only want one.