### PR TITLE
Add @Deprecated annotation to deprecated JAX-RS resources for Swagger

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/Server.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Server.java
@@ -117,7 +117,8 @@ public class Server
         err.println("        --disable-executor-loop      disable workflow executor loop");
         err.println("        --disable-scheduler          disable scheduler");
         err.println("        --disable-local-agent        disable local task execution");
-        err.println("        --enable-swagger             enable swagger api");
+        err.println("        --enable-swagger             enable swagger api. Do not use in production because CORS");
+        err.println("                                     is also enabled on from any domains with all HTTP methods");
         err.println("    -p, --param KEY=VALUE            overwrites a parameter (use multiple times to set many parameters)");
         err.println("    -H, --header KEY=VALUE           a header to include in api HTTP responses");
         err.println("    -P, --params-file PATH.yml       reads parameters from a YAML file");

--- a/digdag-server/src/main/java/io/digdag/server/rs/AdminResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/AdminResource.java
@@ -39,6 +39,7 @@ public class AdminResource
         this.tm = tm;
     }
 
+    @Deprecated
     @GET
     @Path("/api/admin/attempts/{id}/userinfo")
     public Config getUserInfo(@PathParam("id") long id)

--- a/digdag-server/src/main/java/io/digdag/server/rs/AdminResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/AdminResource.java
@@ -9,6 +9,7 @@ import io.digdag.core.repository.StoredRevision;
 import io.digdag.core.session.SessionStoreManager;
 import io.digdag.core.session.StoredSessionAttemptWithSession;
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.NotFoundException;
@@ -42,6 +43,7 @@ public class AdminResource
     @Deprecated
     @GET
     @Path("/api/admin/attempts/{id}/userinfo")
+    @ApiOperation("(deprecated)")
     public Config getUserInfo(@PathParam("id") long id)
             throws ResourceNotFoundException
     {

--- a/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
@@ -227,6 +227,7 @@ public class ProjectResource
         return proj;
     }
 
+    @Deprecated
     @GET
     @Path("/api/project")
     public RestProject getProject(@QueryParam("name") String name)
@@ -299,6 +300,7 @@ public class ProjectResource
         }, ResourceNotFoundException.class);
     }
 
+    @Deprecated
     @GET
     @Path("/api/projects/{id}/workflow")
     public RestWorkflowDefinition getWorkflow(@PathParam("id") int projId, @QueryParam("name") String name, @QueryParam("revision") String revName)

--- a/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
@@ -229,9 +229,11 @@ public class ProjectResource
         return proj;
     }
 
+    // /<singular> style is deprecated. Use /api/projects with filter instead
     @Deprecated
     @GET
     @Path("/api/project")
+    @ApiOperation("(deprecated)")
     public RestProject getProject(@QueryParam("name") String name)
             throws ResourceNotFoundException
     {
@@ -315,9 +317,11 @@ public class ProjectResource
         }, ResourceNotFoundException.class);
     }
 
+    // /<singular> style is deprecated. Use /api/projects/{id}/workflows with filter instead
     @Deprecated
     @GET
     @Path("/api/projects/{id}/workflow")
+    @ApiOperation("(deprecated)")
     public RestWorkflowDefinition getWorkflow(@PathParam("id") int projId, @QueryParam("name") String name, @QueryParam("revision") String revName)
             throws ResourceNotFoundException
     {

--- a/digdag-server/src/main/java/io/digdag/server/rs/WorkflowResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/WorkflowResource.java
@@ -77,6 +77,7 @@ public class WorkflowResource
         this.tm = tm;
     }
 
+    @Deprecated
     @GET
     @Path("/api/workflow")
     public RestWorkflowDefinition getWorkflowDefinition(

--- a/digdag-server/src/main/java/io/digdag/server/rs/WorkflowResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/WorkflowResource.java
@@ -79,9 +79,11 @@ public class WorkflowResource
         this.tm = tm;
     }
 
+    // /<singular> style is deprecated. Use /api/workflows with filter instead
     @Deprecated
     @GET
     @Path("/api/workflow")
+    @ApiOperation("(deprecated)")
     public RestWorkflowDefinition getWorkflowDefinition(
             @QueryParam("project") String projName,
             @QueryParam("revision") String revName,


### PR DESCRIPTION
Swagger API document displays endpoints with `@Deprecated` annotation
with grayed out.