### PR TITLE
Change how to fetch ready tasks in WorkflowExecutor.

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
@@ -60,7 +60,6 @@ import io.digdag.metrics.DigdagTimed;
 import io.digdag.spi.TaskReport;
 import io.digdag.spi.TaskResult;
 import io.digdag.spi.ac.AccessController;
-import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.sqlobject.Bind;
@@ -77,7 +76,6 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.ZoneId;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -288,7 +286,7 @@ public class DatabaseSessionStoreManager
     public List<Long> findAllReadyTaskIds(int maxEntries, boolean randomFetch)
     {
         if (randomFetch) {
-            return autoCommit((handle, dao) -> dao.findAllTaskIdsByStateRandom(TaskStateCode.READY.get(), maxEntries));
+            return autoCommit((handle, dao) -> dao.findAllTaskIdsByStateAtRandom(TaskStateCode.READY.get(), maxEntries));
         }
         else {
             return autoCommit((handle, dao) -> dao.findAllTaskIdsByState(TaskStateCode.READY.get(), maxEntries));
@@ -1667,7 +1665,7 @@ public class DatabaseSessionStoreManager
         Long lockTaskIfNotLocked(@Bind("id") long taskId);
 
         @SqlQuery("select id from tasks where state = :state order by random() limit :limit")
-        List<Long> findAllTaskIdsByStateRandom(@Bind("state") short state, @Bind("limit") int limit);
+        List<Long> findAllTaskIdsByStateAtRandom(@Bind("state") short state, @Bind("limit") int limit);
 
     }
 
@@ -1716,7 +1714,7 @@ public class DatabaseSessionStoreManager
         Long lockTaskIfNotLocked(@Bind("id") long taskId);
 
         @SqlQuery("select id from tasks where state = :state order by random() limit :limit")
-        List<Long> findAllTaskIdsByStateRandom(@Bind("state") short state, @Bind("limit") int limit);
+        List<Long> findAllTaskIdsByStateAtRandom(@Bind("state") short state, @Bind("limit") int limit);
     }
 
     public interface Dao
@@ -2016,7 +2014,7 @@ public class DatabaseSessionStoreManager
         @SqlQuery("select id from tasks where state = :state limit :limit")
         List<Long> findAllTaskIdsByState(@Bind("state") short state, @Bind("limit") int limit);
 
-        List<Long> findAllTaskIdsByStateRandom(@Bind("state") short state, @Bind("limit") int limit);
+        List<Long> findAllTaskIdsByStateAtRandom(@Bind("state") short state, @Bind("limit") int limit);
 
         @SqlQuery("select id, session_id, state_flags, index from session_attempts where id = :attemptId for update")
         SessionAttemptSummary lockAttempt(@Bind("attemptId") long attemptId);

--- a/digdag-core/src/main/java/io/digdag/core/session/SessionStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/session/SessionStoreManager.java
@@ -26,8 +26,17 @@ public interface SessionStoreManager
     // for WorkflowExecutor.runUntilAny
     boolean isAnyNotDoneAttempts();
 
-    // for WorkflowExecutor.enqueueReadyTasks
-    List<Long> findAllReadyTaskIds(int maxEntries);
+    // for WorkflowExecutor.enqueueReadyTasks (Keep for compatibility)
+    default List<Long> findAllReadyTaskIds(int maxEntries) { return findAllReadyTaskIds(maxEntries, false); }
+
+    /**
+     * for WorkflowExecutor.enqueueReadyTasks
+     * @param maxEntries  max number to fetch
+     * @param randomFetch fetch randomly or not(original behavior)
+     * @return
+     */
+    List<Long> findAllReadyTaskIds(int maxEntries, boolean randomFetch);
+
 
     // for AttemptTimeoutEnforcer.enforceAttemptTTLs
     List<StoredSessionAttempt> findActiveAttemptsCreatedBefore(Instant createdBefore, long lastId, int limit);

--- a/digdag-core/src/test/resources/io/digdag/core/workflow/random_enqueue_parallel.dig
+++ b/digdag-core/src/test/resources/io/digdag/core/workflow/random_enqueue_parallel.dig
@@ -1,0 +1,7 @@
++parallel_generate:
+  loop>: 8
+  _parallel: true
+  _do:
+    +task:
+      echo>: "idx:${i}"
+      append_file: out

--- a/digdag-core/src/test/resources/io/digdag/core/workflow/random_enqueue_simple.dig
+++ b/digdag-core/src/test/resources/io/digdag/core/workflow/random_enqueue_simple.dig
@@ -1,0 +1,13 @@
++step1:
+  echo>: step1
+  append_file: out
+
++step2:
+  echo>: step2
+  append_file: out
+
++step3:
+  echo>: step3
+  append_file: out
+
+

--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -384,6 +384,8 @@ In the config file, following parameters are available
 * digdag.secret-encryption-key = (base64 encoded 128-bit AES encryption key)
 * executor.task_ttl (string. default: 1d. A task is killed if it is running longer than this period.)
 * executor.attempt_ttl (string. default: 7d. An attempt is killed if it is running longer than this period.)
+* executor.enqueue_random_fetch (enqueue ready tasks randomly. default: false)
+* executor.enqueue_fetch_size ( Number of tasks to be enqueued. default: 100)
 * api.max_attempts_page_size (integer. The max number of rows of attempts in api response)
 * api.max_sessions_page_size (integer. The max number of rows of sessions in api response)
 * api.max_archive_total_size_limit (integer. The maximum size of an archived project. i.e. ``digdag push`` size. default: 2MB(2\*1024\*1024))


### PR DESCRIPTION
Change how to fetch ready tasks when WorkflowExecutor enqueue them.

WorkflowExecutor fetch ready tasks and then enqueue them.
This PR add option to customize it.

- executor.enqueue_random_fetch change the order to fetch tasks.
   If true, it fetches randomly
- executor.enqueue_fetch_size set the number of tasks to be fetched.

Optimize these parameters affect performance of WorkflowExecutor.
Default value is same as original. So without parameter setting there is no impact to behavior.
