### PR TITLE
Fix n-m db access in ProjectResource.getProjects to add projectsWithLatestRevision

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
@@ -516,6 +516,24 @@ public class DatabaseProjectStoreManager
     public interface H2Dao
             extends Dao
     {
+        // h2 doesn't have max window function.
+        // this is not efficient but gave up optimization on h2.
+        @Override
+        @SqlQuery("select proj.*, rev.name as revision_name, rev.created_at as revision_created_at, rev.archive_type as revision_archive_type, rev.archive_md5 as revision_archive_md5" +
+        " from projects proj" +
+        " join revisions rev on proj.id = rev.project_id" +
+        " join (" +
+            "select project_id, max(id) AS id" +
+            " from revisions" +
+            " group by project_id" +
+        ") a on a.id = rev.id" +
+        " where proj.site_id = :siteId" +
+        " and proj.name is not null" +
+        " and proj.id > :lastId" +
+        " order by proj.id asc" +
+        " limit :limit")
+        List<StoredProjectWithRevision> getProjectsWithLatestRevision(@Bind("siteId") int siteId, @Bind("limit") int limit, @Bind("lastId") int lastId);
+
         // h2's MERGE doesn't return generated id when conflicting row already exists
         @SqlUpdate("merge into projects" +
                 " (site_id, name, created_at)" +
@@ -550,6 +568,21 @@ public class DatabaseProjectStoreManager
     public interface PgDao
             extends Dao
     {
+        @Override
+        @SqlQuery("select id, site_id, name, created_at, deleted_at, deleted_name, revision_name, revision_created_at, revision_archive_type, revision_archive_md5" +
+        " from (" +
+            " select proj.*, rev.name as revision_name, rev.created_at as revision_created_at, rev.archive_type as revision_archive_type, rev.archive_md5 as revision_archive_md5, rev.id as revision_id, max(rev.id) OVER(partition by rev.project_id) as max_revision_id" +
+            " from projects proj" +
+            " join revisions rev on proj.id = rev.project_id" +
+            " where proj.site_id = :siteId" +
+            " and proj.name is not null" +
+            " and proj.id > :lastId" +
+        ") as projects_with_revision" +
+        " where projects_with_revision.revision_id = projects_with_revision.max_revision_id" +
+        " order by id asc" +
+        " limit :limit")
+        List<StoredProjectWithRevision> getProjectsWithLatestRevision(@Bind("siteId") int siteId, @Bind("limit") int limit, @Bind("lastId") int lastId);
+
         @SqlQuery("insert into projects" +
                 " (site_id, name, created_at)" +
                 " values (:siteId, :name, now())" +
@@ -596,19 +629,6 @@ public class DatabaseProjectStoreManager
                 " limit :limit")
         List<StoredProject> getProjects(@Bind("siteId") int siteId, @Bind("limit") int limit, @Bind("lastId") int lastId);
 
-        @SqlQuery("select proj.*, rev.name as revision_name, rev.created_at as revision_created_at, rev.archive_type as revision_archive_type, rev.archive_md5 as revision_archive_md5" +
-                " from projects proj" +
-                " join revisions rev on proj.id = rev.project_id" +
-                " join (" +
-                    "select project_id, max(id) AS id" +
-                    " from revisions" +
-                    " group by project_id" +
-                ") a on a.id = rev.id" +
-                " where proj.site_id = :siteId" +
-                " and proj.name is not null" +
-                " and proj.id > :lastId" +
-                " order by proj.id asc" +
-                " limit :limit")
         List<StoredProjectWithRevision> getProjectsWithLatestRevision(@Bind("siteId") int siteId, @Bind("limit") int limit, @Bind("lastId") int lastId);
 
         @SqlUpdate("update projects" +

--- a/digdag-core/src/main/java/io/digdag/core/database/ThreadLocalTransactionManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/ThreadLocalTransactionManager.java
@@ -65,6 +65,7 @@ public class ThreadLocalTransactionManager
                 DBI dbi = new DBI(ds);
                 ConfigKeyListMapper cklm = new ConfigKeyListMapper();
                 dbi.registerMapper(new DatabaseProjectStoreManager.StoredProjectMapper(configMapper));
+                dbi.registerMapper(new DatabaseProjectStoreManager.StoredProjectWithRevisionMapper(configMapper));
                 dbi.registerMapper(new DatabaseProjectStoreManager.StoredRevisionMapper(configMapper));
                 dbi.registerMapper(new DatabaseProjectStoreManager.StoredWorkflowDefinitionMapper(configMapper));
                 dbi.registerMapper(new DatabaseProjectStoreManager.StoredWorkflowDefinitionWithProjectMapper(configMapper));

--- a/digdag-core/src/main/java/io/digdag/core/repository/ProjectStore.java
+++ b/digdag-core/src/main/java/io/digdag/core/repository/ProjectStore.java
@@ -9,6 +9,8 @@ public interface ProjectStore
 {
     List<StoredProject> getProjects(int pageSize, Optional<Integer> lastId);
 
+    List<StoredProjectWithRevision> getProjectsWithLatestRevision(int pageSize, Optional<Integer> lastId);
+
     ProjectMap getProjectsByIdList(List<Integer> projIdList);
 
     StoredProject getProjectById(int projId)

--- a/digdag-core/src/main/java/io/digdag/core/repository/StoredProjectWithRevision.java
+++ b/digdag-core/src/main/java/io/digdag/core/repository/StoredProjectWithRevision.java
@@ -1,0 +1,46 @@
+package io.digdag.core.repository;
+
+import java.time.Instant;
+import com.google.common.base.*;
+import com.google.common.collect.*;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonSerialize(as = ImmutableStoredProjectWithRevision.class)
+@JsonDeserialize(as = ImmutableStoredProjectWithRevision.class)
+public abstract class StoredProjectWithRevision
+        extends Project
+{
+    public abstract int getId();
+
+    public abstract int getSiteId();
+
+    public abstract Instant getCreatedAt();
+
+    public abstract Optional<Instant> getDeletedAt();
+
+    public abstract String getRevisionName();
+
+    public abstract Instant getRevisionCreatedAt();
+
+    public abstract ArchiveType getRevisionArchiveType();
+
+    public abstract Optional<byte[]> getRevisionArchiveMd5();
+
+    public static StoredProjectWithRevision of(StoredProject proj, StoredRevision rev)
+    {
+        return ImmutableStoredProjectWithRevision.builder()
+            .from((Project)proj)
+            .id(proj.getId())
+            .siteId(proj.getSiteId())
+            .createdAt(proj.getCreatedAt())
+            .deletedAt(proj.getDeletedAt())
+            .revisionName(rev.getName())
+            .revisionCreatedAt(rev.getCreatedAt())
+            .revisionArchiveType(rev.getArchiveType())
+            .revisionArchiveMd5(rev.getArchiveMd5())
+            .build();
+    }
+}

--- a/digdag-core/src/test/java/io/digdag/core/database/DatabaseProjectStoreManagerTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/database/DatabaseProjectStoreManagerTest.java
@@ -162,6 +162,9 @@ public class DatabaseProjectStoreManagerTest
             StoredWorkflowDefinitionWithProject wfDetails3 = StoredWorkflowDefinitionWithProject.of(wf3, proj2, srcRev3);
             StoredWorkflowDefinitionWithProject wfDetails4 = StoredWorkflowDefinitionWithProject.of(wf4, proj2, srcRev3);
 
+            StoredProjectWithRevision proj1Rev1 = StoredProjectWithRevision.of(proj1, rev1);
+            StoredProjectWithRevision proj2Rev3 = StoredProjectWithRevision.of(proj2, rev3);
+
             ProjectStore anotherSite = manager.getProjectStore(1);
 
             ////
@@ -198,6 +201,11 @@ public class DatabaseProjectStoreManagerTest
             assertEquals(ImmutableList.of(proj1), store.getProjects(1, Optional.absent()));
             assertEquals(ImmutableList.of(proj2), store.getProjects(100, Optional.of(proj1.getId())));
             assertEmpty(anotherSite.getProjects(100, Optional.absent()));
+
+            assertEquals(ImmutableList.of(proj1Rev1, proj2Rev3), store.getProjectsWithLatestRevision(100, Optional.absent()));
+            assertEquals(ImmutableList.of(proj1Rev1), store.getProjectsWithLatestRevision(1, Optional.absent()));
+            assertEquals(ImmutableList.of(proj2Rev3), store.getProjectsWithLatestRevision(100, Optional.of(proj1.getId())));
+            assertEmpty(anotherSite.getProjectsWithLatestRevision(100, Optional.absent()));
 
             assertEquals(ImmutableList.of(rev3, rev2), store.getRevisions(proj2.getId(), 100, Optional.absent()));  // revision is returned in reverse order
             assertEquals(ImmutableList.of(rev3), store.getRevisions(proj2.getId(), 1, Optional.absent()));
@@ -328,6 +336,7 @@ public class DatabaseProjectStoreManagerTest
 
             // listing doesn't include deleted projects
             assertEquals(ImmutableList.of(), store.getProjects(100, Optional.absent()));
+            assertEquals(ImmutableList.of(), store.getProjectsWithLatestRevision(100, Optional.absent()));
             assertEquals(ImmutableList.of(), store.getLatestActiveWorkflowDefinitions(100, Optional.absent()));
 
             // lookup by project/revision id succeeds and deletedAt is set

--- a/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
@@ -72,6 +72,7 @@ import io.digdag.core.repository.ResourceConflictException;
 import io.digdag.core.repository.ResourceNotFoundException;
 import io.digdag.core.repository.Revision;
 import io.digdag.core.repository.StoredProject;
+import io.digdag.core.repository.StoredProjectWithRevision;
 import io.digdag.core.repository.StoredRevision;
 import io.digdag.core.repository.StoredWorkflowDefinition;
 import io.digdag.core.repository.WorkflowDefinition;
@@ -260,19 +261,11 @@ public class ProjectResource
                 }
             }
             else {
-                // TODO fix n-m db access
-                collection = ps.getProjects(100, Optional.absent())
+                collection = ps.getProjectsWithLatestRevision(100, Optional.absent())
                         .stream()
-                        .map(proj -> {
-                            try {
-                                StoredRevision rev = ps.getLatestRevision(proj.getId());
-                                return RestModels.project(proj, rev);
-                            }
-                            catch (ResourceNotFoundException ex) {
-                                return null;
-                            }
+                        .map(projWithRev -> {
+                            return RestModels.project(projWithRev);
                         })
-                        .filter(proj -> proj != null)
                         .collect(Collectors.toList());
             }
 

--- a/digdag-server/src/main/java/io/digdag/server/rs/RestModels.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/RestModels.java
@@ -29,6 +29,7 @@ import io.digdag.core.repository.ProjectStore;
 import io.digdag.core.repository.ResourceNotFoundException;
 import io.digdag.core.repository.Revision;
 import io.digdag.core.repository.StoredProject;
+import io.digdag.core.repository.StoredProjectWithRevision;
 import io.digdag.core.repository.StoredRevision;
 import io.digdag.core.repository.StoredWorkflowDefinition;
 import io.digdag.core.repository.StoredWorkflowDefinitionWithProject;
@@ -55,6 +56,20 @@ public final class RestModels
 {
     private RestModels()
     { }
+
+    public static RestProject project(StoredProjectWithRevision projWithRev)
+    {
+        return RestProject.builder()
+            .id(id(projWithRev.getId()))
+            .name(projWithRev.getName())
+            .revision(projWithRev.getRevisionName())
+            .createdAt(projWithRev.getCreatedAt())
+            .updatedAt(projWithRev.getRevisionCreatedAt())
+            .deletedAt(projWithRev.getDeletedAt())
+            .archiveType(projWithRev.getRevisionArchiveType().getName())
+            .archiveMd5(projWithRev.getRevisionArchiveMd5())
+            .build();
+    }
 
     public static RestProject project(StoredProject proj, StoredRevision lastRevision)
     {


### PR DESCRIPTION
## Overview
fix https://github.com/treasure-data/digdag/blob/eb44c91fbee3bc38f869c088814a2a623b831b3d/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java#L263

I fix n-m db access in `ProjectResource.getProjects` to add `projectWithLatestRevision`.


## Reason for fix
I try to change SQL `order by` value dynamically in https://github.com/treasure-data/digdag/pull/1156.
But, getProjects and getRevision SQL separated. So, I can't sort prejects with revision by any value in SQL.
