### PR TITLE
Remove EXPERIMENTAL description

### DIFF
--- a/digdag-docs/src/operators/for_each.md
+++ b/digdag-docs/src/operators/for_each.md
@@ -2,8 +2,6 @@
 
 **for_each>** operator runs subtasks multiple times using sets of variables.
 
-(This operator is EXPERIMENTAL. Parameters may change in a future release)
-
     +repeat:
       for_each>:
         fruit: [apple, orange]

--- a/digdag-docs/src/operators/for_range.md
+++ b/digdag-docs/src/operators/for_range.md
@@ -4,8 +4,6 @@
 
 This operator exports `${range.from}`, `${range.to}`, and `${range.index}` variables for the subtasks. Index begins from 0.
 
-(This operator is EXPERIMENTAL. Parameters may change in a future release)
-
     +repeat:
       for_range>:
         from: 10

--- a/digdag-docs/src/operators/if.md
+++ b/digdag-docs/src/operators/if.md
@@ -1,7 +1,5 @@
 # if>: Conditional execution
 
-(This operator is EXPERIMENTAL. Parameters may change in a future release)
-
 **if>** operator runs `_do` subtasks if `true` is given.
 
     +run_if_param_is_true:


### PR DESCRIPTION
The following are no longer experimental and are now generally available: `for_each>`, `for_range>`, and `if>`. We'd like to remove the "EXPERIMENTAL" description from the documentation.