### PR TITLE
Support new kubernetes podspec resource and pv pvc resource type

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/kubernetes/DefaultKubernetesClient.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/kubernetes/DefaultKubernetesClient.java
@@ -1,14 +1,15 @@
 package io.digdag.standards.command.kubernetes;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.CharStreams;
-import io.digdag.core.storage.StorageManager;
 import io.digdag.client.config.Config;
-import io.digdag.client.config.ConfigException;
 import io.digdag.spi.CommandContext;
 import io.digdag.spi.CommandRequest;
 import io.digdag.spi.TaskRequest;
+import io.fabric8.kubernetes.api.model.Affinity;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
@@ -16,26 +17,19 @@ import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.PodSpecBuilder;
-import io.fabric8.kubernetes.api.model.Affinity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
-import io.fabric8.kubernetes.api.model.Quantity;
-import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.JsonNode;
-
-import com.google.common.annotations.VisibleForTesting;
 
 import java.io.IOException;
 import java.io.Reader;
-import java.util.List;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 public class DefaultKubernetesClient

--- a/digdag-standards/src/main/java/io/digdag/standards/command/kubernetes/DefaultKubernetesClient.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/kubernetes/DefaultKubernetesClient.java
@@ -21,7 +21,6 @@ import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.api.model.Toleration;
 import io.fabric8.kubernetes.api.model.Volume;
 import io.fabric8.kubernetes.api.model.VolumeMount;
-import io.fabric8.kubernetes.api.model.EmptyDirVolumeSource;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.utils.Serialization;
 import org.slf4j.Logger;

--- a/digdag-standards/src/main/java/io/digdag/standards/command/kubernetes/DefaultKubernetesClient.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/kubernetes/DefaultKubernetesClient.java
@@ -70,7 +70,6 @@ public class DefaultKubernetesClient
                 .endMetadata()
                 .withSpec(podSpec)
                 .done();
-
         return Pod.of(pod);
     }
 

--- a/digdag-standards/src/main/java/io/digdag/standards/command/kubernetes/DefaultKubernetesClient.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/kubernetes/DefaultKubernetesClient.java
@@ -149,16 +149,16 @@ public class DefaultKubernetesClient
                 .withArgs(arguments);
 
 
-      final JsonNode node = taskConfig.getInternalObjectNode();
-      if (node.has("kubernetes")) {
-          final JsonNode kubernetesNode = node.get("kubernetes");
-          if (kubernetesNode.has("container")) {
-              final JsonNode containerNode = kubernetesNode.get("container");
-              if (containerNode.has("volumeMounts")) {
-                  containerBuilder.withVolumeMounts(convertToResourceList(containerNode.get("volumeMounts"), VolumeMount.class));
-              }
-          }
-      }
+        final JsonNode node = taskConfig.getInternalObjectNode();
+        if (node.has("kubernetes")) {
+            final JsonNode kubernetesNode = node.get("kubernetes");
+            if (kubernetesNode.has("container")) {
+                final JsonNode containerNode = kubernetesNode.get("container");
+                if (containerNode.has("volumeMounts")) {
+                    containerBuilder.withVolumeMounts(convertToResourceList(containerNode.get("volumeMounts"), VolumeMount.class));
+                }
+            }
+        }
         return containerBuilder.build();
     }
 
@@ -180,25 +180,25 @@ public class DefaultKubernetesClient
                 // https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
                 .withRestartPolicy("Never");
 
-      final JsonNode node = taskConfig.getInternalObjectNode();
-      if (node.has("kubernetes")) {
-          final JsonNode kubernetesNode = node.get("kubernetes");
-          if (kubernetesNode.has("pod")) {
-              final JsonNode podNode = kubernetesNode.get("pod");
-              if (podNode.has("affinity")) {
-                  podSpecBuilder.withAffinity(Serialization.unmarshal(podNode.get("affinity").toString(), Affinity.class));
-              }
+        final JsonNode node = taskConfig.getInternalObjectNode();
+        if (node.has("kubernetes")) {
+            final JsonNode kubernetesNode = node.get("kubernetes");
+            if (kubernetesNode.has("spec")) {
+                final JsonNode podNode = kubernetesNode.get("spec");
+                if (podNode.has("affinity")) {
+                    podSpecBuilder.withAffinity(Serialization.unmarshal(podNode.get("affinity").toString(), Affinity.class));
+                }
 
-              if (podNode.has("tolerations")) {
-                  podSpecBuilder.withTolerations(convertToResourceList(podNode.get("tolerations"), Toleration.class));
-              }
+                if (podNode.has("tolerations")) {
+                    podSpecBuilder.withTolerations(convertToResourceList(podNode.get("tolerations"), Toleration.class));
+                }
 
-              if (podNode.has("volumes")) {
-                  podSpecBuilder.withVolumes(convertToResourceList(podNode.get("volumes"), Volume.class));
-              }
-          }
-      }
-      return podSpecBuilder.build();
+                if (podNode.has("volumes")) {
+                    podSpecBuilder.withVolumes(convertToResourceList(podNode.get("volumes"), Volume.class));
+                }
+            }
+        }
+        return podSpecBuilder.build();
     }
 
     protected <T> List<T> convertToResourceList(final JsonNode node, final Class<T> type)

