### PR TITLE
Follow up: Update JmxAgent to be compatible with JDK 11

### DIFF
--- a/digdag-cli/src/main/sh/selfrun.sh
+++ b/digdag-cli/src/main/sh/selfrun.sh
@@ -32,9 +32,9 @@ if "%overwrite_optimize%" == "true" (
 )
 
 if "%optimize%" == "true" (
-    set java_args=-XX:+AggressiveOpts -XX:+UseConcMarkSweepGC %java_args%
+    set java_args=-XX:+AggressiveOpts -XX:+UseConcMarkSweepGC -Djdk.attach.allowAttachSelf=true %java_args%
 ) else (
-    set java_args=-XX:+AggressiveOpts -XX:TieredStopAtLevel=1 -Xverify:none %java_args%
+    set java_args=-XX:+AggressiveOpts -XX:TieredStopAtLevel=1 -Xverify:none -Djdk.attach.allowAttachSelf=true %java_args%
 )
 
 java -Dio.digdag.cli.launcher=selfrun %java_args% -jar "%this%" %args%
@@ -130,9 +130,9 @@ while true; do
 done
 
 if test "$overwrite_optimize" = "true" -o "$default_optimize" -a "$overwrite_optimize" != "false"; then
-    java_args="-XX:+AggressiveOpts -XX:+UseConcMarkSweepGC $java_args"
+    java_args="-XX:+AggressiveOpts -XX:+UseConcMarkSweepGC -Djdk.attach.allowAttachSelf=true $java_args"
 else
-    java_args="-XX:+AggressiveOpts -XX:TieredStopAtLevel=1 -Xverify:none $java_args"
+    java_args="-XX:+AggressiveOpts -XX:TieredStopAtLevel=1 -Xverify:none -Djdk.attach.allowAttachSelf=true $java_args"
 fi
 
 exec java -Dio.digdag.cli.launcher=selfrun $java_args -jar "$0" "$@"

--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -350,7 +350,7 @@ In the config file, following parameters are available
 * server.http.io-idle-timeout (maximum allowed idle time of reading HTTP request and writing HTTP response in seconds. default: 300)
 * server.http.enable-http2 (enable HTTP/2. default: false)
 * server.http.headers.KEY = VALUE (HTTP header to set on API responses)
-* server.jmx.port (port to listen JMX in integer. default: JMX is disabled)
+* server.jmx.port (port to listen JMX in integer. default: JMX is disabled) Since Java 9, to use this option, you need to set '-Djdk.attach.allowAttachSelf=true' to command line option of java or to JDK_JAVA_OPTIONS environment variable.
 * server.authenticator-class (string) The FQCN of the ``io.digdag.spi.Authenticator`` implementation to use. The implementation is to be provided by a system plugin. The auth plugin configuration is implementation specific. Default: ``io.digdag.standards.auth.jwt.JwtAuthenticator``
 * database.type (enum, "h2" or "postgresql")
 * database.user (string)

--- a/digdag-guice-rs-server/build.gradle
+++ b/digdag-guice-rs-server/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
     compile 'org.embulk:guice-bootstrap:0.2.1'
     compile 'org.weakref:jmxutils:1.19'
+    compile 'javax.annotation:javax.annotation-api:1.3.2'
 }

--- a/digdag-guice-rs-server/src/main/java/io/digdag/guice/rs/server/jmx/JmxAgent.java
+++ b/digdag-guice-rs-server/src/main/java/io/digdag/guice/rs/server/jmx/JmxAgent.java
@@ -2,10 +2,19 @@ package io.digdag.guice.rs.server.jmx;
 
 import com.google.common.base.Throwables;
 import com.google.inject.Inject;
+import com.sun.tools.attach.AttachNotSupportedException;
+import com.sun.tools.attach.VirtualMachine;
 
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
 import java.rmi.server.RemoteObject;
+import java.util.Properties;
+import java.util.stream.IntStream;
 import javax.annotation.PostConstruct;
