### PR TITLE
Add option to copy symbolic links pointing outside of project directory

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/client/Archive.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Archive.java
@@ -35,6 +35,9 @@ public class Archive
     @Parameter(names = {"-o", "--output"})
     String output = "digdag.archive.tar.gz";
 
+    @Parameter(names = {"--copy-outside-symlinks"})
+    boolean copyOutsideSymlinks = false;
+
     @Override
     public void main()
             throws Exception
@@ -52,6 +55,7 @@ public class Archive
         err.println("  Options:");
         err.println("        --project DIR                use this directory as the project directory (default: current directory)");
         err.println("    -o, --output ARCHIVE.tar.gz      output path (default: digdag.archive.tar.gz)");
+        err.println("        --copy-outside-symlinks      transform symbolic links to regular files or directories");
         Main.showCommonOptions(env, err);
         return systemExit(error);
     }
@@ -85,7 +89,7 @@ public class Archive
         Path projectPath = (projectDirName == null) ?
             Paths.get("").toAbsolutePath() :
             Paths.get(projectDirName).normalize().toAbsolutePath();
-        injector.getInstance(Archiver.class).createArchive(projectPath, Paths.get(output));
+        injector.getInstance(Archiver.class).createArchive(projectPath, Paths.get(output), copyOutsideSymlinks);
 
         out.println("Created " + output + ".");
         out.println("Use `" + programName + " upload <path.tar.gz> <project> <revision>` to upload it a server.");

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Archive.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Archive.java
@@ -35,8 +35,8 @@ public class Archive
     @Parameter(names = {"-o", "--output"})
     String output = "digdag.archive.tar.gz";
 
-    @Parameter(names = {"--copy-outside-symlinks"})
-    boolean copyOutsideSymlinks = false;
+    @Parameter(names = {"--copy-outgoing-symlinks"})
+    boolean copyOutgoingSymlinks = false;
 
     @Override
     public void main()
@@ -55,7 +55,7 @@ public class Archive
         err.println("  Options:");
         err.println("        --project DIR                use this directory as the project directory (default: current directory)");
         err.println("    -o, --output ARCHIVE.tar.gz      output path (default: digdag.archive.tar.gz)");
-        err.println("        --copy-outside-symlinks      transform symbolic links to regular files or directories");
+        err.println("        --copy-outgoing-symlinks     transform symbolic links to regular files or directories");
         Main.showCommonOptions(env, err);
         return systemExit(error);
     }
@@ -89,7 +89,7 @@ public class Archive
         Path projectPath = (projectDirName == null) ?
             Paths.get("").toAbsolutePath() :
             Paths.get(projectDirName).normalize().toAbsolutePath();
-        injector.getInstance(Archiver.class).createArchive(projectPath, Paths.get(output), copyOutsideSymlinks);
+        injector.getInstance(Archiver.class).createArchive(projectPath, Paths.get(output), copyOutgoingSymlinks);
 
         out.println("Created " + output + ".");
         out.println("Use `" + programName + " upload <path.tar.gz> <project> <revision>` to upload it a server.");

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Push.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Push.java
@@ -44,6 +44,9 @@ public class Push
     @Parameter(names = {"--schedule-from"})
     String scheduleFromString = null;
 
+    @Parameter(names = {"--copy-outside-symlinks"})
+    boolean copyOutsideSymlinks = false;
+
     @Override
     public void mainWithClientException()
         throws Exception
@@ -61,6 +64,7 @@ public class Push
         err.println("        --project DIR                use this directory as the project directory (default: current directory)");
         err.println("    -r, --revision REVISION          specific revision name instead of auto-generated UUID");
         err.println("        --schedule-from \"yyyy-MM-dd HH:mm:ss Z\"  start schedules from this time instead of current time");
+        err.println("        --copy-outside-symlinks      transform symbolic links to regular files or directories");
         showCommonOptions();
         return systemExit(error);
     }
@@ -107,7 +111,7 @@ public class Push
         Path projectPath = (projectDirName == null) ?
             Paths.get("").toAbsolutePath() :
             Paths.get(projectDirName).normalize().toAbsolutePath();
