### PR TITLE
Prohibit overwrite runtime params

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
@@ -187,8 +187,11 @@ public class OperatorManager
         // evaluate config and creates the complete merged config.
         Config config;
         try {
-            Config all = RuntimeParams.buildRuntimeParams(request.getConfig().getFactory(), request).deepCopy();
+            Config all = cf.create();
             all.merge(request.getConfig());  // export / carry params (TaskRequest.config sent by WorkflowExecutor doesn't include config of this task)
+            Config runtimeParams = RuntimeParams.buildRuntimeParams(request.getConfig().getFactory(), request).deepCopy();
+            all.merge(runtimeParams); //runtime parameter should not be override request parameters
+
             Config evalParams = all.deepCopy();
             all.merge(request.getLocalConfig());
 

--- a/digdag-docs/src/workflow_definition.rst
+++ b/digdag-docs/src/workflow_definition.rst
@@ -127,6 +127,11 @@ You can define variables in 3 ways:
 * Setting variable programmably using API
 * Starting a session with variables
 
+.. note::
+
+    You cannot overwrite built-in variables.
+
+
 Using _export: parameter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/digdag-tests/src/test/java/acceptance/RequireIT.java
+++ b/digdag-tests/src/test/java/acceptance/RequireIT.java
@@ -10,6 +10,7 @@ import org.junit.rules.TemporaryFolder;
 import utils.CommandStatus;
 import utils.TemporaryDigdagServer;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -53,12 +54,7 @@ public class RequireIT
         assertThat(initStatus.errUtf8(), initStatus.code(), is(0));
 
         Path childOutFile = projectDir.resolve("child.out").toAbsolutePath().normalize();
-
-        try (InputStream input = Resources.getResource("acceptance/require/child.dig").openStream()) {
-            String child = new String(ByteStreams.toByteArray(input), "UTF-8")
-                    .replace("__FILE__", childOutFile.toString());
-            Files.write(projectDir.resolve("child.dig"), child.getBytes("UTF-8"));
-        }
+        prepareForChildWF(childOutFile);
         copyResource("acceptance/require/parent.dig", projectDir.resolve("parent.dig"));
 
         // Push the project
@@ -130,4 +126,78 @@ public class RequireIT
                 "parent.dig");
         assertThat(status.errUtf8(), status.code(), is(0));
     }
+
+    @Test
+    public void testIgnoreProjectIdParam()
+            throws Exception
+    {
+        // If require> op. does not have 'project_id' param and session start with --param project_id=,
+        //  --param project_id should be ignored in require> op.
+        // In this test --param project_id= is set in start command.
+        // If the session will finish successfully, it means that project_id of --param is ignored.
+
+        // Create new project
+        CommandStatus initStatus = main("init",
+                "-c", config.toString(),
+                projectDir.toString());
+        assertThat(initStatus.errUtf8(), initStatus.code(), is(0));
+
+        Path childOutFile = projectDir.resolve("child.out").toAbsolutePath().normalize();
+        prepareForChildWF(childOutFile);
+        copyResource("acceptance/require/parent.dig", projectDir.resolve("parent.dig"));
+
+        // Push the project
+        CommandStatus pushStatus = main("push",
+                "--project", projectDir.toString(),
+                "require",
+                "-c", config.toString(),
+                "-e", server.endpoint(),
+                "-r", "4711");
+        assertThat(pushStatus.errUtf8(), pushStatus.code(), is(0));
+
+        // Start the workflow
+        Id attemptId;
+        {
+            CommandStatus startStatus = main("start",
+                    "-c", config.toString(),
+                    "-e", server.endpoint(),
+                    "require", "parent",
+                    "--session", "now",
+                    "--param", "project_id=-1"
+            );
+            assertThat(startStatus.code(), is(0));
+            attemptId = getAttemptId(startStatus);
+        }
+
+        // Wait for the attempt to complete
+        boolean success = false;
+        for (int i = 0; i < 120; i++) {
+            CommandStatus attemptsStatus = main("attempts",
+                    "-c", config.toString(),
+                    "-e", server.endpoint(),
+                    String.valueOf(attemptId));
+            success = attemptsStatus.outUtf8().contains("status: success");
+            if (success) {
+                break;
+            }
+            Thread.sleep(1000);
+        }
+        assertThat(success, is(true)); // --param project_id=-1 is ignored.
+    }
+
+    /***
+     * Replaice __FILE__ to real path then save to project dir
+     * @param childOutFile
+     * @throws IOException
+     */
+    private void prepareForChildWF(Path childOutFile)
+            throws IOException
+    {
+        try (InputStream input = Resources.getResource("acceptance/require/child.dig").openStream()) {
+            String child = new String(ByteStreams.toByteArray(input), "UTF-8")
+                    .replace("__FILE__", childOutFile.toString());
+            Files.write(projectDir.resolve("child.dig"), child.getBytes("UTF-8"));
+        }
+    }
+
 }