--- a/digdag-standards/src/main/java/io/digdag/standards/command/kubernetes/DefaultKubernetesClient.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/kubernetes/DefaultKubernetesClient.java
@@ -3,9 +3,12 @@ package io.digdag.standards.command.kubernetes;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.CharStreams;
+import io.digdag.core.storage.StorageManager;
 import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigException;
 import io.digdag.spi.CommandContext;
 import io.digdag.spi.CommandRequest;
+import io.digdag.spi.TaskRequest;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
 import io.fabric8.kubernetes.api.model.ContainerStatus;
@@ -13,15 +16,25 @@ import io.fabric8.kubernetes.api.model.EnvVar;
 import io.fabric8.kubernetes.api.model.EnvVarBuilder;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.PodSpecBuilder;
+import io.fabric8.kubernetes.api.model.Affinity;
+import io.fabric8.kubernetes.api.model.Toleration;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.Quantity;
 import io.fabric8.kubernetes.api.model.ResourceRequirements;
 import io.fabric8.kubernetes.client.dsl.PodResource;
+import io.fabric8.kubernetes.client.utils.Serialization;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import com.google.common.annotations.VisibleForTesting;
 
 import java.io.IOException;
 import java.io.Reader;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.Map;
 
 public class DefaultKubernetesClient
@@ -51,15 +64,16 @@ public class DefaultKubernetesClient
     {
         final Container container = createContainer(context, request, name, commands, arguments);
         final PodSpec podSpec = createPodSpec(context, request, container);
-        final io.fabric8.kubernetes.api.model.Pod pod = client.pods()
-                .inNamespace(client.getNamespace())
+        io.fabric8.kubernetes.api.model.Pod pod = client.pods()
                 .createNew()
                 .withNewMetadata()
                 .withName(name)
+                .withNamespace(client.getNamespace())
                 .withLabels(getPodLabels())
                 .endMetadata()
                 .withSpec(podSpec)
                 .done();
+
         return Pod.of(pod);
     }
 
@@ -120,26 +134,43 @@ public class DefaultKubernetesClient
         return ImmutableMap.of();
     }
 