+import javax.management.remote.JMXServiceURL;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,52 +48,132 @@ public class JmxAgent
 
     private static void startAgent(int port)
     {
-        System.setProperty("com.sun.management.jmxremote", "true");
-        System.setProperty("com.sun.management.jmxremote.port", Integer.toString(port));
-        System.setProperty("com.sun.management.jmxremote.rmi.port", Integer.toString(port));
-        System.setProperty("com.sun.management.jmxremote.authenticate", "false");
-        System.setProperty("com.sun.management.jmxremote.ssl", "false");
+        try {
+            Class.forName("sun.management.Agent");
+            // If sun.management.Agent exists, it's JDK 8 or older. Use legacy reflection-based code
+            // which doesn't work since JDK 9.
+            try {
+                startAgent8(port);
+                return;
+            }
+            catch (Exception e) {
+                throw Throwables.propagate(e);
+            }
+        }
+        catch (ReflectiveOperationException e) {
+            // expected since JDK 9
+        }
+
+        Properties props = new Properties();
+        props.setProperty("com.sun.management.jmxremote.port", Integer.toString(port));
+        props.setProperty("com.sun.management.jmxremote.rmi.port", Integer.toString(port));
+        props.setProperty("com.sun.management.jmxremote.authenticate", "false");
+        props.setProperty("com.sun.management.jmxremote.ssl", "false");
 
         try {
-            sun.management.Agent.startAgent();
+            long pid = getPid();
+            // Here attaches to this VM. This is prohibited by default since JDK 9 due to
+            // sun.tools.attach.HotSpotVirtualMachine.ALLOW_ATTACH_SELF flag. To bypass this
+            // problem, jdk.attach.allowAttachSelf=true system property is necessary.
+            VirtualMachine virtualMachine = VirtualMachine.attach(Long.toString(pid));
+            try {
+                virtualMachine.startLocalManagementAgent();
+                virtualMachine.startManagementAgent(props);
+            }
+            finally {
+                virtualMachine.detach();
+            }
+        }
+        catch (IOException e) {
+            throw new RuntimeException("Failed to start JMX agent. Please make sure that you add '-Djdk.attach.allowAttachSelf=true' to the command line options of java or to JDK_JAVA_OPTIONS environment variable.", e);
         }
         catch (Exception e) {
             throw Throwables.propagate(e);
         }
 
-        logger.info("JMX agent started on port {}", getJmxRegistryPort(port));
-    }
-
-    private static int getJmxRegistryPort(int defaultPort)
-    {
         try {
-            Object jmxServer = getField(sun.management.Agent.class, "jmxServer");
-            if (jmxServer == null) {
-                logger.warn("Failed to determine JMX port: sun.management.Agent.jmxServer field is null");
-            }
-            else {
-                Object registry = getField(sun.management.jmxremote.ConnectorBootstrap.class, "registry");
-                if (registry == null) {
-                    logger.warn("Failed to determine JMX port: sun.management.jmxremote.ConnectorBootstrap.registry field is null");
-                }
-                else {
-                    return sun.rmi.server.UnicastRef.class.cast(RemoteObject.class.cast(registry).getRef()).getLiveRef().getPort();
-                }
-            }
-            return defaultPort;
+            JMXServiceURL url = new JMXServiceURL("rmi", null, port);
+            int actualPort = url.getPort();
+            logger.info("JMX agent started on port {}", actualPort);
         }
         catch (Exception e) {
             logger.warn("Failed to determine JMX port", e);
-            return defaultPort;
         }
     }
 
