### PR TITLE
Remove a duplicated CLI option in --help

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/Sched.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Sched.java
@@ -68,7 +68,6 @@ public class Sched
         err.println("        --max-task-threads N         limit maximum number of task execution threads");
         err.println("    -p, --param KEY=VALUE            overwrites a parameter (use multiple times to set many parameters)");
         err.println("    -P, --params-file PATH.yml       reads parameters from a YAML file");
-        err.println("    -c, --config PATH.properties     server configuration property path");
         Main.showCommonOptions(env, err);
         return systemExit(error);
     }

--- a/digdag-cli/src/main/java/io/digdag/cli/Server.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Server.java
@@ -121,7 +121,6 @@ public class Server
         err.println("    -p, --param KEY=VALUE            overwrites a parameter (use multiple times to set many parameters)");
         err.println("    -H, --header KEY=VALUE           a header to include in api HTTP responses");
         err.println("    -P, --params-file PATH.yml       reads parameters from a YAML file");
-        err.println("    -c, --config PATH.properties     server configuration property path");
         Main.showCommonOptions(env, err);
         return systemExit(error);
     }

--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -330,9 +330,9 @@ Runs a digdag server. --memory or --database option is required. Examples:
   Example: ``-P params.yml``
 
 :command:`-c, --config PATH`
-  Server configuration property path. See the followings for details.
+  Configuration file to load. (default: ~/.config/digdag/config) See the followings for details.
 
-  Example: ``-c digdag.properties``
+  Example: ``-c digdag-server/server.properties``
 
 
 In the config file, following parameters are available


### PR DESCRIPTION
The `--config` option is duplicated in `digdag server --help` and `digdag sched --help`.

```
$ digdag server --help
2019-11-02 19:29:22 +0900: Digdag v0.9.39
Usage: digdag server [options...]
  Options:
    -n, --port PORT                  port number to listen for web interface and api clients (default: 65432)
    -b, --bind ADDRESS               IP address to listen HTTP clients (default: 127.0.0.1)
    --admin-port PORT                port number to bind admin api on (default: no admin port)
    --admin-bind ADDRESS             IP address to bind admin api on (default: same address with --bind)
    -m, --memory                     uses memory database
    -o, --database DIR               store status to this database
    -O, --task-log DIR               store task logs to this path
    -A, --access-log DIR             store access logs files to this path
        --max-task-threads N         limit maximum number of task execution threads
        --disable-executor-loop      disable workflow executor loop
        --disable-scheduler          disable scheduler
        --disable-local-agent        disable local task execution
        --enable-swagger             enable swagger api
    -p, --param KEY=VALUE            overwrites a parameter (use multiple times to set many parameters)
    -H, --header KEY=VALUE           a header to include in api HTTP responses
    -P, --params-file PATH.yml       reads parameters from a YAML file
    -c, --config PATH.properties     server configuration property path
    -L, --log PATH                   output log messages to a file (default: -)
    -l, --log-level LEVEL            log level (error, warn, info, debug or trace)
    -X KEY=VALUE                     add a performance system config
    -c, --config PATH.properties     Configuration file (default: /home/blacky/.config/digdag/config)
    --version                        show client version
```