--- a/digdag-tests/src/test/java/acceptance/RuntimeParamsIT.java
+++ b/digdag-tests/src/test/java/acceptance/RuntimeParamsIT.java
@@ -1,0 +1,201 @@
+package acceptance;
+
+import com.google.common.io.ByteStreams;
+import com.google.common.io.Resources;
+import io.digdag.client.api.Id;
+import io.digdag.client.config.Config;
+
+import io.digdag.client.config.ConfigFactory;
+import io.digdag.core.config.YamlConfigLoader;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import utils.CommandStatus;
+import utils.TemporaryDigdagServer;
+import utils.TestUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThat;
+import static utils.TestUtils.getAttemptId;
+import static utils.TestUtils.main;
+
+public class RuntimeParamsIT
+{
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Rule
+    public TemporaryDigdagServer server = TemporaryDigdagServer.of();
+
+    private static final ConfigFactory CF = TestUtils.configFactory();
+    private static final YamlConfigLoader Y = new YamlConfigLoader();
+
+
+    private Path config;
+    private Path projectDir;
+    private Path outFile;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        projectDir = folder.getRoot().toPath().resolve("foobar");
+        Files.createDirectories(projectDir);
+        config = folder.newFile().toPath();
+
+        outFile = projectDir.resolve("run.out").toAbsolutePath().normalize();
+
+        // Create new project
+        CommandStatus initStatus = main("init",
+                "-c", config.toString(),
+                projectDir.toString());
+        assertThat(initStatus.errUtf8(), initStatus.code(), is(0));
+    }
+
+
+    private void pushProject(String srcDigFileName)
+            throws IOException
+    {
+        try (InputStream input = Resources.getResource("acceptance/runtime_params/" + srcDigFileName).openStream()) {
+            String dig = new String(ByteStreams.toByteArray(input), "UTF-8")
+                    .replace("__FILE__", outFile.toString());
+            Files.write(projectDir.resolve(srcDigFileName), dig.getBytes("UTF-8"));
+        }
+
+        // Push the project
+        CommandStatus pushStatus = main("push",
+                "--project", projectDir.toString(),
+                "runtime_params",
+                "-c", config.toString(),
+                "-e", server.endpoint(),
+                "-r", "3333"
+        );
+        assertThat(pushStatus.errUtf8(), pushStatus.code(), is(0));
+    }
+
+    private Id startWorkflow(String workflowName, String retryName, String params)
+    {
+        CommandStatus startStatus = main("start",
+                "-c", config.toString(),
+                "-e", server.endpoint(),
+                "runtime_params", workflowName,
+                "--session", "now",
+                "--retry", retryName,
+                "--param", params
+
+        );
+        assertThat(startStatus.code(), is(0));
+        return getAttemptId(startStatus);
+    }
+
+    private void waitFinishAttempt(Id attemptId)
+            throws InterruptedException
+    {
+        // Wait for the attempt to complete
+        boolean success = false;
+        for (int i = 0; i < 120; i++) {
+            CommandStatus attemptsStatus = main("attempts",
+                    "-c", config.toString(),
+                    "-e", server.endpoint(),
+                    String.valueOf(attemptId));
+            success = attemptsStatus.outUtf8().contains("status: success");
+            if (success) {
+                break;
+            }
+            Thread.sleep(1000);
+        }
+        assertThat(success, is(true));
+    }
+
+    private Config loadYamlFile(Path name) throws IOException
+    {
+        return Y.loadFile(outFile.toFile()).toConfig(CF);
+    }
+
+
+    @Test
+    public void testParamWithoutSchedule()
+            throws Exception
+    {
+        String[] params = {
+                "project_id=-1", "session_id=-2", "attempt_id=-3",
+                "session_time=2010-02-02T11:22:33+00:00",
+                "next_session_time=2010-03-03T11:22:33+00:00",
+                "last_session_time=2010-01-01T11:22:33+00:00",
+                "session_uuid=012345",
+                "timezone=JST",
+                "task_name=tasktasktask",
+                "retry_attempt_name=retryretryretry"
+        };
+
+        pushProject("params1_no_sch.dig");
+        Id attemptId = startWorkflow("params1_no_sch", "retry01", String.join(",", params));
+        waitFinishAttempt(attemptId);
+
+        // Verify that the file created by the child workflow is there
+        assertThat(Files.exists(outFile), is(true));
+
+        // load output of workflow as yaml.
+        Config result = loadYamlFile(outFile);
+
+        // These parameters must not be overwritten.
+        assertNotEquals("-1", result.get("project_id", String.class));
+        assertNotEquals("-2", result.get("session_id", String.class));
+        assertNotEquals("-3", result.get("attempt_id", String.class));
+        assertNotEquals("2010-02-02T11:22:33+00:00", result.get("session_time", String.class));
+        assertNotEquals("012345", result.get("session_uuid", String.class));
+        assertEquals("UTC", result.get("timezone", String.class));
+        assertEquals("+params1_no_sch+t_task_name", result.get("task_name", String.class));
+        assertEquals("retry01", result.get("retry_attempt_name", String.class));
+
+        // These parameter is overwritten because no schedule.
+        assertEquals("2010-03-03T11:22:33+00:00", result.get("next_session_time", String.class));
+        assertEquals("2010-01-01T11:22:33+00:00", result.get("last_session_time", String.class));
+    }
+
+    @Test
+    public void testParamWithSchedule()
+            throws Exception
+    {
+        String[] params = {
+                "project_id=-1", "session_id=-2", "attempt_id=-3",
+                "session_time=2010-02-02T11:22:33+00:00",
+                "next_session_time=2010-03-03T11:22:33+00:00",
+                "last_session_time=2010-01-01T11:22:33+00:00",
+                "session_uuid=012345",
+                "timezone=JST",
+                "task_name=tasktasktask",
+                "retry_attempt_name=retryretryretry"
+        };
+
+        pushProject("params2_sch.dig");
+        Id attemptId = startWorkflow("params2_sch", "retry01", String.join(",", params));
+        waitFinishAttempt(attemptId);
+
+        // Verify that the file created by the child workflow is there
+        assertThat(Files.exists(outFile), is(true));
+
+        // load output of workflow as yaml.
+        Config result = loadYamlFile(outFile);
+
+        // These parameters must not be overwritten.
+        assertNotEquals("-1", result.get("project_id", String.class));
+        assertNotEquals("-2", result.get("session_id", String.class));
+        assertNotEquals("-3", result.get("attempt_id", String.class));
+        assertNotEquals("2010-02-02T11:22:33+00:00", result.get("session_time", String.class));
+        assertNotEquals("2010-03-03T11:22:33+00:00", result.get("next_session_time", String.class));
+        assertNotEquals("2010-01-01T11:22:33+00:00", result.get("last_session_time", String.class));
+        assertNotEquals("012345", result.get("session_uuid", String.class));
+        assertEquals("UTC", result.get("timezone", String.class));
+        assertEquals("+params2_sch+t_task_name", result.get("task_name", String.class));
+        assertEquals("retry01", result.get("retry_attempt_name", String.class));
+    }
+}