-        List<String> workflows = injector.getInstance(Archiver.class).createArchive(projectPath, archivePath);
+        List<String> workflows = injector.getInstance(Archiver.class).createArchive(projectPath, archivePath, copyOutsideSymlinks);
         out.println("Workflows:");
         if (workflows.isEmpty()) {
             out.println("  WARNING: This project doesn't include workflows. Usually, this is a mistake.");

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Push.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Push.java
@@ -44,8 +44,8 @@ public class Push
     @Parameter(names = {"--schedule-from"})
     String scheduleFromString = null;
 
-    @Parameter(names = {"--copy-outside-symlinks"})
-    boolean copyOutsideSymlinks = false;
+    @Parameter(names = {"--copy-outgoing-symlinks"})
+    boolean copyOutgoingSymlinks = false;
 
     @Override
     public void mainWithClientException()
@@ -64,7 +64,7 @@ public class Push
         err.println("        --project DIR                use this directory as the project directory (default: current directory)");
         err.println("    -r, --revision REVISION          specific revision name instead of auto-generated UUID");
         err.println("        --schedule-from \"yyyy-MM-dd HH:mm:ss Z\"  start schedules from this time instead of current time");
-        err.println("        --copy-outside-symlinks      transform symbolic links to regular files or directories");
+        err.println("        --copy-outgoing-symlinks     transform symbolic links to regular files or directories");
         showCommonOptions();
         return systemExit(error);
     }
@@ -111,7 +111,7 @@ public class Push
         Path projectPath = (projectDirName == null) ?
             Paths.get("").toAbsolutePath() :
             Paths.get(projectDirName).normalize().toAbsolutePath();
-        List<String> workflows = injector.getInstance(Archiver.class).createArchive(projectPath, archivePath, copyOutsideSymlinks);
+        List<String> workflows = injector.getInstance(Archiver.class).createArchive(projectPath, archivePath, copyOutgoingSymlinks);
         out.println("Workflows:");
         if (workflows.isEmpty()) {
             out.println("  WARNING: This project doesn't include workflows. Usually, this is a mistake.");

--- a/digdag-core/src/main/java/io/digdag/core/archive/ProjectArchive.java
+++ b/digdag-core/src/main/java/io/digdag/core/archive/ProjectArchive.java
@@ -30,7 +30,7 @@ public class ProjectArchive
 
     public interface PathConsumer
     {
-        public void accept(String resourceName, Path absolutePath) throws IOException;
+        public boolean accept(String resourceName, Path absolutePath) throws IOException;
     }
 
     private final Path projectPath;
@@ -97,8 +97,8 @@ public class ProjectArchive
             for (Path path : ds) {
                 String resourceName = realPathToResourceName(projectPath, path);
                 if (listed.add(resourceName)) {
-                    consumer.accept(resourceName, path);
-                    if (Files.isDirectory(path)) {
+                    boolean cont = consumer.accept(resourceName, path);
+                    if (cont && Files.isDirectory(path)) {
                         listFilesRecursively(projectPath, path, consumer, listed);
                     }
                 }

--- a/digdag-core/src/main/java/io/digdag/core/archive/ProjectArchiveLoader.java
+++ b/digdag-core/src/main/java/io/digdag/core/archive/ProjectArchiveLoader.java
@@ -51,6 +51,7 @@ public class ProjectArchiveLoader
                     errors.add(ex);
                 }
             }
+            return true;
         });
 
         try {

--- a/digdag-core/src/test/java/io/digdag/core/archive/ProjectArchiveTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/archive/ProjectArchiveTest.java
@@ -79,7 +79,10 @@ public class ProjectArchiveTest
         }
 
         Map<String, Path> files = new HashMap<>();
-        projectArchive().listFiles(files::put);
+        projectArchive().listFiles((name, path) -> {
+            files.put(name, path);
+            return true;
+        });
 
         // keys are normalized path names
         ImmutableMap.Builder<String, Path> expected = ImmutableMap.builder();
