### PR TITLE
Fix Travis CI error in install OracleJDK8 (v0_10)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: required
 
 language: java
 
+dist: trusty
+
 jdk:
   - oraclejdk8
 


### PR DESCRIPTION
Cherry pick #1230 to v0_10 to fix OracleJD8 error in TravisCI.
