### PR TITLE
Improve ConfigEvalEngine performance by remove unnecessarry calls

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/agent/ConfigEvalEngine.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/ConfigEvalEngine.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.IOException;
+import java.util.regex.Pattern;
 import javax.script.ScriptEngine;
 import javax.script.ScriptException;
 import javax.script.Invocable;
@@ -233,9 +234,11 @@ public class ConfigEvalEngine
         }
     }
 
+    private static final Pattern requireInvokdetemplatePattern = Pattern.compile("(?m)^.*[$].*$", Pattern.MULTILINE);
+
     @VisibleForTesting
     protected boolean requireInvokdetemplate(String code) {
-        return code != null && code.matches("^.*[$].*$");
+        return code != null && requireInvokdetemplatePattern.matcher(code).find();
     }
 
     @Override

--- a/digdag-core/src/main/java/io/digdag/core/agent/ConfigEvalEngine.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/ConfigEvalEngine.java
@@ -18,7 +18,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.io.CharStreams;
 import com.google.inject.Inject;
 import io.digdag.metrics.DigdagTimed;
-import io.digdag.spi.metrics.DigdagMetrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import jdk.nashorn.api.scripting.NashornScriptEngineFactory;
@@ -63,7 +62,6 @@ public class ConfigEvalEngine
 
     private final ObjectMapper jsonMapper;
     private final NashornScriptEngineFactory jsEngineFactory;
-    private DigdagMetrics metrics;
 
     @Inject
     public ConfigEvalEngine()
@@ -113,8 +111,7 @@ public class ConfigEvalEngine
             throw new TemplateException("Failed to serialize parameters to JSON", ex);
         }
         try {
-            String evaluated = (String) templateInvocable.invokeFunction("template", code, context);
-            return evaluated;
+            return (String) templateInvocable.invokeFunction("template", code, context);
         }
         catch (ScriptException ex) {
             String message;
@@ -145,13 +142,10 @@ public class ConfigEvalEngine
             this.params = params;
         }
 
-        // ToDo Lombok Getter(lazy=true)
         private Invocable lazyGetTemplateInvocable()
         {
             if (templateInvocable == null) {
-                synchronized(this) {
-                    templateInvocable = newTemplateInvocable(params);
-                }
+                templateInvocable = newTemplateInvocable(params);
             }
             return templateInvocable;
         }
@@ -219,7 +213,7 @@ public class ConfigEvalEngine
                 scopedParams.set(pair.getKey(), pair.getValue());
             }
             String resultText = null;
-            if (requireInvokdetemplate(code)) {
+            if (requireInvokedTemplate(code)) {
                 resultText = invokeTemplate(lazyGetTemplateInvocable(), code, scopedParams);
             }
             else {
@@ -234,12 +228,12 @@ public class ConfigEvalEngine
         }
     }
 
-    private static final Pattern requireInvokdeTemplatePattern = Pattern.compile("\\$");
+    private static final Pattern requireInvokedTemplatePattern = Pattern.compile("\\$");
 
     @VisibleForTesting
-    protected boolean requireInvokdeTemplate(String code)
+    protected boolean requireInvokedTemplate(String code)
     {
-        return code != null && requireInvokdetemplatePattern.matcher(code).find();
+        return code != null && requireInvokedTemplatePattern.matcher(code).find();
     }
 
     @Override
@@ -247,7 +241,7 @@ public class ConfigEvalEngine
         throws TemplateException
     {
         String resultText = null;
-        if (requireInvokdetemplate(content)) {
+        if (requireInvokedTemplate(content)) {
             Invocable templateInvocable = newTemplateInvocable(params);
             resultText = invokeTemplate(templateInvocable, content, params);
         }

--- a/digdag-core/src/main/java/io/digdag/core/agent/ConfigEvalEngine.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/ConfigEvalEngine.java
@@ -234,7 +234,7 @@ public class ConfigEvalEngine
         }
     }
 