-    private static Object getField(Class<?> clazz, String name)
+    private static long getPid()
+    {
+        String name = ManagementFactory.getRuntimeMXBean().getName();
+        int index = name.indexOf('@');
+        return Long.parseLong(name.substring(0, index));
+    }
+
+    private static void startAgent8(int port)
             throws ReflectiveOperationException
     {
-        Field field = clazz.getDeclaredField(name);
+        System.setProperty("com.sun.management.jmxremote", "true");
+        System.setProperty("com.sun.management.jmxremote.port", Integer.toString(port));
+        System.setProperty("com.sun.management.jmxremote.rmi.port", Integer.toString(port));
+        System.setProperty("com.sun.management.jmxremote.authenticate", "false");
+        System.setProperty("com.sun.management.jmxremote.ssl", "false");
+        invokeStaticMethod("sun.management.Agent", "startAgent");
+        try {
+            int actualPort = getJmxRegistryPort8(port);
+            logger.info("JMX agent started on port {}", actualPort);
+        }
+        catch (Exception e) {
+            logger.warn("Failed to determine JMX port", e);
+        }
+    }
+
+    private static int getJmxRegistryPort8(int defaultPort)
+            throws ReflectiveOperationException
+    {
+        Object jmxServer = getDeclaredStaticField("sun.management.Agent", "jmxServer");
+        if (jmxServer == null) {
+            logger.warn("Failed to determine JMX port: sun.management.Agent.jmxServer field is null");
+        }
+        else {
+            Object registry = getDeclaredStaticField("sun.management.jmxremote.ConnectorBootstrap", "registry");
+            if (registry == null) {
+                logger.warn("Failed to determine JMX port: sun.management.jmxremote.ConnectorBootstrap.registry field is null");
+            }
+            else {
+                return (int) invokeMethod(invokeMethod(RemoteObject.class.cast(registry).getRef(), "getLiveRef"), "getPort");
+            }
+        }
+        return defaultPort;
+    }
+
+    private static Object getDeclaredStaticField(String className, String fieldName)
+            throws ReflectiveOperationException
+    {
+        Class clazz = Class.forName(className);
+        Field field = clazz.getDeclaredField(fieldName);
         field.setAccessible(true);
         return field.get(clazz);
+    }
+
+    private static Object invokeStaticMethod(String className, String methodName, Object... typesArgs)
+            throws ReflectiveOperationException
+    {
+        Class[] types = IntStream.range(0, typesArgs.length).filter(i -> i % 2 == 0)
+            .mapToObj(i -> (Class) typesArgs[i]).toArray(Class[]::new);
+        Object[] args = IntStream.range(0, typesArgs.length).filter(i -> i % 2 == 1)
+            .mapToObj(i -> typesArgs[i]).toArray(Object[]::new);
+        Method method = Class.forName(className).getMethod(methodName, types);
+        return method.invoke(null, args);
+    }
+
+    private static Object invokeMethod(Object object, String methodName, Object... typesArgs)
+            throws ReflectiveOperationException
+    {
+        Class[] types = IntStream.range(0, typesArgs.length).filter(i -> i % 2 == 0)
+            .mapToObj(i -> (Class) typesArgs[i]).toArray(Class[]::new);
+        Object[] args = IntStream.range(0, typesArgs.length).filter(i -> i % 2 == 1)
+            .mapToObj(i -> typesArgs[i]).toArray(Object[]::new);
+        Method method = object.getClass().getMethod(methodName, types);
+        return method.invoke(object, args);
     }
 
     // Agent class doesn't have methods to stop agent

--- a/digdag-tests/src/test/java/utils/TemporaryDigdagServer.java
+++ b/digdag-tests/src/test/java/utils/TemporaryDigdagServer.java
@@ -337,6 +337,7 @@ public class TemporaryDigdagServer
             processArgs.addAll(asList(
                     "-cp", classPath,
                     "-XX:TieredStopAtLevel=1", "-Xverify:none",  // for faster startup and less memory consumption on CI
+                    "-Djdk.attach.allowAttachSelf=true", // for io.digdag.guice.rs.server.jmx.JmxAgent
                     "-Xms128m", "-Xmx128m"));
             if (version.isPresent()) {
                 processArgs.add("-D" + VERSION_PROPERTY + "=" + version.get());


### PR DESCRIPTION
This is follow up PR for #790 .
Rebase to latest master and fixed conflict.

The commit changes are as follows.

1. commit A
- original: https://github.com/treasure-data/digdag/pull/790/commits/8eb00f85c866026d159fde65e3b87ddc4fd4c0ed
- followup: https://github.com/treasure-data/digdag/pull/1342/commits/3f8fdb0b0aafd1968c9c9c381187934910d67bcb
2. commit B
- original https://github.com/treasure-data/digdag/pull/790/commits/2cbb2cf39e5c9d00c0b80a51abf9f70d8d0e3bae
- followup: https://github.com/treasure-data/digdag/pull/1342/commits/9622c3e657c3f614b329059f0daccc0d594b90df

My changes to resolve conflict is as follows:
- digdag-docs/src/command_reference.rst
- digdag-tests/src/test/java/acceptance/ServerJmxIT.java