### PR TITLE
Change core.TaskCallbackApi to pass TaskRequest object to each interface method

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/Run.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Run.java
@@ -682,10 +682,8 @@ public class Run
                 try (SetThreadName threadName = new SetThreadName(origThreadName)) {
                     logger.warn("Skipped");
                 }
-                callback.taskSucceeded(request.getSiteId(),
-                        request.getTaskId(), request.getLockId(), agentId,
-                        result);
-        }
+                callback.taskSucceeded(request, agentId, result);
+            }
             else {
                 super.run(request);
             }

--- a/digdag-core/src/main/java/io/digdag/core/agent/TaskCallbackApi.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/TaskCallbackApi.java
@@ -18,22 +18,16 @@ public interface TaskCallbackApi
 {
     TaskLogger newTaskLogger(TaskRequest request);
 
-    void taskHeartbeat(int siteId,
-            List<String> lockedIds, AgentId agentId, int lockSeconds);
+    void taskHeartbeat(int siteId, List<TaskRequest> requests, AgentId agentId, int lockSeconds);
 
     Optional<StorageObject> openArchive(TaskRequest request)
         throws IOException;
 
-    void taskSucceeded(int siteId,
-            long taskId, String lockId, AgentId agentId,
-            TaskResult result);
+    void taskSucceeded(TaskRequest request, AgentId agentId, TaskResult result);
 
-    void taskFailed(int siteId,
-            long taskId, String lockId, AgentId agentId,
-            Config error);
+    void taskFailed(TaskRequest request, AgentId agentId, Config error);
 
-    void retryTask(int siteId,
-            long taskId, String lockId, AgentId agentId,
+    void retryTask(TaskRequest request, AgentId agentId,
             int retryInterval, Config retryStateParams,
             Optional<Config> error);
 


### PR DESCRIPTION
In this PR we changed the signatures of interface methods in `io.digdag.core.TaskCallbackApi` to pass `TaskRequest` object to those methods. It would make more change tolerant.