### PR TITLE
Change polling interval in operators with CommandExecutor

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/operator/EmbulkOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/EmbulkOperatorFactory.java
@@ -77,7 +77,7 @@ public class EmbulkOperatorFactory
             extends BaseOperator
     {
         // TODO extract as config params.
-        final int scriptPollInterval = (int) Duration.ofSeconds(3).getSeconds();
+        final int scriptPollInterval = (int) Duration.ofSeconds(10).getSeconds();
 
         public EmbulkOperator(OperatorContext context)
         {

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/PyOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/PyOperatorFactory.java
@@ -99,7 +99,7 @@ public class PyOperatorFactory
             extends BaseOperator
     {
         // TODO extract as config params.
-        final int scriptPollInterval = (int) Duration.ofSeconds(3).getSeconds();
+        final int scriptPollInterval = (int) Duration.ofSeconds(10).getSeconds();
 
         public PyOperator(OperatorContext context)
         {

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/RbOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/RbOperatorFactory.java
@@ -86,7 +86,7 @@ public class RbOperatorFactory
             extends BaseOperator
     {
         // TODO extract as config params.
-        final int scriptPollInterval = (int) Duration.ofSeconds(3).getSeconds();
+        final int scriptPollInterval = (int) Duration.ofSeconds(10).getSeconds();
 
         public RbOperator(OperatorContext context)
         {

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/ShOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/ShOperatorFactory.java
@@ -73,7 +73,7 @@ public class ShOperatorFactory
             extends BaseOperator
     {
         // TODO extract as config params.
-        final int scriptPollInterval = (int) Duration.ofSeconds(3).getSeconds();
+        final int scriptPollInterval = (int) Duration.ofSeconds(10).getSeconds();
 
         public ShOperator(OperatorContext context)
         {


### PR DESCRIPTION
py>, rb>, sh>, embulk> operators poll the running task in CommandExecutor.
Currently its interval is 3 secs and too small in some CommandExecutor.
So change it from 3 secs to 10 secs. 
It is better if configurable, but not yet implemented in this PR.

