### PR TITLE
Filter project revisions API by name

### DIFF
--- a/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
@@ -335,7 +335,8 @@ public class ProjectResource
                 catch (ResourceNotFoundException ex) {
                     revs = ImmutableList.of();
                 }
-            } else {
+            }
+            else {
                 revs = ps.getRevisions(proj.getId(), 100, Optional.fromNullable(lastId));
             }
 


### PR DESCRIPTION
~This PR introduces Revision API for a specific Project. With the current implementation, there's no way to fetch the latest or specfic revision from REST API. This prevents to get user information associated with revision with the specific project.~

This PR introduces filter by name for Revisions API associated with a specific Project. With the current implementation, we don't have a way to get user info with revision without fetching revisions, but this endpoint fetches fixed number (100) of revisions and we can't fetch older revision than 100.