@@ -112,7 +115,10 @@ public class ProjectArchiveTest
         }
 
         Map<String, Path> files = new HashMap<>();
-        projectArchive().listFiles(files::put);
+        projectArchive().listFiles((name, path) -> {
+            files.put(name, path);
+            return true;
+        });
 
         ImmutableMap.Builder<String, Path> expected = ImmutableMap.builder();
         expected.put("d1", d1);

--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -835,6 +835,10 @@ Creates a project archive and upload it to the server. This command uploads work
 
   Example: ``--schedule-from "2017-07-29 00:00:00 +0200"``
 
+:command:`--copy-outside-symlinks`
+  Transform symlinks to regular files or directories if the symlink points a file or directory outside of the target directory. Without this option, such case fails because the files or directories won't be included unless copying.
+
+  Example: ``--copy-outside-symlinks``
 
 download
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/digdag-tests/src/test/java/acceptance/CliArchiveIT.java
+++ b/digdag-tests/src/test/java/acceptance/CliArchiveIT.java
@@ -1,5 +1,11 @@
 package acceptance;
 
+import com.google.common.io.ByteStreams;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -10,9 +16,12 @@ import utils.TemporaryDigdagServer;
 import java.nio.file.Path;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static utils.TestUtils.copyResource;
 import static utils.TestUtils.main;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class CliArchiveIT
 {
@@ -37,7 +46,6 @@ public class CliArchiveIT
     public void archiveProject()
             throws Exception
     {
-
         // Create new project
         CommandStatus initStatus = main("init",
                 "-c", config.toString(),
@@ -67,5 +75,122 @@ public class CliArchiveIT
                     "-e", server.endpoint());
             assertThat(uploadStatus.errUtf8(), uploadStatus.code(), is(0));
         }
+    }
+
+    @Test
+    public void rejectSymlinksPointingParents()
+            throws Exception
+    {
+        Path sub = Files.createDirectories(projectDir.resolve("sub"));
+
+        // sub/from1 points ../to1 => should success
+        Files.createSymbolicLink(sub.resolve("from1"), Paths.get("..").resolve("to1"));
+        CommandStatus status1 = main(
+                "archive",
+                "--project", projectDir.toString(),
+                "--output", "test_archive.tar.gz",
+                "-c", config.toString()
+        );
+        assertThat(status1.errUtf8(), status1.code(), is(0));
+
+        // sub/from1 points ../../to1 => should fail
+        Files.createSymbolicLink(sub.resolve("from2"), Paths.get("..").resolve("..").resolve("to2"));
+        CommandStatus status2 = main(
+                "archive",
+                "--project", projectDir.toString(),
+                "--output", "test_archive.tar.gz",
+                "-c", config.toString()
+        );
+        assertThat(status2.errUtf8(), status2.code(), is(1));
+        assertThat(status2.errUtf8(), containsString("is outside of project directory"));
+    }
+
+    @Test
+    public void copyOutsideSymlinksCopiesFile()
+            throws Exception
+    {
+        Files.createDirectories(projectDir);
+        Path archivePath = projectDir.resolve("..").resolve("test_archive.tar.gz");
+
+        // ../to1 => "text1"
+        Path to1 = projectDir.resolve("..").resolve("to1");
+        Files.write(to1, "text1".getBytes(UTF_8));
+
+        // sub/from1 points ../../to1
+        Path sub = Files.createDirectories(projectDir.resolve("sub"));
+        Files.createSymbolicLink(sub.resolve("from1"), Paths.get("..").resolve("..").resolve("to1"));
+
+        // archive with --copy-symlink
+        CommandStatus status1 = main(
+                "archive",
+                "--project", projectDir.toString(),
+                "--output", archivePath.toString(),
+                "--copy-outside-symlinks",
+                "-c", config.toString()
+        );
+        assertThat(status1.errUtf8(), status1.code(), is(0));
+
+        boolean found = false;
+        try (TarArchiveInputStream s = new TarArchiveInputStream(
+                new GzipCompressorInputStream(Files.newInputStream(archivePath)))) {
+            while (true) {
+                TarArchiveEntry entry = s.getNextTarEntry();
+                if (entry == null) {
+                    break;
+                }
+
+                if (entry.getName().equals("sub1/from1")) {
+                    found = true;
+                    String contents = new String(ByteStreams.toByteArray(s), UTF_8);
+                    assertThat(contents, is("text1"));
+                }
+            }
+        }
+        assertThat(found, is(false));
+    }
+
+    @Test
+    public void copyOutsideSymlinksCopiesDirectory()
+            throws Exception
+    {
+        Files.createDirectories(projectDir);
+        Path archivePath = projectDir.resolve("..").resolve("test_archive.tar.gz");
+
+        // ../to1/file => "text1"
+        Path to1 = projectDir.resolve("..").resolve("to1");
+        Files.createDirectories(to1);
+        Files.write(to1.resolve("file"), "text1".getBytes(UTF_8));
+
+        // sub/from1 points ../../to1/
+        Path sub = Files.createDirectories(projectDir.resolve("sub"));
+        Files.createSymbolicLink(sub.resolve("from1"), Paths.get("..").resolve("..").resolve("to1"));
+
+        // archive with --copy-symlink
+        CommandStatus status1 = main(
+                "archive",
+                "--project", projectDir.toString(),
+                "--output", archivePath.toString(),
+                "--copy-outside-symlinks",
+                "-c", config.toString()
+        );
+        assertThat(status1.errUtf8(), status1.code(), is(0));
+
+        boolean found = false;
+        try (TarArchiveInputStream s = new TarArchiveInputStream(
+                new GzipCompressorInputStream(Files.newInputStream(archivePath)))) {
+            while (true) {
+                TarArchiveEntry entry = s.getNextTarEntry();
+                if (entry == null) {
+                    break;
+                }
+
+                if (entry.getName().equals("sub1/from1/file")) {
+                    found = true;
+                    String contents = new String(ByteStreams.toByteArray(s), UTF_8);
+                    assertThat(contents, is("text1"));
+                }
+            }
+        }
+        assertThat(found, is(false));
     }
 }

