### PR TITLE
Add swagger documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ venv*
 .venv*
 /dist/*.tar.gz
 /config/test_postgresql.properties
+/config/dummy.properties
 MANIFEST
 pom.xml
 .digdag

--- a/README.md
+++ b/README.md
@@ -109,18 +109,6 @@ You also need following steps after new version has been released.
 ./gradlew releaseSnapshot
 ```
 
-### Checking REST API document
-
-Use `--enable-swagger` option to check the current Digdag REST API.
-
-```
-$ ./gradlew cli
-$ ./pkg/digdag-<current version>.jar server --memory --enable-swagger # Run server with --enable-swagger option
-
-$ docker run -dp 8080:8080 swaggerapi/swagger-ui # Run Swagger-UI on different console
-$ open http://localhost:8080/?url=http://localhost:65432/api/swagger.json # Open api/swagger.json on Swagger-UI
-```
-
 ### Develop digdag-ui
 
 Node.js development server is useful because it reloads changes of digdag-ui source code automatically.
@@ -143,6 +131,23 @@ $ npm install
 $ npm run dev    # starts dev server on http://localhost:9000/
 ```
 
+### Updating REST API document
+
+Run this command to update REST API document at digdag-docs/src/_static/swagger.yaml.
+
+```
+./gradlew swaggerYaml  # dump swagger.yaml file
+```
+
+Use `--enable-swagger` option to check the current Digdag REST API.
+
+```
+$ ./gradlew cli
+$ ./pkg/digdag-<current version>.jar server --memory --enable-swagger # Run server with --enable-swagger option
+
+$ docker run -dp 8080:8080 swaggerapi/swagger-ui # Run Swagger-UI on different console
+$ open http://localhost:8080/?url=http://localhost:65432/api/swagger.json # Open api/swagger.json on Swagger-UI
+```
 
 ### Updating documents
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 Please check [digdag.io](https://digdag.io) and [docs.digdag.io](https://docs.digdag.io) for installation & user manual.
 
+REST API document is available at [swagger.digdag.io](http://swagger.digdag.io/).
+
 ## Development
 
 ### Prerequirements
@@ -35,18 +37,6 @@ $ brew install node
   * sphinx
   * sphinx_rtd_theme
   * recommonmark
-
-### Check Digdag REST API
-
-Use `--enable-swagger` option to check the current Digdag REST API.
-
-```
-$ ./gradlew cli
-$ ./pkg/digdag-<current version>.jar server --memory --enable-swagger # Run server with --enable-swagger option
-
-$ docker run -dp 8080:8080 swaggerapi/swagger-ui # Run Swagger-UI on different console
-$ open http://localhost:8080/?url=http://localhost:65432/api/swagger.json # Open api/swagger.json on Swagger-UI
-```
 
 ### Running tests
 
@@ -119,6 +109,17 @@ You also need following steps after new version has been released.
 ./gradlew releaseSnapshot
 ```
 
+### Checking REST API document
+
+Use `--enable-swagger` option to check the current Digdag REST API.
+
+```
+$ ./gradlew cli
+$ ./pkg/digdag-<current version>.jar server --memory --enable-swagger # Run server with --enable-swagger option
+
+$ docker run -dp 8080:8080 swaggerapi/swagger-ui # Run Swagger-UI on different console
+$ open http://localhost:8080/?url=http://localhost:65432/api/swagger.json # Open api/swagger.json on Swagger-UI
+```
 
 ### Develop digdag-ui
 

--- a/build.gradle
+++ b/build.gradle
@@ -408,6 +408,17 @@ task classpath(dependsOn: [':digdag-cli:classpath']){
     }
 }
 
+task swaggerYaml(dependsOn: ':digdag-cli:shadowJar') {
+    doLast {
+        file("config/dummy.properties").write("")
+        Process server = ["java", "-jar", "digdag-cli/build/libs/digdag-cli-${project.version}-all.jar", "server", "-c", "config/dummy.properties", "--memory", "--enable-swagger"].execute()
+        sleep(5 * 1000)
+        ["curl", "http://127.0.0.1:65432/api/swagger.yaml", "-o", "digdag-docs/src/_static/swagger.yaml"].execute().waitFor()
+        server.destroy()
+        server.waitForOrKill(1000)
+    }
+}
+
 clean {
     delete 'classpath'
     delete 'pkg'

--- a/digdag-docs/src/_static/swagger.yaml
+++ b/digdag-docs/src/_static/swagger.yaml
@@ -1,0 +1,1711 @@
+---
+swagger: "2.0"
+info:
+  description: "Digdag server API"
+  version: "0.9.41-SNAPSHOT"
+  title: "Digdag"
+tags:
+- name: "Schedule"
+- name: "Project"
+- name: "Attempt"
+- name: "Admin"
+- name: "Workflow"
+- name: "Log"
+- name: "Session"
+- name: "Version"
+paths:
+  /api/admin/attempts/{id}/userinfo:
+    get:
+      tags:
+      - "Admin"
+      operationId: "getUserInfo"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        required: true
+        type: "integer"
+        format: "int64"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/Config"
+          headers: {}
+  /api/attempts:
+    get:
+      tags:
+      - "Attempt"
+      summary: "List attempts with filters"
+      description: ""
+      operationId: "getAttempts"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "project"
+        in: "query"
+        description: "exact matching filter on project name"
+        required: false
+        type: "string"
+      - name: "workflow"
+        in: "query"
+        description: "exact matching filter on workflow name"
+        required: false
+        type: "string"
+      - name: "include_retried"
+        in: "query"
+        description: "list more than 1 attempts per session"
+        required: false
+        type: "boolean"
+      - name: "last_id"
+        in: "query"
+        description: "list attempts whose id is grater than this id for pagination"
+        required: false
+        type: "integer"
+        format: "int64"
+      - name: "page_size"
+        in: "query"
+        description: "number of attempts to return"
+        required: false
+        type: "integer"
+        format: "int32"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/RestSessionAttemptCollection"
+    put:
+      tags:
+      - "Attempt"
+      summary: "Start a workflow execution as a new session or a new attempt of an\
+        \ existing session"
+      description: ""
+      operationId: "startAttempt"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/RestSessionAttemptRequest"
+      responses:
+        default:
+          description: "successful operation"
+  /api/attempts/{id}:
+    get:
+      tags:
+      - "Attempt"
+      summary: "Get an attempt"
+      description: ""
+      operationId: "getAttempt"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "attempt id"
+        required: true
+        type: "integer"
+        format: "int64"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/RestSessionAttempt"
+  /api/attempts/{id}/kill:
+    post:
+      tags:
+      - "Attempt"
+      summary: "Set a cancel-requested flag on a running attempt"
+      description: ""
+      operationId: "killAttempt"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "attempt id"
+        required: true
+        type: "integer"
+        format: "int64"
+      responses:
+        default:
+          description: "successful operation"
+  /api/attempts/{id}/retries:
+    get:
+      tags:
+      - "Attempt"
+      summary: "List attempts of a session of a given attempt"
+      description: ""
+      operationId: "getAttemptRetries"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "attempt id"
+        required: true
+        type: "integer"
+        format: "int64"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/RestSessionAttemptCollection"
+  /api/attempts/{id}/tasks:
+    get:
+      tags:
+      - "Attempt"
+      summary: "List tasks of an attempt"
+      description: ""
+      operationId: "getTasks"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "attempt id"
+        required: true
+        type: "integer"
+        format: "int64"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/RestTaskCollection"
+  /api/logs/{attempt_id}/files:
+    get:
+      tags:
+      - "Log"
+      summary: "List log files of an attempt with filters"
+      description: ""
+      operationId: "getFileHandles"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "attempt_id"
+        in: "path"
+        description: "attempt id"
+        required: true
+        type: "integer"
+        format: "int64"
+      - name: "task"
+        in: "query"
+        description: "partial prefix match filter on task name"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/RestLogFileHandleCollection"
+    put:
+      tags:
+      - "Log"
+      operationId: "putFile"
+      consumes:
+      - "application/gzip"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "attempt_id"
+        in: "path"
+        required: true
+        type: "integer"
+        format: "int64"
+      - name: "task"
+        in: "query"
+        required: false
+        type: "string"
+      - name: "file_time"
+        in: "query"
+        required: false
+        type: "integer"
+        format: "int64"
+      - name: "node_id"
+        in: "query"
+        required: false
+        type: "string"
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/InputStream"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/RestLogFilePutResult"
+          headers: {}
+  /api/logs/{attempt_id}/files/{file_name}:
+    get:
+      tags:
+      - "Log"
+      summary: "Download a log file"
+      description: ""
+      operationId: "getFile"
+      produces:
+      - "application/gzip"
+      parameters:
+      - name: "attempt_id"
+        in: "path"
+        description: "attempt id"
+        required: true
+        type: "integer"
+        format: "int64"
+      - name: "file_name"
+        in: "path"
+        description: "log file name"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              type: "string"
+              format: "byte"
+  /api/logs/{attempt_id}/upload_handle:
+    get:
+      tags:
+      - "Log"
+      operationId: "getFileHandles"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "attempt_id"
+        in: "path"
+        required: true
+        type: "integer"
+        format: "int64"
+      - name: "task"
+        in: "query"
+        required: false
+        type: "string"
+      - name: "file_time"
+        in: "query"
+        required: false
+        type: "integer"
+        format: "int64"
+      - name: "node_id"
+        in: "query"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/DirectUploadHandle"
+          headers: {}
+  /api/project:
+    get:
+      tags:
+      - "Project"
+      operationId: "getProject"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "name"
+        in: "query"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/RestProject"
+          headers: {}
+  /api/projects:
+    get:
+      tags:
+      - "Project"
+      summary: "List projects with filters"
+      description: ""
+      operationId: "getProjects"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "name"
+        in: "query"
+        description: "exact matching filter on project name"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/RestProjectCollection"
+    put:
+      tags:
+      - "Project"
+      summary: "Upload a project archive as a new project or a new revision of an\
+        \ existing project"
+      description: ""
+      operationId: "putProject"
+      consumes:
+      - "application/gzip"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "project"
+        in: "query"
+        description: "project name"
+        required: true
+        type: "string"
+      - name: "revision"
+        in: "query"
+        description: "revision"
+        required: true
+        type: "string"
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/InputStream"
+      - name: "Content-Length"
+        in: "header"
+        required: false
+        type: "integer"
+        format: "int64"
+      - name: "schedule_from"
+        in: "query"
+        description: "start scheduling of new workflows from the given time instead\
+          \ of current time"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/RestProject"
+  /api/projects/{id}:
+    get:
+      tags:
+      - "Project"
+      summary: "Get a project"
+      description: ""
+      operationId: "getProject"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "project id"
+        required: true
+        type: "integer"
+        format: "int32"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/RestProject"
+    delete:
+      tags:
+      - "Project"
+      summary: "Delete a project"
+      description: ""
+      operationId: "deleteProject"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        required: true
+        type: "integer"
+        format: "int32"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/RestProject"
+  /api/projects/{id}/archive:
+    get:
+      tags:
+      - "Project"
+      summary: "Download a project archive file"
+      description: ""
+      operationId: "getArchive"
+      produces:
+      - "application/gzip"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "project id"
+        required: true
+        type: "integer"
+        format: "int32"
+      - name: "revision"
+        in: "query"
+        description: "use a given revision of a project instead of the latest revision"
+        required: true
+        type: "string"
+      responses:
+        default:
+          description: "successful operation"
+  /api/projects/{id}/revisions:
+    get:
+      tags:
+      - "Project"
+      summary: "List revisions of a project"
+      description: ""
+      operationId: "getRevisions"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        required: true
+        type: "integer"
+        format: "int32"
+      - name: "last_id"
+        in: "query"
+        description: "deprecated - do not use"
+        required: false
+        type: "integer"
+        format: "int32"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/RestRevisionCollection"
+  /api/projects/{id}/schedules:
+    get:
+      tags:
+      - "Project"
+      summary: "List schedules of a project with filters"
+      description: ""
+      operationId: "getSchedules"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "project id"
+        required: true
+        type: "integer"
+        format: "int32"
+      - name: "workflow"
+        in: "query"
+        description: "exact matching filter on workflow name"
+        required: false
+        type: "string"
+      - name: "last_id"
+        in: "query"
+        description: "list schedules whose id is grater than this id for pagination"
+        required: false
+        type: "integer"
+        format: "int32"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/RestScheduleCollection"
+  /api/projects/{id}/secrets:
+    get:
+      tags:
+      - "Project"
+      summary: "List secret keys of a project"
+      description: ""
+      operationId: "getProjectSecrets"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "project id"
+        required: true
+        type: "integer"
+        format: "int32"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/RestSecretList"
+  /api/projects/{id}/secrets/{key}:
+    put:
+      tags:
+      - "Project"
+      summary: "Set a secret to a project"
+      description: ""
+      operationId: "putProjectSecret"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "project id"
+        required: true
+        type: "integer"
+        format: "int32"
+      - name: "key"
+        in: "path"
+        description: "secret key"
+        required: true
+        type: "string"
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/RestSetSecretRequest"
+      responses:
+        default:
+          description: "successful operation"
+    delete:
+      tags:
+      - "Project"
+      summary: "Delete a secret from a project"
+      description: ""
+      operationId: "deleteProjectSecret"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "project id"
+        required: true
+        type: "integer"
+        format: "int32"
+      - name: "key"
+        in: "path"
+        description: "secret key"
+        required: true
+        type: "string"
+      responses:
+        default:
+          description: "successful operation"
+  /api/projects/{id}/sessions:
+    get:
+      tags:
+      - "Project"
+      summary: "List sessions of a project with filters"
+      description: ""
+      operationId: "getSessions"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "project id"
+        required: true
+        type: "integer"
+        format: "int32"
+      - name: "workflow"
+        in: "query"
+        description: "exact matching filter on workflow name"
+        required: false
+        type: "string"
+      - name: "last_id"
+        in: "query"
+        description: "list sessions whose id is grater than this id for pagination"
+        required: false
+        type: "integer"
+        format: "int64"
+      - name: "page_size"
+        in: "query"
+        description: "number of sessions to return"
+        required: false
+        type: "integer"
+        format: "int32"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/RestSessionCollection"
+  /api/projects/{id}/workflow:
+    get:
+      tags:
+      - "Project"
+      operationId: "getWorkflow"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        required: true
+        type: "integer"
+        format: "int32"
+      - name: "name"
+        in: "query"
+        required: false
+        type: "string"
+      - name: "revision"
+        in: "query"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/RestWorkflowDefinition"
+          headers: {}
+  /api/projects/{id}/workflows:
+    get:
+      tags:
+      - "Project"
+      summary: "List workflows of a project with filters"
+      description: ""
+      operationId: "getWorkflows"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "project id"
+        required: true
+        type: "integer"
+        format: "int32"
+      - name: "revision"
+        in: "query"
+        description: "use a given revision of the project instead of the latest revision"
+        required: true
+        type: "string"
+      - name: "name"
+        in: "query"
+        description: "exact matching filter on workflow name"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/RestWorkflowDefinitionCollection"
+  /api/projects/{id}/workflows/{name}:
+    get:
+      tags:
+      - "Project"
+      operationId: "getWorkflowByName"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        required: true
+        type: "integer"
+        format: "int32"
+      - name: "name"
+        in: "path"
+        required: true
+        type: "string"
+      - name: "revision"
+        in: "query"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/RestWorkflowDefinition"
+          headers: {}
+  /api/schedules:
+    get:
+      tags:
+      - "Schedule"
+      summary: "List schedules"
+      description: ""
+      operationId: "getSchedules"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "last_id"
+        in: "query"
+        description: "list schedules whose id is grater than this id for pagination"
+        required: false
+        type: "integer"
+        format: "int32"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/RestScheduleCollection"
+  /api/schedules/{id}:
+    get:
+      tags:
+      - "Schedule"
+      summary: "Get a schedule"
+      description: ""
+      operationId: "getSchedules"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "schedule id"
+        required: true
+        type: "integer"
+        format: "int32"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/RestSchedule"
+  /api/schedules/{id}/backfill:
+    post:
+      tags:
+      - "Schedule"
+      summary: "Re-schedule past sessions by count or duration"
+      description: ""
+      operationId: "backfillSchedule"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "session id"
+        required: true
+        type: "integer"
+        format: "int32"
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/RestScheduleBackfillRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/RestSessionAttemptCollection"
+  /api/schedules/{id}/disable:
+    post:
+      tags:
+      - "Schedule"
+      summary: "Disable scheduling of new sessions"
+      description: ""
+      operationId: "disableSchedule"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "session id"
+        required: true
+        type: "integer"
+        format: "int32"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/RestScheduleSummary"
+  /api/schedules/{id}/enable:
+    post:
+      tags:
+      - "Schedule"
+      summary: "Re-enable disabled scheduling"
+      description: ""
+      operationId: "enableSchedule"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "session id"
+        required: true
+        type: "integer"
+        format: "int32"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/RestScheduleSummary"
+  /api/schedules/{id}/skip:
+    post:
+      tags:
+      - "Schedule"
+      summary: "Skip future sessions by count or time"
+      description: ""
+      operationId: "skipSchedule"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "session id"
+        required: true
+        type: "integer"
+        format: "int32"
+      - in: "body"
+        name: "body"
+        required: false
+        schema:
+          $ref: "#/definitions/RestScheduleSkipRequest"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/RestScheduleSummary"
+  /api/sessions:
+    get:
+      tags:
+      - "Session"
+      summary: "List sessions"
+      description: ""
+      operationId: "getSessions"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "last_id"
+        in: "query"
+        description: "list sessions whose id is grater than this id for pagination"
+        required: false
+        type: "integer"
+        format: "int64"
+      - name: "page_size"
+        in: "query"
+        description: "number of sessions to return"
+        required: false
+        type: "integer"
+        format: "int32"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/RestSessionCollection"
+  /api/sessions/{id}:
+    get:
+      tags:
+      - "Session"
+      summary: "Get a session"
+      description: ""
+      operationId: "getSession"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "session id"
+        required: true
+        type: "integer"
+        format: "int64"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/RestSession"
+  /api/sessions/{id}/attempts:
+    get:
+      tags:
+      - "Session"
+      summary: "List attempts of a session"
+      description: ""
+      operationId: "getSessionAttempts"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "session id"
+        required: true
+        type: "integer"
+        format: "int64"
+      - name: "last_id"
+        in: "query"
+        description: "list attempts whose id is grater than this id for pagination"
+        required: false
+        type: "integer"
+        format: "int64"
+      - name: "page_size"
+        in: "query"
+        description: "number of attempts to return"
+        required: false
+        type: "integer"
+        format: "int32"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/RestSessionAttemptCollection"
+  /api/version:
+    get:
+      tags:
+      - "Version"
+      summary: "Get server version"
+      description: ""
+      operationId: "getVersion"
+      produces:
+      - "application/json"
+      parameters: []
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "object"
+            additionalProperties:
+              type: "object"
+  /api/version/check:
+    get:
+      tags:
+      - "Version"
+      summary: "Check client version compatibility"
+      description: ""
+      operationId: "checkClientVersion"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "client"
+        in: "query"
+        description: "client version"
+        required: true
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/RestVersionCheckResult"
+  /api/workflow:
+    get:
+      tags:
+      - "Workflow"
+      operationId: "getWorkflowDefinition"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "project"
+        in: "query"
+        required: false
+        type: "string"
+      - name: "revision"
+        in: "query"
+        required: false
+        type: "string"
+      - name: "name"
+        in: "query"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/RestWorkflowDefinition"
+          headers: {}
+  /api/workflows:
+    get:
+      tags:
+      - "Workflow"
+      summary: "List workflows"
+      description: ""
+      operationId: "getWorkflowDefinitions"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "last_id"
+        in: "query"
+        description: "list workflows whose id is grater than this id for pagination"
+        required: false
+        type: "integer"
+        format: "int64"
+      - name: "count"
+        in: "query"
+        description: "number of workflows to return"
+        required: false
+        type: "integer"
+        format: "int32"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/RestWorkflowDefinitionCollection"
+  /api/workflows/{id}:
+    get:
+      tags:
+      - "Workflow"
+      summary: "Get a workflow"
+      description: ""
+      operationId: "getWorkflowDefinition"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "workflow id"
+        required: true
+        type: "integer"
+        format: "int64"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/RestWorkflowDefinition"
+  /api/workflows/{id}/truncated_session_time:
+    get:
+      tags:
+      - "Workflow"
+      summary: "Get truncated local time based on the time zone of a workflow"
+      description: ""
+      operationId: "getWorkflowDefinition"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        description: "workflow id"
+        required: true
+        type: "integer"
+        format: "int64"
+      - name: "session_time"
+        in: "query"
+        description: "session time to be truncated"
+        required: true
+        type: "string"
+      - name: "mode"
+        in: "query"
+        description: "truncation mode - second, minute, hour, day, schedule, or next_schedule"
+        required: false
+        type: "string"
+        enum:
+        - "SECOND"
+        - "MINUTE"
+        - "HOUR"
+        - "DAY"
+        - "SCHEDULE"
+        - "NEXT_SCHEDULE"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            $ref: "#/definitions/RestWorkflowSessionTime"
+definitions:
+  ResumeFrom:
+    allOf:
+    - $ref: "#/definitions/Resume"
+    - type: "object"
+      properties:
+        from:
+          type: "string"
+          readOnly: true
+  DirectUploadHandle:
+    type: "object"
+  Config:
+    type: "object"
+    properties:
+      empty:
+        type: "boolean"
+        default: false
+      factory:
+        $ref: "#/definitions/ConfigFactory"
+      keys:
+        type: "array"
+        items:
+          type: "string"
+  RestSession:
+    type: "object"
+    properties:
+      project:
+        $ref: "#/definitions/IdAndName"
+      id:
+        $ref: "#/definitions/Id"
+      sessionUuid:
+        type: "string"
+        format: "uuid"
+      sessionTime:
+        $ref: "#/definitions/OffsetDateTime"
+      workflow:
+        $ref: "#/definitions/NameOptionalId"
+      lastAttempt:
+        $ref: "#/definitions/Attempt"
+  RestSchedule:
+    type: "object"
+    properties:
+      project:
+        $ref: "#/definitions/IdAndName"
+      id:
+        $ref: "#/definitions/Id"
+      disabledAt:
+        type: "integer"
+        format: "int64"
+      nextScheduleTime:
+        $ref: "#/definitions/OffsetDateTime"
+      nextRunTime:
+        type: "integer"
+        format: "int64"
+      workflow:
+        $ref: "#/definitions/IdAndName"
+  RestProject:
+    type: "object"
+    properties:
+      name:
+        type: "string"
+      id:
+        $ref: "#/definitions/Id"
+      revision:
+        type: "string"
+      archiveType:
+        type: "string"
+      archiveMd5:
+        type: "array"
+        items:
+          type: "string"
+          format: "byte"
+      createdAt:
+        type: "integer"
+        format: "int64"
+      deletedAt:
+        type: "integer"
+        format: "int64"
+      updatedAt:
+        type: "integer"
+        format: "int64"
+  RestLogFileHandle:
+    type: "object"
+    properties:
+      fileSize:
+        type: "integer"
+        format: "int64"
+      agentId:
+        type: "string"
+      direct:
+        $ref: "#/definitions/RestDirectDownloadHandle"
+      fileName:
+        type: "string"
+      taskName:
+        type: "string"
+      fileTime:
+        type: "integer"
+        format: "int64"
+  IdAndName:
+    type: "object"
+    properties:
+      name:
+        type: "string"
+      id:
+        $ref: "#/definitions/Id"
+  ZoneOffset:
+    type: "object"
+    properties:
+      totalSeconds:
+        type: "integer"
+        format: "int32"
+      id:
+        type: "string"
+      rules:
+        $ref: "#/definitions/ZoneRules"
+  RestProjectCollection:
+    type: "object"
+    properties:
+      projects:
+        type: "array"
+        items:
+          $ref: "#/definitions/RestProject"
+  RestVersionCheckResult:
+    type: "object"
+    properties:
+      apiCompatible:
+        type: "boolean"
+        default: false
+      serverVersion:
+        type: "string"
+      upgradeRecommended:
+        type: "boolean"
+        default: false
+  RestWorkflowDefinitionCollection:
+    type: "object"
+    properties:
+      workflows:
+        type: "array"
+        items:
+          $ref: "#/definitions/RestWorkflowDefinition"
+  Attempt:
+    type: "object"
+    properties:
+      id:
+        $ref: "#/definitions/Id"
+      createdAt:
+        type: "integer"
+        format: "int64"
+      retryAttemptName:
+        type: "string"
+      params:
+        $ref: "#/definitions/Config"
+      finishedAt:
+        type: "integer"
+        format: "int64"
+      success:
+        type: "boolean"
+        default: false
+      done:
+        type: "boolean"
+        default: false
+      cancelRequested:
+        type: "boolean"
+        default: false
+  RestLogFilePutResult:
+    type: "object"
+    properties:
+      fileName:
+        type: "string"
+  RestWorkflowDefinition:
+    type: "object"
+    properties:
+      project:
+        $ref: "#/definitions/IdAndName"
+      name:
+        type: "string"
+      id:
+        $ref: "#/definitions/Id"
+      config:
+        $ref: "#/definitions/Config"
+      revision:
+        type: "string"
+      timezone:
+        readOnly: true
+        $ref: "#/definitions/ZoneId"
+  RestWorkflowSessionTime:
+    type: "object"
+    properties:
+      project:
+        $ref: "#/definitions/IdAndName"
+      revision:
+        type: "string"
+      sessionTime:
+        $ref: "#/definitions/OffsetDateTime"
+      timezone:
+        readOnly: true
+        $ref: "#/definitions/ZoneId"
+  RestScheduleBackfillRequest:
+    type: "object"
+    properties:
+      fromTime:
+        type: "integer"
+        format: "int64"
+      attemptName:
+        type: "string"
+      dryRun:
+        type: "boolean"
+        default: false
+      count:
+        type: "integer"
+        format: "int32"
+  ZoneOffsetTransition:
+    type: "object"
+    properties:
+      offsetBefore:
+        $ref: "#/definitions/ZoneOffset"
+      offsetAfter:
+        $ref: "#/definitions/ZoneOffset"
+      overlap:
+        type: "boolean"
+        default: false
+      instant:
+        type: "integer"
+        format: "int64"
+      duration:
+        $ref: "#/definitions/Duration"
+      gap:
+        type: "boolean"
+        default: false
+      dateTimeBefore:
+        type: "string"
+        format: "date-time"
+      dateTimeAfter:
+        type: "string"
+        format: "date-time"
+  RestRevision:
+    type: "object"
+    properties:
+      userInfo:
+        $ref: "#/definitions/Config"
+      revision:
+        type: "string"
+      archiveType:
+        type: "string"
+      archiveMd5:
+        type: "array"
+        items:
+          type: "string"
+          format: "byte"
+      createdAt:
+        type: "integer"
+        format: "int64"
+  RestSessionCollection:
+    type: "object"
+    properties:
+      sessions:
+        type: "array"
+        items:
+          $ref: "#/definitions/RestSession"
+  RestTaskCollection:
+    type: "object"
+    properties:
+      tasks:
+        type: "array"
+        items:
+          $ref: "#/definitions/RestTask"
+  ZoneOffsetTransitionRule:
+    type: "object"
+    properties:
+      month:
+        type: "string"
+        enum:
+        - "JANUARY"
+        - "FEBRUARY"
+        - "MARCH"
+        - "APRIL"
+        - "MAY"
+        - "JUNE"
+        - "JULY"
+        - "AUGUST"
+        - "SEPTEMBER"
+        - "OCTOBER"
+        - "NOVEMBER"
+        - "DECEMBER"
+      timeDefinition:
+        type: "string"
+        enum:
+        - "UTC"
+        - "WALL"
+        - "STANDARD"
+      standardOffset:
+        $ref: "#/definitions/ZoneOffset"
+      offsetBefore:
+        $ref: "#/definitions/ZoneOffset"
+      offsetAfter:
+        $ref: "#/definitions/ZoneOffset"
+      dayOfMonthIndicator:
+        type: "integer"
+        format: "int32"
+      localTime:
+        $ref: "#/definitions/LocalTime"
+      midnightEndOfDay:
+        type: "boolean"
+        default: false
+      dayOfWeek:
+        type: "string"
+        enum:
+        - "MONDAY"
+        - "TUESDAY"
+        - "WEDNESDAY"
+        - "THURSDAY"
+        - "FRIDAY"
+        - "SATURDAY"
+        - "SUNDAY"
+  RestSetSecretRequest:
+    type: "object"
+  LocalTime:
+    type: "object"
+    properties:
+      hour:
+        type: "integer"
+        format: "int32"
+      minute:
+        type: "integer"
+        format: "int32"
+      second:
+        type: "integer"
+        format: "int32"
+      nano:
+        type: "integer"
+        format: "int32"
+  ZoneId:
+    type: "object"
+    properties:
+      rules:
+        $ref: "#/definitions/ZoneRules"
+      id:
+        type: "string"
+  RestTask:
+    type: "object"
+    properties:
+      group:
+        type: "boolean"
+        default: false
+      id:
+        $ref: "#/definitions/Id"
+      state:
+        type: "string"
+      startedAt:
+        type: "integer"
+        format: "int64"
+      fullName:
+        type: "string"
+      parentId:
+        $ref: "#/definitions/Id"
+      upstreams:
+        type: "array"
+        items:
+          $ref: "#/definitions/Id"
+      retryAt:
+        type: "integer"
+        format: "int64"
+      config:
+        $ref: "#/definitions/Config"
+      exportParams:
+        $ref: "#/definitions/Config"
+      storeParams:
+        $ref: "#/definitions/Config"
+      stateParams:
+        $ref: "#/definitions/Config"
+      error:
+        $ref: "#/definitions/Config"
+      updatedAt:
+        type: "integer"
+        format: "int64"
+      cancelRequested:
+        type: "boolean"
+        default: false
+  TemporalUnit:
+    type: "object"
+    properties:
+      duration:
+        $ref: "#/definitions/Duration"
+      durationEstimated:
+        type: "boolean"
+        default: false
+      dateBased:
+        type: "boolean"
+        default: false
+      timeBased:
+        type: "boolean"
+        default: false
+  RestScheduleSummary:
+    type: "object"
+    properties:
+      id:
+        $ref: "#/definitions/Id"
+      disabledAt:
+        type: "integer"
+        format: "int64"
+      nextScheduleTime:
+        $ref: "#/definitions/OffsetDateTime"
+      nextRunTime:
+        type: "integer"
+        format: "int64"
+      createdAt:
+        type: "integer"
+        format: "int64"
+      updatedAt:
+        type: "integer"
+        format: "int64"
+      workflow:
+        $ref: "#/definitions/IdAndName"
+  InputStream:
+    type: "object"
+  RestScheduleSkipRequest:
+    type: "object"
+    properties:
+      nextRunTime:
+        type: "integer"
+        format: "int64"
+      fromTime:
+        type: "integer"
+        format: "int64"
+      dryRun:
+        type: "boolean"
+        default: false
+      nextTime:
+        $ref: "#/definitions/LocalTimeOrInstant"
+      count:
+        type: "integer"
+        format: "int32"
+  RestDirectDownloadHandle:
+    type: "object"
+  Duration:
+    type: "object"
+    properties:
+      seconds:
+        type: "integer"
+        format: "int64"
+      nano:
+        type: "integer"
+        format: "int32"
+      zero:
+        type: "boolean"
+        default: false
+      negative:
+        type: "boolean"
+        default: false
+      units:
+        type: "array"
+        items:
+          $ref: "#/definitions/TemporalUnit"
+  NameOptionalId:
+    type: "object"
+    properties:
+      name:
+        type: "string"
+      id:
+        $ref: "#/definitions/Id"
+  ConfigFactory:
+    type: "object"
+  RestRevisionCollection:
+    type: "object"
+    properties:
+      revisions:
+        type: "array"
+        items:
+          $ref: "#/definitions/RestRevision"
+  RestSessionAttempt:
+    type: "object"
+    properties:
+      project:
+        $ref: "#/definitions/IdAndName"
+      id:
+        $ref: "#/definitions/Id"
+      createdAt:
+        type: "integer"
+        format: "int64"
+      sessionUuid:
+        type: "string"
+        format: "uuid"
+      retryAttemptName:
+        type: "string"
+      params:
+        $ref: "#/definitions/Config"
+      sessionId:
+        $ref: "#/definitions/Id"
+      finishedAt:
+        type: "integer"
+        format: "int64"
+      sessionTime:
+        $ref: "#/definitions/OffsetDateTime"
+      workflow:
+        $ref: "#/definitions/NameOptionalId"
+      success:
+        type: "boolean"
+        default: false
+      done:
+        type: "boolean"
+        default: false
+      cancelRequested:
+        type: "boolean"
+        default: false
+      index:
+        type: "integer"
+        format: "int32"
+  OffsetDateTime:
+    type: "object"
+    properties:
+      offset:
+        $ref: "#/definitions/ZoneOffset"
+      nano:
+        type: "integer"
+        format: "int32"
+      hour:
+        type: "integer"
+        format: "int32"
+      minute:
+        type: "integer"
+        format: "int32"
+      dayOfYear:
+        type: "integer"
+        format: "int32"
+      dayOfWeek:
+        type: "string"
+        enum:
+        - "MONDAY"
+        - "TUESDAY"
+        - "WEDNESDAY"
+        - "THURSDAY"
+        - "FRIDAY"
+        - "SATURDAY"
+        - "SUNDAY"
+      month:
+        type: "string"
+        enum:
+        - "JANUARY"
+        - "FEBRUARY"
+        - "MARCH"
+        - "APRIL"
+        - "MAY"
+        - "JUNE"
+        - "JULY"
+        - "AUGUST"
+        - "SEPTEMBER"
+        - "OCTOBER"
+        - "NOVEMBER"
+        - "DECEMBER"
+      dayOfMonth:
+        type: "integer"
+        format: "int32"
+      year:
+        type: "integer"
+        format: "int32"
+      second:
+        type: "integer"
+        format: "int32"
+      monthValue:
+        type: "integer"
+        format: "int32"
+  LocalTimeOrInstant:
+    type: "object"
+  RestScheduleCollection:
+    type: "object"
+    properties:
+      schedules:
+        type: "array"
+        items:
+          $ref: "#/definitions/RestSchedule"
+  RestSecretList:
+    type: "object"
+  ZoneRules:
+    type: "object"
+    properties:
+      fixedOffset:
+        type: "boolean"
+        default: false
+      transitions:
+        type: "array"
+        items:
+          $ref: "#/definitions/ZoneOffsetTransition"
+      transitionRules:
+        type: "array"
+        items:
+          $ref: "#/definitions/ZoneOffsetTransitionRule"
+  RestSessionAttemptCollection:
+    type: "object"
+    properties:
+      attempts:
+        type: "array"
+        items:
+          $ref: "#/definitions/RestSessionAttempt"
+  RestLogFileHandleCollection:
+    type: "object"
+    properties:
+      files:
+        type: "array"
+        items:
+          $ref: "#/definitions/RestLogFileHandle"
+  Id:
+    type: "object"
+  ResumeFailed:
+    allOf:
+    - $ref: "#/definitions/Resume"
+    - type: "object"
+      properties: {}
+  RestSessionAttemptRequest:
+    type: "object"
+    properties:
+      retryAttemptName:
+        type: "string"
+      params:
+        $ref: "#/definitions/Config"
+      sessionTime:
+        type: "integer"
+        format: "int64"
+      workflowId:
+        $ref: "#/definitions/Id"
+      resume:
+        $ref: "#/definitions/Resume"
+  Resume:
+    type: "object"
+    discriminator: "mode"
+    properties:
+      attemptId:
+        readOnly: true
+        $ref: "#/definitions/Id"
+      mode:
+        type: "string"
+        readOnly: true
+        enum:
+        - "FROM"
+        - "FAILED"

--- a/digdag-docs/src/index.md
+++ b/digdag-docs/src/index.md
@@ -28,6 +28,7 @@ Digdag fits simple replacement of cron, IT operations automation, data analytics
    command_reference.rst
    python_api.rst
    ruby_api.rst
+   rest_api.rst
    internal.rst
    releases.rst
    logo.md

--- a/digdag-docs/src/rest_api.rst
+++ b/digdag-docs/src/rest_api.rst
@@ -1,0 +1,5 @@
+REST API
+==================================
+
+Open API document is available at `swagger.digdag.io <https://swagger.digdag.io/>`_.
+

--- a/digdag-server/src/main/java/io/digdag/server/rs/AttemptResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/AttemptResource.java
@@ -32,6 +32,8 @@ import io.digdag.client.config.ConfigFactory;
 import io.digdag.client.api.*;
 import io.digdag.spi.ScheduleTime;
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 
 @Api("Attempt")
 @Path("/")
@@ -82,11 +84,17 @@ public class AttemptResource
 
     @GET
     @Path("/api/attempts")
+    @ApiOperation("List attempts with filters")
     public RestSessionAttemptCollection getAttempts(
+            @ApiParam(value="exact matching filter on project name", required=false)
             @QueryParam("project") String projName,
+            @ApiParam(value="exact matching filter on workflow name", required=false)
             @QueryParam("workflow") String wfName,
+            @ApiParam(value="list more than 1 attempts per session", required=false)
             @QueryParam("include_retried") boolean includeRetried,
+            @ApiParam(value="list attempts whose id is grater than this id for pagination", required=false)
             @QueryParam("last_id") Long lastId,
+            @ApiParam(value="number of attempts to return", required=false)
             @QueryParam("page_size") Integer pageSize)
             throws ResourceNotFoundException
     {
@@ -119,7 +127,10 @@ public class AttemptResource
 
     @GET
     @Path("/api/attempts/{id}")
-    public RestSessionAttempt getAttempt(@PathParam("id") long id)
+    @ApiOperation("Get an attempt")
+    public RestSessionAttempt getAttempt(
+            @ApiParam(value="attempt id", required=true)
+            @PathParam("id") long id)
             throws ResourceNotFoundException
     {
         return tm.begin(() -> {
@@ -134,7 +145,10 @@ public class AttemptResource
 
     @GET
     @Path("/api/attempts/{id}/retries")
-    public RestSessionAttemptCollection getAttemptRetries(@PathParam("id") long id)
+    @ApiOperation("List attempts of a session of a given attempt")
+    public RestSessionAttemptCollection getAttemptRetries(
+            @ApiParam(value="attempt id", required=true)
+            @PathParam("id") long id)
             throws ResourceNotFoundException
     {
         return tm.begin(() -> {
@@ -147,7 +161,10 @@ public class AttemptResource
 
     @GET
     @Path("/api/attempts/{id}/tasks")
-    public RestTaskCollection getTasks(@PathParam("id") long id)
+    @ApiOperation("List tasks of an attempt")
+    public RestTaskCollection getTasks(
+            @ApiParam(value="attempt id", required=true)
+            @PathParam("id") long id)
     {
         return tm.begin(() -> {
             List<ArchivedTask> tasks = sm.getSessionStore(getSiteId())
@@ -159,6 +176,7 @@ public class AttemptResource
     @PUT
     @Consumes("application/json")
     @Path("/api/attempts")
+    @ApiOperation("Start a workflow execution as a new session or a new attempt of an existing session")
     public Response startAttempt(RestSessionAttemptRequest request)
             throws AttemptLimitExceededException, TaskLimitExceededException, ResourceNotFoundException
     {
@@ -273,7 +291,10 @@ public class AttemptResource
     @POST
     @Consumes("application/json")
     @Path("/api/attempts/{id}/kill")
-    public void killAttempt(@PathParam("id") long id)
+    @ApiOperation("Set a cancel-requested flag on a running attempt")
+    public void killAttempt(
+            @ApiParam(value="attempt id", required=true)
+            @PathParam("id") long id)
             throws ResourceNotFoundException, ResourceConflictException
     {
         tm.<Void, ResourceNotFoundException, ResourceConflictException>begin(() -> {

--- a/digdag-server/src/main/java/io/digdag/server/rs/LogResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/LogResource.java
@@ -24,6 +24,8 @@ import io.digdag.core.log.LogServerManager;
 import io.digdag.client.api.*;
 import io.digdag.spi.*;
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 
 import static io.digdag.core.log.LogServerManager.logFilePrefixFromSessionAttempt;
 
@@ -106,8 +108,11 @@ public class LogResource
 
     @GET
     @Path("/api/logs/{attempt_id}/files")
+    @ApiOperation("List log files of an attempt with filters")
     public RestLogFileHandleCollection getFileHandles(
+            @ApiParam(value="attempt id", required=true)
             @PathParam("attempt_id") long attemptId,
+            @ApiParam(value="partial prefix match filter on task name", required=false)
             @QueryParam("task") String taskName)
             throws ResourceNotFoundException
     {
@@ -121,8 +126,11 @@ public class LogResource
     @GET
     @Produces("application/gzip")
     @Path("/api/logs/{attempt_id}/files/{file_name}")
+    @ApiOperation("Download a log file")
     public byte[] getFile(
+            @ApiParam(value="attempt id", required=true)
             @PathParam("attempt_id") long attemptId,
+            @ApiParam(value="log file name", required=true)
             @PathParam("file_name") String fileName)
             throws ResourceNotFoundException, IOException, StorageFileNotFoundException
     {

--- a/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
@@ -98,6 +98,8 @@ import io.digdag.spi.StorageFileNotFoundException;
 import io.digdag.spi.StorageObject;
 import io.digdag.util.Md5CountInputStream;
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
@@ -244,7 +246,10 @@ public class ProjectResource
 
     @GET
     @Path("/api/projects")
-    public RestProjectCollection getProjects(@QueryParam("name") String name)
+    @ApiOperation("List projects with filters")
+    public RestProjectCollection getProjects(
+            @ApiParam(value="exact matching filter on project name", required=false)
+            @QueryParam("name") String name)
     {
         return tm.begin(() -> {
             ProjectStore ps = rm.getProjectStore(getSiteId());
@@ -275,7 +280,10 @@ public class ProjectResource
 
     @GET
     @Path("/api/projects/{id}")
-    public RestProject getProject(@PathParam("id") int projId)
+    @ApiOperation("Get a project")
+    public RestProject getProject(
+            @ApiParam(value="project id", required=false)
+            @PathParam("id") int projId)
             throws ResourceNotFoundException
     {
         return tm.begin(() -> {
@@ -288,7 +296,14 @@ public class ProjectResource
 
     @GET
     @Path("/api/projects/{id}/revisions")
-    public RestRevisionCollection getRevisions(@PathParam("id") int projId, @QueryParam("last_id") Integer lastId)
+    @ApiOperation("List revisions of a project")
+    public RestRevisionCollection getRevisions(
+            @PathParam("id") int projId,
+            // last_id exists but impossible to use for pagination purpose because
+            // RestRevision doesn't return id. This is a REST API design bug. No
+            // clients can use this parameter appropriately.
+            @ApiParam(value="deprecated - do not use")
+            @QueryParam("last_id") Integer lastId)
             throws ResourceNotFoundException
     {
         return tm.begin(() -> {
@@ -333,9 +348,13 @@ public class ProjectResource
 
     @GET
     @Path("/api/projects/{id}/workflows")
+    @ApiOperation("List workflows of a project with filters")
     public RestWorkflowDefinitionCollection getWorkflows(
+            @ApiParam(value="project id", required=true)
             @PathParam("id") int projId,
+            @ApiParam(value="use a given revision of the project instead of the latest revision", required=true)
             @QueryParam("revision") String revName,
+            @ApiParam(value="exact matching filter on workflow name", required=false)
             @QueryParam("name") String name)
             throws ResourceNotFoundException
     {
@@ -370,10 +389,14 @@ public class ProjectResource
     }
 
     @GET
+    @ApiOperation("List schedules of a project with filters")
     @Path("/api/projects/{id}/schedules")
     public RestScheduleCollection getSchedules(
+            @ApiParam(value="project id", required=true)
             @PathParam("id") int projectId,
+            @ApiParam(value="exact matching filter on workflow name", required=false)
             @QueryParam("workflow") String workflowName,
+            @ApiParam(value="list schedules whose id is grater than this id for pagination", required=false)
             @QueryParam("last_id") Integer lastId)
             throws ResourceNotFoundException
     {
@@ -403,11 +426,16 @@ public class ProjectResource
     }
 
     @GET
+    @ApiOperation("List sessions of a project with filters")
     @Path("/api/projects/{id}/sessions")
     public RestSessionCollection getSessions(
+            @ApiParam(value="project id", required=true)
             @PathParam("id") int projectId,
+            @ApiParam(value="exact matching filter on workflow name", required=false)
             @QueryParam("workflow") String workflowName,
+            @ApiParam(value="list sessions whose id is grater than this id for pagination", required=false)
             @QueryParam("last_id") Long lastId,
+            @ApiParam(value="number of sessions to return", required=false)
             @QueryParam("page_size") Integer pageSize)
             throws ResourceNotFoundException
     {
@@ -433,7 +461,12 @@ public class ProjectResource
     @GET
     @Path("/api/projects/{id}/archive")
     @Produces("application/gzip")
-    public Response getArchive(@PathParam("id") int projId, @QueryParam("revision") String revName)
+    @ApiOperation("Download a project archive file")
+    public Response getArchive(
+            @ApiParam(value="project id", required=true)
+            @PathParam("id") int projId,
+            @ApiParam(value="use a given revision of a project instead of the latest revision", required=true)
+            @QueryParam("revision") String revName)
             throws ResourceNotFoundException
     {
         return tm.begin(() -> {
@@ -491,6 +524,7 @@ public class ProjectResource
 
     @DELETE
     @Path("/api/projects/{id}")
+    @ApiOperation("Delete a project")
     public RestProject deleteProject(@PathParam("id") int projId)
             throws ResourceNotFoundException
     {
@@ -506,8 +540,15 @@ public class ProjectResource
     @PUT
     @Consumes("application/gzip")
     @Path("/api/projects")
-    public RestProject putProject(@QueryParam("project") String name, @QueryParam("revision") String revision,
-            InputStream body, @HeaderParam("Content-Length") long contentLength,
+    @ApiOperation("Upload a project archive as a new project or a new revision of an existing project")
+    public RestProject putProject(
+            @ApiParam(value="project name", required=true)
+            @QueryParam("project") String name,
+            @ApiParam(value="revision", required=true)
+            @QueryParam("revision") String revision,
+            InputStream body,
+            @HeaderParam("Content-Length") long contentLength,
+            @ApiParam(value="start scheduling of new workflows from the given time instead of current time", required=false)
             @QueryParam("schedule_from") String scheduleFromString)
             throws ResourceConflictException, IOException, ResourceNotFoundException
     {
@@ -703,7 +744,13 @@ public class ProjectResource
     @PUT
     @Consumes("application/json")
     @Path("/api/projects/{id}/secrets/{key}")
-    public void putProjectSecret(@PathParam("id") int projectId, @PathParam("key") String key, RestSetSecretRequest request)
+    @ApiOperation("Set a secret to a project")
+    public void putProjectSecret(
+            @ApiParam(value="project id", required=true)
+            @PathParam("id") int projectId,
+            @ApiParam(value="secret key", required=true)
+            @PathParam("key") String key,
+            RestSetSecretRequest request)
             throws ResourceNotFoundException
     {
         tm.begin(() -> {
@@ -725,7 +772,12 @@ public class ProjectResource
 
     @DELETE
     @Path("/api/projects/{id}/secrets/{key}")
-    public void deleteProjectSecret(@PathParam("id") int projectId, @PathParam("key") String key)
+    @ApiOperation("Delete a secret from a project")
+    public void deleteProjectSecret(
+            @ApiParam(value="project id", required=true)
+            @PathParam("id") int projectId,
+            @ApiParam(value="secret key", required=true)
+            @PathParam("key") String key)
             throws ResourceNotFoundException
     {
         tm.begin(() -> {
@@ -748,7 +800,10 @@ public class ProjectResource
     @GET
     @Path("/api/projects/{id}/secrets")
     @Produces("application/json")
-    public RestSecretList getProjectSecrets(@PathParam("id") int projectId)
+    @ApiOperation("List secret keys of a project")
+    public RestSecretList getProjectSecrets(
+            @ApiParam(value="project id", required=true)
+            @PathParam("id") int projectId)
             throws ResourceNotFoundException
     {
         return tm.begin(() -> {

--- a/digdag-server/src/main/java/io/digdag/server/rs/ScheduleResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/ScheduleResource.java
@@ -21,6 +21,8 @@ import io.digdag.core.schedule.ScheduleStoreManager;
 import io.digdag.core.schedule.StoredSchedule;
 import io.digdag.core.session.StoredSessionAttemptWithSession;
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
@@ -66,7 +68,10 @@ public class ScheduleResource
 
     @GET
     @Path("/api/schedules")
-    public RestScheduleCollection getSchedules(@QueryParam("last_id") Integer lastId)
+    @ApiOperation("List schedules")
+    public RestScheduleCollection getSchedules(
+            @ApiParam(value="list schedules whose id is grater than this id for pagination", required=false)
+            @QueryParam("last_id") Integer lastId)
     {
         return tm.begin(() -> {
             List<StoredSchedule> scheds = sm.getScheduleStore(getSiteId())
@@ -78,7 +83,10 @@ public class ScheduleResource
 
     @GET
     @Path("/api/schedules/{id}")
-    public RestSchedule getSchedules(@PathParam("id") int id)
+    @ApiOperation("Get a schedule")
+    public RestSchedule getSchedules(
+            @ApiParam(value="schedule id", required=true)
+            @PathParam("id") int id)
             throws ResourceNotFoundException
     {
         return tm.begin(() -> {
@@ -94,7 +102,11 @@ public class ScheduleResource
     @POST
     @Consumes("application/json")
     @Path("/api/schedules/{id}/skip")
-    public RestScheduleSummary skipSchedule(@PathParam("id") int id, RestScheduleSkipRequest request)
+    @ApiOperation("Skip future sessions by count or time")
+    public RestScheduleSummary skipSchedule(
+            @ApiParam(value="session id", required=true)
+            @PathParam("id") int id,
+            RestScheduleSkipRequest request)
             throws ResourceConflictException, ResourceNotFoundException
     {
         return tm.<RestScheduleSummary, ResourceConflictException, ResourceNotFoundException>begin(() -> {
@@ -136,7 +148,11 @@ public class ScheduleResource
     @POST
     @Consumes("application/json")
     @Path("/api/schedules/{id}/backfill")
-    public RestSessionAttemptCollection backfillSchedule(@PathParam("id") int id, RestScheduleBackfillRequest request)
+    @ApiOperation("Re-schedule past sessions by count or duration")
+    public RestSessionAttemptCollection backfillSchedule(
+            @ApiParam(value="session id", required=true)
+            @PathParam("id") int id,
+            RestScheduleBackfillRequest request)
             throws ResourceConflictException, ResourceLimitExceededException, ResourceNotFoundException
     {
         return tm.<RestSessionAttemptCollection, ResourceConflictException, ResourceLimitExceededException, ResourceNotFoundException>begin(() ->
@@ -153,7 +169,10 @@ public class ScheduleResource
 
     @POST
     @Path("/api/schedules/{id}/disable")
-    public RestScheduleSummary disableSchedule(@PathParam("id") int id)
+    @ApiOperation("Disable scheduling of new sessions")
+    public RestScheduleSummary disableSchedule(
+            @ApiParam(value="session id", required=true)
+            @PathParam("id") int id)
             throws ResourceNotFoundException, ResourceConflictException
     {
         return tm.<RestScheduleSummary, ResourceConflictException, ResourceNotFoundException>begin(() ->
@@ -175,7 +194,10 @@ public class ScheduleResource
 
     @POST
     @Path("/api/schedules/{id}/enable")
-    public RestScheduleSummary enableSchedule(@PathParam("id") int id)
+    @ApiOperation("Re-enable disabled scheduling")
+    public RestScheduleSummary enableSchedule(
+            @ApiParam(value="session id", required=true)
+            @PathParam("id") int id)
             throws ResourceNotFoundException, ResourceConflictException
     {
         return tm.<RestScheduleSummary, ResourceConflictException, ResourceNotFoundException>begin(() -> {

--- a/digdag-server/src/main/java/io/digdag/server/rs/SessionResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/SessionResource.java
@@ -18,6 +18,8 @@ import io.digdag.core.session.StoredSession;
 import io.digdag.core.session.StoredSessionAttempt;
 import io.digdag.core.session.StoredSessionWithLastAttempt;
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -62,8 +64,11 @@ public class SessionResource
 
     @GET
     @Path("/api/sessions")
+    @ApiOperation("List sessions")
     public RestSessionCollection getSessions(
+            @ApiParam(value="list sessions whose id is grater than this id for pagination", required=false)
             @QueryParam("last_id") Long lastId,
+            @ApiParam(value="number of sessions to return", required=false)
             @QueryParam("page_size") Integer pageSize)
     {
         int validPageSize = QueryParamValidator.validatePageSize(Optional.fromNullable(pageSize), MAX_SESSIONS_PAGE_SIZE, DEFAULT_SESSIONS_PAGE_SIZE);
@@ -80,7 +85,10 @@ public class SessionResource
 
     @GET
     @Path("/api/sessions/{id}")
-    public RestSession getSession(@PathParam("id") long id)
+    @ApiOperation("Get a session")
+    public RestSession getSession(
+            @ApiParam(value="session id", required=true)
+            @PathParam("id") long id)
             throws ResourceNotFoundException
     {
         return tm.begin(() -> {
@@ -96,9 +104,13 @@ public class SessionResource
 
     @GET
     @Path("/api/sessions/{id}/attempts")
+    @ApiOperation("List attempts of a session")
     public RestSessionAttemptCollection getSessionAttempts(
+            @ApiParam(value="session id", required=true)
             @PathParam("id") long id,
+            @ApiParam(value="list attempts whose id is grater than this id for pagination", required=false)
             @QueryParam("last_id") Long lastId,
+            @ApiParam(value="number of attempts to return", required=false)
             @QueryParam("page_size") Integer pageSize)
             throws ResourceNotFoundException
     {

--- a/digdag-server/src/main/java/io/digdag/server/rs/VersionResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/VersionResource.java
@@ -6,6 +6,8 @@ import io.digdag.client.Version;
 import io.digdag.client.api.RestVersionCheckResult;
 import io.digdag.server.ClientVersionChecker;
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 
 import java.util.Map;
 import javax.ws.rs.GET;
@@ -33,6 +35,7 @@ public class VersionResource
 
     @GET
     @Path("/api/version")
+    @ApiOperation("Get server version")
     public Map<String, Object> getVersion()
     {
         return ImmutableMap.of("version", version.toString());
@@ -40,7 +43,10 @@ public class VersionResource
 
     @GET
     @Path("/api/version/check")
-    public RestVersionCheckResult checkClientVersion(@QueryParam("client") String clientVersionString)
+    @ApiOperation("Check client version compatibility")
+    public RestVersionCheckResult checkClientVersion(
+            @ApiParam(value="client version", required=true)
+            @QueryParam("client") String clientVersionString)
     {
         Version clientVersion = Version.parse(clientVersionString);
         return RestVersionCheckResult.builder()

--- a/digdag-server/src/main/java/io/digdag/server/rs/WorkflowResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/WorkflowResource.java
@@ -40,6 +40,8 @@ import io.digdag.spi.ScheduleTime;
 import io.digdag.spi.Scheduler;
 import io.digdag.client.api.*;
 import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 import org.apache.commons.compress.archivers.ArchiveInputStream;
 import org.apache.commons.compress.archivers.ArchiveEntry;
@@ -105,8 +107,11 @@ public class WorkflowResource
 
     @GET
     @Path("/api/workflows")
+    @ApiOperation("List workflows")
     public RestWorkflowDefinitionCollection getWorkflowDefinitions(
+            @ApiParam(value="list workflows whose id is grater than this id for pagination", required=false)
             @QueryParam("last_id") Long lastId,
+            @ApiParam(value="number of workflows to return", required=false)
             @QueryParam("count") Integer count)
             throws ResourceNotFoundException
     {
@@ -120,7 +125,10 @@ public class WorkflowResource
 
     @GET
     @Path("/api/workflows/{id}")
-    public RestWorkflowDefinition getWorkflowDefinition(@PathParam("id") long id)
+    @ApiOperation("Get a workflow")
+    public RestWorkflowDefinition getWorkflowDefinition(
+            @ApiParam(value="workflow id", required=true)
+            @PathParam("id") long id)
             throws ResourceNotFoundException
     {
         return tm.begin(() -> {
@@ -133,9 +141,13 @@ public class WorkflowResource
 
     @GET
     @Path("/api/workflows/{id}/truncated_session_time")
+    @ApiOperation("Get truncated local time based on the time zone of a workflow")
     public RestWorkflowSessionTime getWorkflowDefinition(
+            @ApiParam(value="workflow id", required=true)
             @PathParam("id") long id,
+            @ApiParam(value="session time to be truncated", required=true)
             @QueryParam("session_time") LocalTimeOrInstant localTime,
+            @ApiParam(value="truncation mode - second, minute, hour, day, schedule, or next_schedule", required=false)
             @QueryParam("mode") SessionTimeTruncate mode)
             throws ResourceNotFoundException
     {


### PR DESCRIPTION
This PR adds swagger annotations and link to https://swagger.digdag.io.

New `swaggerYaml` task of build.gradle dumps results of `/api/swagger.yaml` to `digdag-docs/src/_static/swagger.yaml` so that it's available at https://docs.digdag.io/_static/swagger.yaml. When we update Swagger API document, we should run `./gradlew swaggerYaml` task to update the file.
