### PR TITLE
Add metrics.fluency.step parameter

### DIFF
--- a/digdag-docs/src/metrics.md
+++ b/digdag-docs/src/metrics.md
@@ -35,6 +35,7 @@ metrics.jmx.categories = api,default
 metrics.fluency.categories = agent,executor,default
 metrics.fluency.host = localhost:24224
 metrics.fluency.tag = digdag_metrics
+metrics.fluency.step = 60   #step to send metrics. default is 60 seconds
 ```
 
 ## API metrics

--- a/digdag-server/src/main/java/io/digdag/server/metrics/DigdagMetricsModule.java
+++ b/digdag-server/src/main/java/io/digdag/server/metrics/DigdagMetricsModule.java
@@ -128,7 +128,7 @@ public class DigdagMetricsModule
                 .getMonitorSystemConfig("fluency")
                 .or(() -> {throw new ConfigException("fluency is disabled");});
         Fluency fluency = FluencyMonitorSystemConfig.createFluency(fconfig);
-        FluencyRegistryConfig regConfig = new FluencyRegistryConfig(fconfig.getTag(), "digdag", Duration.ofSeconds(60));
+        FluencyRegistryConfig regConfig = new FluencyRegistryConfig(fconfig.getTag(), "digdag", Duration.ofSeconds(fconfig.getStep()));
         return FluencyMeterRegistry.apply(regConfig, HierarchicalNameMapper.DEFAULT, Clock.SYSTEM, fluency);
     }
 

--- a/digdag-server/src/main/java/io/digdag/server/metrics/fluency/FluencyMonitorSystemConfig.java
+++ b/digdag-server/src/main/java/io/digdag/server/metrics/fluency/FluencyMonitorSystemConfig.java
@@ -44,6 +44,9 @@ public interface FluencyMonitorSystemConfig extends MonitorSystemConfig
     default String getHost() { return "localhost:24224"; }
 
     @Value.Default
+    default long getStep() { return 60L; }
+
+    @Value.Default
     default Optional<String> getBackupDir() { return Optional.absent(); }
 
 
@@ -68,6 +71,7 @@ public interface FluencyMonitorSystemConfig extends MonitorSystemConfig
                 .tag(config.getOptional("metrics.fluency.tag", String.class).or("digdag"))
                 .host(config.getOptional("metrics.fluency.host", String.class).or("localhost:24224"))
                 .backupDir(config.getOptional("metrics.fluency.host", String.class))
+                .step(config.getOptional("metrics.fluency.step", Long.class).or(60L))
                 .build();
     }
 

--- a/digdag-server/src/test/java/io/digdag/server/metrics/DigdagMetricsConfigTest.java
+++ b/digdag-server/src/test/java/io/digdag/server/metrics/DigdagMetricsConfigTest.java
@@ -5,8 +5,6 @@ import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigElement;
 import io.digdag.client.config.ConfigFactory;
 import io.digdag.server.metrics.fluency.FluencyMonitorSystemConfig;
-import io.digdag.server.metrics.fluency.ImmutableFluencyMonitorSystemConfig;
-import io.digdag.server.metrics.jmx.ImmutableJmxMonitorSystemConfig;
 import io.digdag.server.metrics.jmx.JmxMonitorSystemConfig;
 import io.digdag.spi.metrics.DigdagMetrics;
 import static io.digdag.client.DigdagClient.objectMapper;
@@ -107,6 +105,7 @@ public class DigdagMetricsConfigTest
         assertTrue("category 'db' is enable", fluencyConfig.get().enable(DigdagMetrics.Category.DB));
         assertTrue("category 'executor' is enable", fluencyConfig.get().enable(DigdagMetrics.Category.EXECUTOR));
         assertTrue("category 'default' is enable", fluencyConfig.get().enable(DigdagMetrics.Category.DEFAULT));
+        assertEquals("step is 60 secs as default", 60L,  fluencyConfig.get().getStep());
     }
 
     @Test
@@ -121,7 +120,8 @@ public class DigdagMetricsConfigTest
                         "\"metrics.enable\": \" fluency \", " +
                         "\"metrics.fluency.categories\": \"agent, executor\", " +
                         "\"metrics.fluency.host\": \"server01:9999\", " +
-                        "\"metrics.fluency.tag\": \"tag0001\" " +
+                        "\"metrics.fluency.tag\": \"tag0001\", " +
+                        "\"metrics.fluency.step\": 120" +
                         "}");
         DigdagMetricsConfig metricsConfig = new DigdagMetricsConfig(config);
 
@@ -135,5 +135,6 @@ public class DigdagMetricsConfigTest
         assertFalse("category 'default' is enable", fluencyConfig.get().enable(DigdagMetrics.Category.DEFAULT));
         assertEquals("host", "server01:9999", fluencyConfig.get().getHost());
         assertEquals("tag", "tag0001", fluencyConfig.get().getTag());
+        assertEquals("step", 120L, fluencyConfig.get().getStep());
     }
 }


### PR DESCRIPTION
I would like to add new parameter _metrics.fluency.step_.
This parameter configure the step seconds to send metrics.
Default is 60 seconds.