--- a/digdag-tests/src/test/resources/acceptance/runtime_params/params1_no_sch.dig
+++ b/digdag-tests/src/test/resources/acceptance/runtime_params/params1_no_sch.dig
@@ -1,0 +1,33 @@
+timezone: UTC
+
++t_project_id:
+  sh>: 'echo "project_id: ${project_id}" > __FILE__'
+
++t_session_id:
+  sh>: 'echo "session_id: ${session_id}" >> __FILE__'
+
++t_attempt_id:
+  sh>: 'echo "attempt_id: ${attempt_id}" >> __FILE__'
+
++t_session_time:
+  sh>: 'echo "session_time: ${session_time}" >> __FILE__'
+
++t_next_session_time:
+  sh>: 'echo "next_session_time: ${next_session_time}" >> __FILE__'
+
++t_last_session_time:
+  sh>: 'echo "last_session_time: ${last_session_time}" >> __FILE__'
+
++t_session_uuid:
+  sh>: 'echo "session_uuid: ${session_uuid}" >> __FILE__'
+
++t_timezone:
+  sh>: 'echo "timezone: ${timezone}" >> __FILE__'
+
++t_task_name:
+  sh>: 'echo "task_name: ${task_name}" >> __FILE__'
+
++t_retry_attempt_name:
+  sh>: 'echo "retry_attempt_name: ${retry_attempt_name}" >> __FILE__'
+
+

--- a/digdag-tests/src/test/resources/acceptance/runtime_params/params2_sch.dig
+++ b/digdag-tests/src/test/resources/acceptance/runtime_params/params2_sch.dig
@@ -1,0 +1,36 @@
+timezone: UTC
+
+schedule:
+  daily>: 10:00:00
+
++t_project_id:
+  sh>: 'echo "project_id: ${project_id}" > __FILE__'
+
++t_session_id:
+  sh>: 'echo "session_id: ${session_id}" >> __FILE__'
+
++t_attempt_id:
+  sh>: 'echo "attempt_id: ${attempt_id}" >> __FILE__'
+
++t_session_time:
+  sh>: 'echo "session_time: ${session_time}" >> __FILE__'
+
++t_next_session_time:
+  sh>: 'echo "next_session_time: ${next_session_time}" >> __FILE__'
+
++t_last_session_time:
+  sh>: 'echo "last_session_time: ${last_session_time}" >> __FILE__'
+
++t_session_uuid:
+  sh>: 'echo "session_uuid: ${session_uuid}" >> __FILE__'
+
++t_timezone:
+  sh>: 'echo "timezone: ${timezone}" >> __FILE__'
+
++t_task_name:
+  sh>: 'echo "task_name: ${task_name}" >> __FILE__'
+
++t_retry_attempt_name:
+  sh>: 'echo "retry_attempt_name: ${retry_attempt_name}" >> __FILE__'
+
+


### PR DESCRIPTION
Digdag generates some parameters such as project_id,session_id and others.
These parameters should not be overwritten by --param because it will cause of unstable, security issues.
To do that I change evaluation order of parameters in OperatorManager. And runtime params overwrite user defined ones by --param.
