### PR TITLE
Update jCenter URL to https

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/plugin/RemotePluginLoader.java
+++ b/digdag-core/src/main/java/io/digdag/core/plugin/RemotePluginLoader.java
@@ -47,7 +47,7 @@ public class RemotePluginLoader
 
     private static final List<RemoteRepository> DEFAULT_REPOSITORIES = ImmutableList.copyOf(new RemoteRepository[] {
         new RemoteRepository.Builder("central", "default", "https://repo1.maven.org/maven2/").build(),
-        new RemoteRepository.Builder("jcenter", "default", "http://jcenter.bintray.com/").build(),
+        new RemoteRepository.Builder("jcenter", "default", "https://jcenter.bintray.com/").build(),
     });
 
     private static final List<String> PARENT_FIRST_PACKAGES = ImmutableList.copyOf(new String[] {


### PR DESCRIPTION
To avoid a 403 error we need to update URL to https for jCenter as well (similar to #1321).
Please see the details: https://jfrog.com/blog/secure-jcenter-with-https/
