### PR TITLE
[Master to v0_10] Fix bq output parameter, bq.last_jobid MUST NOT be used

### DIFF
--- a/digdag-docs/src/operators/bq.md
+++ b/digdag-docs/src/operators/bq.md
@@ -159,4 +159,4 @@ When you set those parameters, use [digdag secrets command](https://docs.digdag.
 
 * **bq.last_job_id** or **bq.last_jobid**
 
-  The id of the BigQuery job that performed this export. `bq.last_jobid` will be kept for compatibility and remove in near future release.
+  The id of the BigQuery job that executed this query. `bq.last_jobid` will be kept for compatibility and remove in near future release.

--- a/digdag-docs/src/operators/bq.md
+++ b/digdag-docs/src/operators/bq.md
@@ -157,6 +157,9 @@ When you set those parameters, use [digdag secrets command](https://docs.digdag.
 
 ## Output parameters
 
-* **bq.last_job_id** or **bq.last_jobid**
+* **bq.last_job_id**
 
-  The id of the BigQuery job that executed this query. `bq.last_jobid` will be kept for compatibility and remove in near future release.
+  The id of the BigQuery job that executed this query.
+
+  Note: `bq.last_jobid` parameter is kept only for backward compatibility but you must not use it because it will be removed removed in a near future release.
+

--- a/digdag-docs/src/operators/bq.md
+++ b/digdag-docs/src/operators/bq.md
@@ -157,7 +157,6 @@ When you set those parameters, use [digdag secrets command](https://docs.digdag.
 
 ## Output parameters
 
-* **bq.last_job_id**
+* **bq.last_job_id** or **bq.last_jobid**
 
-  The id of the BigQuery job that executed this query.
-
+  The id of the BigQuery job that performed this export. `bq.last_jobid` will be kept for compatibility and remove in near future release.

--- a/digdag-docs/src/operators/bq_extract.md
+++ b/digdag-docs/src/operators/bq_extract.md
@@ -101,6 +101,9 @@ When you set those parameters, use [digdag secrets command](https://docs.digdag.
 
 ## Output parameters
 
-* **bq.last_job_id** or **bq.last_jobid**
+* **bq.last_job_id**
 
-  The id of the BigQuery job that performed this export. `bq.last_jobid` will be kept for compatibility and remove in near future release.
+  The id of the BigQuery job that performed this export.
+
+  Note: `bq.last_jobid` parameter is kept only for backward compatibility but you must not use it because it will be removed removed in a near future release.
+

--- a/digdag-docs/src/operators/bq_extract.md
+++ b/digdag-docs/src/operators/bq_extract.md
@@ -101,7 +101,6 @@ When you set those parameters, use [digdag secrets command](https://docs.digdag.
 
 ## Output parameters
 
-* **bq.last_job_id**
+* **bq.last_job_id** or **bq.last_jobid**
 
-  The id of the BigQuery job that performed this export.
-
+  The id of the BigQuery job that performed this export. `bq.last_jobid` will be kept for compatibility and remove in near future release.

--- a/digdag-docs/src/operators/bq_load.md
+++ b/digdag-docs/src/operators/bq_load.md
@@ -275,6 +275,6 @@ When you set those parameters, use [digdag secrets command](https://docs.digdag.
 
 ## Output parameters
 
-* **bq.last_job_id**
+* **bq.last_job_id** or **bq.last_jobid**
 
-  The id of the BigQuery job that performed this import.
+  The id of the BigQuery job that performed this export. `bq.last_jobid` will be kept for compatibility and remove in near future release.

--- a/digdag-docs/src/operators/bq_load.md
+++ b/digdag-docs/src/operators/bq_load.md
@@ -277,4 +277,4 @@ When you set those parameters, use [digdag secrets command](https://docs.digdag.
 
 * **bq.last_job_id** or **bq.last_jobid**
 
-  The id of the BigQuery job that performed this export. `bq.last_jobid` will be kept for compatibility and remove in near future release.
+  The id of the BigQuery job that performed this import. `bq.last_jobid` will be kept for compatibility and remove in near future release.

--- a/digdag-docs/src/operators/bq_load.md
+++ b/digdag-docs/src/operators/bq_load.md
@@ -275,6 +275,9 @@ When you set those parameters, use [digdag secrets command](https://docs.digdag.
 
 ## Output parameters
 
-* **bq.last_job_id** or **bq.last_jobid**
+* **bq.last_job_id**
 
-  The id of the BigQuery job that performed this import. `bq.last_jobid` will be kept for compatibility and remove in near future release.
+  The id of the BigQuery job that performed this import.
+
+  Note: `bq.last_jobid` parameter is kept only for backward compatibility but you must not use it because it will be removed removed in a near future release.
+

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/gcp/BaseBqJobOperator.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/gcp/BaseBqJobOperator.java
@@ -32,9 +32,11 @@ abstract class BaseBqJobOperator
         Config result = cf.create();
         Config bq = result.getNestedOrSetEmpty("bq");
         bq.set("last_job_id", job.getId());
+        bq.set("last_jobid", job.getId());
         return TaskResult.defaultBuilder(request)
                 .storeParams(result)
                 .addResetStoreParams(ConfigKey.of("bq", "last_job_id"))
+                .addResetStoreParams(ConfigKey.of("bq", "last_jobid"))
                 .build();
     }
 

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/gcp/BaseBqJobOperator.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/gcp/BaseBqJobOperator.java
@@ -31,10 +31,10 @@ abstract class BaseBqJobOperator
         ConfigFactory cf = request.getConfig().getFactory();
         Config result = cf.create();
         Config bq = result.getNestedOrSetEmpty("bq");
-        bq.set("last_jobid", job.getId());
+        bq.set("last_job_id", job.getId());
         return TaskResult.defaultBuilder(request)
                 .storeParams(result)
-                .addResetStoreParams(ConfigKey.of("bq", "last_jobid"))
+                .addResetStoreParams(ConfigKey.of("bq", "last_job_id"))
                 .build();
     }
 


### PR DESCRIPTION
cherry-pick 5b7ec6d7fd4fd1bb54c36495171139ccc1b6b768  6b7b65246ab0d5ab556f74d861b02e3a162cca9b  e9904cdcea7fcefcb932e3c896ee05cd94b95b07  e56abd2fc2b0f98040cf49f505e834447624d858
cherry-pick 62c335172e2b4dee131a05a4fef7cd34646cfe8a