-    protected Container createContainer(final CommandContext context, final CommandRequest request,
+    @VisibleForTesting
+    Container createContainer(final CommandContext context, final CommandRequest request,
             final String name, final List<String> commands, final List<String> arguments)
     {
-        return new ContainerBuilder()
+        final TaskRequest taskRequest = context.getTaskRequest();
+        final Config taskConfig = taskRequest.getConfig();
+        ContainerBuilder containerBuilder = new ContainerBuilder()
                 .withName(name)
                 .withImage(getContainerImage(context, request))
                 .withEnv(toEnvVars(getEnvironments(context, request)))
                 .withResources(toResourceRequirements(getResourceLimits(context, request), getResourceRequests(context, request)))
                 .withCommand(commands)
-                .withArgs(arguments)
-                .build();
+                .withArgs(arguments);
+
+
+      final JsonNode node = taskConfig.getInternalObjectNode();
+      if (node.has("kubernetes")) {
+          final JsonNode kubernetesNode = node.get("kubernetes");
+          if (kubernetesNode.has("container")) {
+              final JsonNode containerNode = kubernetesNode.get("container");
+              if (containerNode.has("volumeMounts")) {
+                  containerBuilder.withVolumeMounts(convertToResourceList(containerNode.get("volumeMounts"), VolumeMount.class));
+              }
+          }
+      }
+        return containerBuilder.build();
     }
 
-    protected PodSpec createPodSpec(final CommandContext context, final CommandRequest request,
+    @VisibleForTesting
+    PodSpec createPodSpec(final CommandContext context, final CommandRequest request,
             final Container container)
     {
         // TODO
         // Revisit what values should be extracted as config params or system config params
-
-        return new PodSpecBuilder()
+        final TaskRequest taskRequest = context.getTaskRequest();
+        final Config taskConfig = taskRequest.getConfig();
+        PodSpecBuilder podSpecBuilder =  new PodSpecBuilder()
                 //.withHostNetwork(true);
                 //.withDnsPolicy("ClusterFirstWithHostNet");
                 .addToContainers(container)
@@ -147,8 +178,40 @@ public class DefaultKubernetesClient
                 // Restart policy is "Never" by default since it needs to avoid executing the operator multiple times. It might not
                 // make the script idempotent.
                 // https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy
-                .withRestartPolicy("Never")
-                .build();
+                .withRestartPolicy("Never");
+
+      final JsonNode node = taskConfig.getInternalObjectNode();
+      if (node.has("kubernetes")) {
+          final JsonNode kubernetesNode = node.get("kubernetes");
+          if (kubernetesNode.has("pod")) {
+              final JsonNode podNode = kubernetesNode.get("pod");
+              if (podNode.has("affinity")) {
+                  podSpecBuilder.withAffinity(Serialization.unmarshal(podNode.get("affinity").toString(), Affinity.class));
+              }
+
+              if (podNode.has("tolerations")) {
+                  podSpecBuilder.withTolerations(convertToResourceList(podNode.get("tolerations"), Toleration.class));
+              }
+
+              if (podNode.has("volumes")) {
+                  podSpecBuilder.withVolumes(convertToResourceList(podNode.get("volumes"), Volume.class));
+              }
+          }
+      }
+      return podSpecBuilder.build();
+    }
+
+    protected <T> List<T> convertToResourceList(final JsonNode node, final Class<T> type)
+    {
+        List<T> resourcesList = new ArrayList<>();
+        if (node.isArray()){
+            for (JsonNode resource : node) {
+                resourcesList.add(Serialization.unmarshal(resource.toString(), type));
+            }
+        } else {
+            resourcesList.add(Serialization.unmarshal(node.toString(), type));
+        }
+        return resourcesList;
     }
 
     protected String getContainerImage(final CommandContext context, final CommandRequest request)
@@ -183,7 +246,7 @@ public class DefaultKubernetesClient
         return envVars.build();
     }
 
-    private static ResourceRequirements toResourceRequirements(
+    protected static ResourceRequirements toResourceRequirements(
             final Map<String, String> limits,
             final Map<String, String> requests)
     {

--- a/digdag-standards/src/test/java/io/digdag/standards/command/kubernetes/DefaultKubernetesClientTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/command/kubernetes/DefaultKubernetesClientTest.java
@@ -102,13 +102,15 @@ public class DefaultKubernetesClientTest
                   operator: Exists
                   effect: NoSchedule
               PersistentVolumeClaim:
-                accessModes:
-                - ReadWriteOnce
-                resources:
-                  requests:
-                    storage: 10Gi
-                  limits:
-                    storage: 8Gi
+                name: testPersistentVolumeClaim
+                spec:
+                  accessModes:
+                  - ReadWriteOnce
+                  resources:
+                    requests:
+                      storage: 10Gi
+                    limits:
+                      storage: 8Gi
               PersistentVolume:
                 name: testPersistentVolume
                 spec:

--- a/digdag-standards/src/test/java/io/digdag/standards/command/kubernetes/DefaultKubernetesClientTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/command/kubernetes/DefaultKubernetesClientTest.java
@@ -92,6 +92,24 @@ public class DefaultKubernetesClientTest
                 - key: test2
                   operator: Exists
                   effect: NoSchedule
+              PersistentVolumeClaim:
+                accessModes:
+                - ReadWriteOnce
+                volumeMode: Block
+                resources:
+                  requests:
+                    storage: 10Gi
+              PersistentVolume:
+                capacity:
+                  storage: 10Gi
+                accessModes:
+                - ReadWriteOnce
+                volumeMode: "Block"
+                persistentVolumeReclaimPolicy: "ReadWriteOnce"
+                fc:
+                  targetWWNs: ["50060e801049cfd1"]
+                  lun: 0
+                  readOnly: false
         */
         testKubernetesConfig = newConfig()
                 .set("Pod", newConfig()
@@ -112,7 +130,20 @@ public class DefaultKubernetesClientTest
                                                                 newConfig().set("key", "test1").set("operator", "In").set("values", ImmutableList.of("test1")))))))))
                         .set("tolerations", ImmutableList.of(
                                 newConfig().set("key", "test").set("operator", "Exists").set("effect", "NoSchedule"),
-                                newConfig().set("key", "test2").set("operator", "Exists").set("effect", "NoSchedule"))));
+                                newConfig().set("key", "test2").set("operator", "Exists").set("effect", "NoSchedule"))))
+                .set("PersistentVolumeClaim", newConfig()
+                        .set("accessModes", ImmutableList.of("ReadWriteOnce"))
+                        .set("volumeMode", "Block")
+                        .set("resources", newConfig().set("requests", newConfig().set("storage", "10Gi"))))
+                .set("PersistentVolume", newConfig()
+                        .set("capacity", newConfig().set("storage", "10Gi"))
+                        .set("accessModes", ImmutableList.of("ReadWriteOnce"))
+                        .set("volumeMode", "Block")
+                        .set("persistentVolumeReclaimPolicy", "Retain")
+                        .set("fc", newConfig()
+                                .set("targetWWNs", ImmutableList.of("50060e801049cfd1"))
+                                .set("lun", "0")
+                                .set("readOnly", "false")));
     }
 
     @Test

