### PR TITLE
Optimize DatabaseProjectStoreManager.getProjectsWithLatestRevision

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
@@ -581,8 +581,9 @@ public class DatabaseProjectStoreManager
             " order by rev.id desc" +
             " limit 1" +
         ") rev" +
-        " where site_id = :siteId" +
-        " and id > :lastId" +
+        " where proj.site_id = :siteId" +
+        " and proj.name is not null" +
+        " and proj.id > :lastId" +
         " order by id asc" +
         " limit :limit")
         List<StoredProjectWithRevision> getProjectsWithLatestRevision(@Bind("siteId") int siteId, @Bind("limit") int limit, @Bind("lastId") int lastId);


### PR DESCRIPTION
Make sure it uses index and always avoid sort or full scan.

Following-up of #1187.

PostgreSQL - before this change:
Index scan on projects
-> Join them with revisions (using nested loop join)
-> Sort them by project_id
-> For each project_id, apply WindowAgg of MAX
-> Filter them by revision_id =max_revision_id

After this change:
Index scan on projects
-> Join them with revisions (using lateral nested loop join)
-> (No sort because result is already sorted by the first index scan)


Details - PostgreSQL before this change:

```
explain analyze select id, site_id, name, created_at, deleted_at, deleted_name, revision_name, revision_created_at, revision_archive_type, revision_archive_md5
from (
 select proj.*, rev.name as revision_name, rev.created_at as revision_created_at, rev.archive_type as revision_archive_type, rev.archive_md5 as revision_archive_md5, rev.id as revision_id, max(rev.id) OVER(partition by rev.project_id) as max_revision_id
 from projects proj
 join revisions rev on proj.id = rev.project_id
 where proj.site_id = 1
 and proj.name is not null
 and proj.id > 0
) projects_with_revision
where projects_with_revision.revision_id = projects_with_revision.max_revision_id
order by id asc
limit 10
;
                                                                                    QUERY PLAN
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=8587.75..8617.09 rows=5 width=131) (actual time=21.412..21.625 rows=10 loops=1)
   ->  Subquery Scan on projects_with_revision  (cost=8587.75..8617.09 rows=5 width=131) (actual time=21.411..21.617 rows=10 loops=1)
         Filter: (projects_with_revision.revision_id = projects_with_revision.max_revision_id)
         Rows Removed by Filter: 120
         ->  WindowAgg  (cost=8587.75..8604.87 rows=978 width=139) (actual time=21.404..21.577 rows=130 loops=1)
               ->  Sort  (cost=8587.75..8590.20 rows=978 width=139) (actual time=21.395..21.438 rows=140 loops=1)
                     Sort Key: rev.project_id
                     Sort Method: quicksort  Memory: 2008kB
                     ->  Nested Loop  (cost=0.84..8539.18 rows=978 width=139) (actual time=0.028..16.594 rows=7600 loops=1)
                           ->  Index Scan using projects_on_site_id_and_name on projects proj  (cost=0.42..278.31 rows=199 width=61) (actual time=0.019..1.091 rows=1080 loops=1)
                                 Index Cond: ((site_id = 1) AND (name IS NOT NULL))
                                 Filter: (id > 0)
                           ->  Index Scan using revisions_on_project_id_and_id on revisions rev  (cost=0.42..41.02 rows=49 width=78) (actual time=0.003..0.009 rows=7 loops=1080)
                                 Index Cond: (project_id = proj.id)
 Planning time: 0.364 ms
 Execution time: 21.692 ms
(16 rows)
```

PostgreSQL after this change:

```
explain analyze select id, site_id, name, created_at, deleted_at, deleted_name, rev.*
from projects proj,
lateral (
  select rev.name as revision_name, rev.created_at as revision_created_at, rev.archive_type as revision_archive_type, rev.archive_md5 as revision_archive_md5
  from revisions rev
  where rev.project_id = proj.id
  order by rev.id desc
  limit 1
) rev
where site_id=1
and name is not null
and id > 0
order by id asc
limit 10
;
                                                                             QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.84..352.74 rows=10 width=131) (actual time=0.031..0.108 rows=10 loops=1)
   ->  Nested Loop  (cost=0.84..7003.55 rows=199 width=131) (actual time=0.030..0.100 rows=10 loops=1)
         ->  Index Scan using projects_pkey on projects proj  (cost=0.42..6728.48 rows=199 width=61) (actual time=0.020..0.044 rows=10 loops=1)
               Index Cond: (id > 0)
               Filter: ((name IS NOT NULL) AND (site_id = 1))
               Rows Removed by Filter: 78
         ->  Limit  (cost=0.42..1.36 rows=1 width=74) (actual time=0.005..0.005 rows=1 loops=10)
               ->  Index Scan using revisions_on_project_id_and_id on revisions rev  (cost=0.42..46.35 rows=49 width=74) (actual time=0.004..0.004 rows=1 loops=10)
                     Index Cond: (project_id = proj.id)
 Planning time: 0.259 ms
 Execution time: 0.145 ms
(11 rows)
```


