### PR TITLE
http> operator shows response body to investigate the cause

### DIFF
--- a/digdag-tests/src/test/java/utils/TestUtils.java
+++ b/digdag-tests/src/test/java/utils/TestUtils.java
@@ -493,19 +493,19 @@ public class TestUtils
         copyResource(resource, project.resolve(workflowName));
     }
 
-    public static void runWorkflow(TemporaryFolder folder, String resource, Map<String, String> params)
+    public static CommandStatus runWorkflow(TemporaryFolder folder, String resource, Map<String, String> params)
             throws IOException
     {
-        runWorkflow(folder, resource, params, ImmutableMap.of());
+        return runWorkflow(folder, resource, params, ImmutableMap.of());
     }
 
-    public static void runWorkflow(TemporaryFolder folder, String resource, Map<String, String> params, Map<String, String> config)
+    public static CommandStatus runWorkflow(TemporaryFolder folder, String resource, Map<String, String> params, Map<String, String> config)
             throws IOException
     {
-        runWorkflow(folder, resource, params, config, 0);
+        return runWorkflow(folder, resource, params, config, 0);
     }
 
-    public static void runWorkflow(TemporaryFolder folder, String resource, Map<String, String> params, Map<String, String> config, int expectedStatus)
+    public static CommandStatus runWorkflow(TemporaryFolder folder, String resource, Map<String, String> params, Map<String, String> config, int expectedStatus)
             throws IOException
     {
         Path workflow = Paths.get(resource);
@@ -526,6 +526,7 @@ public class TestUtils
             copyResource(resource, file);
             CommandStatus status = main(runCommand);
             assertThat(status.errUtf8(), status.code(), is(expectedStatus));
+            return status;
         }
         finally {
             FileUtils.deleteQuietly(tempdir.toFile());


### PR DESCRIPTION
http> and http_call> operators was showing HTTP status code only. But
it's very difficult to investigate the cause and fix the workflow. HTTP
response body contains much valuable information to investigate.

This change shows at most first 200 bytes of response body when
server returned an error.