--- a/digdag-standards/src/test/java/io/digdag/standards/command/kubernetes/DefaultKubernetesClientTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/command/kubernetes/DefaultKubernetesClientTest.java
@@ -97,7 +97,7 @@ public class DefaultKubernetesClientTest
     {
         final Config taskRequestConfig = newConfig()
                 .set("kubernetes", newConfig().set(
-                        "pod", newConfig().set(
+                        "spec", newConfig().set(
                                 "affinity", newConfig().set(
                                         "nodeAffinity", newConfig().set(
                                                 "requiredDuringSchedulingIgnoredDuringExecution", newConfig().set(

--- a/digdag-standards/src/test/java/io/digdag/standards/command/kubernetes/DefaultKubernetesClientTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/command/kubernetes/DefaultKubernetesClientTest.java
@@ -14,7 +14,15 @@ import io.fabric8.kubernetes.api.model.NodeSelectorRequirementBuilder;
 import io.fabric8.kubernetes.api.model.NodeSelectorTermBuilder;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.PodSpecBuilder;
+import io.fabric8.kubernetes.api.model.Quantity;
+import io.fabric8.kubernetes.api.model.ResourceRequirementsBuilder;
+import io.fabric8.kubernetes.api.model.Toleration;
+import io.fabric8.kubernetes.api.model.TolerationBuilder;
+import io.fabric8.kubernetes.api.model.Volume;
+import io.fabric8.kubernetes.api.model.VolumeBuilder;
+import io.fabric8.kubernetes.api.model.VolumeMount;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+import io.fabric8.kubernetes.api.model.EmptyDirVolumeSource;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,6 +47,7 @@ public class DefaultKubernetesClientTest
     private io.fabric8.kubernetes.client.DefaultKubernetesClient k8sDefaultKubernetesClient;
     private CommandContext commandContext;
     private CommandRequest commandRequest;
+    private Config testKubernetesConfig;
 
     @Before
     public void setUp()
@@ -48,36 +57,156 @@ public class DefaultKubernetesClientTest
         k8sDefaultKubernetesClient =  mock(io.fabric8.kubernetes.client.DefaultKubernetesClient.class);
         commandContext = mock(CommandContext.class);
         commandRequest = mock(CommandRequest.class);
+
+        /*
+            kubernetes:
+              Pod:
+                volumeMounts:
+                - mountPath: "/test-ebs"
+                  name: "test"
+                - mountPath: "/test-ebs"
+                  name: "test2"
+                volumes:
+                - name: test
+                  emptyDir: {}
+                - name: test2
+                  emptyDir: {}
+                resources:
+                  limits:
+                    memory: 200Mi
+                  requests:
+                    memory: 100Mi
+                affinity:
+                  nodeAffinity:
+                    requiredDuringSchedulingIgnoredDuringExecution
+                      nodeSelectorTerms:
+                      - matchExpressions
+                        - key: test
+                          operator: In
+                          values:
+                          - test
+                tolerations:
+                - key: test
+                  operator: Exists
+                  effect: NoSchedule
+                - key: test2
+                  operator: Exists
+                  effect: NoSchedule
+              PersistentVolumeClaim:
+                accessModes:
+                - ReadWriteOnce
+                volumeMode: Block
+                resources:
+                  requests:
+                    storage: 10Gi
+              PersistentVolume:
+                capacity:
+                  storage: 10Gi
+                accessModes:
+                - ReadWriteOnce
+                volumeMode: "Block"
+                persistentVolumeReclaimPolicy: "ReadWriteOnce"
+                fc:
+                  targetWWNs: ["50060e801049cfd1"]
+                  lun: 0
+                  readOnly: false
+        */
+        testKubernetesConfig = newConfig()
+                .set("Pod", newConfig()
+                        .set("volumeMounts", ImmutableList.of(
+                                newConfig().set("mountPath", "/test-ebs").set("name", "test"),
+                                newConfig().set("mountPath", "/test-ebs2").set("name", "test2")))
+                        .set("volumes", ImmutableList.of(
+                                newConfig().set("name", "test").set("emptyDir", newConfig()),
+                                newConfig().set("name", "test2").set("emptyDir", newConfig())))
+                        .set("resources", newConfig()
+                                .set("limits", newConfig().set("memory", "200Mi"))
+                                .set("requests", newConfig().set("memory", "100Mi")))
+                        .set("affinity", newConfig()
+                                .set("nodeAffinity", newConfig()
+                                        .set("requiredDuringSchedulingIgnoredDuringExecution", newConfig()
+                                                .set("nodeSelectorTerms", ImmutableList.of(
+                                                        newConfig().set("matchExpressions", ImmutableList.of(
+                                                                newConfig().set("key", "test1").set("operator", "In").set("values", ImmutableList.of("test1")))))))))
+                        .set("tolerations", ImmutableList.of(
+                                newConfig().set("key", "test").set("operator", "Exists").set("effect", "NoSchedule"),
+                                newConfig().set("key", "test2").set("operator", "Exists").set("effect", "NoSchedule"))))
+                .set("PersistentVolumeClaim", newConfig()
+                        .set("accessModes", ImmutableList.of("ReadWriteOnce"))
+                        .set("volumeMode", "Block")
+                        .set("resources", newConfig().set("requests", newConfig().set("storage", "10Gi"))))
+                .set("PersistentVolume", newConfig()
+                        .set("capacity", newConfig().set("storage", "10Gi"))
+                        .set("accessModes", ImmutableList.of("ReadWriteOnce"))
+                        .set("volumeMode", "Block")
+                        .set("persistentVolumeReclaimPolicy", "Retain")
+                        .set("fc", newConfig()
+                                .set("targetWWNs", ImmutableList.of("50060e801049cfd1"))
+                                .set("lun", "0")
+                                .set("readOnly", "false")));
+
     }
 
     @Test
     public void testCreateContainer()
             throws Exception
     {
-        final Config taskRequestConfig = newConfig()
-                .set("kubernetes", newConfig().set(
-                        "container", newConfig()
-                                .set("volumeMounts", ImmutableList.of(
-                                      newConfig().set("mountPath", "/test-ebs").set("name", "test")))))
-                .set("docker", newConfig().set("image", "test"));
+        final Config taskRequestConfig = newConfig().set("docker", newConfig().set("image", "test"));
 
         final TaskRequest taskRequest = newTaskRequest().withConfig(taskRequestConfig);
         when(commandContext.getTaskRequest()).thenReturn(taskRequest);
-        DefaultKubernetesClient defaultKubernetesClient = new DefaultKubernetesClient(kubernetesClientConfig, k8sDefaultKubernetesClient);
 
         String podName = "test";
         List<String> commands = new ArrayList<>();
         List<String> arguments = new ArrayList<>();
-        final Config kubernetesConfig = taskRequest.getConfig().getNested("kubernetes");
-        Container container = defaultKubernetesClient.createContainer(commandContext, commandRequest, kubernetesConfig, podName, commands, arguments);
+
+        DefaultKubernetesClient defaultKubernetesClient = new DefaultKubernetesClient(kubernetesClientConfig, k8sDefaultKubernetesClient);
+        Container container = defaultKubernetesClient.createContainer(commandContext, commandRequest, null, podName, commands, arguments);
 
         Container desiredContainer = new ContainerBuilder()
-            .withName(podName)
-            .withImage("test")
-            .withCommand(commands)
-            .withArgs(arguments)
-            .withResources(null)
-            .withVolumeMounts(Arrays.asList(new VolumeMountBuilder().withName("test").withMountPath("/test-ebs").build())).build();
+                .withName(podName)
+                .withImage("test")
+                .withCommand(commands)
+                .withArgs(arguments)
+                .withResources(null)
+                .withVolumeMounts((List<VolumeMount>) null)
+                .build();
+
+        assertThat(container, is(desiredContainer));
+    }
+
+    @Test
+    public void testCreateContainerWithKubernetesConfig()
+            throws Exception
+    {
+        final Config kubernetesPodConfig = testKubernetesConfig.get("Pod", Config.class);
+        final Config taskRequestConfig = newConfig()
+                .set("kubernetes", testKubernetesConfig)
+                .set("docker", newConfig().set("image", "test"));
+
+        final TaskRequest taskRequest = newTaskRequest().withConfig(taskRequestConfig);
+        when(commandContext.getTaskRequest()).thenReturn(taskRequest);
+
+        String podName = "test";
+        List<String> commands = new ArrayList<>();
+        List<String> arguments = new ArrayList<>();
+
+        DefaultKubernetesClient defaultKubernetesClient = new DefaultKubernetesClient(kubernetesClientConfig, k8sDefaultKubernetesClient);
+        Container container = defaultKubernetesClient.createContainer(commandContext, commandRequest, kubernetesPodConfig, podName, commands, arguments);
+
+        Container desiredContainer = new ContainerBuilder()
+                .withName(podName)
+                .withImage("test")
+                .withCommand(commands)
+                .withArgs(arguments)
+                .withResources(new ResourceRequirementsBuilder()
+                        .addToLimits("memory", new Quantity("200Mi"))
+                        .addToRequests("memory", new Quantity("100Mi"))
+                        .build())
+                .withVolumeMounts(Arrays.asList(
+                        new VolumeMountBuilder().withName("test").withMountPath("/test-ebs").build(),
+                        new VolumeMountBuilder().withName("test2").withMountPath("/test-ebs2").build()))
+                .build();
 
         assertThat(container, is(desiredContainer));
     }
@@ -86,51 +215,65 @@ public class DefaultKubernetesClientTest
     public void testCreatePodSPec()
             throws Exception
     {
-        final Config taskRequestConfig = newConfig()
-                .set("kubernetes", newConfig().set(
-                        "spec", newConfig().set(
-                                "affinity", newConfig().set(
-                                        "nodeAffinity", newConfig().set(
-                                                "requiredDuringSchedulingIgnoredDuringExecution", newConfig().set(
-                                                        "nodeSelectorTerms", ImmutableList.of(
-                                                                newConfig().set(
-                                                                        "matchExpressions", ImmutableList.of(
-                                                                                newConfig().set("key", "failure-domain.beta.kubernetes.io/zone")
-                                                                                .set("operator", "In")
-                                                                                .set("values", ImmutableList.of(
-                                                                                                "asia-northeast1-a"
-                                )))))))))));
+        final Config taskRequestConfig = newConfig().set("docker", newConfig().set("image", "test"));
 
         final TaskRequest taskRequest = newTaskRequest().withConfig(taskRequestConfig);
         when(commandContext.getTaskRequest()).thenReturn(taskRequest);
-        DefaultKubernetesClient defaultKubernetesClient = new DefaultKubernetesClient(kubernetesClientConfig, k8sDefaultKubernetesClient);
-
         Container container = mock(Container.class);
-        final Config kubernetesConfig = taskRequest.getConfig().getNested("kubernetes");
-        PodSpec podSpec = defaultKubernetesClient.createPodSpec(commandContext, commandRequest, kubernetesConfig, container);
+
+        DefaultKubernetesClient defaultKubernetesClient = new DefaultKubernetesClient(kubernetesClientConfig, k8sDefaultKubernetesClient);
+        PodSpec podSpec = defaultKubernetesClient.createPodSpec(commandContext, commandRequest, null, container);
+
+        PodSpec desiredPodSpec = new PodSpecBuilder()
+            .addToContainers(container)
+            .withRestartPolicy("Never")
+            .withAffinity(null)
+            .withTolerations((List<Toleration>)null)
+            .withVolumes((List<Volume>)null)
+            .build();
+
+        assertThat(podSpec, is(desiredPodSpec));
+    }
+
+    @Test
+    public void testCreatePodSPecWithKubernetesConfig()
+            throws Exception
+    {
+        final Config kubernetesPodConfig = testKubernetesConfig.get("Pod", Config.class);
+        final Config taskRequestConfig = newConfig()
+                .set("kubernetes", testKubernetesConfig)
+                .set("docker", newConfig().set("image", "test"));
+
+        final TaskRequest taskRequest = newTaskRequest().withConfig(taskRequestConfig);
+        when(commandContext.getTaskRequest()).thenReturn(taskRequest);
+        Container container = mock(Container.class);
+
+        DefaultKubernetesClient defaultKubernetesClient = new DefaultKubernetesClient(kubernetesClientConfig, k8sDefaultKubernetesClient);
+        PodSpec podSpec = defaultKubernetesClient.createPodSpec(commandContext, commandRequest, kubernetesPodConfig, container);
 
         PodSpec desiredPodSpec = new PodSpecBuilder()
             .addToContainers(container)
             .withRestartPolicy("Never")
             .withAffinity(new AffinityBuilder()
                 .withNodeAffinity(new NodeAffinityBuilder()
-                  .withRequiredDuringSchedulingIgnoredDuringExecution(new NodeSelectorBuilder()
-                    .addToNodeSelectorTerms(0,
-                      new NodeSelectorTermBuilder().addToMatchExpressions(0,
-                        new NodeSelectorRequirementBuilder()
-                          .withKey("failure-domain.beta.kubernetes.io/zone")
-                          .addToValues(0,"asia-northeast1-a")
-                          .withOperator("In")
-                          .build()
-                        )
-                      .build()
-                      )
-                    .build()
-                    )
-                  .build()
-                  )
-                .build()
-                )
+                        .withRequiredDuringSchedulingIgnoredDuringExecution(new NodeSelectorBuilder()
+                                .addToNodeSelectorTerms(0,
+                                        new NodeSelectorTermBuilder()
+                                                .addToMatchExpressions(0, new NodeSelectorRequirementBuilder()
+                                                        .withKey("test1")
+                                                        .addToValues(0, "test1")
+                                                        .withOperator("In")
+                                                        .build()
+                                                ).build()
+                                ).build()
+                        ).build()
+                ).build())
+                .withTolerations(Arrays.asList(
+                        new TolerationBuilder().withKey("test").withOperator("Exists").withEffect("NoSchedule").build(),
+                        new TolerationBuilder().withKey("test2").withOperator("Exists").withEffect("NoSchedule").build()))
+                .withVolumes(Arrays.asList(
+                        new VolumeBuilder().withName("test").withEmptyDir(new EmptyDirVolumeSource()).build(),
+                        new VolumeBuilder().withName("test2").withEmptyDir(new EmptyDirVolumeSource()).build()))
             .build();
 
         assertThat(podSpec, is(desiredPodSpec));

--- a/digdag-standards/src/test/java/io/digdag/standards/command/kubernetes/DefaultKubernetesClientTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/command/kubernetes/DefaultKubernetesClientTest.java
@@ -1,47 +1,35 @@
 package io.digdag.standards.command.kubernetes;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-
+import io.digdag.client.config.Config;
 import io.digdag.spi.CommandContext;
 import io.digdag.spi.CommandRequest;
-import static io.digdag.client.config.ConfigUtils.newConfig;
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertThat;
-import static io.digdag.core.workflow.OperatorTestingUtils.newContext;
-
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.when;
-
+import io.digdag.spi.TaskRequest;
+import io.fabric8.kubernetes.api.model.AffinityBuilder;
 import io.fabric8.kubernetes.api.model.Container;
 import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.NodeAffinityBuilder;
+import io.fabric8.kubernetes.api.model.NodeSelectorBuilder;
+import io.fabric8.kubernetes.api.model.NodeSelectorRequirementBuilder;
+import io.fabric8.kubernetes.api.model.NodeSelectorTermBuilder;
 import io.fabric8.kubernetes.api.model.PodSpec;
 import io.fabric8.kubernetes.api.model.PodSpecBuilder;
 import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
-import io.fabric8.kubernetes.api.model.AffinityBuilder;
-import io.fabric8.kubernetes.api.model.NodeAffinityBuilder;
-import io.fabric8.kubernetes.api.model.NodeSelectorBuilder;
-import io.fabric8.kubernetes.api.model.NodeSelectorTermBuilder;
-import io.fabric8.kubernetes.api.model.NodeSelectorRequirementBuilder;
-import io.fabric8.kubernetes.api.model.Toleration;
-import io.fabric8.kubernetes.api.model.Volume;
-import io.fabric8.kubernetes.api.model.Container;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import io.digdag.spi.TaskRequest;
-import io.digdag.client.config.Config;
-import static io.digdag.core.workflow.OperatorTestingUtils.newTaskRequest;
-import static io.digdag.core.workflow.OperatorTestingUtils.newContext;
-
-import java.util.List;
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static io.digdag.client.config.ConfigUtils.newConfig;
+import static io.digdag.core.workflow.OperatorTestingUtils.newTaskRequest;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DefaultKubernetesClientTest

--- a/digdag-standards/src/test/java/io/digdag/standards/command/kubernetes/DefaultKubernetesClientTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/command/kubernetes/DefaultKubernetesClientTest.java
@@ -92,24 +92,6 @@ public class DefaultKubernetesClientTest
                 - key: test2
                   operator: Exists
                   effect: NoSchedule
-              PersistentVolumeClaim:
-                accessModes:
-                - ReadWriteOnce
-                volumeMode: Block
-                resources:
-                  requests:
-                    storage: 10Gi
-              PersistentVolume:
-                capacity:
-                  storage: 10Gi
-                accessModes:
-                - ReadWriteOnce
-                volumeMode: "Block"
-                persistentVolumeReclaimPolicy: "ReadWriteOnce"
-                fc:
-                  targetWWNs: ["50060e801049cfd1"]
-                  lun: 0
-                  readOnly: false
         */
         testKubernetesConfig = newConfig()
                 .set("Pod", newConfig()
@@ -130,21 +112,7 @@ public class DefaultKubernetesClientTest
                                                                 newConfig().set("key", "test1").set("operator", "In").set("values", ImmutableList.of("test1")))))))))
                         .set("tolerations", ImmutableList.of(
                                 newConfig().set("key", "test").set("operator", "Exists").set("effect", "NoSchedule"),
-                                newConfig().set("key", "test2").set("operator", "Exists").set("effect", "NoSchedule"))))
-                .set("PersistentVolumeClaim", newConfig()
-                        .set("accessModes", ImmutableList.of("ReadWriteOnce"))
-                        .set("volumeMode", "Block")
-                        .set("resources", newConfig().set("requests", newConfig().set("storage", "10Gi"))))
-                .set("PersistentVolume", newConfig()
-                        .set("capacity", newConfig().set("storage", "10Gi"))
-                        .set("accessModes", ImmutableList.of("ReadWriteOnce"))
-                        .set("volumeMode", "Block")
-                        .set("persistentVolumeReclaimPolicy", "Retain")
-                        .set("fc", newConfig()
-                                .set("targetWWNs", ImmutableList.of("50060e801049cfd1"))
-                                .set("lun", "0")
-                                .set("readOnly", "false")));
-
+                                newConfig().set("key", "test2").set("operator", "Exists").set("effect", "NoSchedule"))));
     }
 
     @Test

