### PR TITLE
Trim space for td operator logger message

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdRunOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdRunOperatorFactory.java
@@ -96,7 +96,7 @@ public class TdRunOperatorFactory
                     .build();
 
             String jobId = op.submitNewJobWithRetry(client -> client.startSavedQuery(req));
-            logger.info("Started a saved query id={} with time={}, job id= {}", id, sessionTime, jobId);
+            logger.info("Started a saved query id={} with time={}, job id={}", id, sessionTime, jobId);
             return jobId;
         }
 
@@ -109,7 +109,7 @@ public class TdRunOperatorFactory
                     .build();
 
             String jobId = op.submitNewJobWithRetry(client -> client.startSavedQuery(req));
-            logger.info("Started a saved query name={} with time={}, job id= {}", name, sessionTime, jobId);
+            logger.info("Started a saved query name={} with time={}, job id={}", name, sessionTime, jobId);
             return jobId;
         }
 


### PR DESCRIPTION
before
`2019-08-14 17:58:56 +0900 [INFO] (0017@[0:default]+****+execute): Started a saved query name=DATA-419 with time=2019-08-13T00:00:00Z, job id= 540192525`

after
`2019-08-14 17:58:56 +0900 [INFO] (0017@[0:default]+****+execute): Started a saved query name=DATA-419 with time=2019-08-13T00:00:00Z, job id=540192525`