### PR TITLE
[Doc] Add _check and _error example

### DIFF
--- a/digdag-docs/src/concepts.md
+++ b/digdag-docs/src/concepts.md
@@ -79,6 +79,18 @@ But loops and branches are useful. To solve this issue, Digdag dynamically appen
 
 `_error` task is generated after failure of a task. This is useful to notify failure of a task to external systems.
 
+The following example output `success` on succeeding the tasks. And also, It output the message `fail` on failing the tasks.
+
+```yaml
++example:
+  sh>: your_script.sh
+  _check:
+    +succeed:
+      echo>: success
+  _error:
+    +failed:
+      echo>: fail
+```
 
 ## Task naming and resuming
 


### PR DESCRIPTION
A user told me there is no example of `_check` usages.
This PR adds how to use `_check` and `_error` tasks

@yoyama, @szyn What do you think?

Ref: [Twitter](https://twitter.com/_osna329_/status/1201863710056144898?s=20) Japanese