### PR TITLE
Fix the message of invalid ISO time format error

### DIFF
--- a/digdag-client/src/main/java/io/digdag/client/api/JacksonTimeModule.java
+++ b/digdag-client/src/main/java/io/digdag/client/api/JacksonTimeModule.java
@@ -68,7 +68,7 @@ public class JacksonTimeModule
                 return Instant.from(DateTimeFormatter.ISO_DATE_TIME.parse(value));
             }
             catch (DateTimeParseException ex) {
-                throw new JsonMappingException("Invalid ISO time format: %s" + value, ex);
+                throw new JsonMappingException("Invalid ISO time format: " + value, ex);
             }
         }
     }


### PR DESCRIPTION
Fixed `Invalid ISO time format` message

Reference: #1164

Before

```
> Invalid ISO time format: %s2016-01-01T01:01:01+0000 (json mapping)
```

After (Remove `%s`)

```
> Invalid ISO time format: 2016-01-01T01:01:01+0000 (json mapping)
```