### PR TITLE
Add an index to sessions table

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseMigrator.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseMigrator.java
@@ -39,6 +39,7 @@ public class DatabaseMigrator
         new Migration_20170116090744_AddAttemptIndexColumn2(),
         new Migration_20170223220127_AddLastSessionTimeAndFlagsToSessions(),
         new Migration_20190318175338_AddIndexToSessionAttempts(),
+        new Migration_20191105105927_AddIndexToSessions(),
     })
     .sorted(Comparator.comparing(m -> m.getVersion()))
     .collect(Collectors.toList());

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20191105105927_AddIndexToSessions.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20191105105927_AddIndexToSessions.java
@@ -1,0 +1,23 @@
+package io.digdag.core.database.migrate;
+
+import org.skife.jdbi.v2.Handle;
+
+public class Migration_20191105105927_AddIndexToSessions
+        implements Migration
+{
+    @Override
+    public void migrate(Handle handle, MigrationContext context)
+    {
+        if (context.isPostgres()) {
+            handle.update("create index concurrently sessions_on_project_id_and_workflow_name_desc on sessions (project_id, workflow_name, id DESC)");
+        } else {
+            handle.update("create index sessions_on_project_id_and_workflow_name_desc on sessions (project_id, workflow_name, id DESC)");
+        }
+    }
+
+    @Override
+    public boolean noTransaction(MigrationContext context)
+    {
+        return context.isPostgres();
+    }
+}


### PR DESCRIPTION
Added an index named `sessions_on_project_id_and_workflow_name_desc` to improve the performance.