### PR TITLE
Add new option to http_call operator to override Content-Type

### DIFF
--- a/digdag-docs/src/operators/http_call.md
+++ b/digdag-docs/src/operators/http_call.md
@@ -7,6 +7,8 @@ This operator parses response body based on returned Content-Type header. Conten
 * **application/json**: Parse the response as JSON.
 * **application/x-yaml**: Use the returned body as-is.
 
+If appropriate Content-Type header is not returned, use content_type_override option.
+
 ## Options
 
 * **http_call>**: URI
@@ -18,6 +20,19 @@ This operator parses response body based on returned Content-Type header. Conten
   ```
   http_call>: https://api.example.com/foobar
   ```
+
+* **content_type_override**: application/x-yaml or application/json
+
+  Overrides Content-Type response header returned from the server. This option is useful when the server doesn't return an appropriate Content-Type but returns a generic value such as text/plain or application/octet-stream.
+
+  Examples:
+
+  ```
+  http_call>: https://api.example.com/foobar
+  content_type_override: application/x-yaml
+  ```
+
+## Other options
 
 Same parameters with **http>** operator are also supported except the parameters listed below. The name of the operator is similar to [http> operator](http.html). But the role is different. See also [http> operator document](http.html).
 

--- a/digdag-tests/src/test/java/utils/TestUtils.java
+++ b/digdag-tests/src/test/java/utils/TestUtils.java
@@ -493,19 +493,19 @@ public class TestUtils
         copyResource(resource, project.resolve(workflowName));
     }
 
-    public static void runWorkflow(TemporaryFolder folder, String resource, Map<String, String> params)
+    public static CommandStatus runWorkflow(TemporaryFolder folder, String resource, Map<String, String> params)
             throws IOException
     {
-        runWorkflow(folder, resource, params, ImmutableMap.of());
+        return runWorkflow(folder, resource, params, ImmutableMap.of());
     }
 
-    public static void runWorkflow(TemporaryFolder folder, String resource, Map<String, String> params, Map<String, String> config)
+    public static CommandStatus runWorkflow(TemporaryFolder folder, String resource, Map<String, String> params, Map<String, String> config)
             throws IOException
     {
-        runWorkflow(folder, resource, params, config, 0);
+        return runWorkflow(folder, resource, params, config, 0);
     }
 
-    public static void runWorkflow(TemporaryFolder folder, String resource, Map<String, String> params, Map<String, String> config, int expectedStatus)
+    public static CommandStatus runWorkflow(TemporaryFolder folder, String resource, Map<String, String> params, Map<String, String> config, int expectedStatus)
             throws IOException
     {
         Path workflow = Paths.get(resource);
@@ -526,6 +526,7 @@ public class TestUtils
             copyResource(resource, file);
             CommandStatus status = main(runCommand);
             assertThat(status.errUtf8(), status.code(), is(expectedStatus));
+            return status;
         }
         finally {
             FileUtils.deleteQuietly(tempdir.toFile());

--- a/digdag-tests/src/test/resources/acceptance/http_call/http_call_yaml_override.dig
+++ b/digdag-tests/src/test/resources/acceptance/http_call/http_call_yaml_override.dig
@@ -1,0 +1,3 @@
++http_call:
+  http_call>: ${test_uri}
+  content_type_override: application/x-yaml; charset=utf-8


### PR DESCRIPTION
HTTP server doesn't always return appropriate Content-Type response
header especially when the server is prepared to distribute generic
contents. In such cases, having an option to override Content-Type
header is useful.

The new option is not content_type or content_format just because
they're already taken (by http operator).