H2 before this change:

```
SELECT
    PROJ.ID,
    PROJ.SITE_ID,
    PROJ.NAME,
    PROJ.CREATED_AT,
    PROJ.DELETED_AT,
    PROJ.DELETED_NAME,
    REV.NAME AS REVISION_NAME,
    REV.CREATED_AT AS REVISION_CREATED_AT,
    REV.ARCHIVE_TYPE AS REVISION_ARCHIVE_TYPE,
    REV.ARCHIVE_MD5 AS REVISION_ARCHIVE_MD5
FROM (
    SELECT
        PROJECT_ID,
        MAX(ID) AS ID
    FROM PUBLIC.REVISIONS
    GROUP BY PROJECT_ID
) A
    /* SELECT
        PROJECT_ID,
        MAX(ID) AS ID
    FROM PUBLIC.REVISIONS
        /++ PUBLIC.REVISIONS_ON_PROJECT_ID_AND_ID ++/
    GROUP BY PROJECT_ID
     */
INNER JOIN PUBLIC.REVISIONS REV
    /* PUBLIC.PRIMARY_KEY_6: ID = A.ID */
    ON 1=1
    /* WHERE A.ID = REV.ID
    */
INNER JOIN PUBLIC.PROJECTS PROJ
    /* PUBLIC.PRIMARY_KEY_EC4: ID > 0
        AND ID = REV.PROJECT_ID
     */
    ON 1=1
WHERE ((PROJ.ID > 0)
    AND ((PROJ.SITE_ID = 1)
    AND (PROJ.NAME IS NOT NULL)))
    AND ((A.ID = REV.ID)
    AND (PROJ.ID = REV.PROJECT_ID))
ORDER BY 1
LIMIT 10
```

H2 after this change:

```
SELECT
    PROJ.ID,
    PROJ.SITE_ID,
    PROJ.NAME,
    PROJ.CREATED_AT,
    PROJ.DELETED_AT,
    PROJ.DELETED_NAME,
    REV.NAME AS REVISION_NAME,
    REV.CREATED_AT AS REVISION_CREATED_AT,
    REV.ARCHIVE_TYPE AS REVISION_ARCHIVE_TYPE,
    REV.ARCHIVE_MD5 AS REVISION_ARCHIVE_MD5
FROM PUBLIC.PROJECTS PROJ
    /* PUBLIC.PRIMARY_KEY_EC4 */
INNER JOIN (
    SELECT
        PROJECT_ID,
        MAX(REV.ID) AS LATEST_REVISION_ID
    FROM PUBLIC.REVISIONS REV
    INNER JOIN (
        SELECT
            ID
        FROM PUBLIC.PROJECTS PROJ
        WHERE (PROJ.ID > 0)
            AND ((PROJ.SITE_ID = 1)
            AND (PROJ.NAME IS NOT NULL))
        ORDER BY 1
        LIMIT 10
    ) PROJ
        ON 1=1
    WHERE TRUE
    GROUP BY PROJECT_ID
) PROJ_REV
    /* SELECT
        PROJECT_ID,
        MAX(REV.ID) AS LATEST_REVISION_ID
    FROM PUBLIC.REVISIONS REV
        /++ PUBLIC.REVISIONS_ON_PROJECT_ID_AND_ID: PROJECT_ID IS ?1 ++/
        /++ WHERE PROJECT_ID IS ?1
        ++/
    INNER JOIN (
        SELECT
            ID
        FROM PUBLIC.PROJECTS PROJ
        WHERE (PROJ.ID > 0)
            AND ((PROJ.SITE_ID = 1)
            AND (PROJ.NAME IS NOT NULL))
        ORDER BY 1
        LIMIT 10
    ) PROJ
        /++ SELECT
            ID
        FROM PUBLIC.PROJECTS PROJ
            /++ PUBLIC.PROJECTS_ON_SITE_ID_AND_NAME: SITE_ID = 1 ++/
        WHERE (PROJ.ID > 0)
            AND ((PROJ.SITE_ID = 1)
            AND (PROJ.NAME IS NOT NULL))
        ORDER BY 1
        LIMIT 10
         ++/
        ON 1=1
    WHERE PROJECT_ID IS ?1
    GROUP BY PROJECT_ID: PROJECT_ID = PROJ.ID
     */
    ON 1=1
    /* WHERE PROJ.ID = PROJ_REV.PROJECT_ID
    */
INNER JOIN PUBLIC.REVISIONS REV
    /* PUBLIC.PRIMARY_KEY_6: ID = PROJ_REV.LATEST_REVISION_ID
        AND ID = PROJ_REV.LATEST_REVISION_ID
     */
    ON 1=1
WHERE (REV.ID = PROJ_REV.LATEST_REVISION_ID)
    AND (PROJ.ID = PROJ_REV.PROJECT_ID)
ORDER BY 1
/* index sorted */
--
```