### PR TITLE
Refactoring LocalFileLogServerFactory

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/log/CountingLogOutputStream.java
+++ b/digdag-core/src/main/java/io/digdag/core/log/CountingLogOutputStream.java
@@ -6,7 +6,7 @@ import java.nio.file.Path;
 import java.time.Instant;
 import java.util.zip.GZIPOutputStream;
 
-public class CountingLogOutputStream
+class CountingLogOutputStream
     extends GZIPOutputStream
 {
     private final Path path;


### PR DESCRIPTION
* Avoid creating empty file by checking file size before writing (not
  after) when log rotation happens and then task finishes immediately.

* Removed duplicated `;`

* Omit multiple calls of LogFiles.{formatDataDir,.formatSessionAttemptDir} and getPrefixDir

* Prefer synchronized over ReentrantReadWriteLock because read-write
  lock is unnecessary

Following-up of #1209.