--- a/digdag-standards/src/test/java/io/digdag/standards/command/kubernetes/DefaultKubernetesClientTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/command/kubernetes/DefaultKubernetesClientTest.java
@@ -1,0 +1,146 @@
+package io.digdag.standards.command.kubernetes;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+
+import io.digdag.spi.CommandContext;
+import io.digdag.spi.CommandRequest;
+import static io.digdag.client.config.ConfigUtils.newConfig;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static io.digdag.core.workflow.OperatorTestingUtils.newContext;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.ContainerBuilder;
+import io.fabric8.kubernetes.api.model.PodSpec;
+import io.fabric8.kubernetes.api.model.PodSpecBuilder;
+import io.fabric8.kubernetes.api.model.VolumeMountBuilder;
+import io.fabric8.kubernetes.api.model.AffinityBuilder;
+import io.fabric8.kubernetes.api.model.NodeAffinityBuilder;
+import io.fabric8.kubernetes.api.model.NodeSelectorBuilder;
+import io.fabric8.kubernetes.api.model.NodeSelectorTermBuilder;
+import io.fabric8.kubernetes.api.model.NodeSelectorRequirementBuilder;
+import io.fabric8.kubernetes.api.model.Container;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import io.digdag.spi.TaskRequest;
+import io.digdag.client.config.Config;
+import static io.digdag.core.workflow.OperatorTestingUtils.newTaskRequest;
+import static io.digdag.core.workflow.OperatorTestingUtils.newContext;
+
+import java.util.List;
+import java.util.Arrays;
+import java.util.ArrayList;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DefaultKubernetesClientTest
+{
+
+    private KubernetesClientConfig kubernetesClientConfig;
+    private io.fabric8.kubernetes.client.DefaultKubernetesClient k8sDefaultKubernetesClient;
+    private CommandContext commandContext;
+    private CommandRequest commandRequest;
+
+    @Before
+    public void setUp()
+            throws Exception
+    {
+        kubernetesClientConfig = mock(KubernetesClientConfig.class);
+        k8sDefaultKubernetesClient =  mock(io.fabric8.kubernetes.client.DefaultKubernetesClient.class);
+        commandContext = mock(CommandContext.class);
+        commandRequest = mock(CommandRequest.class);
+    }
+
+    @Test
+    public void testCreateContainer()
+            throws Exception
+    {
+        final Config taskRequestConfig = newConfig()
+                .set("kubernetes", newConfig().set(
+                        "container", newConfig().set(
+                                "volumeMounts", ImmutableList.of(
+                                      newConfig().set("mountPath", "/test-ebs").set("name", "test")))))
+                .set("docker", newConfig().set("image", "test"));
+
+        final TaskRequest taskRequest = newTaskRequest().withConfig(taskRequestConfig);
+        when(commandContext.getTaskRequest()).thenReturn(taskRequest);
+        DefaultKubernetesClient defaultKubernetesClient = new DefaultKubernetesClient(kubernetesClientConfig, k8sDefaultKubernetesClient);
+
+        String podName = "test";
+        List<String> commands = new ArrayList<>();
+        List<String> arguments = new ArrayList<>();
+        Container container = defaultKubernetesClient.createContainer(commandContext, commandRequest, podName, commands, arguments);
+
+        Container desiredContainer = new ContainerBuilder()
+            .withName(podName)
+            .withImage("test")
+            .withCommand(commands)
+            .withArgs(arguments)
+            .withResources(defaultKubernetesClient.toResourceRequirements(defaultKubernetesClient.getResourceLimits(commandContext, commandRequest), defaultKubernetesClient.getResourceRequests(commandContext, commandRequest)))
+            .withVolumeMounts(Arrays.asList(new VolumeMountBuilder().withName("test").withMountPath("/test-ebs").build())).build();
+
+        assertThat(container, is(desiredContainer));
+    }
+
+    @Test
+    public void testCreatePodSPec()
+            throws Exception
+    {
+        final Config taskRequestConfig = newConfig()
+                .set("kubernetes", newConfig().set(
+                        "pod", newConfig().set(
+                                "affinity", newConfig().set(
+                                        "nodeAffinity", newConfig().set(
+                                                "requiredDuringSchedulingIgnoredDuringExecution", newConfig().set(
+                                                        "nodeSelectorTerms", ImmutableList.of(
+                                                                newConfig().set(
+                                                                        "matchExpressions", ImmutableList.of(
+                                                                                newConfig().set("key", "failure-domain.beta.kubernetes.io/zone")
+                                                                                .set("operator", "In")
+                                                                                .set("values", ImmutableList.of(
+                                                                                                "asia-northeast1-a"
+                                )))))))))));
+
+        final TaskRequest taskRequest = newTaskRequest().withConfig(taskRequestConfig);
+        when(commandContext.getTaskRequest()).thenReturn(taskRequest);
+        DefaultKubernetesClient defaultKubernetesClient = new DefaultKubernetesClient(kubernetesClientConfig, k8sDefaultKubernetesClient);
+
+        Container container = mock(Container.class);
+        PodSpec podSpec = defaultKubernetesClient.createPodSpec(commandContext, commandRequest, container);
+
+        PodSpec desiredPodSpec = new PodSpecBuilder()
+            .addToContainers(container)
+            .withRestartPolicy("Never")
+            .withAffinity(new AffinityBuilder()
+                .withNodeAffinity(new NodeAffinityBuilder()
+                  .withRequiredDuringSchedulingIgnoredDuringExecution(new NodeSelectorBuilder()
+                    .addToNodeSelectorTerms(0,
+                      new NodeSelectorTermBuilder().addToMatchExpressions(0,
+                        new NodeSelectorRequirementBuilder()
+                          .withKey("failure-domain.beta.kubernetes.io/zone")
+                          .addToValues(0,"asia-northeast1-a")
+                          .withOperator("In")
+                          .build()
+                        )
+                      .build()
+                      )
+                    .build()
+                    )
+                  .build()
+                  )
+                .build()
+                )
+            .build();
+
+        assertThat(podSpec, is(desiredPodSpec));
+    }
+}


