### PR TITLE
Fix KubernetesCommandExecutor's bash arguments

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/KubernetesCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/KubernetesCommandExecutor.java
@@ -167,6 +167,8 @@ public class KubernetesCommandExecutor
         // Revisit we need it or not for debugging. If the command will be enabled, pods will show commands are executed
         // by the executor and will include pre-signed URLs in the commands.
         //bashArguments.add("set -eux");
+        bashArguments.add(s("mkdir -p %s", projectPath.toString()));
+        bashArguments.add(s("cd %s", projectPath.toString()));
         bashArguments.add(s("mkdir -p %s", ioDirectoryPath.toString()));
 
         // Create project archive on local. Input contents, e.g. input config file and runner script, are included


### PR DESCRIPTION
Here is an example that fails.
```yaml
+test:
  _export:
    kubernetes: #requires https://github.com/treasure-data/digdag/pull/1279
      name: test
      master: https://127.0.0.1
      certs_ca_data: xxxxxx=
      oauth_token: xxxxxx= 
      namespace: default
    docker:
      image: ruby:2.5.1
  rb>: Setup.set_state
  require: 'tasks/setup'
```
```ruby
# tasks/setup.rb
require 'yaml'

class Setup
  def set_state
    environment = Digdag.env.params['environment']

    config = YAML.load_file('config/config.yml')[environment]
    config.each do |key, value|
      Digdag.env.store(key.to_sym => value)
    end
  end
end
```

If you execute the above task with kubernetes command executor, the pod will be in a failed state.
The pod log is as follows.
```
/ /
/usr/local/lib/ruby/site_ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require': cannot load such file -- tasks/setup (LoadError)
        from /usr/local/lib/ruby/site_ruby/2.5.0/rubygems/core_ext/kernel_require.rb:59:in `require'
