### PR TITLE
Change log level and log contents in EcsCommandExecutor

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -116,7 +116,7 @@ public class EcsCommandExecutor
             }
         }
         catch (ConfigException e) {
-            logger.info("EcsCommandExecutor is not executed.", e);
+            logger.trace("Fall back to DockerCommandExecutor: {}", e.toString());
             return docker.run(commandContext, commandRequest); // fall back to DockerCommandExecutor
         }
     }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -116,7 +116,7 @@ public class EcsCommandExecutor
             }
         }
         catch (ConfigException e) {
-            logger.trace("Fall back to DockerCommandExecutor: {}", e.toString());
+            logger.debug("Fall back to DockerCommandExecutor: {}", e.toString());
             return docker.run(commandContext, commandRequest); // fall back to DockerCommandExecutor
         }
     }


### PR DESCRIPTION
If we use sh> in  v0_10 branch , following exception logs are written and very noisy.
```
2019-07-25 15:58:53 +0900 [INFO] (0017@[0:default]+test_retry1+group1+taskB) io.digdag.core.agent.OperatorManager: sh>: echo hoge; exit 1
2019-07-25 15:58:53 +0900 [INFO] (0017@[0:default]+test_retry1+group1+taskB) io.digdag.standards.command.EcsCommandExecutor: EcsCommandExecutor is not executed.
io.digdag.client.config.ConfigException: Parameter 'agent.command_executor.ecs.name' is required but not set
        at io.digdag.client.config.Config.get(Config.java:233)
        at io.digdag.standards.command.ecs.EcsClientConfig.createFromSystemConfig(EcsClientConfig.java:42)
        at io.digdag.standards.command.ecs.EcsClientConfig.of(EcsClientConfig.java:17)
        at io.digdag.standards.command.EcsCommandExecutor.createEcsClientConfig(EcsCommandExecutor.java:450)
        at io.digdag.standards.command.EcsCommandExecutor.run(EcsCommandExecutor.java:107)
        at io.digdag.standards.operator.ShOperatorFactory$ShOperator.runCommand(ShOperatorFactory.java:195)
        at io.digdag.standards.operator.ShOperatorFactory$ShOperator.runCode(ShOperatorFactory.java:107)
        at io.digdag.standards.operator.ShOperatorFactory$ShOperator.runTask(ShOperatorFactory.java:88)
        at io.digdag.util.BaseOperator.run(BaseOperator.java:35)
        at io.digdag.core.agent.OperatorManager.callExecutor(OperatorManager.java:318)
        at io.digdag.cli.Run$OperatorManagerWithSkip.callExecutor(Run.java:708)
        at io.digdag.core.agent.OperatorManager.runWithWorkspace(OperatorManager.java:260)
        at io.digdag.core.agent.OperatorManager.lambda$runWithHeartbeat$2(OperatorManager.java:137)
        at io.digdag.core.agent.LocalWorkspaceManager.withExtractedArchive(LocalWorkspaceManager.java:25)
        at io.digdag.core.agent.OperatorManager.runWithHeartbeat(OperatorManager.java:135)
        at io.digdag.core.agent.OperatorManager.run(OperatorManager.java:119)
        at io.digdag.cli.Run$OperatorManagerWithSkip.run(Run.java:690)
        at io.digdag.core.agent.MultiThreadAgent.lambda$null$0(MultiThreadAgent.java:127)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
hoge
2019-07-25 15:58:53 +0900 [ERROR] (0017
```

I would like to change its log as follows.
```
2019-07-25 16:04:42 +0900 [INFO] (0017@[0:default]+test_retry1+group1+taskB) io.digdag.core.agent.OperatorManager: sh>: echo hoge; exit 1
2019-07-25 16:04:42 +0900 [TRACE] (0017@[0:default]+test_retry1+group1+taskB) io.digdag.standards.operator.ShOperatorFactory$ShOperator: Ignoring invalid env
var key: sh>
2019-07-25 16:04:42 +0900 [TRACE] (0017@[0:default]+test_retry1+group1+taskB) io.digdag.standards.command.EcsCommandExecutor: Fall back to DockerCommandExecutor: io.digdag.client.config.ConfigException: Parameter 'agent.command_executor.ecs.name' is required but not set
hoge
```

- Change log level to TRACE
- Show it is normal fall back process and only exception message.