### PR DESCRIPTION
### Objective
Additional supports `affinity`, ` tolerations`, `volumes` and `volumeMounts` to pod.
Additinal supports `PersistentVolumeClaim` and `PersistentVolume` resource.

### Summarize
If we export following options(`volumeMounts`, `volumes`, `affinity`, `tolerations`) and when use kubernetes command executor,  It operates as follows. 
※ options syntax should be same as kubernetes yaml And these options have not be required.

- `volumeMounts` indicate that  mount volume to pod with `mountPath` 
  -  mount `models` volume to `/tmp/models`
- `volumes` indicate that define volume (such as nfs, emptyDir, and configMap) for volumeMounts
  -  define volume as emptyDir.
- `affinity` indicate that A more flexible way to schedule pods to nodes than `nodeSelector`
- `toleration` indicate that Whether to allow "Taint".
  - if key ('app') is not 'hoge' it will not be scheduled
- (`resources`) Any resources supported by api can be specified, such as `nvidia.com/gpu` and `cloud-tpus.google.com/v2` 

```yaml
_export:
  kubernetes:
    Pod:
      volumeMounts:
      - mountPath: "/test-ebs"
        name: "test"
      - mountPath: "/test-ebs"
        name: "test2"
      volumes:
      - name: test
        emptyDir: {}
      - name: test2
        emptyDir: {}
      resources:
        limits:
          memory: 200Mi
        requests:
          memory: 100Mi
      affinity:
        nodeAffinity:
          requiredDuringSchedulingIgnoredDuringExecution
            nodeSelectorTerms:
            - matchExpressions
              - key: test
                operator: In
                values:
                - test
      tolerations:
      - key: test
        operator: Exists
        effect: NoSchedule
      - key: test2
        operator: Exists
        effect: NoSchedule
    PersistentVolumeClaim:
　    name: testPersistentVolumeClaim
      spec:
        accessModes:
        - ReadWriteOnce
        resources:
          requests:
            storage: 10Gi
          limits:
            storage: 8Gi
    PersistentVolume:
      name: testPersistentVolume
      spec:
        capacity:
          storage: 10Gi
        accessModes:
        - ReadWriteOnce
        persistentVolumeReclaimPolicy: "ReadWriteOnce"
```

ref.
affinity https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
tolerations https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
volumes https://kubernetes.io/docs/concepts/storage/volumes/#emptydir
