### PR TITLE
Add workflow definition ID to notification

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/notification/MailNotificationSender.java
+++ b/digdag-core/src/main/java/io/digdag/core/notification/MailNotificationSender.java
@@ -117,6 +117,7 @@ public class MailNotificationSender
                 .timeZone(ZoneOffset.UTC)
                 .sessionUuid(UUID.randomUUID())
                 .sessionTime(OffsetDateTime.now())
+                .workflowDefinitionId(5L)
                 .build();
         try {
             body(notification);

--- a/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java
+++ b/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java
@@ -1037,6 +1037,7 @@ public class WorkflowExecutor
                 .localConfig(localConfig)
                 .config(params)
                 .lastStateParams(task.getStateParams())
+                .workflowDefinitionId(attempt.getWorkflowDefinitionId())
                 .build();
 
             return Optional.of(request);

--- a/digdag-server/src/main/java/io/digdag/server/WorkflowExecutionTimeoutEnforcer.java
+++ b/digdag-server/src/main/java/io/digdag/server/WorkflowExecutionTimeoutEnforcer.java
@@ -229,6 +229,7 @@ public class WorkflowExecutionTimeoutEnforcer
                 .sessionId(attempt.getSessionId())
                 .siteId(attempt.getSiteId())
                 .workflowName(workflow.transform(wf -> wf.getName()))
+                .workflowDefinitionId(wfId)
                 .build();
 
         try {

--- a/digdag-spi/src/main/java/io/digdag/spi/Notification.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/Notification.java
@@ -58,6 +58,9 @@ public interface Notification
     @JsonProperty("session_time")
     Optional<OffsetDateTime> getSessionTime();
 
+    @JsonProperty("workflow_definition_id")
+    Optional<Long> getWorkflowDefinitionId();
+
     static ImmutableNotification.Builder builder(Instant timestamp, String message) {
         return ImmutableNotification.builder()
                 .timestamp(timestamp)

--- a/digdag-spi/src/main/java/io/digdag/spi/TaskRequest.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/TaskRequest.java
@@ -22,6 +22,8 @@ public interface TaskRequest
 
     String getWorkflowName();
 
+    Optional<Long> getWorkflowDefinitionId();
+
     Optional<String> getRevision();
 
     long getTaskId();

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/NotifyOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/NotifyOperatorFactory.java
@@ -70,6 +70,7 @@ public class NotifyOperatorFactory
                     .timeZone(request.getTimeZone())
                     .sessionUuid(request.getSessionUuid())
                     .sessionTime(OffsetDateTime.ofInstant(request.getSessionTime(), request.getTimeZone()))
+                    .workflowDefinitionId(request.getWorkflowDefinitionId())
                     .build();
 
             try {


### PR DESCRIPTION
This PR adds workflow_definition_id to TaskRequest SPI and Notification SPI because it would be helpful for identifying which workflow definition has the problem if the workflow execution failed.

This is added as an optional field, so should be backwards compatible in terms of client/server communication.