### PR TITLE
Fix pom task repo url from http to https.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -534,7 +534,7 @@ task pom {
                 repositories {
                     repository {
                         id 'jcenter'
-                        url 'http://jcenter.bintray.com'
+                        url 'https://jcenter.bintray.com'
                         releases {
                             enabled 'true'
                         }


### PR DESCRIPTION
The repository for pom task also uses http in jcenter repository.
Change http to https.
