### PR TITLE
Allow ECS max retries to be set in digdag config

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/DefaultEcsClientFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/DefaultEcsClientFactory.java
@@ -9,8 +9,6 @@ import com.amazonaws.services.logs.AWSLogs;
 import com.amazonaws.services.logs.AWSLogsClient;
 import io.digdag.client.config.ConfigException;
 
-import javax.validation.constraints.NotNull;
-
 public class DefaultEcsClientFactory
         implements EcsClientFactory
 {
@@ -23,7 +21,8 @@ public class DefaultEcsClientFactory
                 new BasicAWSCredentials(ecsClientConfig.getAccessKeyId(), ecsClientConfig.getSecretAccessKey()));
         // TODO improve to enable more options
         final ClientConfiguration clientConfig = new ClientConfiguration()
-                .withProtocol(Protocol.HTTPS);
+                .withProtocol(Protocol.HTTPS)
+                .withMaxErrorRetry(ecsClientConfig.getMaxRetries());
 
         final AmazonECSClient ecsClient = (AmazonECSClient) AmazonECSClient.builder()
                 .withRegion(ecsClientConfig.getRegion())

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
@@ -52,7 +52,8 @@ public class EcsClientConfig
                 extracted.get("access_key_id", String.class),
                 extracted.get("secret_access_key", String.class),
                 extracted.get("region", String.class),
-                extracted.get("subnets", String.class)
+                extracted.get("subnets", String.class),
+                extracted.get("max_retries", Integer.class)
         );
     }
 
@@ -62,13 +63,15 @@ public class EcsClientConfig
     private final String secretAccessKey;
     private final String region;
     private final List<String> subnets;
+    private final Integer maxRetries;
 
     private EcsClientConfig(final String clusterName,
             final String launchType,
             final String accessKeyId,
             final String secretAccessKey,
             final String region,
-            final String subnets)
+            final String subnets,
+            final Integer maxRetries)
     {
         this.clusterName = clusterName;
         this.launchType = launchType;
@@ -76,6 +79,7 @@ public class EcsClientConfig
         this.secretAccessKey = secretAccessKey;
         this.region = region;
         this.subnets = Arrays.asList(subnets.split(",")); // TODO more robust
+        this.maxRetries = maxRetries;
     }
 
     public String getClusterName()
@@ -107,4 +111,6 @@ public class EcsClientConfig
     {
         return subnets;
     }
+
+    public Integer getMaxRetries() { return maxRetries; }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
@@ -53,7 +53,7 @@ public class EcsClientConfig
                 extracted.get("secret_access_key", String.class),
                 extracted.get("region", String.class),
                 extracted.get("subnets", String.class),
-                extracted.get("max_retries", Integer.class)
+                extracted.get("max_retries", int.class)
         );
     }
 
@@ -63,7 +63,7 @@ public class EcsClientConfig
     private final String secretAccessKey;
     private final String region;
     private final List<String> subnets;
-    private final Integer maxRetries;
+    private final int maxRetries;
 
     private EcsClientConfig(final String clusterName,
             final String launchType,
@@ -71,7 +71,7 @@ public class EcsClientConfig
             final String secretAccessKey,
             final String region,
             final String subnets,
-            final Integer maxRetries)
+            final int maxRetries)
     {
         this.clusterName = clusterName;
         this.launchType = launchType;
@@ -112,5 +112,8 @@ public class EcsClientConfig
         return subnets;
     }
 
-    public Integer getMaxRetries() { return maxRetries; }
+    public int getMaxRetries()
+    {
+        return maxRetries;
+    }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
@@ -53,7 +53,7 @@ public class EcsClientConfig
                 extracted.get("secret_access_key", String.class),
                 extracted.get("region", String.class),
                 extracted.get("subnets", String.class),
-                extracted.get("max_retries", int.class)
+                extracted.get("max_retries", int.class, 3)
         );
     }
 


### PR DESCRIPTION
The default number is 3, using an exponential backoff with jitter. The
default retry policy suggests setting this at anything up to 30, but
caps the maximum retry time at 20 seconds.