### PR TITLE
Guarantee single thread for migration for noTransaction migrations

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseModule.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseModule.java
@@ -50,7 +50,7 @@ public class DatabaseModule
         public void migrate()
         {
             if (migrator != null) {
-                migrator.migrateWithRetry();
+                migrator.migrate();
                 migrator = null;
             }
         }

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration.java
@@ -22,7 +22,10 @@ public interface Migration
      * This is introduced because 'create index concurrently' cannot run in transaction.
      * @return
      */
-    default boolean noTransaction() { return false; }
+    default boolean noTransaction(MigrationContext context)
+    {
+        return false;
+    }
 
     void migrate(Handle handle, MigrationContext context);
 }

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration.java
@@ -19,7 +19,13 @@ public interface Migration
 
     /**
      * If true, this Migration apply without transaction.
-     * This is introduced because 'create index concurrently' cannot run in transaction.
+     * This is introduced specifically for PostgreSQL's CREATE INDEX CONCURRENTLY statement.
+     *
+     * If this method returns true, the migration MUST RUN ONLY ONE DDL STATEMENT.
+     * Otherwise, a failure in the middle of multiple statements causes inconsistency, and
+     * retrying the migration may never success because the first DDL statement is already
+     * applied and next migration attempt will also apply the same DDL statement.
+     *
      * @return
      */
     default boolean noTransaction(MigrationContext context)

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20190318175338_AddIndexToSessionAttempts.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20190318175338_AddIndexToSessionAttempts.java
@@ -19,5 +19,8 @@ public class Migration_20190318175338_AddIndexToSessionAttempts
     }
 
     @Override
-    public boolean noTransaction() { return true; }
+    public boolean noTransaction(MigrationContext context)
+    {
+        return context.isPostgres();
+    }
 }

--- a/digdag-core/src/test/java/io/digdag/core/database/DatabaseTestingUtils.java
+++ b/digdag-core/src/test/java/io/digdag/core/database/DatabaseTestingUtils.java
@@ -78,7 +78,7 @@ public class DatabaseTestingUtils
         DBI dbi = new DBI(dsp.get());
         TransactionManager tm = new ThreadLocalTransactionManager(dsp.get(), autoAutoCommit);
         // FIXME
-        new DatabaseMigrator(dbi, config).migrateWithRetry();
+        new DatabaseMigrator(dbi, config).migrate();
 
         cleanDatabase(config.getType(), dbi);
 


### PR DESCRIPTION
Commit a6430d2 added support for no-transaction database migration.
It had two potential problems:

* Two or more threads may run migration concurrently and all threads
  except one fail.

* Checking whether a migration is applied or not was atomic. When two
  or more threads are running migrations concurrently, some of them may
  run duplicated migrations depending on the timing.

This change adds locking for each migration and perform checking within
the lock.
