### PR TITLE
Introduce timeout to s3_wait> operator.

### DIFF
--- a/digdag-docs/src/operators/s3_wait.md
+++ b/digdag-docs/src/operators/s3_wait.md
@@ -81,6 +81,21 @@ For more information about SSE-C, See the [AWS S3 Documentation](http://docs.aws
   An optional flag to control whether to use path-style or virtual hosted-style access when accessing S3.
   *Note:* Enabling `path_style_access` also requires specifying a `region`.
 
+* **timeout**: TIMEOUT
+
+  Set timeout.
+
+  Examples: wait 120 seconds
+
+  ```
+  timeout: 120s
+  ```
+
+* **ignore_timeout_error**: true/false (default:false)
+
+  If ignore_timeout_error is set to true, the task will finish successfully.
+  *Note* s3 variable is not accessible.
+
 ## Output Parameters
 
 * **s3.last_object**

--- a/digdag-docs/src/operators/s3_wait.md
+++ b/digdag-docs/src/operators/s3_wait.md
@@ -94,7 +94,18 @@ For more information about SSE-C, See the [AWS S3 Documentation](http://docs.aws
 * **continue_on_timeout**: true/false (default:false)
 
   If continue_on_timeout is set to true, the task will finish successfully on timeout.
-  s3.last_object.result is set to false.
+  s3.last_object is empty in this case. Empty check is required in following tasks if access to s3.last_object.
+  
+  ```
+  +task1:
+    s3_wait>: bucket/object
+    timeout: 60s
+    continue_on_timeout: true
+  +task2:
+    if>: ${s3.last_object}
+    _do:
+      echo>: "No timeout"
+  ```
 
 ## Output Parameters
 

--- a/digdag-docs/src/operators/s3_wait.md
+++ b/digdag-docs/src/operators/s3_wait.md
@@ -91,10 +91,10 @@ For more information about SSE-C, See the [AWS S3 Documentation](http://docs.aws
   timeout: 120s
   ```
 
-* **ignore_timeout_error**: true/false (default:false)
+* **continue_on_timeout**: true/false (default:false)
 
-  If ignore_timeout_error is set to true, the task will finish successfully.
-  *Note* s3 variable is not accessible.
+  If continue_on_timeout is set to true, the task will finish successfully on timeout.
+  s3.last_object.result is set to false.
 
 ## Output Parameters
 

--- a/digdag-docs/src/operators/s3_wait.md
+++ b/digdag-docs/src/operators/s3_wait.md
@@ -95,7 +95,7 @@ For more information about SSE-C, See the [AWS S3 Documentation](http://docs.aws
 
   If continue_on_timeout is set to true, the task will finish successfully on timeout.
   s3.last_object is empty in this case. Empty check is required in following tasks if access to s3.last_object.
-  
+
   ```
   +task1:
     s3_wait>: bucket/object

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/aws/S3WaitOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/aws/S3WaitOperatorFactory.java
@@ -199,7 +199,7 @@ public class S3WaitOperatorFactory
                         .build();
             }
             catch (PollingTimeoutException e) {
-                logger.debug(e.toString());
+                logger.debug("s3_wait timed out: {} (making the task {})", (ignoreTimeoutError ? "continued" : "failed"), , e.toString());
                 if (ignoreTimeoutError) {
                     return TaskResult.defaultBuilder(request)
                             .resetStoreParams(ImmutableList.of(ConfigKey.of("s3", "last_object")))

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/aws/S3WaitOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/aws/S3WaitOperatorFactory.java
@@ -214,12 +214,12 @@ public class S3WaitOperatorFactory
             Config params = request.getConfig().getFactory().create();
             Config object = params.getNestedOrSetEmpty("s3").getNestedOrSetEmpty("last_object");
             if (objectMetadata.isPresent()) {
-                object.set("result", true);
+                object.set("stored", true);
                 object.set("metadata", objectMetadata.get().getRawMetadata());
                 object.set("user_metadata", objectMetadata.get().getUserMetadata());
             }
             else { // Timeout happen
-                object.set("result", false);
+                object.set("stored", false);
             }
             return params;
         }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/aws/S3WaitOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/aws/S3WaitOperatorFactory.java
@@ -45,6 +45,7 @@ public class S3WaitOperatorFactory
     private static Logger logger = LoggerFactory.getLogger(S3WaitOperatorFactory.class);
 
     private static final DurationInterval POLL_INTERVAL = DurationInterval.of(Duration.ofSeconds(5), Duration.ofMinutes(5));
+    private static final double NEXT_INTERVAL_EXP_BASE = 1.2; // interval time will increase 5sec *1.2**N until 5min.
 
     private final AmazonS3ClientFactory s3ClientFactory;
     private final Map<String, String> environment;
@@ -177,6 +178,7 @@ public class S3WaitOperatorFactory
             try {
                 ObjectMetadata objectMetadata = pollingWaiter(state, "EXISTS")
                         .withPollInterval(POLL_INTERVAL)
+                        .withNextIntervalExpBase(NEXT_INTERVAL_EXP_BASE)
                         .withTimeout(timeout)
                         .withWaitMessage("Object '%s/%s' does not yet exist", bucket.get(), key.get())
                         .await(pollState -> pollingRetryExecutor(pollState, "POLL")

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/aws/S3WaitOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/aws/S3WaitOperatorFactory.java
@@ -212,14 +212,14 @@ public class S3WaitOperatorFactory
         private Config storeParams(Optional<ObjectMetadata> objectMetadata)
         {
             Config params = request.getConfig().getFactory().create();
-            Config object = params.getNestedOrSetEmpty("s3").getNestedOrSetEmpty("last_object");
+            Config s3object = params.getNestedOrSetEmpty("s3");
             if (objectMetadata.isPresent()) {
-                object.set("stored", true);
+                Config object = s3object.getNestedOrSetEmpty("last_object");
                 object.set("metadata", objectMetadata.get().getRawMetadata());
                 object.set("user_metadata", objectMetadata.get().getUserMetadata());
             }
             else { // Timeout happen
-                object.set("stored", false);
+                s3object.getNestedOrGetEmpty("last_object");
             }
             return params;
         }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/aws/S3WaitOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/aws/S3WaitOperatorFactory.java
@@ -29,7 +29,6 @@ import io.digdag.standards.operator.DurationInterval;
 import io.digdag.standards.operator.state.PollingTimeoutException;
 import io.digdag.standards.operator.state.TaskState;
 import io.digdag.util.DurationParam;
-import io.digdag.util.Durations;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,7 +45,6 @@ public class S3WaitOperatorFactory
     private static Logger logger = LoggerFactory.getLogger(S3WaitOperatorFactory.class);
 
     private static final DurationInterval POLL_INTERVAL = DurationInterval.of(Duration.ofSeconds(5), Duration.ofMinutes(5));
-    private static final double NEXT_INTERVAL_EXP_BASE = 1.2; // interval time will increase 5sec *1.2**N until 5min.
 
     private final AmazonS3ClientFactory s3ClientFactory;
     private final Map<String, String> environment;

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/gcp/GcsWaitOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/gcp/GcsWaitOperatorFactory.java
@@ -67,6 +67,8 @@ class GcsWaitOperatorFactory
             Optional<String> bucket = params.getOptional("bucket", String.class);
             Optional<String> object = params.getOptional("object", String.class);
 
+            //ToDo implement timeout parameter. Please refer to s3_wait>
+
             if (command.isPresent() && (bucket.isPresent() || object.isPresent()) ||
                     !command.isPresent() && (!bucket.isPresent() || !object.isPresent())) {
                 throw new ConfigException("Either the gcs_wait operator command or both 'bucket' and 'object' parameters must be set");

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/state/PollingTimeoutException.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/state/PollingTimeoutException.java
@@ -1,0 +1,9 @@
+package io.digdag.standards.operator.state;
+
+public class PollingTimeoutException extends RuntimeException
+{
+    public PollingTimeoutException(String message)
+    {
+        super(message);
+    }
+}

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/state/PollingWaiter.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/state/PollingWaiter.java
@@ -14,7 +14,6 @@ import java.util.Objects;
 public class PollingWaiter
 {
     private static final DurationInterval DEFAULT_POLL_INTERVAL = DurationInterval.of(Duration.ofSeconds(1), Duration.ofSeconds(30));
-    private static final double DEFAULT_NEXT_INTERVAL_EXP_BASE = 2.0;
     private static final Optional<Duration> DEFAULT_TIMEOUT = Optional.absent();
 
     private static Logger logger = LoggerFactory.getLogger(PollingWaiter.class);
@@ -143,7 +142,6 @@ public class PollingWaiter
 
         return result.get();
     }
-
 
     private int calculateNextInterval(Instant now, Instant startTime, int iteration)
     {

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/state/PollingWaiter.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/state/PollingWaiter.java
@@ -131,7 +131,7 @@ public class PollingWaiter
         TaskState operationState = pollState.nestedState(OPERATION);
 
         //Check timeout
-        Long now = System.currentTimeMillis();
+        long now = System.currentTimeMillis();
         if (timeout.isPresent() && timeout.get().toMillis() <= now - startTime) {
             logger.debug("Timeout happened. startTime:{}, timeout:{}", startTime, timeout.get());
             throw new PollingTimeoutException("Timeout happened");

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/state/PollingWaiter.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/state/PollingWaiter.java
@@ -130,7 +130,7 @@ public class PollingWaiter
         }
         TaskState operationState = pollState.nestedState(OPERATION);
 
-        //Check timeout
+        // Check timeout
         long now = System.currentTimeMillis();
         if (timeout.isPresent() && timeout.get().toMillis() <= now - startTime) {
             logger.debug("Timeout happened. startTime:{}, timeout:{}", startTime, timeout.get());

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/aws/S3WaitOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/aws/S3WaitOperatorFactoryTest.java
@@ -19,7 +19,6 @@ import io.digdag.spi.OperatorContext;
 import io.digdag.spi.TaskExecutionException;
 import io.digdag.spi.TaskRequest;
 import io.digdag.spi.TaskResult;
-import io.digdag.standards.operator.aws.S3WaitOperatorFactory;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -52,7 +51,9 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class S3WaitOperatorFactoryTest
 {
+    private static final int MINI_POLL_INTERVAL = 5;
     private static final int MAX_POLL_INTERVAL = 300;
+    private static final double NEXT_INTERVAL_EXP_BASE = 1.2;
 
     private static final String BUCKET = "test.bucket";
     private static final String KEY = "a/test/key";
@@ -197,7 +198,7 @@ public class S3WaitOperatorFactoryTest
 
         List<Integer> retryIntervals = new ArrayList<>();
 
-        for (int i = 0; i < 10; i++) {
+        for (int i = 0; i < 30; i++) {
             try {
                 operator.run();
                 fail();
@@ -214,7 +215,7 @@ public class S3WaitOperatorFactoryTest
         for (int i = 1; i < retryIntervals.size(); i++) {
             int prevInterval = retryIntervals.get(i - 1);
             int interval = retryIntervals.get(i);
-            assertThat(interval, is(Math.min(MAX_POLL_INTERVAL, prevInterval * 2)));
+            assertThat(interval, is((int)Math.min(MAX_POLL_INTERVAL, MINI_POLL_INTERVAL * Math.pow(NEXT_INTERVAL_EXP_BASE, i))));
         }
 
         assertThat(retryIntervals.get(retryIntervals.size() - 1), is(MAX_POLL_INTERVAL));

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/aws/S3WaitOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/aws/S3WaitOperatorFactoryTest.java
@@ -51,7 +51,6 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class S3WaitOperatorFactoryTest
 {
-    private static final int MINI_POLL_INTERVAL = 5;
     private static final int MAX_POLL_INTERVAL = 300;
 
     private static final String BUCKET = "test.bucket";
@@ -171,7 +170,6 @@ public class S3WaitOperatorFactoryTest
         expectedStoreParams
                 .getNestedOrSetEmpty("s3")
                 .getNestedOrSetEmpty("last_object")
-                .set("stored", true)
                 .set("metadata", objectMetadata.getRawMetadata())
                 .set("user_metadata", objectMetadata.getUserMetadata());
 
@@ -198,7 +196,7 @@ public class S3WaitOperatorFactoryTest
 
         List<Integer> retryIntervals = new ArrayList<>();
 
-        for (int i = 0; i < 30; i++) {
+        for (int i = 0; i < 10; i++) {
             try {
                 operator.run();
                 fail();
@@ -215,7 +213,7 @@ public class S3WaitOperatorFactoryTest
         for (int i = 1; i < retryIntervals.size(); i++) {
             int prevInterval = retryIntervals.get(i - 1);
             int interval = retryIntervals.get(i);
-            assertThat(interval, is((int)Math.min(MAX_POLL_INTERVAL, prevInterval * 2)));
+            assertThat(interval, is(Math.min(MAX_POLL_INTERVAL, prevInterval * 2)));
         }
 
         assertThat(retryIntervals.get(retryIntervals.size() - 1), is(MAX_POLL_INTERVAL));

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/aws/S3WaitOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/aws/S3WaitOperatorFactoryTest.java
@@ -53,7 +53,6 @@ public class S3WaitOperatorFactoryTest
 {
     private static final int MINI_POLL_INTERVAL = 5;
     private static final int MAX_POLL_INTERVAL = 300;
-    private static final double NEXT_INTERVAL_EXP_BASE = 1.2;
 
     private static final String BUCKET = "test.bucket";
     private static final String KEY = "a/test/key";
@@ -172,6 +171,7 @@ public class S3WaitOperatorFactoryTest
         expectedStoreParams
                 .getNestedOrSetEmpty("s3")
                 .getNestedOrSetEmpty("last_object")
+                .set("stored", true)
                 .set("metadata", objectMetadata.getRawMetadata())
                 .set("user_metadata", objectMetadata.getUserMetadata());
 
@@ -215,7 +215,7 @@ public class S3WaitOperatorFactoryTest
         for (int i = 1; i < retryIntervals.size(); i++) {
             int prevInterval = retryIntervals.get(i - 1);
             int interval = retryIntervals.get(i);
-            assertThat(interval, is((int)Math.min(MAX_POLL_INTERVAL, MINI_POLL_INTERVAL * Math.pow(NEXT_INTERVAL_EXP_BASE, i))));
+            assertThat(interval, is((int)Math.min(MAX_POLL_INTERVAL, prevInterval * 2)));
         }
 
         assertThat(retryIntervals.get(retryIntervals.size() - 1), is(MAX_POLL_INTERVAL));

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/state/PollingWaiterTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/state/PollingWaiterTest.java
@@ -1,0 +1,86 @@
+package io.digdag.standards.operator.state;
+
+import com.google.common.base.Optional;
+import io.digdag.client.DigdagClient;
+import io.digdag.client.config.ConfigFactory;
+import io.digdag.spi.TaskExecutionException;
+import io.digdag.standards.operator.DurationInterval;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+
+import static io.digdag.standards.operator.state.PollingWaiter.pollingWaiter;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class PollingWaiterTest
+{
+    private static Logger logger = LoggerFactory.getLogger(PollingWaiterTest.class);
+
+    private static final ConfigFactory CF = new ConfigFactory(DigdagClient.objectMapper());
+    private static final DurationInterval POLL_INTERVAL = DurationInterval.of(Duration.ofSeconds(5), Duration.ofSeconds(20));
+
+    @Test
+    public void testNotimeout()
+    {
+        Integer expected = 99;
+        Integer answer = null;
+        List<Optional<Integer>> reterns = Arrays.asList(Optional.absent(), Optional.absent(), Optional.of(expected));
+        TaskState state = TaskState.of(CF.create());
+        for (Optional<Integer> ret: reterns) {
+            logger.debug("state:{}", state);
+            try {
+                answer = pollingWaiter(state, "EXISTS")
+                        .withPollInterval(POLL_INTERVAL)
+                        .withWaitMessage("Return value does not exist")
+                        .await( pollstate  -> { return ret;} );
+            }
+            catch (TaskExecutionException te) {
+                logger.debug("TaskExecutionException interval:{}", te.getRetryInterval());
+                if (te.getRetryInterval().isPresent()) {
+                    try {
+                        Thread.sleep(te.getRetryInterval().get() * 1000);
+                    }
+                    catch (InterruptedException ie) {
+
+                    }
+                }
+            }
+        }
+        assertThat("Get answer finally", answer != null);
+        assertThat("Correct answer ", answer.intValue() == expected.intValue());
+    }
+
+    @Test(expected = PollingTimeoutException.class)
+    public void testTimeout()
+    {
+        Integer expected = 99;
+        Integer answer = null;
+        List<Optional<Integer>> reterns = Arrays.asList(Optional.absent(), Optional.absent(), Optional.of(expected));
+        TaskState state = TaskState.of(CF.create());
+        for (Optional<Integer> ret: reterns) {
+            logger.debug("state:{}", state);
+            try {
+                answer = pollingWaiter(state, "EXISTS")
+                        .withTimeout(Optional.of(Duration.ofSeconds(10)))
+                        .withPollInterval(POLL_INTERVAL)
+                        .withWaitMessage("Return value does not exist")
+                        .await( pollstate  -> { return ret;} );
+            }
+            catch (TaskExecutionException te) {
+                logger.debug("TaskExecutionException interval:{}", te.getRetryInterval());
+                if (te.getRetryInterval().isPresent()) {
+                    try {
+                        Thread.sleep(te.getRetryInterval().get() * 1000);
+                    }
+                    catch (InterruptedException ie) {
+
+                    }
+                }
+            }
+        }
+    }
+}

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/state/PollingWaiterTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/state/PollingWaiterTest.java
@@ -22,7 +22,7 @@ public class PollingWaiterTest
     private static Logger logger = LoggerFactory.getLogger(PollingWaiterTest.class);
 
     private static final ConfigFactory CF = new ConfigFactory(DigdagClient.objectMapper());
-    private static final DurationInterval POLL_INTERVAL = DurationInterval.of(Duration.ofSeconds(5), Duration.ofSeconds(20));
+    private static final DurationInterval POLL_INTERVAL = DurationInterval.of(Duration.ofSeconds(5), Duration.ofSeconds(300));
 
     @Test
     public void testNotimeout()
@@ -97,9 +97,8 @@ public class PollingWaiterTest
         for (int loop = 0; loop < 10 && pollException == null; loop++){
             try {
                 answer = pollingWaiter(state, "EXISTS")
-                        .withTimeout(Optional.of(Duration.ofSeconds(30)))
+                        .withTimeout(Optional.of(Duration.ofSeconds(10)))
                         .withPollInterval(POLL_INTERVAL)
-                        .withNextIntervalExpBase(1.2)
                         .withWaitMessage("Return value does not exist")
                         .await(pollstate -> {
                             return Optional.absent();
@@ -119,9 +118,5 @@ public class PollingWaiterTest
             }
         }
         assertThat( "PollingTimeoutException must be caught", pollException != null);
-        // floor(5*1.2**N) : 5, 6, 7, 8, 10...
-        assertThat("First interval must be 5", intervalList.get(0).intValue() == 5);
-        assertThat("Second interval must be 6", intervalList.get(1).intValue() == 6);
-        assertThat("Second interval must be 7", intervalList.get(2).intValue() == 7);
     }
 }

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/state/PollingWaiterTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/state/PollingWaiterTest.java
@@ -61,13 +61,13 @@ public class PollingWaiterTest
         Integer expected = 99;
         Integer answer = null;
         List<Integer> intervalList = new ArrayList<>();
-        List<Optional<Integer>> reterns = Arrays.asList(Optional.absent(), Optional.absent(), Optional.of(expected));
+        List<Optional<Integer>> reterns = Arrays.asList(Optional.absent(), Optional.absent(), Optional.absent(), Optional.of(expected));
         TaskState state = TaskState.of(CF.create());
         for (Optional<Integer> ret: reterns) {
             logger.debug("state:{}", state);
             try {
                 answer = pollingWaiter(state, "EXISTS")
-                        .withTimeout(Optional.of(Duration.ofSeconds(10)))
+                        .withTimeout(Optional.of(Duration.ofSeconds(20)))
                         .withPollInterval(POLL_INTERVAL)
                         .withWaitMessage("Return value does not exist")
                         .await( pollstate  -> { return ret;} );
@@ -97,7 +97,7 @@ public class PollingWaiterTest
         for (int loop = 0; loop < 10 && pollException == null; loop++){
             try {
                 answer = pollingWaiter(state, "EXISTS")
-                        .withTimeout(Optional.of(Duration.ofSeconds(10)))
+                        .withTimeout(Optional.of(Duration.ofSeconds(20)))
                         .withPollInterval(POLL_INTERVAL)
                         .withWaitMessage("Return value does not exist")
                         .await(pollstate -> {
@@ -117,6 +117,9 @@ public class PollingWaiterTest
                 pollException = pe;
             }
         }
+        assertThat("First interval is 5", intervalList.get(0) == 5);
+        assertThat("Second interval is 10", intervalList.get(1) == 10);
+        assertThat("Third interval is less than 20", intervalList.get(2) < 20);
         assertThat( "PollingTimeoutException must be caught", pollException != null);
     }
 }

--- a/digdag-tests/src/test/java/acceptance/S3WaitIT.java
+++ b/digdag-tests/src/test/java/acceptance/S3WaitIT.java
@@ -251,7 +251,7 @@ public class S3WaitIT
         //Verify outfile
         String outfileText = new String(Files.readAllBytes(outfile), UTF_8);
         assertThat(outfileText.contains("Finished task +wait"), is(true));
-        assertThat(outfileText.contains("Read s3 variable"), is(true));
+        assertThat(outfileText.contains("Empty is good"), is(true));
 
     }
 

--- a/digdag-tests/src/test/java/acceptance/S3WaitIT.java
+++ b/digdag-tests/src/test/java/acceptance/S3WaitIT.java
@@ -1,8 +1,12 @@
 package acceptance;
 
 import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.client.builder.AwsClientBuilder;
+import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.util.StringInputStream;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -12,13 +16,14 @@ import io.digdag.client.DigdagClient;
 import io.digdag.client.api.Id;
 import io.digdag.client.api.RestSessionAttempt;
 import org.apache.commons.lang3.RandomUtils;
-import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.littleshoot.proxy.HttpProxyServer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import utils.TemporaryDigdagServer;
 import utils.TestUtils;
 
@@ -28,6 +33,7 @@ import java.time.Duration;
 import java.util.Base64;
 import java.util.UUID;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isEmptyOrNullString;
 import static org.hamcrest.Matchers.not;
@@ -41,6 +47,8 @@ import static utils.TestUtils.startWorkflow;
 
 public class S3WaitIT
 {
+    private static Logger logger = LoggerFactory.getLogger(S3WaitIT.class);
+
     private static final String TEST_S3_ENDPOINT = System.getenv("TEST_S3_ENDPOINT");
     private static final String TEST_S3_ACCESS_KEY_ID = System.getenv().getOrDefault("TEST_S3_ACCESS_KEY_ID", "test");
     private static final String TEST_S3_SECRET_ACCESS_KEY = System.getenv().getOrDefault("TEST_S3_SECRET_ACCESS_KEY", "test");
@@ -57,7 +65,7 @@ public class S3WaitIT
     private HttpProxyServer proxyServer;
     private String bucket;
 
-    private AmazonS3Client s3;
+    private AmazonS3 s3;
 
     @Before
     public void setUp()
@@ -87,8 +95,10 @@ public class S3WaitIT
         bucket = UUID.randomUUID().toString();
 
         AWSCredentials credentials = new BasicAWSCredentials(TEST_S3_ACCESS_KEY_ID, TEST_S3_SECRET_ACCESS_KEY);
-        s3 = new AmazonS3Client(credentials);
-        s3.setEndpoint(TEST_S3_ENDPOINT);
+        s3 = AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(TEST_S3_ENDPOINT, null))
+                .build();
         s3.createBucket(bucket);
     }
 
@@ -163,4 +173,87 @@ public class S3WaitIT
         int contentLength = objectMetadata.get("metadata").get("Content-Length").asInt();
         assertThat(contentLength, is(content.length()));
     }
+
+    @Test
+    public void testTimeout()
+            throws Exception
+    {
+        String key = UUID.randomUUID().toString();
+
+        Path outfile = folder.newFolder().toPath().resolve("out");
+
+        createProject(projectDir);
+        addWorkflow(projectDir, "acceptance/s3/s3_wait_timeout.dig");
+
+        Id projectId = TestUtils.pushProject(server.endpoint(), projectDir);
+
+        // Configure AWS credentials
+        client.setProjectSecret(projectId, "aws.s3.access_key_id", TEST_S3_ACCESS_KEY_ID);
+        client.setProjectSecret(projectId, "aws.s3.secret_access_key", TEST_S3_SECRET_ACCESS_KEY);
+        client.setProjectSecret(projectId, "aws.s3.endpoint", TEST_S3_ENDPOINT);
+
+        // Start workflow
+        String projectName = projectDir.getFileName().toString();
+        Id attemptId = startWorkflow(server.endpoint(), projectName, "s3_wait_timeout", ImmutableMap.of(
+                "path", bucket + "/" + key,
+                "outfile", outfile.toString()
+        ));
+
+        // Wait for s3 polling finish because of timeout
+        expect(Duration.ofSeconds(30), () -> {
+            RestSessionAttempt attempt = client.getSessionAttempt(attemptId);
+            return attempt.getDone();
+        });
+
+        // Verify that the attempt is done and failed
+        RestSessionAttempt attempt = client.getSessionAttempt(attemptId);
+        assertThat(attempt.getDone(), is(true));
+        assertThat(attempt.getSuccess(), is(false));
+        assertThat(attempt.getFinishedAt().isPresent(), is(true));
+    }
+
+    @Test
+    public void testIgnoreTimeoutError()
+            throws Exception
+    {
+        String key = UUID.randomUUID().toString();
+
+        Path outfile = folder.newFolder().toPath().resolve("out");
+
+        createProject(projectDir);
+        addWorkflow(projectDir, "acceptance/s3/s3_wait_ignore_timeout_error.dig");
+
+        Id projectId = TestUtils.pushProject(server.endpoint(), projectDir);
+
+        // Configure AWS credentials
+        client.setProjectSecret(projectId, "aws.s3.access_key_id", TEST_S3_ACCESS_KEY_ID);
+        client.setProjectSecret(projectId, "aws.s3.secret_access_key", TEST_S3_SECRET_ACCESS_KEY);
+        client.setProjectSecret(projectId, "aws.s3.endpoint", TEST_S3_ENDPOINT);
+
+        // Start workflow
+        String projectName = projectDir.getFileName().toString();
+        Id attemptId = startWorkflow(server.endpoint(), projectName, "s3_wait_ignore_timeout_error", ImmutableMap.of(
+                "path", bucket + "/" + key,
+                "outfile", outfile.toString()
+        ));
+
+        // Wait for s3 polling finish because of timeout
+        expect(Duration.ofSeconds(30), () -> {
+            RestSessionAttempt attempt = client.getSessionAttempt(attemptId);
+            return attempt.getDone();
+        });
+
+        // Verify that the attempt is done and failed
+        RestSessionAttempt attempt = client.getSessionAttempt(attemptId);
+        assertThat(attempt.getDone(), is(true));
+        assertThat(attempt.getSuccess(), is(false));
+        assertThat(attempt.getFinishedAt().isPresent(), is(true));
+
+        //Verify outfile
+        String outfileText = new String(Files.readAllBytes(outfile), UTF_8);
+        assertThat(outfileText.contains("Finished task +wait"), is(true));
+        assertThat(outfileText.contains("Read s3 variable"), is(false));
+
+    }
+
 }

--- a/digdag-tests/src/test/java/acceptance/S3WaitIT.java
+++ b/digdag-tests/src/test/java/acceptance/S3WaitIT.java
@@ -199,7 +199,7 @@ public class S3WaitIT
         ));
 
         // Wait for s3 polling finish because of timeout
-        expect(Duration.ofSeconds(30), () -> {
+        expect(Duration.ofSeconds(60), () -> {
             RestSessionAttempt attempt = client.getSessionAttempt(attemptId);
             return attempt.getDone();
         });
@@ -237,7 +237,7 @@ public class S3WaitIT
         ));
 
         // Wait for s3 polling finish because of timeout
-        expect(Duration.ofSeconds(30), () -> {
+        expect(Duration.ofSeconds(60), () -> {
             RestSessionAttempt attempt = client.getSessionAttempt(attemptId);
             return attempt.getDone();
         });

--- a/digdag-tests/src/test/resources/acceptance/s3/s3_wait_continue_on_timeout.dig
+++ b/digdag-tests/src/test/resources/acceptance/s3/s3_wait_continue_on_timeout.dig
@@ -2,7 +2,7 @@
 +wait:
   s3_wait>: ${path}
   timeout: 10s
-  ignore_timeout_error: true
+  continue_on_timeout: true
 
 +task1:
   sh>: echo 'Finished task +wait' > '${outfile}'

--- a/digdag-tests/src/test/resources/acceptance/s3/s3_wait_continue_on_timeout.dig
+++ b/digdag-tests/src/test/resources/acceptance/s3/s3_wait_continue_on_timeout.dig
@@ -7,5 +7,9 @@
 +task1:
   sh>: echo 'Finished task +wait' > '${outfile}'
 
-+end:
-  sh>: echo 'Read s3 variable ${s3}' > '${outfile}'
++check_object:
+  if>: ${s3.last_object}
+  _do:
+    sh>: echo "Not empty is bad" >> '${outfile}'
+  _else_do:
+    sh>: echo "Empty is good" >> '${outfile}'

--- a/digdag-tests/src/test/resources/acceptance/s3/s3_wait_ignore_timeout_error.dig
+++ b/digdag-tests/src/test/resources/acceptance/s3/s3_wait_ignore_timeout_error.dig
@@ -1,0 +1,11 @@
+
++wait:
+  s3_wait>: ${path}
+  timeout: 10s
+  ignore_timeout_error: true
+
++task1:
+  sh>: echo 'Finished task +wait' > '${outfile}'
+
++end:
+  sh>: echo 'Read s3 variable ${s3}' > '${outfile}'

--- a/digdag-tests/src/test/resources/acceptance/s3/s3_wait_timeout.dig
+++ b/digdag-tests/src/test/resources/acceptance/s3/s3_wait_timeout.dig
@@ -1,0 +1,6 @@
+
++wait:
+  s3_wait>: ${path}
+  timeout: 10s
++end:
+  sh>: echo '${s3.last_object}' > '${outfile}'


### PR DESCRIPTION
This PR introduces timeout for s3_wait> operator.
The following two options are introduced.

- **timeout**  : set timeout duration.
- **ignore_timeout_error** : if true, the task will finish successfully.

example:
```
+task1:
  s3_wait>: <buckect>/<file>
  timeout: 120s
  ignore_timeout_error: true
```

### Interval calculation
This PR changed the interval calculation.
Interval start 5 seconds and gradually increase and  5 minutes is max.
The current formula is as follows.
```
 5sec * 2^(n-1)    (n: num of iteration)
```
It is too much increase if timeout parameter is not so large.
For example if timeout is 180s, the task will be time out after n=6 because total interval is 155. But next interval in n=6 is 160. So the task wait time will be 315seconds. 
It is over 130 seconds.

|               | n=1  | 2   | 3     | 4   | 5  |6  |   7|
|:-:           |:-:     |:-:   |:-:    |:-:   |:-: |:-: |  :-: |
| interval |  5     | 10  | 20  | 40 | 80|160|320|
|total       |  0     | 5    | 15   |35  |75 |155|315|

To mitigate, this PR changed exponential base value from 2 to 1.2.
In this case, total wait time will be 197 seconds and the over time is 17.
