### PR TITLE
Change log level of Database Migrator

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseMigrator.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseMigrator.java
@@ -84,9 +84,9 @@ public class DatabaseMigrator
         final int maxRetry = 3;
         for (int i = 0; i < maxRetry; i++) {
             try {
-                logger.info("Database migration started");
+                logger.debug("Database migration started");
                 migrate();
-                logger.info("Database migration successfully finished.");
+                logger.debug("Database migration successfully finished.");
                 return;
             }
             catch (RuntimeException re) {
@@ -122,7 +122,7 @@ public class DatabaseMigrator
             for (Migration m : migrations) {
                 Set<String> appliedSet = getAppliedMigrationNames(handle);
                 if (appliedSet.add(m.getVersion())) {
-                    logger.info("Applying database migration:" + m.getVersion());
+                    logger.debug("Applying database migration:" + m.getVersion());
                     numApplied++;
                     if (m.noTransaction()) {
                         // In no transaction we can't lock schema_migrations table


### PR DESCRIPTION
This PR is related to #1061. That PR became to show messages about the migration status of the database each time the CLI is running. But these messages seem not always needed for users, so I updated these messages log level from info to debug.