/
tar: .digdag/tmp: file changed as we read it
```

The commands executed in the pod are as follows.
```
2020-01-27 08:05:42.271 +0000 [DEBUG] (0068@[0:hairstyle-dev]+scoring+test) io.digdag.standards.command.KubernetesCommandExecutor: Submit command line arguments to Kubernetes API: [-c, mkdir -p .digdag/tmp/digdag-rb-590-8724207461419925152; curl -s "https://storage.googleapis.com/test-gcp-project-digdag-archive/590/archive-input-5450624355021829071.tar.gz?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=digdag%40test-gcp-project.iam.gserviceaccount.com%2F20200127%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20200127T080542Z&X-Goog-Expires=600&X-Goog-SignedHeaders=host&X-Goog-Signature=541a05f79d90ffb910fecd87b1b4bafa1ff4033107b97b07c623cbcb78018b5a6932d08f3956b473f685b5df963041a7d9b1b3363bf73630b0f56fb63a8f5d673ad8138c7970ae297d81f130a4af0ec7130d71d2d1fbef3550590f9bbc532a0a95f9e9c35e81fb9bec399835c790595b402eadeffbf5aeaf82459b983f0a1c1882fe7da63c87bbb77c2e6c5f9342f110b43152f7514b92722e9e3a22d97c10fb21131ddd082bace498d9936165668db670fe9690735a56d935a55bb67008e53c645a388dcf56a2a3ac52241ff2c201f30d0f66af21eb72993441a8aafc75f7b29672efdaf9625618b9655d9345779d4be65b2ceac2b6a4e659966d25f05ba486" --output .digdag/tmp/archive-input-5450624355021829071.tar.gz; tar -zxf .digdag/tmp/archive-input-5450624355021829071.tar.gz; pushd .; ruby -I /tmp/digdag-tempdir1500446572381288342/workspace/1_scoring_44_590_8587473721624652545 -r tasks/setup -- .digdag/tmp/digdag-rb-590-8724207461419925152/runner.rb Setup.set_state .digdag/tmp/digdag-rb-590-8724207461419925152/input.json .digdag/tmp/digdag-rb-590-8724207461419925152/output.json; exit_code=$?; popd; tar -zcf .digdag/tmp/archive-output.tar.gz  --exclude .digdag/tmp/archive-input-5450624355021829071.tar.gz --exclude .digdag/tmp/archive-output.tar.gz .digdag/tmp/; curl -s -X PUT -T .digdag/tmp/archive-output.tar.gz -L "https://storage.googleapis.com/test-gcp-project-digdag-archive/590/archive-output.tar.gz?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=digdag%40test-gcp-project.iam.gserviceaccount.com%2F20200127%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20200127T080542Z&X-Goog-Expires=600&X-Goog-SignedHeaders=host&X-Goog-Signature=0c138aa41856033b13b4cd0568a88f1fe7afb67d32b9d7fbdf1d59121cef4b88a67eddd7d8e48743af03f82c10639561915e97461f1ee5a54040d7db278abea63a55bd15e36a7dd3f114726d037bff7df1869972723a5090ba296ead68bfdf41e2bc49160f72252d524063ef5e1c331e135f1d8426be256c9d8dfc6bb21f16a07ecefc1f72e297ee218dbb7ca2b1a6ce6801a60d5fde72ff88f5572e6b6fec0f92a78756adb624d57030be3e1a86398acda702fe130934b6b9d652a150c297d06a3408a3de0c53fad9300bfda9e8afb17d170851b6b2b1867d4095d0732a78838470a76bd994607cc0f5f6187a598fa87e7a2e35ff1ea7e7b6f2e5d8e9902b04"; exit $exit_code]
```
The location to load is specified by the argument `-I`, but the above error has occurred because it does not actually exist.

So fix command arguments to solve above problems.
```
2020-01-27 07:46:29.543 +0000 [DEBUG] (0058@[0:hairstyle-dev]+scoring+test) io.digdag.standards.command.KubernetesCommandExecutor: Submit command line arguments to Kubernetes API: [-c, mkdir -p /tmp/digdag-tempdir7874298179773833314/workspace/1_scoring_41_548_1022647631963152030; cd /tmp/digdag-tempdir7874298179773833314/workspace/1_scoring_41_548_1022647631963152030; mkdir -p .digdag/tmp/digdag-rb-548-2832194056362479611; curl -s "https://storage.googleapis.com/test-gcp-project-digdag-archive/548/archive-input-1303077822488292264.tar.gz?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=digdag%40test-gcp-project.iam.gserviceaccount.com%2F20200127%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20200127T074629Z&X-Goog-Expires=600&X-Goog-SignedHeaders=host&X-Goog-Signature=957e41073a44bd85fd44d3e166eaaf390c59db524d77bcb58055753d591a426b44e5ddd67c298aba14871bd5f2c8eadb407cf23cdf180b4e6348f3bee07e83bd7bea95ab986e971932f6cb363933f5faad4b1fd347ad2e7c423495cd9a206116f07134fd702321a2866a7414e4e82498a556701ffbca12f1a55ea00ce52aab5c2c1ffc7f3f0a479f0ad25eb662b184600be29e231192687ec51247c25b0f84308767c0dc35cf6e460867e6f7c4ba6a9981b282a2099d8b6418d4968ffb0bb62ea662a2112e93feda7d1be5727fe1dfc389f5b1bb5beb45edc3b206f88ff2c447415074407269c679d8d2440087998899953a4806fde75c912ba6036c57a21393" --output .digdag/tmp/archive-input-1303077822488292264.tar.gz; tar -zxf .digdag/tmp/archive-input-1303077822488292264.tar.gz; pushd .; ruby -I /tmp/digdag-tempdir7874298179773833314/workspace/1_scoring_41_548_1022647631963152030 -r tasks/setup -- .digdag/tmp/digdag-rb-548-2832194056362479611/runner.rb Setup.set_state .digdag/tmp/digdag-rb-548-2832194056362479611/input.json .digdag/tmp/digdag-rb-548-2832194056362479611/output.json; exit_code=$?; popd; tar -zcf .digdag/tmp/archive-output.tar.gz  --exclude .digdag/tmp/archive-input-1303077822488292264.tar.gz --exclude .digdag/tmp/archive-output.tar.gz .digdag/tmp/; curl -s -X PUT -T .digdag/tmp/archive-output.tar.gz -L "https://storage.googleapis.com/test-gcp-project-digdag-archive/548/archive-output.tar.gz?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=digdag%40test-gcp-project.iam.gserviceaccount.com%2F20200127%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20200127T074629Z&X-Goog-Expires=600&X-Goog-SignedHeaders=host&X-Goog-Signature=9e289f8ba924bd9943afe4f1861fc9938002bf321088d146eed17304bbe45c196637c1e5374d7d886844554673dc3588e5b87e784d464652652dcb303476671252e1aca987be24946ba7c43b6eac672552816f0db2236fec8327ddf2d7c610690f8176eceedb02560e35e2b9c4743dc77fc6dea1d35c081503f3a962ef4a2ccecec3107d487b7afb07857f0e8aea471869dc0e2bc0efb237f720300c66c0d3ac91209eb32dfafea6306762d9b26847e704e5eabd382248619963131ab727abb16af5f9d459d4d10b81384ed62a4e233233536519fdaeec291a0032205c9af1152f5c2720e936d00f5bd0155ee109ca738ceec7a839d057ef41a45c3cf7a32545"; exit $exit_code]
```