-    private static final Pattern requireInvokdetemplatePattern = Pattern.compile("(?m)^.*[$].*$", Pattern.MULTILINE);
+    private static final Pattern requireInvokdeTemplatePattern = Pattern.compile("\\$");
 
     @VisibleForTesting
     protected boolean requireInvokdetemplate(String code) {

--- a/digdag-core/src/main/java/io/digdag/core/agent/ConfigEvalEngine.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/ConfigEvalEngine.java
@@ -237,7 +237,8 @@ public class ConfigEvalEngine
     private static final Pattern requireInvokdeTemplatePattern = Pattern.compile("\\$");
 
     @VisibleForTesting
-    protected boolean requireInvokdetemplate(String code) {
+    protected boolean requireInvokdeTemplate(String code)
+    {
         return code != null && requireInvokdetemplatePattern.matcher(code).find();
     }
 

--- a/digdag-core/src/main/java/io/digdag/core/agent/ConfigEvalEngine.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/ConfigEvalEngine.java
@@ -5,20 +5,19 @@ import java.util.Map;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.charset.Charset;
 import javax.script.ScriptEngine;
-import javax.script.ScriptEngineManager;
 import javax.script.ScriptException;
 import javax.script.Invocable;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.CharStreams;
 import com.google.inject.Inject;
+import io.digdag.metrics.DigdagTimed;
+import io.digdag.spi.metrics.DigdagMetrics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import jdk.nashorn.api.scripting.NashornScriptEngineFactory;
@@ -63,6 +62,7 @@ public class ConfigEvalEngine
 
     private final ObjectMapper jsonMapper;
     private final NashornScriptEngineFactory jsEngineFactory;
+    private DigdagMetrics metrics;
 
     @Inject
     public ConfigEvalEngine()
@@ -71,6 +71,7 @@ public class ConfigEvalEngine
         this.jsEngineFactory = new NashornScriptEngineFactory();
     }
 
+    @DigdagTimed(value = "ceval_", category = "agent", appendMethodName = true)
     protected Config eval(Config config, Config params)
         throws TemplateException
     {
@@ -79,7 +80,8 @@ public class ConfigEvalEngine
         return config.getFactory().create(built);
     }
 
-    private Invocable newTemplateInvocable(Config params)
+    @DigdagTimed(value = "ceval_", category = "agent", appendMethodName = true)
+    protected Invocable newTemplateInvocable(Config params)
     {
         ScriptEngine jsEngine = jsEngineFactory.getScriptEngine(new String[] {
             //"--language=es6",  // this is not even accepted with jdk1.8.0_20 and has a bug with jdk1.8.0_51
@@ -98,7 +100,8 @@ public class ConfigEvalEngine
         return (Invocable) jsEngine;
     }
 
-    private String invokeTemplate(Invocable templateInvocable, String code, Config params)
+    @DigdagTimed(value = "ceval_", category = "agent", appendMethodName = true)
+    protected String invokeTemplate(Invocable templateInvocable, String code, Config params)
         throws TemplateException
     {
         String context;
@@ -109,7 +112,8 @@ public class ConfigEvalEngine
             throw new TemplateException("Failed to serialize parameters to JSON", ex);
         }
         try {
-            return (String) templateInvocable.invokeFunction("template", code, context);
+            String evaluated = (String) templateInvocable.invokeFunction("template", code, context);
+            return evaluated;
         }
         catch (ScriptException ex) {
             String message;
@@ -132,13 +136,23 @@ public class ConfigEvalEngine
     private class Context
     {
         private final Config params;
-        private final Invocable templateInvocable;
+        private Invocable templateInvocable = null;
         private final ImmutableList<String> noEvaluatedKeys = ImmutableList.of("_do",  "_else_do");
 
         public Context(Config params)
         {
             this.params = params;
-            this.templateInvocable = newTemplateInvocable(params);
+        }
+
+        // ToDo Lombok Getter(lazy=true)
+        private Invocable lazyGetTemplateInvocable()
+        {
+            if (templateInvocable == null) {
+                synchronized(this) {
+                    templateInvocable = newTemplateInvocable(params);
+                }
+            }
+            return templateInvocable;
         }
 
         private ObjectNode evalObjectRecursive(ObjectNode local)
@@ -203,7 +217,13 @@ public class ConfigEvalEngine
             for (Map.Entry<String, JsonNode> pair : ImmutableList.copyOf(local.fields())) {
                 scopedParams.set(pair.getKey(), pair.getValue());
             }
-            String resultText = invokeTemplate(templateInvocable, code, scopedParams);
+            String resultText = null;
+            if (requireInvokdetemplate(code)) {
+                resultText = invokeTemplate(lazyGetTemplateInvocable(), code, scopedParams);
+            }
+            else {
+                resultText = code;
+            }
             if (resultText == null) {
                 return jsonMapper.getNodeFactory().nullNode();
             }
@@ -213,12 +233,23 @@ public class ConfigEvalEngine
         }
     }
 
+    @VisibleForTesting
+    protected boolean requireInvokdetemplate(String code) {
+        return code != null && code.matches("^.*[$].*$");
+    }
+
     @Override
     public String template(String content, Config params)
         throws TemplateException
     {
-        Invocable templateInvocable = newTemplateInvocable(params);
-        String resultText = invokeTemplate(templateInvocable, content, params);
+        String resultText = null;
+        if (requireInvokdetemplate(content)) {
+            Invocable templateInvocable = newTemplateInvocable(params);
+            resultText = invokeTemplate(templateInvocable, content, params);
+        }
+        else {
+            resultText = content;
+        }
         if (resultText == null) {
             return "";
         }

--- a/digdag-core/src/main/java/io/digdag/core/agent/ConfigEvalEngine.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/ConfigEvalEngine.java
@@ -213,7 +213,7 @@ public class ConfigEvalEngine
                 scopedParams.set(pair.getKey(), pair.getValue());
             }
             String resultText = null;
-            if (requireInvokedTemplate(code)) {
+            if (isInvokeTemplateRequired(code)) {
                 resultText = invokeTemplate(lazyGetTemplateInvocable(), code, scopedParams);
             }
             else {
@@ -228,12 +228,12 @@ public class ConfigEvalEngine
         }
     }
 
-    private static final Pattern requireInvokedTemplatePattern = Pattern.compile("\\$");
+    private static final Pattern InvokeTemplateRequiredPattern = Pattern.compile("\\$");
 
     @VisibleForTesting
-    protected boolean requireInvokedTemplate(String code)
+    protected boolean isInvokeTemplateRequired(String code)
     {
-        return code != null && requireInvokedTemplatePattern.matcher(code).find();
+        return code != null && InvokeTemplateRequiredPattern.matcher(code).find();
     }
 
     @Override
@@ -241,7 +241,7 @@ public class ConfigEvalEngine
         throws TemplateException
     {
         String resultText = null;
-        if (requireInvokedTemplate(content)) {
+        if (isInvokeTemplateRequired(content)) {
             Invocable templateInvocable = newTemplateInvocable(params);
             resultText = invokeTemplate(templateInvocable, content, params);
         }

--- a/digdag-core/src/test/java/io/digdag/core/agent/ConfigEvalEngineTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/agent/ConfigEvalEngineTest.java
@@ -116,7 +116,7 @@ public class ConfigEvalEngineTest
     public void testRequireInvokdetemplate()
     {
         assertThat(engine.requireInvokdetemplate(""), is(false));
-        assertThat(engine.requireInvokdetemplate("¥n"), is(false));
-        assertThat(engine.requireInvokdetemplate("aa${hoge}bb"), is(true));
+        assertThat(engine.requireInvokdetemplate("\n"), is(false));
+        assertThat(engine.requireInvokdetemplate("Digdag Notification\naa${hoge}bb"), is(true));
     }
 }

--- a/digdag-core/src/test/java/io/digdag/core/agent/ConfigEvalEngineTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/agent/ConfigEvalEngineTest.java
@@ -1,11 +1,8 @@
 package io.digdag.core.agent;
 
-import com.google.common.base.Optional;
 
 import io.digdag.client.config.Config;
-import io.digdag.core.config.YamlConfigLoader;
 import io.digdag.spi.TemplateException;
-import io.digdag.spi.SecretSelector;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -113,5 +110,13 @@ public class ConfigEvalEngineTest
         assertThat(
                 engine.eval(newConfig().set("key", "${moment().format()}"), params()).get("key", String.class),
                 not(is("")));
+    }
+
+    @Test
+    public void testRequireInvokdetemplate()
+    {
+        assertThat(engine.requireInvokdetemplate(""), is(false));
+        assertThat(engine.requireInvokdetemplate("¥n"), is(false));
+        assertThat(engine.requireInvokdetemplate("aa${hoge}bb"), is(true));
     }
 }

--- a/digdag-core/src/test/java/io/digdag/core/agent/ConfigEvalEngineTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/agent/ConfigEvalEngineTest.java
@@ -113,10 +113,10 @@ public class ConfigEvalEngineTest
     }
 
     @Test
-    public void testRequireInvokdetemplate()
+    public void testIsInvokeTemplateRequired()
     {
-        assertThat(engine.requireInvokedTemplate(""), is(false));
-        assertThat(engine.requireInvokedTemplate("\n"), is(false));
-        assertThat(engine.requireInvokedTemplate("Digdag Notification\naa${hoge}bb"), is(true));
+        assertThat(engine.isInvokeTemplateRequired(""), is(false));
+        assertThat(engine.isInvokeTemplateRequired("\n"), is(false));
+        assertThat(engine.isInvokeTemplateRequired("Digdag Notification\naa${hoge}bb"), is(true));
     }
 }