--- a/digdag-tests/src/test/java/acceptance/CliArchiveIT.java
+++ b/digdag-tests/src/test/java/acceptance/CliArchiveIT.java
@@ -106,7 +106,7 @@ public class CliArchiveIT
     }
 
     @Test
-    public void copyOutsideSymlinksCopiesFile()
+    public void copyOutgoingSymlinksCopiesFile()
             throws Exception
     {
         Files.createDirectories(projectDir);
@@ -125,7 +125,7 @@ public class CliArchiveIT
                 "archive",
                 "--project", projectDir.toString(),
                 "--output", archivePath.toString(),
-                "--copy-outside-symlinks",
+                "--copy-outgoing-symlinks",
                 "-c", config.toString()
         );
         assertThat(status1.errUtf8(), status1.code(), is(0));
@@ -150,7 +150,7 @@ public class CliArchiveIT
     }
 
     @Test
-    public void copyOutsideSymlinksCopiesDirectory()
+    public void copyOutgoingSymlinksCopiesDirectory()
             throws Exception
     {
         Files.createDirectories(projectDir);
@@ -170,7 +170,7 @@ public class CliArchiveIT
                 "archive",
                 "--project", projectDir.toString(),
                 "--output", archivePath.toString(),
-                "--copy-outside-symlinks",
+                "--copy-outgoing-symlinks",
                 "-c", config.toString()
         );
         assertThat(status1.errUtf8(), status1.code(), is(0));


### PR DESCRIPTION
`digdag push` fails if the project includes a symbolic link that points
outside of the project directory. This is hard to avoid because the
archive package must be self-contained but such files pointed by the
symlinks won't be included in the archive.

This new option provides a solution to it. If the option is given, the
command copies files or directories instead of throwing an exception.

It might make sense to make this behavior default (with warning messages)
at a future major version upgrade.

This is especially useful to avoid a workaround as mentioned at
https://qiita.com/sonots/items/9cf643279da62fce5cdf