### PR TITLE
Fix Travis CI error in install OracleJDK8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: required
 
 language: java
 
+dist: trusty
+
 jdk:
   - oraclejdk8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ sudo: required
 
 language: java
 
-dist: xenial
-
 jdk:
   - oraclejdk8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: required
 
 language: java
 
+dist: xenial
+
 jdk:
   - oraclejdk8
 


### PR DESCRIPTION
Travis CI fail because the failure of installing OracleJDK8.

As workaround, try to fix the distribution.
