### PR TITLE
add command executor provider

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/CommandExecutorModule.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/CommandExecutorModule.java
@@ -1,6 +1,7 @@
 package io.digdag.standards.command;
 
 import com.google.inject.Binder;
+import com.google.inject.Module;
 import com.google.inject.Scopes;
 import io.digdag.spi.CommandExecutor;
 import io.digdag.standards.command.ecs.DefaultEcsClientFactory;

--- a/digdag-standards/src/main/java/io/digdag/standards/command/CommandExecutorModule.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/CommandExecutorModule.java
@@ -1,11 +1,12 @@
 package io.digdag.standards.command;
 
 import com.google.inject.Binder;
-import com.google.inject.Module;
 import com.google.inject.Scopes;
 import io.digdag.spi.CommandExecutor;
 import io.digdag.standards.command.ecs.DefaultEcsClientFactory;
 import io.digdag.standards.command.ecs.EcsClientFactory;
+import io.digdag.standards.command.kubernetes.DefaultKubernetesClientFactory;
+import io.digdag.standards.command.kubernetes.KubernetesClientFactory;
 
 public class CommandExecutorModule
     implements Module
@@ -13,11 +14,8 @@ public class CommandExecutorModule
     @Override
     public void configure(Binder binder)
     {
-        binder.bind(CommandExecutor.class).to(EcsCommandExecutor.class).in(Scopes.SINGLETON);
         binder.bind(EcsClientFactory.class).to(DefaultEcsClientFactory.class).in(Scopes.SINGLETON);
-        //binder.bind(CommandExecutor.class).to(KubernetesCommandExecutor.class).in(Scopes.SINGLETON);
-        //binder.bind(KubernetesClientFactory.class).to(DefaultKubernetesClientFactory.class).in(Scopes.SINGLETON);
-        binder.bind(SimpleCommandExecutor.class).in(Scopes.SINGLETON);
-        binder.bind(DockerCommandExecutor.class).in(Scopes.SINGLETON);
+        binder.bind(KubernetesClientFactory.class).to(DefaultKubernetesClientFactory.class).in(Scopes.SINGLETON);
+        binder.bind(CommandExecutor.class).toProvider(CommandExecutorProvider.class).in(Scopes.SINGLETON);
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/CommandExecutorProvider.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/CommandExecutorProvider.java
@@ -1,0 +1,58 @@
+package io.digdag.standards.command;
+
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigException;
+import io.digdag.core.archive.ProjectArchiveLoader;
+import io.digdag.core.storage.StorageManager;
+import io.digdag.spi.CommandExecutor;
+import io.digdag.spi.CommandLogger;
+import io.digdag.standards.command.ecs.EcsClientFactory;
+import io.digdag.standards.command.kubernetes.KubernetesClientFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CommandExecutorProvider
+        implements Provider<CommandExecutor>
+{
+    CommandExecutor executor;
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    @Inject
+    public CommandExecutorProvider(
+            final Config systemConfig,
+            final EcsClientFactory ecsClientFactory,
+            final KubernetesClientFactory kubernetesClientFactory,
+            final StorageManager storageManager,
+            final ProjectArchiveLoader projectArchiveLoader,
+            final CommandLogger clog)
+    {
+        SimpleCommandExecutor simple = new SimpleCommandExecutor(clog);
+        DockerCommandExecutor docker = new DockerCommandExecutor(clog, simple);
+
+        String executorType = systemConfig.get("agent.command_executor.type", String.class, "");
+        logger.debug("Using command executor type: {}", executorType);
+
+        switch (executorType) {
+            case "ecs":
+                executor = new EcsCommandExecutor(systemConfig, ecsClientFactory, docker, storageManager, projectArchiveLoader, clog);
+                break;
+            case "kubernetes":
+                executor = new KubernetesCommandExecutor(systemConfig, kubernetesClientFactory, docker, storageManager, projectArchiveLoader, clog);
+                break;
+            case "":
+                executor = docker;
+                break;
+            default:
+                throw new ConfigException("Unsupported agent.command_executor.type : " + executorType);
+        }
+    }
+
+    @Override
+    public CommandExecutor get()
+    {
+        return executor;
+    }
+}
+


### PR DESCRIPTION
I made `CommandExecutorProvider` to select a command executor with `agent.command_executor.type`.