### PR TITLE
Split task log by size.

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/log/BufferedRemoteTaskLogger.java
+++ b/digdag-core/src/main/java/io/digdag/core/log/BufferedRemoteTaskLogger.java
@@ -1,16 +1,14 @@
 package io.digdag.core.log;
 
 import java.time.Instant;
-import java.util.zip.GZIPOutputStream;
 import java.io.InputStream;
-import java.io.OutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
-import java.time.Instant;
+
 import com.google.common.base.Throwables;
 import com.google.common.io.ByteStreams;
 import io.digdag.core.TempFileManager;
@@ -135,49 +133,4 @@ public class BufferedRemoteTaskLogger
         }
     }
 
-    private static class CountingLogOutputStream
-        extends GZIPOutputStream
-    {
-        private final Path path;
-        private final Instant openTime;
-        private int count;
-
-        public CountingLogOutputStream(Path path)
-            throws IOException
-        {
-            super(Files.newOutputStream(path), 8*1024);
-            this.def.setLevel(9);
-            this.path = path;
-            this.openTime = Instant.now();
-        }
-
-        @Override
-        public void write(int b) throws IOException
-        {
-            super.write(b);
-            count++;
-        }
-
-        @Override
-        public void write(byte b[], int off, int len) throws IOException
-        {
-            super.write(b, off, len);
-            count += len;
-        }
-
-        public Path getPath()
-        {
-            return path;
-        }
-
-        public Instant getOpenTime()
-        {
-            return openTime;
-        }
-
-        public int getUncompressedSize()
-        {
-            return count;
-        }
-    }
 }

--- a/digdag-core/src/main/java/io/digdag/core/log/CountingLogOutputStream.java
+++ b/digdag-core/src/main/java/io/digdag/core/log/CountingLogOutputStream.java
@@ -1,0 +1,53 @@
+package io.digdag.core.log;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.zip.GZIPOutputStream;
+
+public class CountingLogOutputStream
+    extends GZIPOutputStream
+{
+    private final Path path;
+    private final Instant openTime;
+    private int count;
+
+    public CountingLogOutputStream(Path path)
+        throws IOException
+    {
+        super(Files.newOutputStream(path), 8*1024);
+        this.def.setLevel(9);
+        this.path = path;
+        this.openTime = Instant.now();
+    }
+
+    @Override
+    public void write(int b) throws IOException
+    {
+        super.write(b);
+        count++;
+    }
+
+    @Override
+    public void write(byte b[], int off, int len) throws IOException
+    {
+        super.write(b, off, len);
+        count += len;
+    }
+
+    public Path getPath()
+    {
+        return path;
+    }
+
+    public Instant getOpenTime()
+    {
+        return openTime;
+    }
+
+    public int getUncompressedSize()
+    {
+        return count;
+    }
+}

