### PR TITLE
Upgrade fluency-meter-registry to support old fluentd

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,9 @@ allprojects {
         maven {
             url "https://oss.sonatype.org/content/repositories/snapshots"
         }
+        maven {
+            url "https://dl.bintray.com/yoyama/maven"
+        }
     }
 
     jacoco {
@@ -102,7 +105,7 @@ subprojects {
         compile 'org.slf4j:slf4j-api:1.7.25'
         compile group: 'io.micrometer', name: 'micrometer-core', version: '1.2.0'
         compile group: 'io.micrometer', name: 'micrometer-registry-jmx', version: '1.2.0'
-        compile(group: 'io.github.yoyama', name: 'fluency-meter-registory_2.12', version: '0.2.0') {
+        compile(group: 'io.github.yoyama', name: 'fluency-meter-registory_2.12', version: '0.4.0') {
             exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
             exclude group: 'org.slf4j', module: 'slf4j-api'
             exclude group: 'org.msgpack', module: 'msgpack-core'

--- a/digdag-tests/src/test/java/acceptance/FluencyDigdagMetricsIT.java
+++ b/digdag-tests/src/test/java/acceptance/FluencyDigdagMetricsIT.java
@@ -23,7 +23,6 @@ import org.junit.Before;
 import org.junit.Test;
 import static org.junit.Assert.*;
 
-import org.komamitsu.fluency.EventTime;
 import org.komamitsu.fluency.Fluency;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -61,7 +60,7 @@ public class FluencyDigdagMetricsIT
             }
         })
         .when(fluency)
-        .emit(any(String.class), any(EventTime.class), any(Map.class));
+        .emit(any(String.class), any(Long.class), any(Map.class));
 
         FluencyMeterRegistry meter = FluencyMeterRegistry.apply(regConfig, HierarchicalNameMapper.DEFAULT, Clock.SYSTEM, fluency);
 


### PR DESCRIPTION
To support old fluentd, I would like to upgrade fluency-meter-registry to 0.4.0.
Ver. 0.4.0 stop using EventTime.

The differences in fluency-meter-registr between previous version and 0.4.0 are as follows.

https://github.com/yoyama/FluencyMeterRegistry/compare/rel-0.2.0...rel-0.4.0

The related modification is as follows.

https://github.com/yoyama/FluencyMeterRegistry/compare/rel-0.2.0...rel-0.4.0#diff-f94b8cc5451f8031df3b29761290e71dR168
