### PR TITLE
get k8s config from requestConfig. and added test.

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/kubernetes/KubernetesClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/kubernetes/KubernetesClientConfig.java
@@ -28,7 +28,7 @@ public class KubernetesClientConfig
         Config extractedSystemConfig = null;
         if (systemConfig != null && systemConfig.get("agent.command_executor.type", String.class, "").equals("kubernetes")) {
             if (clusterName == null) {
-                clusterName = systemConfig.get(KUBERNETES_CLIENT_PARAMS_PREFIX + "name", String.class);
+                clusterName = systemConfig.get(KUBERNETES_CLIENT_PARAMS_PREFIX + "name", String.class); // ConfigException
             }
             final String keyPrefix = KUBERNETES_CLIENT_PARAMS_PREFIX + clusterName + ".";
             extractedSystemConfig = StorageManager.extractKeyPrefix(systemConfig, keyPrefix);
@@ -37,7 +37,7 @@ public class KubernetesClientConfig
         Config extractedRequestConfig = null;
         if (requestConfig != null && requestConfig.has("kubernetes")) {
             if (clusterName == null) {
-                clusterName = requestConfig.get("name", String.class);
+                clusterName = requestConfig.get("name", String.class); // ConfigException
             }
             extractedRequestConfig = requestConfig.getNested("kubernetes");
         }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/kubernetes/KubernetesClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/kubernetes/KubernetesClientConfig.java
@@ -21,7 +21,7 @@ public class KubernetesClientConfig
     {
         if (requestConfig != null && requestConfig.has("kubernetes")) {
             // from task request config
-            return KubernetesClientConfig.createFromTaskRequestConfig(name, requestConfig);
+            return KubernetesClientConfig.createFromTaskRequestConfig(name, requestConfig.getNested("kubernetes"));
         }
         else {
             // from system config
@@ -31,13 +31,8 @@ public class KubernetesClientConfig
 
     @VisibleForTesting
     private static KubernetesClientConfig createFromTaskRequestConfig(final Optional<String> name,
-                                                                      final Config requestConfig)
+            final Config kubernetesConfig)
     {
-        if (!requestConfig.has("kubernetes")) {
-            throw new ConfigException("not found 'kubernetes'");
-        }
-        final Config kubernetesConfig = requestConfig.getNested("kubernetes");
-
         final String clusterName;
         if (!name.isPresent()) {
             clusterName = kubernetesConfig.get("name", String.class);
@@ -49,7 +44,8 @@ public class KubernetesClientConfig
     }
 
     @VisibleForTesting
-    static KubernetesClientConfig createFromSystemConfig(final Optional<String> name, final Config systemConfig)
+    static KubernetesClientConfig createFromSystemConfig(final Optional<String> name,
+            final Config systemConfig)
     {
         final String clusterName;
         if (!name.isPresent()) {

--- a/digdag-standards/src/main/java/io/digdag/standards/command/kubernetes/KubernetesClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/kubernetes/KubernetesClientConfig.java
@@ -31,21 +31,21 @@ public class KubernetesClientConfig
 
     @VisibleForTesting
     private static KubernetesClientConfig createFromTaskRequestConfig(final Optional<String> name,
-            final Config kubernetesConfig)
+            final Config config)
     {
         final String clusterName;
         if (!name.isPresent()) {
-            clusterName = kubernetesConfig.get("name", String.class);
+            clusterName = config.get("name", String.class);
         }
         else {
             clusterName = name.get();
         }
-        return createKubeConfig(clusterName, kubernetesConfig);
+        return createKubeConfig(clusterName, config);
     }
 
     @VisibleForTesting
     static KubernetesClientConfig createFromSystemConfig(final Optional<String> name,
-            final Config systemConfig)
+            final io.digdag.client.config.Config systemConfig)
     {
         final String clusterName;
         if (!name.isPresent()) {

--- a/digdag-standards/src/test/java/io/digdag/standards/command/kubernetes/KubernetesClientConfigTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/command/kubernetes/KubernetesClientConfigTest.java
@@ -61,7 +61,16 @@ public class KubernetesClientConfigTest
           .set(KUBERNETES_CLIENT_PARAMS_PREFIX+"test.oauth_token", "test=")
           .set(KUBERNETES_CLIENT_PARAMS_PREFIX+"test.namespace", "default");
 
-        KubernetesClientConfig kubernetesClientConfig = KubernetesClientConfig.create(clusterName, systemConfig);
+        final Config kubernetesConfig = cf.create()
+                .set("test.master", "https://127.0.0.1")
+                .set("test.certs_ca_data", "test=")
+                .set("test.oauth_token", "test=")
+                .set("test.namespace", "default");
+
+        final Config requestConfig = cf.create()
+                .setNested("kubernetes", kubernetesConfig);
+
+        KubernetesClientConfig kubernetesClientConfig = KubernetesClientConfig.create(clusterName, systemConfig, null);
 
         String masterUrl = "https://127.0.0.1";
         String namespace = "default";
@@ -81,7 +90,7 @@ public class KubernetesClientConfigTest
           .set("agent.command_executor.type", "kubernetes")
           .set(KUBERNETES_CLIENT_PARAMS_PREFIX+"test.kube_config_path", kubeConfigPath);
 
-        KubernetesClientConfig kubernetesClientConfig = KubernetesClientConfig.create(clusterName, systemConfig);
+        KubernetesClientConfig kubernetesClientConfig = KubernetesClientConfig.create(clusterName, systemConfig, null);
 
         String masterUrl = "https://127.0.0.1";
         String namespace = "default";
@@ -94,29 +103,24 @@ public class KubernetesClientConfigTest
     }
 
     @Test
-    public void testCreateFromLocalConfig()
+    public void testCreateFromRequestConfig()
             throws Exception
     {
-        final Config systemConfig = cf.create()
-                .set("agent.command_executor.type", "kubernetes")
-                .set(KUBERNETES_CLIENT_PARAMS_PREFIX+"test.master", "https://127.0.0.1")
-                .set(KUBERNETES_CLIENT_PARAMS_PREFIX+"test.certs_ca_data", "test=")
-                .set(KUBERNETES_CLIENT_PARAMS_PREFIX+"test.oauth_token", "test=")
-                .set(KUBERNETES_CLIENT_PARAMS_PREFIX+"test.namespace", "default");
+        final Config kubernetesConfig = cf.create()
+                .set("master", "https://127.0.0.1")
+                .set("certs_ca_data", "test=")
+                .set("oauth_token", "test=")
+                .set("namespace", "default");
 
-        final Config localConfig = cf.create()
-                .set("agent.command_executor.type", "kubernetes")
-                .set(KUBERNETES_CLIENT_PARAMS_PREFIX+"test.master", "https://localhost")
-                .set(KUBERNETES_CLIENT_PARAMS_PREFIX+"test.certs_ca_data", "testlocal=")
-                .set(KUBERNETES_CLIENT_PARAMS_PREFIX+"test.oauth_token", "testlocal=")
-                .set(KUBERNETES_CLIENT_PARAMS_PREFIX+"test.namespace", "local");
+        final Config requestConfig = cf.create()
+                .setNested("kubernetes", kubernetesConfig);
 
-        KubernetesClientConfig kubernetesClientConfig = KubernetesClientConfig.create(clusterName, systemConfig, localConfig);
+        KubernetesClientConfig kubernetesClientConfig = KubernetesClientConfig.create(clusterName, null, requestConfig);
 
-        String masterUrl = "https://localhost";
-        String namespace = "local";
-        String caCertData = "testlocal=";
-        String oauthToken = "testlocal=";
+        String masterUrl = "https://127.0.0.1";
+        String namespace = "default";
+        String caCertData = "test=";
+        String oauthToken = "test=";
         assertThat(masterUrl, is(kubernetesClientConfig.getMaster()));
         assertThat(caCertData, is(kubernetesClientConfig.getCertsCaData()));
         assertThat(oauthToken, is(kubernetesClientConfig.getOauthToken()));
@@ -124,22 +128,17 @@ public class KubernetesClientConfigTest
     }
 
     @Test
-    public void testCreateFromLocalConfigWithKubeConfig()
+    public void testCreateFromRequestConfigWithKubeConfig()
             throws Exception
     {
 
-        final Config systemConfig = cf.create()
-                .set("agent.command_executor.type", "kubernetes")
-                .set(KUBERNETES_CLIENT_PARAMS_PREFIX+"test.master", "https://localhost")
-                .set(KUBERNETES_CLIENT_PARAMS_PREFIX+"test.certs_ca_data", "testlocal=")
-                .set(KUBERNETES_CLIENT_PARAMS_PREFIX+"test.oauth_token", "testlocal=")
-                .set(KUBERNETES_CLIENT_PARAMS_PREFIX+"test.namespace", "local");
+        final Config kubernetesConfig = cf.create()
+                .set("kube_config_path", kubeConfigPath);
 
-        final Config localConfig = cf.create()
-                .set("agent.command_executor.type", "kubernetes")
-                .set(KUBERNETES_CLIENT_PARAMS_PREFIX+"test.kube_config_path", kubeConfigPath);
+        final Config requestConfig = cf.create()
+                .setNested("kubernetes", kubernetesConfig);
 
-        KubernetesClientConfig kubernetesClientConfig = KubernetesClientConfig.create(clusterName, systemConfig, localConfig);
+        KubernetesClientConfig kubernetesClientConfig = KubernetesClientConfig.create(clusterName, null, requestConfig);
 
         String masterUrl = "https://127.0.0.1";
         String namespace = "default";

--- a/digdag-standards/src/test/java/io/digdag/standards/command/kubernetes/KubernetesClientConfigTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/command/kubernetes/KubernetesClientConfigTest.java
@@ -128,20 +128,30 @@ public class KubernetesClientConfigTest
     }
 
     @Test
-    public void testCreateFromRequestConfigWithKubeConfig()
+    public void testCreateFromRequestConfigAndSystemConfigMerge()
             throws Exception
     {
 
+        final Config systemConfig = cf.create()
+                .set("agent.command_executor.type", "kubernetes")
+                .set(KUBERNETES_CLIENT_PARAMS_PREFIX+"test.master", "https://127.0.0.1")
+                .set(KUBERNETES_CLIENT_PARAMS_PREFIX+"test.certs_ca_data", "test=")
+                .set(KUBERNETES_CLIENT_PARAMS_PREFIX+"test.oauth_token", "test=")
+                .set(KUBERNETES_CLIENT_PARAMS_PREFIX+"test.namespace", "default");
+
         final Config kubernetesConfig = cf.create()
-                .set("kube_config_path", kubeConfigPath);
+                .set("master", "https://localhost")
+//                .set("certs_ca_data", "test=")
+//                .set("oauth_token", "test=")
+                .set("namespace", "request");
 
         final Config requestConfig = cf.create()
                 .setNested("kubernetes", kubernetesConfig);
 
-        KubernetesClientConfig kubernetesClientConfig = KubernetesClientConfig.create(clusterName, null, requestConfig);
+        KubernetesClientConfig kubernetesClientConfig = KubernetesClientConfig.create(clusterName, systemConfig, requestConfig);
 
-        String masterUrl = "https://127.0.0.1";
-        String namespace = "default";
+        String masterUrl = "https://localhost";
+        String namespace = "request";
         String caCertData = "test=";
         String oauthToken = "test=";
         assertThat(masterUrl, is(kubernetesClientConfig.getMaster()));


### PR DESCRIPTION
Currently, only k8s configuration in `SystemConfig` is available.
With this PR, the k8s configuration contained in RequestConfig will be used.