### PR TITLE
Add diff API to compare two revisions by REST API

### DIFF
--- a/digdag-client/src/main/java/io/digdag/client/api/RestCompareResult.java
+++ b/digdag-client/src/main/java/io/digdag/client/api/RestCompareResult.java
@@ -1,0 +1,42 @@
+package io.digdag.client.api;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.base.Optional;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonDeserialize(as = ImmutableRestCompareResult.class)
+public interface RestCompareResult
+{
+    String getRaw();
+
+    // {
+    //   files: [
+    //     {
+    //       from: "a",
+    //       to: "b",
+    //       diff: [
+    //         {
+    //           from: {
+    //             line: "a",
+    //             column: "b",
+    //             text: "...",
+    //           },
+    //           to: {
+    //             line: "...",
+    //             column: "...",
+    //             text: "...",
+    //           }
+    //         }
+    //       ]
+    //     },
+    //     {
+    //     }
+    //   ]
+    // }
+
+    static ImmutableRestCompareResult.Builder builder()
+    {
+        return ImmutableRestCompareResult.builder();
+    }
+}

--- a/digdag-server/src/main/java/io/digdag/server/ServerModule.java
+++ b/digdag-server/src/main/java/io/digdag/server/ServerModule.java
@@ -20,6 +20,7 @@ import io.digdag.server.ac.DefaultAccessController;
 import io.digdag.server.rs.AdminResource;
 import io.digdag.server.rs.AdminRestricted;
 import io.digdag.server.rs.AttemptResource;
+import io.digdag.server.rs.DiffRunner;
 import io.digdag.server.rs.LogResource;
 import io.digdag.server.rs.ProjectResource;
 import io.digdag.server.rs.ScheduleResource;
@@ -105,6 +106,7 @@ public class ServerModule
                 VersionResource.class,
                 AdminResource.class
             );
+        binder().bind(DiffRunner.class).in(Scopes.SINGLETON);
     }
 
     protected void bindAuthenticator()

--- a/digdag-server/src/main/java/io/digdag/server/rs/DiffRunner.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/DiffRunner.java
@@ -1,0 +1,64 @@
+package io.digdag.server.rs;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.ByteStreams;
+import com.google.inject.Inject;
+import io.digdag.client.api.RestCompareResult;
+import io.digdag.client.config.Config;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.List;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+public class DiffRunner
+{
+    private final String diffCommand;
+
+    @Inject
+    public DiffRunner(Config systemConfig)
+    {
+        this.diffCommand = systemConfig.getOptional("api.compare.diff_command", String.class).or("diff");
+    }
+
+    public RestCompareResult diff(
+            Path fromPath, String fromName,
+            Path toPath, String toName)
+        throws IOException
+    {
+        // -u: unified format
+        // -c: context format
+        List<String> cmdline = ImmutableList.<String>builder()
+            .add(diffCommand)
+            .add("-N")
+            .add("-r")
+            .add("-u")
+            .add(fromPath.toAbsolutePath().toString())
+            .add(toPath.toAbsolutePath().toString())
+            .build();
+        ProcessBuilder pb = new ProcessBuilder(cmdline);
+        pb.redirectOutput(ProcessBuilder.Redirect.PIPE);
+        pb.redirectErrorStream(false);
+
+        try {
+            Process p = pb.start();
+            try (InputStream in = p.getInputStream()) {
+                return parseDiff(in);
+            }
+            finally {
+                p.waitFor();
+            }
+        }
+        catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(ex);
+        }
+    }
+
+    private RestCompareResult parseDiff(InputStream in)
+            throws IOException
+    {
+        String raw = new String(ByteStreams.toByteArray(in), UTF_8);
+        return RestCompareResult.builder().raw(raw).build();
+    }
+}


### PR DESCRIPTION
This change adds `/api/projects/{id}/compare?from=&to=` API which
compares two revisions and returns diff of them. This API is useful when
a session failed after pushing a new revision and investigate which
change made the impact.