### PR TITLE
Fix EcsCommandExecutor to use finish marker to know if logging is finished or not

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -300,7 +300,7 @@ public class EcsCommandExecutor
             long timeout = taskFinishedAt.get() + 60;
             do {
                 previousExecutorStatus = fetchLogEvents(client, task, previousStatus, previousExecutorStatus);
-                if (previousExecutorStatus.get("logging_finished") != null) {
+                if (previousExecutorStatus.get("logging_finished_at") != null) {
                     break;
                 }
             } while (Instant.now().getEpochSecond() < timeout);
@@ -389,7 +389,7 @@ public class EcsCommandExecutor
             for (final OutputLogEvent logEvent : logEvents) {
                 String log = logEvent.getMessage();
                 if (log.contains(ECS_END_OF_TASK_LOG_MARK)) {
-                    nextExecutorStatus.set("logging_finished", JsonNodeFactory.instance.textNode("true"));
+                    nextExecutorStatus.put("logging_finished_at", Instant.now().getEpochSecond());
                 } else {
                     log(log + "\n", clog);
                 }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -316,9 +316,6 @@ public class EcsCommandExecutor
             final ObjectNode nextStatus = previousStatus.deepCopy();
             nextStatus.set("executor_state", previousExecutorStatus);
 
-            // Set exit code of container finished to nextStatus
-            nextStatus.put("status_code", task.getContainers().get(0).getExitCode());
-
             return EcsCommandStatus.of(true, nextStatus);
         }
 
@@ -347,6 +344,8 @@ public class EcsCommandExecutor
             // To fetch log until all logs is written in CloudWatch,
             // finish this poll once and wait finish marker in head of this method in next poll, considering risk of crushing in this poll.
             nextStatus.put("task_finished_at", Instant.now().getEpochSecond());
+            // Set exit code of container finished to nextStatus
+            nextStatus.put("status_code", task.getContainers().get(0).getExitCode());
         }
         else if (defaultCommandTaskTTL.isPresent() && isRunningLongerThanTTL(previousStatus)) {
             final TaskRequest request = commandContext.getTaskRequest();

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -390,7 +390,8 @@ public class EcsCommandExecutor
                 String log = logEvent.getMessage();
                 if (log.contains(ECS_END_OF_TASK_LOG_MARK)) {
                     nextExecutorStatus.put("logging_finished_at", Instant.now().getEpochSecond());
-                } else {
+                } 
+                else {
                     log(log + "\n", clog);
                 }
             }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -390,7 +390,7 @@ public class EcsCommandExecutor
                 String log = logEvent.getMessage();
                 if (log.contains(ECS_END_OF_TASK_LOG_MARK)) {
                     nextExecutorStatus.put("logging_finished_at", Instant.now().getEpochSecond());
-                } 
+                }
                 else {
                     log(log + "\n", clog);
                 }
@@ -650,7 +650,7 @@ public class EcsCommandExecutor
         }
         bashArguments.add(s("tar -zcf %s  --exclude %s --exclude %s .digdag/tmp/", outputProjectArchivePathName, relativeProjectArchivePath.toString(), outputProjectArchivePathName));
         bashArguments.add(s("curl -s -X PUT -T %s -L \"%s\"", outputProjectArchivePathName, outputProjectArchiveDirectUploadUrl));
-        bashArguments.add(s("echo %s", ECS_END_OF_TASK_LOG_MARK));
+        bashArguments.add(s("echo \"%s\"", ECS_END_OF_TASK_LOG_MARK));
         bashArguments.add(s("exit $exit_code"));
 
         final List<String> bashCommand = ImmutableList.<String>builder()

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -387,7 +387,7 @@ public class EcsCommandExecutor
         else {
             for (final OutputLogEvent logEvent : logEvents) {
                 String log = logEvent.getMessage();
-                if (log.equals(ECS_TASK_FINISHED)) {
+                if (log.contains(ECS_TASK_FINISHED)) {
                     nextExecutorStatus.set("logging_finished", JsonNodeFactory.instance.textNode("true"));
                 } else {
                     log(log + "\n", clog);


### PR DESCRIPTION
Currently we cannot get all ECS logs sometimes.
We need to know when task and logging is finished, and after that we should finish logs manipulation.