### PR TITLE
Use https://repo1.maven.org/maven2/ instead of http://central.maven.org/maven2/

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/plugin/RemotePluginLoader.java
+++ b/digdag-core/src/main/java/io/digdag/core/plugin/RemotePluginLoader.java
@@ -46,7 +46,7 @@ public class RemotePluginLoader
     private static final Logger logger = LoggerFactory.getLogger(RemotePluginLoader.class);
 
     private static final List<RemoteRepository> DEFAULT_REPOSITORIES = ImmutableList.copyOf(new RemoteRepository[] {
-        new RemoteRepository.Builder("central", "default", "http://central.maven.org/maven2/").build(),
+        new RemoteRepository.Builder("central", "default", "https://repo1.maven.org/maven2/").build(),
         new RemoteRepository.Builder("jcenter", "default", "http://jcenter.bintray.com/").build(),
     });
 


### PR DESCRIPTION
When accessing to http://central.maven.org/maven2/, maven requires https, so digdag should change this url to maven recommended one.

![image](https://user-images.githubusercontent.com/4525500/72479589-411d8880-3838-11ea-8fc2-8c5007e30531.png)
