### PR TITLE
Fix some metrics are not exported in digdag-metrics 

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
@@ -136,7 +136,7 @@ public class OperatorManager
     }
 
     @DigdagTimed(value = "opm_", category = "agent", taskRequest = true, appendMethodName = true)
-    void runWithHeartbeat(TaskRequest request)
+    protected void runWithHeartbeat(TaskRequest request)
     {
         try {
             workspaceManager.withExtractedArchive(request, () -> callback.openArchive(request), (projectPath) -> {
@@ -182,7 +182,7 @@ public class OperatorManager
     }
 
     @DigdagTimed(value = "opm_", category = "agent", taskRequest = true, appendMethodName = true)
-    Config evalConfig(TaskRequest request)
+    protected Config evalConfig(TaskRequest request)
             throws RuntimeException, AssertionError
     {
         try {
@@ -203,7 +203,7 @@ public class OperatorManager
     }
 
     @DigdagTimed(value = "opm_", category = "agent", taskRequest = true, appendMethodName = true)
-    void runWithWorkspace(Path projectPath, TaskRequest request)
+    protected void runWithWorkspace(Path projectPath, TaskRequest request)
         throws TaskExecutionException
     {
         // evaluate config and creates the complete merged config.

--- a/digdag-server/src/main/java/io/digdag/server/metrics/DigdagTimedMethodInterceptor.java
+++ b/digdag-server/src/main/java/io/digdag/server/metrics/DigdagTimedMethodInterceptor.java
@@ -27,6 +27,19 @@ public class DigdagTimedMethodInterceptor implements MethodInterceptor
     public Object invoke(MethodInvocation invocation)
             throws Throwable
     {
+        try {
+            return invokeMain(invocation);
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+            logger.debug("invocationMain Failed. {}", e.toString());
+            throw e;
+        }
+    }
+
+    public Object invokeMain(MethodInvocation invocation)
+            throws Throwable
+    {
         DigdagTimed timed = invocation.getMethod().getAnnotation(DigdagTimed.class);
 
         Category category = Category.fromString(timed.category());
@@ -52,6 +65,8 @@ public class DigdagTimedMethodInterceptor implements MethodInterceptor
             try {
                 metrics.timerStop(category, metricsName, taskTags.and(timed.extraTags()), sample);
             } catch (Exception e) {
+                e.printStackTrace();
+                logger.warn(e.toString());
                 // ignoring on purpose
             }
         }


### PR DESCRIPTION
Methods which are added metrics annotation should be protect or public.
And improvement in annotation on exception handling.