### PR TITLE
Allow REST clients to disable direct download by query param

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/log/AbstractFileLogServer.java
+++ b/digdag-core/src/main/java/io/digdag/core/log/AbstractFileLogServer.java
@@ -39,7 +39,7 @@ public abstract class AbstractFileLogServer
     protected abstract byte[] getFile(String dateDir, String attemptDir, String fileName)
             throws StorageFileNotFoundException;
 
-    protected abstract void listFiles(String dateDir, String attemptDir, FileMetadataConsumer fileNameConsumer);
+    protected abstract void listFiles(String dateDir, String attemptDir, boolean enableDirectDownload, FileMetadataConsumer fileNameConsumer);
 
     public interface FileMetadataConsumer
     {
@@ -77,14 +77,14 @@ public abstract class AbstractFileLogServer
     }
 
     @Override
-    public List<LogFileHandle> getFileHandles(LogFilePrefix prefix, Optional<String> taskName)
+    public List<LogFileHandle> getFileHandles(LogFilePrefix prefix, Optional<String> taskName, boolean enableDirectDownload)
     {
         String dateDir = LogFiles.formatDataDir(prefix);
         String attemptDir = LogFiles.formatSessionAttemptDir(prefix);
 
         List<LogFileHandle> handles = new ArrayList<>();
 
-        listFiles(dateDir, attemptDir, (name, size, direct) -> {
+        listFiles(dateDir, attemptDir, enableDirectDownload, (name, size, direct) -> {
             if (name.endsWith(LogFiles.LOG_GZ_FILE_SUFFIX) && (!taskName.isPresent() || name.startsWith(taskName.get()))) {
                 LogFileHandle handle = LogFiles.buildLogFileHandleFromFileName(name, size);
                 if (handle != null) {

--- a/digdag-core/src/main/java/io/digdag/core/log/LocalFileLogServerFactory.java
+++ b/digdag-core/src/main/java/io/digdag/core/log/LocalFileLogServerFactory.java
@@ -100,7 +100,7 @@ public class LocalFileLogServerFactory
         }
 
         @Override
-        protected void listFiles(String dateDir, String attemptDir, FileMetadataConsumer consumer)
+        protected void listFiles(String dateDir, String attemptDir, boolean enableDirectDownload, FileMetadataConsumer consumer)
         {
             Path dir = getPrefixDir(dateDir, attemptDir);
             if (!Files.exists(dir)) {

--- a/digdag-core/src/main/java/io/digdag/core/log/NullLogServerFactory.java
+++ b/digdag-core/src/main/java/io/digdag/core/log/NullLogServerFactory.java
@@ -49,7 +49,7 @@ public class NullLogServerFactory
         }
 
         @Override
-        public List<LogFileHandle> getFileHandles(LogFilePrefix prefix, Optional<String> taskName)
+        public List<LogFileHandle> getFileHandles(LogFilePrefix prefix, Optional<String> taskName, boolean enableDirectDownload)
         {
             return ImmutableList.of();
         }

--- a/digdag-core/src/main/java/io/digdag/core/log/StorageFileLogServer.java
+++ b/digdag-core/src/main/java/io/digdag/core/log/StorageFileLogServer.java
@@ -73,7 +73,7 @@ public class StorageFileLogServer
     }
 
     @Override
-    protected void listFiles(String dateDir, String attemptDir, FileMetadataConsumer consumer)
+    protected void listFiles(String dateDir, String attemptDir, boolean enableDirectDownload, FileMetadataConsumer consumer)
     {
         String dir = getPrefixDir(dateDir, attemptDir);
 
@@ -85,7 +85,7 @@ public class StorageFileLogServer
                     consumer.accept(
                             fileName,
                             meta.getContentLength(),
-                            directDownloadEnabled ? storage.getDirectDownloadHandle(key).orNull() : null);
+                            (directDownloadEnabled && enableDirectDownload) ? storage.getDirectDownloadHandle(key).orNull() : null);
             });
         });
     }

--- a/digdag-spi/src/main/java/io/digdag/spi/LogServer.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/LogServer.java
@@ -11,7 +11,7 @@ public interface LogServer
 
     Optional<DirectUploadHandle> getDirectUploadHandle(LogFilePrefix prefix, String taskName, Instant firstLogTime, String agentId);
 
-    List<LogFileHandle> getFileHandles(LogFilePrefix prefix, Optional<String> taskName);
+    List<LogFileHandle> getFileHandles(LogFilePrefix prefix, Optional<String> taskName, boolean enableDirectDownload);
 
     byte[] getFile(LogFilePrefix prefix, String fileName)
         throws StorageFileNotFoundException;


### PR DESCRIPTION
As commit 49f3ec160396241a3f0e9816a850cebdccd183a1 describes, file
storage is not reachable directly from some clients. Those clients need
to download files through digdag-server.

In some cases, server doesn't know accessing client can reach the
storage directly and only clients know about it. In those cases, system
config such as `log-server.<type>.direct_download` doesn't work.

With this change, following two paths accepts a new query parameter
`?direct_download=false` so that clients can tell the server that direct
download should be disabled.

* /api/projects/{id}/archive
* /api/logs/{attempt_id}/files