### PR TITLE
Add Graal JavaScript engine in addition to Nashorn

### DIFF
--- a/digdag-core/build.gradle
+++ b/digdag-core/build.gradle
@@ -24,6 +24,9 @@ dependencies {
     compile 'com.google.code.findbugs:annotations:3.0.1'
     compile 'org.weakref:jmxutils:1.19'
 
+    // JavaScript engine
+    compile 'org.graalvm.js:js:19.2.1'
+
     // mail
     compile 'javax.mail:javax.mail-api:1.5.6'
     compile 'com.sun.mail:javax.mail:1.5.6'   // 'com.sun.mail:smtp' doesn't work because enabling mail.debug property throws java.lang.NoClassDefFoundError: com/sun/mail/util/MailLogger

--- a/digdag-core/src/main/java/io/digdag/core/agent/GraalJsEngine.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/GraalJsEngine.java
@@ -85,7 +85,7 @@ public class GraalJsEngine
                 throw new TemplateException("Failed to serialize parameters to JSON", ex);
             }
             try {
-                Value result = context.getBindings("js").invokeMember("template", code, paramsJson);
+                Value result = context.getBindings("js").getMember("template").execute(code, paramsJson);
                 return result.asString();
             }
             catch (PolyglotException ex) {

--- a/digdag-core/src/main/java/io/digdag/core/agent/GraalJsEngine.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/GraalJsEngine.java
@@ -1,0 +1,109 @@
+package io.digdag.core.agent;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.digdag.client.config.Config;
+import io.digdag.core.agent.ConfigEvalEngine.JsEngine;
+import io.digdag.spi.TemplateException;
+import java.io.IOException;
+import java.time.ZoneId;
+import org.graalvm.polyglot.Context;
+import org.graalvm.polyglot.Engine;
+import org.graalvm.polyglot.PolyglotException;
+import org.graalvm.polyglot.Source;
+import org.graalvm.polyglot.Value;
+import static io.digdag.core.agent.ConfigEvalEngine.LIBRARY_JS_CONTENTS;
+
+public class GraalJsEngine
+    implements JsEngine
+{
+    private final Engine engine;
+    private final Source[] libraryJsSources;
+
+    public GraalJsEngine()
+    {
+        this.engine = Engine.newBuilder()
+            .allowExperimentalOptions(true)
+            .option("js.nashorn-compat", "true")
+            .build();
+        try {
+            this.libraryJsSources = new Source[LIBRARY_JS_CONTENTS.length];
+            for (int i = 0; i < LIBRARY_JS_CONTENTS.length; i++) {
+                libraryJsSources[i] = Source.newBuilder("js", LIBRARY_JS_CONTENTS[i][1], LIBRARY_JS_CONTENTS[i][0]).build();
+            }
+        }
+        catch (IOException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+    public JsEngine.Evaluator newEvaluator(Config params)
+    {
+        Context.Builder contextBuilder = Context.newBuilder()
+            .engine(engine)
+            .allowAllAccess(false)
+            .timeZone(getWorkflowZoneId(params));
+        Context context = contextBuilder.build();
+        try {
+            for (Source lib : libraryJsSources) {
+                context.eval(lib);
+            }
+            GraalEvaluator evaluator = new GraalEvaluator(context);
+            context = null;
+            return evaluator;
+        }
+        finally {
+            if (context != null) {
+                context.close();
+            }
+        }
+    }
+
+    private static ZoneId getWorkflowZoneId(Config params)
+    {
+        return ZoneId.of(params.get("timezone", String.class));
+    }
+
+    private static class GraalEvaluator
+            implements JsEngine.Evaluator
+    {
+        private final Context context;
+
+        GraalEvaluator(Context context)
+        {
+            this.context = context;
+        }
+
+        @Override
+        public String evaluate(String code, Config scopedParams, ObjectMapper jsonMapper)
+                throws TemplateException
+        {
+            String paramsJson;
+            try {
+                paramsJson = jsonMapper.writeValueAsString(scopedParams);
+            }
+            catch (RuntimeException | IOException ex) {
+                throw new TemplateException("Failed to serialize parameters to JSON", ex);
+            }
+            try {
+                Value result = context.getBindings("js").invokeMember("template", code, paramsJson);
+                return result.asString();
+            }
+            catch (PolyglotException ex) {
+                String message;
+                if (ex.getCause() != null) {
+                    message = ex.getCause().getMessage();
+                }
+                else {
+                    message = ex.getMessage();
+                }
+                throw new TemplateException("Failed to evaluate a variable " + code + " (" + message + ")");
+            }
+        }
+
+        @Override
+        public void close()
+        {
+            context.close();
+        }
+    }
+}

--- a/digdag-core/src/main/java/io/digdag/core/agent/NashornJsEngine.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/NashornJsEngine.java
@@ -1,0 +1,74 @@
+package io.digdag.core.agent;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.digdag.client.config.Config;
+import io.digdag.core.agent.ConfigEvalEngine.JsEngine;
+import io.digdag.spi.TemplateException;
+import java.io.IOException;
+import javax.script.Invocable;
+import javax.script.ScriptEngine;
+import javax.script.ScriptException;
+import jdk.nashorn.api.scripting.NashornScriptEngineFactory;
+import static io.digdag.core.agent.ConfigEvalEngine.LIBRARY_JS_CONTENTS;
+
+public class NashornJsEngine
+    implements JsEngine
+{
+    private final NashornScriptEngineFactory jsEngineFactory;
+
+    public NashornJsEngine()
+    {
+        this.jsEngineFactory = new NashornScriptEngineFactory();
+    }
+
+    public JsEngine.Evaluator newEvaluator(Config params)
+    {
+        ScriptEngine scriptEngine = jsEngineFactory.getScriptEngine(new String[] {
+            //"--language=es6",  // this is not even accepted with jdk1.8.0_20 and has a bug with jdk1.8.0_51
+            "--no-java",
+            "--no-syntax-extensions",
+            "-timezone=" + params.get("timezone", String.class),
+        });
+        try {
+            for (int i = 0; i < LIBRARY_JS_CONTENTS.length; i++) {
+                scriptEngine.eval(LIBRARY_JS_CONTENTS[i][1]);
+            }
+        }
+        catch (ScriptException | ClassCastException ex) {
+            throw new IllegalStateException("Unexpected script evaluation failure", ex);
+        }
+        final Invocable invocable = (Invocable) scriptEngine;
+        return (code, scopedParams, jsonMapper) -> invokeTemplate(invocable, code, scopedParams, jsonMapper);
+    }
+
+    private String invokeTemplate(Invocable templateInvocable, String code, Config scopedParams, ObjectMapper jsonMapper)
+        throws TemplateException
+    {
+        String paramsJson;
+        try {
+            paramsJson = jsonMapper.writeValueAsString(scopedParams);
+        }
+        catch (RuntimeException | IOException ex) {
+            throw new TemplateException("Failed to serialize parameters to JSON", ex);
+        }
+        try {
+            return (String) templateInvocable.invokeFunction("template", code, paramsJson);
+        }
+        catch (ScriptException ex) {
+            String message;
+            if (ex.getCause() != null) {
+                // ScriptException.getMessage includes filename and line number but they
+                // are confusing because filename is always dummy file name and line number
+                // is not accurate.
+                message = ex.getCause().getMessage();
+            }
+            else {
+                message = ex.getMessage();
+            }
+            throw new TemplateException("Failed to evaluate a variable " + code + " (" + message + ")");
+        }
+        catch (NoSuchMethodException ex) {
+            throw new TemplateException("Failed to evaluate JavaScript code: " + code, ex);
+        }
+    }
+}

--- a/digdag-core/src/main/resources/io/digdag/core/agent/digdag.js
+++ b/digdag-core/src/main/resources/io/digdag/core/agent/digdag.js
@@ -1,10 +1,5 @@
-// Code from Underscore.js
-function template(code, variables)
+function template(input, variables)
 {
-  var matcher = RegExp([
-    (/\${(?![a-z]+:)([\s\S]+?)}/g).source  // exclude operator-defined templates such as ${secret:sec.ret.key}
-  ].join('|') + '|$', 'g');
-
   var escapes = {
     "'":      "'",
     '\\':     '\\',
@@ -20,18 +15,68 @@ function template(code, variables)
     return '\\' + escapes[match];
   };
 
-  var index = 0;
-  var source = "__p+='";
-  code.replace(matcher, function(match, expression, offset) {
-    source += code.slice(index, offset).replace(/\$\$/g, "$").replace(escaper, escapeChar);
-    index = offset + match.length;
+  if (typeof Graal != 'undefined') {
+    // (?![a-z]+:) => exclude operator-defined templates such as ${secret:sec.ret.key}
+    var matcher = /\$\{(?![a-z]+:)([\s\S]+)|$/;
 
-    if (expression) {
-      source += "'+\n((__t=(" + expression + "))==null?'':(typeof __t==\"string\"?__t:JSON.stringify(__t)))+\n'";
+    var position = 0;
+    var source = "__p+='";
+    while (position < input.length) {
+      m = input.slice(position).match(matcher);
+      if (m) {
+        all = m[0];
+        match = m[1];
+        // append text before '${' - THIS_TEXT${...}
+        source += input.slice(position, position + m.index).replace(/\$\$/g, "$").replace(escaper, escapeChar);
+        position += m.index;
+
+        if (match) {
+          // for the text after '${' - ${THIS_TEXT}
+          var paren = 0;
+          var script = "";
+          for (var i = 0; i < match.length; i++) {
+            if (match[i] == '{') {
+              paren++;
+            } else if (match[i] == '}') {
+              paren--;
+              if (paren == -1) {
+                script = match.slice(0, i);
+                break;
+              }
+            }
+          }
+
+          if (paren != -1) {
+            source += all.replace(/\$\$/g, "$").replace(escaper, escapeChar);
+            position += all.length;
+          } else {
+            if (script) {
+              source += "'+\n((__t=(" + script + "))==null?'':(typeof __t==\"string\"?__t:JSON.stringify(__t)))+\n'";
+            }
+            position += script.length + (all.length - match.length + 1);
+          }
+        }
+      }
     }
 
-    return match;
-  });
+  } else {
+    // (?![a-z]+:) => exclude operator-defined templates such as ${secret:sec.ret.key}
+    var matcher = /\${(?![a-z]+:)((?:\{)|[\s\S]+?)}|$/g;
+
+    var index = 0;
+    var source = "__p+='";
+    input.replace(matcher, function(match, expression, offset) {
+      source += input.slice(index, offset).replace(/\$\$/g, "$").replace(escaper, escapeChar);
+      index = offset + match.length;
+
+      if (expression) {
+        source += "'+\n((__t=(" + expression + "))==null?'':(typeof __t==\"string\"?__t:JSON.stringify(__t)))+\n'";
+      }
+
+      return match;
+    });
+  }
+
   source += "';\n";
 
   source = "var __t,__p='',__j=Array.prototype.join," +

--- a/digdag-core/src/test/java/io/digdag/core/agent/ConfigEvalEngineTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/agent/ConfigEvalEngineTest.java
@@ -23,7 +23,7 @@ public class ConfigEvalEngineTest
     @Rule
     public final ExpectedException exception = ExpectedException.none();
 
-    private ConfigEvalEngine engine = new ConfigEvalEngine();
+    private ConfigEvalEngine engine = new ConfigEvalEngine(ConfigEvalEngine.defaultJsEngineType());
 
     private Config params()
     {

--- a/digdag-core/src/test/java/io/digdag/core/agent/ConfigEvalEngineTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/agent/ConfigEvalEngineTest.java
@@ -50,6 +50,15 @@ public class ConfigEvalEngineTest
     }
 
     @Test
+    public void testTemplate()
+            throws Exception
+    {
+        assertThat(
+                engine.eval(loadYamlResource("/io/digdag/core/agent/eval/template.dig"), params()),
+                is(loadYamlResource("/io/digdag/core/agent/eval/template_expected.dig")));
+    }
+
+    @Test
     public void undefinedVariable()
             throws Exception
     {

--- a/digdag-core/src/test/resources/io/digdag/core/agent/eval/template.dig
+++ b/digdag-core/src/test/resources/io/digdag/core/agent/eval/template.dig
@@ -1,0 +1,9 @@
+dollor: $
+dollor_dollor: $$
+dollor_dollor_format: p$$s
+open: ${
+non_closed: ${v
+non_closed_prefix: p${v
+close: "}"
+format: p${1}s
+format_multi: p${1}m$$m${2}s

--- a/digdag-core/src/test/resources/io/digdag/core/agent/eval/template_expected.dig
+++ b/digdag-core/src/test/resources/io/digdag/core/agent/eval/template_expected.dig
@@ -1,0 +1,9 @@
+dollor: $
+dollor_dollor: $
+dollor_dollor_format: p$s
+open: ${
+non_closed: ${v
+non_closed_prefix: p${v
+close: "}"
+format: p1s
+format_multi: p1m$m2s

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/jdbc/JdbcOpTestHelper.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/jdbc/JdbcOpTestHelper.java
@@ -15,6 +15,7 @@ import io.digdag.core.agent.ConfigEvalEngine;
 import io.digdag.spi.TaskRequest;
 import io.digdag.spi.TemplateEngine;
 
+import static io.digdag.client.config.ConfigUtils.newConfig;
 import static io.digdag.core.workflow.OperatorTestingUtils.newTaskRequest;
 
 import java.io.IOException;
@@ -37,6 +38,7 @@ public class JdbcOpTestHelper
         public void configure(Binder binder)
         {
             binder.bind(TemplateEngine.class).to(ConfigEvalEngine.class).in(Scopes.SINGLETON);
+            binder.bind(Config.class).toInstance(newConfig());
         }
     }
 


### PR DESCRIPTION
New option `eval.js-engine-type` chooses engine type:

* eval.js-engine-type=nashorn: use Nashorn
* eval.js-engine-type=graal: use Graal.js
* eval.js-engine-type=nashorn-graal-check: use Nashorn but also use
Graal and check the result. If the result is different from Nashorn's
result, show a error message to logger.

Default engine type is Nashorn if JVM is older than 11. Otherwie,
Graal.js.

Graal.js enables nashorn-compatible mode to minimize impact.

In addition to the change, JavaScript parameter evaluation
supports nested parens in JavaScript if engine is Graal.

Config eval engine had a problem where JavaScript code can't use useful
functional methods such as Array.map because code couldn't include `}`
character. With this change, `}` is assumed as a part of JavaScript code
if number of `{` and `}` matches. We can see similar strategy in Ruby
(`%{...}` syntax).

This change is enabled only for Graal JavaScript engine so that it
doesn't make unexpected backward incompatibility.