### PR TITLE
Add echo log output to task log.

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/operator/EchoOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/EchoOperatorFactory.java
@@ -2,11 +2,15 @@ package io.digdag.standards.operator;
 
 import com.google.inject.Inject;
 import io.digdag.client.config.Config;
+import io.digdag.core.log.TaskContextLogging;
+import io.digdag.core.log.TaskLogger;
 import io.digdag.spi.Operator;
 import io.digdag.spi.OperatorContext;
 import io.digdag.spi.OperatorFactory;
 import io.digdag.spi.TaskRequest;
 import io.digdag.spi.TaskResult;
+
+import java.nio.charset.StandardCharsets;
 
 public class EchoOperatorFactory
         implements OperatorFactory
@@ -44,6 +48,11 @@ public class EchoOperatorFactory
             String message = params.get("_command", String.class);
 
             System.out.println(message);
+
+            // To store the message to task log
+            TaskLogger logger = TaskContextLogging.getContext().getLogger();
+            byte[] messageBytes = message.getBytes(StandardCharsets.UTF_8);
+            logger.log(messageBytes, 0, messageBytes.length);
 
             return TaskResult.empty(request);
         }


### PR DESCRIPTION
This PR fix to store output of echo> operator in task log.

```
+task1:
  echo>: "Session ID: ${session_id}"
```
On above WF, server mode with 0.9.39, currently only following log is stored.

```
$ digdag log 1417
2019-09-12 17:18:59 +0900: Digdag v0.9.39
2019-09-12 17:16:24.668 +0900 [INFO] (0048@[0:group_retry_fix_IT1]+test_echo+task1) io.digdag.core.agent.OperatorManager: echo>: Session ID: 1196
```

With this PR task log output become as follows.
```
$ digdag log 1418
2019-09-12 17:20:41 +0900: Digdag v0.9.39
2019-09-12 17:17:19.496 +0900 [INFO] (0039@[0:group_retry_fix_IT1]+test_echo+task1) io.digdag.core.agent.OperatorManager: echo>: Session ID: 1197
Session ID: 1197
```

I believe this is better because output of sh> operator is also stored to task log.


