### PR TITLE
Disable TaskQueueServer in CLI

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/client/Archive.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Archive.java
@@ -66,6 +66,7 @@ public class Archive
                 .withWorkflowExecutor(false)
                 .withScheduleExecutor(false)
                 .withLocalAgent(false)
+                .withTaskQueueServer(false)
                 .addModules(binder -> {
                     binder.bind(YamlMapper.class).in(Scopes.SINGLETON);
                     binder.bind(Archiver.class).in(Scopes.SINGLETON);

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Push.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Push.java
@@ -84,6 +84,7 @@ public class Push
                 .withWorkflowExecutor(false)
                 .withScheduleExecutor(false)
                 .withLocalAgent(false)
+                .withTaskQueueServer(false)
                 .addModules(binder -> {
                     binder.bind(YamlMapper.class).in(Scopes.SINGLETON);
                     binder.bind(Archiver.class).in(Scopes.SINGLETON);

--- a/digdag-cli/src/main/java/io/digdag/cli/client/Start.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/Start.java
@@ -99,6 +99,7 @@ public class Start
             .withWorkflowExecutor(false)
             .withScheduleExecutor(false)
             .withLocalAgent(false)
+            .withTaskQueueServer(false)
             .addModules(binder -> {
                 binder.bind(ConfigLoaderManager.class).in(Scopes.SINGLETON);
             })

--- a/digdag-core/src/main/java/io/digdag/core/DigdagEmbed.java
+++ b/digdag-core/src/main/java/io/digdag/core/DigdagEmbed.java
@@ -57,6 +57,7 @@ public class DigdagEmbed
         private boolean withScheduleExecutor = true;
         private boolean withLocalAgent = true;
         private boolean withExtensionLoader = true;
+        private boolean withTaskQueueServer = true;
         private Map<String, String> environment = ImmutableMap.of();
 
         public Bootstrap addModules(Module... additionalModules)
@@ -128,6 +129,12 @@ public class DigdagEmbed
             return this;
         }
 
+        public Bootstrap withTaskQueueServer(boolean v)
+        {
+            this.withTaskQueueServer = v;
+            return this;
+        }
+
         public DigdagEmbed initialize()
         {
             return build(true);
@@ -171,13 +178,12 @@ public class DigdagEmbed
                         .registerModule(new JacksonTimeModule()),
                     new DynamicPluginModule(),
                     new SystemPluginModule(systemPlugins),
-                    new DatabaseModule(),
+                    new DatabaseModule(withTaskQueueServer),
                     new AgentModule(),
                     new LogModule(),
                     new ScheduleModule(),
                     new ConfigModule(),
                     new WorkflowModule(),
-                    new QueueModule(),
                     new NotificationModule(),
                     new StorageModule(),
                     new EnvironmentModule(environment),
@@ -204,6 +210,10 @@ public class DigdagEmbed
             }
             if (withExtensionLoader) {
                 builder.add(new ExtensionServiceLoaderModule());
+            }
+            if (withTaskQueueServer) {
+                builder.add(new QueueModule());
+
             }
             return builder.build();
         }

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseModule.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseModule.java
@@ -16,6 +16,13 @@ import org.skife.jdbi.v2.DBI;
 public class DatabaseModule
         implements Module
 {
+    private boolean withTaskQueueServer;
+
+    public DatabaseModule(boolean withTaskQueueServer)
+    {
+        this.withTaskQueueServer = withTaskQueueServer;
+    }
+
     @Override
     public void configure(Binder binder)
     {
@@ -30,8 +37,10 @@ public class DatabaseModule
         binder.bind(QueueSettingStoreManager.class).to(DatabaseQueueSettingStoreManager.class).in(Scopes.SINGLETON);
         binder.bind(SessionStoreManager.class).to(DatabaseSessionStoreManager.class).in(Scopes.SINGLETON);
         binder.bind(ScheduleStoreManager.class).to(DatabaseScheduleStoreManager.class).in(Scopes.SINGLETON);
-        binder.bind(DatabaseTaskQueueConfig.class).in(Scopes.SINGLETON);
-        binder.bind(DatabaseTaskQueueServer.class).in(Scopes.SINGLETON);
+        if (withTaskQueueServer) {
+            binder.bind(DatabaseTaskQueueConfig.class).in(Scopes.SINGLETON);
+            binder.bind(DatabaseTaskQueueServer.class).in(Scopes.SINGLETON);
+        }
     }
 
     public static class AutoMigrator


### PR DESCRIPTION
CLI create unused TaskQueueServer instance and which generate errors. Because it cannot access to digdag schema in h2 memory DB (schema is not created by #1137).
These errors happened in CI and one of cause of CI abort.
To mitigate it, disable to create TaskQueueServer in CLI.

