### PR TITLE
[Master to v0_10] Fix typo, wrong database name.

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseConfig.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseConfig.java
@@ -199,7 +199,7 @@ public interface DatabaseConfig
         switch (config.getType()) {
         case "h2":
             if (config.getRemoteDatabaseConfig().isPresent()) {
-                throw new IllegalArgumentException("Database type is postgresql but remoteDatabaseConfig is not set unexpectedly");
+                throw new IllegalArgumentException("Database type is h2 but remoteDatabaseConfig is not set unexpectedly");
             }
             if (config.getPath().isPresent()) {
                 Path dir = FileSystems.getDefault().getPath(config.getPath().get());


### PR DESCRIPTION
cherry-pick aac839be46d0ac3cd7ab5987e77eddc5211d3f9e