--- a/digdag-core/src/test/java/io/digdag/core/agent/ConfigEvalEngineTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/agent/ConfigEvalEngineTest.java
@@ -115,8 +115,8 @@ public class ConfigEvalEngineTest
     @Test
     public void testRequireInvokdetemplate()
     {
-        assertThat(engine.requireInvokdetemplate(""), is(false));
-        assertThat(engine.requireInvokdetemplate("\n"), is(false));
-        assertThat(engine.requireInvokdetemplate("Digdag Notification\naa${hoge}bb"), is(true));
+        assertThat(engine.requireInvokedTemplate(""), is(false));
+        assertThat(engine.requireInvokedTemplate("\n"), is(false));
+        assertThat(engine.requireInvokedTemplate("Digdag Notification\naa${hoge}bb"), is(true));
     }
 }


### PR DESCRIPTION
This PR improve performance of operator processing by reducing call of Javascript engine processing.
Current code always call invokeTemplate().
But if there is no evaluated code in the text, we don't need to call it.
This PR checks text contains '$' char and only call invokeTemplate() if exists.

I tested with the following dig and measured the time with output _digdag_ attempt <id>_ .

|   secs  | 1  | 2  | 3  | Avg.  |
|:-:      |:-: |:-: |:-: |:-:    |
|original |17  |12  |13  | 14.0  |
|modified |14  | 9  | 9  | 10.67 |

As above, the PR is faster than original in this dig.
Performance depends on the dig.
But in most case it improve the performance.

- This PR improve the performance of operator by skip invokeTemplate() if needless
- Will improve CPU utilization
- Even though we move to GraalJS, this code(or way) is still effective.


```
+task1:
  for_each>:
    fruit: [apple, orange, banana]
    color: [white, black, blue, green, red, yellow]
    verb: [eat, throw, look]
  _parallel: true
  _do:
    echo>: ${verb} ${color} ${fruit}

+task2:
  for_each>:
    fruit: [apple, orange, banana]
    color: [white, black, blue, green, red, yellow]
    verb: [eat, throw, look]
  _parallel: true
  _do:
    echo>: aaaaa
```

As additional test, I measured with +task1 only WF. In this case, task always have '$' the performance should be near equivalent.

|   secs  | 1  | 2  | 3  | Avg.  |
|:-:      |:-: |:-: |:-: |:-:    |
|original |10  |7  | 6 | 7.67  |
|modified |11  |7  | 5  |7.67  |

The result is as expected. In not good condition for this PR,  performance is almost all same.
