### PR TITLE
Modify wrong sample

### DIFF
--- a/digdag-docs/src/operators/td_run.md
+++ b/digdag-docs/src/operators/td_run.md
@@ -10,7 +10,7 @@
       td_run>: 12345
     +step2:
       td_run>: myquery2
-      session_time: 2016-01-01T01:01:01+0000
+      session_time: 2016-01-01T01:01:01+00:00
 
 ## Examples
 


### PR DESCRIPTION
Current sample is wrong.

**Current Sample**

```
+step2:
  td_run>: myquery2
  session_time: 2016-01-01T01:01:01+0000
```

**Result**

```
io.digdag.core.agent.OperatorManager: Configuration error at task +kammy_td_run_sched_time+task1: Expected class java.time.Instant for key 'session_time' but got "2016-01-01T01:01:01+0000" (string) (config)
> Invalid ISO time format: %s2016-01-01T01:01:01+0000 (json mapping)
> Text '2016-01-01T01:01:01+0000' could not be parsed, unparsed text found at index 19 (date time parse)
```

**Correct Sample**

```
+step2:
  td_run>: myquery2
  session_time: 2016-01-01T01:01:01+00:00
```

**Result**

```
io.digdag.standards.operator.td.TdRunOperatorFactory$TdRunOperator: Started a saved query name=kammy_td_sched_time with time=2016-01-01T01:01:01Z, job id= ******
```
