### PR TITLE
Fix bq output parameter.

### DIFF
--- a/digdag-docs/src/operators/bq.md
+++ b/digdag-docs/src/operators/bq.md
@@ -159,4 +159,4 @@ When you set those parameters, use [digdag secrets command](https://docs.digdag.
 
 * **bq.last_job_id** or **bq.last_jobid**
 
-  The id of the BigQuery job that performed this export. `bq.last_jobid` will be kept for compatibility and remove in near future release.
+  The id of the BigQuery job that executed this query. `bq.last_jobid` will be kept for compatibility and remove in near future release.

--- a/digdag-docs/src/operators/bq.md
+++ b/digdag-docs/src/operators/bq.md
@@ -157,7 +157,6 @@ When you set those parameters, use [digdag secrets command](https://docs.digdag.
 
 ## Output parameters
 
-* **bq.last_job_id**
+* **bq.last_job_id** or **bq.last_jobid**
 
-  The id of the BigQuery job that executed this query.
-
+  The id of the BigQuery job that performed this export. `bq.last_jobid` will be kept for compatibility and remove in near future release.

--- a/digdag-docs/src/operators/bq_extract.md
+++ b/digdag-docs/src/operators/bq_extract.md
@@ -101,7 +101,6 @@ When you set those parameters, use [digdag secrets command](https://docs.digdag.
 
 ## Output parameters
 
-* **bq.last_job_id**
+* **bq.last_job_id** or **bq.last_jobid**
 
-  The id of the BigQuery job that performed this export.
-
+  The id of the BigQuery job that performed this export. `bq.last_jobid` will be kept for compatibility and remove in near future release.

--- a/digdag-docs/src/operators/bq_load.md
+++ b/digdag-docs/src/operators/bq_load.md
@@ -275,6 +275,6 @@ When you set those parameters, use [digdag secrets command](https://docs.digdag.
 
 ## Output parameters
 
-* **bq.last_job_id**
+* **bq.last_job_id** or **bq.last_jobid**
 
-  The id of the BigQuery job that performed this import.
+  The id of the BigQuery job that performed this export. `bq.last_jobid` will be kept for compatibility and remove in near future release.

--- a/digdag-docs/src/operators/bq_load.md
+++ b/digdag-docs/src/operators/bq_load.md
@@ -277,4 +277,4 @@ When you set those parameters, use [digdag secrets command](https://docs.digdag.
 
 * **bq.last_job_id** or **bq.last_jobid**
 
-  The id of the BigQuery job that performed this export. `bq.last_jobid` will be kept for compatibility and remove in near future release.
+  The id of the BigQuery job that performed this import. `bq.last_jobid` will be kept for compatibility and remove in near future release.

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/gcp/BaseBqJobOperator.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/gcp/BaseBqJobOperator.java
@@ -32,9 +32,11 @@ abstract class BaseBqJobOperator
         Config result = cf.create();
         Config bq = result.getNestedOrSetEmpty("bq");
         bq.set("last_job_id", job.getId());
+        bq.set("last_jobid", job.getId());
         return TaskResult.defaultBuilder(request)
                 .storeParams(result)
                 .addResetStoreParams(ConfigKey.of("bq", "last_job_id"))
+                .addResetStoreParams(ConfigKey.of("bq", "last_jobid"))
                 .build();
     }
 

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/gcp/BaseBqJobOperator.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/gcp/BaseBqJobOperator.java
@@ -31,10 +31,10 @@ abstract class BaseBqJobOperator
         ConfigFactory cf = request.getConfig().getFactory();
         Config result = cf.create();
         Config bq = result.getNestedOrSetEmpty("bq");
-        bq.set("last_jobid", job.getId());
+        bq.set("last_job_id", job.getId());
         return TaskResult.defaultBuilder(request)
                 .storeParams(result)
-                .addResetStoreParams(ConfigKey.of("bq", "last_jobid"))
+                .addResetStoreParams(ConfigKey.of("bq", "last_job_id"))
                 .build();
     }
 


### PR DESCRIPTION
Hello,

The `bq`, `bq_extract`, and `bq_load` operators are documented as accepting `bq.last_job_id` as an output parameter, but in the current implementation it is `bq.last_jobid`.

Since the td operator can use `td.last_job_id`, I thought `last_job_id` may be correct and fixed it like that.