### PR TITLE
upgrade kubernetes client library version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,8 +123,8 @@ subprojects {
     }
 
     ext {
-        jacksonVersion = "2.9.9"
-        jacksonDatabindVersion = "2.9.9"
+        jacksonVersion = "2.9.10"
+        jacksonDatabindVersion = "2.9.10"
         awsJavaSdkVersion = "1.11.545"
         guavaVersion = "19.0"
     }

--- a/digdag-standards/build.gradle
+++ b/digdag-standards/build.gradle
@@ -41,7 +41,13 @@ dependencies {
     compile ('com.google.apis:google-api-services-storage:v1-rev88-1.22.0') { exclude group: 'com.google.guava', module: 'guava-jdk5' }
 
     // kubernetes
-    compile ('io.fabric8:kubernetes-client:3.1.5')
+    compile ('io.fabric8:kubernetes-client:4.6.2') {
+        // Avoid compilation failures due to dependencies
+        exclude group: 'org.slf4j', module: 'slf4j-api'
+        // TODO: digdag use version 3.12.0, upgrade to version 3.12.6.
+        exclude group: 'com.squareup.okhttp3', module: 'okhttp'
+        exclude group: 'com.fasterxml.jackson.dataformat', module: 'jackson-module-jaxb-annotations'
+    }
 
     // dependency conflict resolution
     compile 'joda-time:joda-time:2.9.4'


### PR DESCRIPTION
# Motivation
I want to support the latest kubernetes version. 
But compile error when upgrade kubernetes-client version to 4.6.2 due to dependency.
So some libraries exclude to avoid compilation failures due to dependencies and jacksonVersion and jacksonDatabindVersion upgrade  to 2.9.10.

This PR is necessary to solve the following issues
https://github.com/treasure-data/digdag/issues/1254