--- a/digdag-core/src/test/java/io/digdag/core/log/LocalFileLogServerFactoryTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/log/LocalFileLogServerFactoryTest.java
@@ -1,0 +1,141 @@
+package io.digdag.core.log;
+
+import io.digdag.client.DigdagClient;
+import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigFactory;
+import io.digdag.core.agent.AgentId;
+import io.digdag.core.config.PropertyUtils;
+import io.digdag.spi.LogFilePrefix;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.ZoneId;
+import com.google.common.base.Optional;
+import java.util.Properties;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import io.digdag.core.log.LocalFileLogServerFactory.LocalFileLogServer.LocalFileDirectTaskLogger;
+
+public class LocalFileLogServerFactoryTest
+{
+    private static final ConfigFactory CONFIG_FACTORY = new ConfigFactory(DigdagClient.objectMapper());
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    Path taskLogPath;
+    Properties props;
+    Config systemConfig;
+    LocalFileLogServerFactory logServerFactory;
+    LocalFileLogServerFactory.LocalFileLogServer localServer;
+
+    LogFilePrefix prefix = LogFilePrefix.builder()
+            .createdAt(Instant.now())
+            .retryAttemptName(Optional.absent())
+            .projectId(1)
+            .sessionTime(Instant.now())
+            .siteId(1)
+            .timeZone(ZoneId.systemDefault())
+            .workflowName("test1")
+            .build();
+    LocalFileDirectTaskLogger taskLogger;
+
+    @Before
+    public void setUp() throws IOException
+    {
+        taskLogPath = tempFolder.newFolder("task_logs").toPath();
+    }
+
+    private void setUpTaskLogger(Optional<String> size)
+    {
+        props = new Properties();
+        props.setProperty("log-server.local.path", taskLogPath.toString());
+        if (size.isPresent()) {
+            props.setProperty("log-server.local.split_size", size.get());
+        }
+        else {
+        }
+        systemConfig = PropertyUtils.toConfigElement(props).toConfig(CONFIG_FACTORY);
+        System.out.println(systemConfig);
+        logServerFactory = new LocalFileLogServerFactory(systemConfig, AgentId.of("agentA"));
+        localServer = (LocalFileLogServerFactory.LocalFileLogServer) logServerFactory.getLogServer();
+        taskLogger = localServer.newDirectTaskLogger(prefix, "+task1");
+    }
+
+    @Test
+    public void checkSplitSize()
+    {
+        setUpTaskLogger(Optional.of("100"));
+        String msg = repeatedString("a", 51);
+        taskLogger.log(msg.getBytes(UTF_8), 0, msg.length());
+        taskLogger.log(msg.getBytes(UTF_8), 0, msg.length());
+        for (File f : taskLogPath.toFile().listFiles()) {
+            for (File f2: f.listFiles()) {
+                File[] taskLogs = f2.listFiles();
+                for (File f3: taskLogs) {
+                    System.out.println(f3);
+                }
+                assertThat("log file should be splitted", f2.listFiles().length > 1, is(true));
+            }
+        }
+    }
+
+    @Test
+    public void checkSplitSizeIsZero()
+    {
+        setUpTaskLogger(Optional.of("0"));
+
+        String msg = repeatedString("a", 51);
+        for (int i = 0; i < 100; i++) {
+            taskLogger.log(msg.getBytes(UTF_8), 0, msg.length());
+        }
+        for (File f : taskLogPath.toFile().listFiles()) {
+            for (File f2: f.listFiles()) {
+                File[] taskLogs = f2.listFiles();
+                for (File f3: taskLogs) {
+                    System.out.println(f3);
+                }
+                assertThat("log file should be a file", f2.listFiles().length, is(1));
+            }
+        }
+    }
+
+    @Test
+    public void checkNoSplitSize()
+    {
+        setUpTaskLogger(Optional.absent());
+
+        String msg = repeatedString("a", 51);
+        for (int i = 0; i < 100; i++) {
+            taskLogger.log(msg.getBytes(UTF_8), 0, msg.length());
+        }
+        for (File f : taskLogPath.toFile().listFiles()) {
+            for (File f2: f.listFiles()) {
+                File[] taskLogs = f2.listFiles();
+                for (File f3: taskLogs) {
+                    System.out.println(f3);
+                }
+                assertThat("log file should be a file", f2.listFiles().length, is(1));
+            }
+        }
+    }
+
+    private String repeatedString(String v, int num)
+    {
+        StringBuilder b = new StringBuilder();
+        for (int i = 0; i < num; i++) {
+            b.append(v);
+        }
+        return b.toString();
+    }
+}

--- a/digdag-core/src/test/java/io/digdag/core/log/LocalFileLogServerFactoryTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/log/LocalFileLogServerFactoryTest.java
@@ -77,8 +77,10 @@ public class LocalFileLogServerFactoryTest
     {
         setUpTaskLogger(Optional.of("100"));
         String msg = repeatedString("a", 51);
-        taskLogger.log(msg.getBytes(UTF_8), 0, msg.length());
-        taskLogger.log(msg.getBytes(UTF_8), 0, msg.length());
+        for (int i = 0; i < 100; i++) {
+            taskLogger.log(msg.getBytes(UTF_8), 0, msg.length());
+        }
+        taskLogger.close();
         for (File f : taskLogPath.toFile().listFiles()) {
             for (File f2: f.listFiles()) {
                 File[] taskLogs = f2.listFiles();
@@ -99,6 +101,7 @@ public class LocalFileLogServerFactoryTest
         for (int i = 0; i < 100; i++) {
             taskLogger.log(msg.getBytes(UTF_8), 0, msg.length());
         }
+        taskLogger.close();
         for (File f : taskLogPath.toFile().listFiles()) {
             for (File f2: f.listFiles()) {
                 File[] taskLogs = f2.listFiles();
@@ -119,6 +122,7 @@ public class LocalFileLogServerFactoryTest
         for (int i = 0; i < 100; i++) {
             taskLogger.log(msg.getBytes(UTF_8), 0, msg.length());
         }
+        taskLogger.close();
         for (File f : taskLogPath.toFile().listFiles()) {
             for (File f2: f.listFiles()) {
                 File[] taskLogs = f2.listFiles();

--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -382,6 +382,8 @@ In the config file, following parameters are available
 * log-server.s3.credentials.access-key-id (string. default: instance profile)
 * log-server.s3.credentials.secret-access-key (string. default: instance profile)
 * log-server.s3.path-style-access (boolean. default: false)
+* log-server.local.path (string. default: digdag.log)
+* log-server.local.split_size (long. default: 0  (not splitted))
 * digdag.secret-encryption-key = (base64 encoded 128-bit AES encryption key)
 * executor.task_ttl (string. default: 1d. A task is killed if it is running longer than this period.)
 * executor.attempt_ttl (string. default: 7d. An attempt is killed if it is running longer than this period.)


### PR DESCRIPTION
This PR is the purpose to resolve #1193 and replace PR #700. 

This PR splits task log by the configured size.
So long running task can also show the log by **digdag log -f**.
If server admin configured the size to small one, user can show the task log in near real time.
