### PR TITLE
[doc] Add param_server option description. 

### DIFF
--- a/digdag-docs/src/operators/param_get.md
+++ b/digdag-docs/src/operators/param_get.md
@@ -40,6 +40,38 @@
 
   String of the password of the ParamServer
 
+* **param_server.loginTimeout (optional)**:
+
+  Seconds in integer. default: 30
+
+* **param_server.socketTimeout (optional)**:
+
+  Seconds in integer. default: 1800
+
+* **param_server.ssl (optional)**:
+
+  Boolean. default: false
+
+* **param_server.connectionTimeout (optional)**:
+
+  Seconds in integer. default: 30
+
+* **param_server.idleTimeout (optional)**:
+
+  Seconds in integer. default: 600
+
+* **param_server.validationTimeout (optional)**:
+
+  Seconds in integer. default: 5
+
+* **param_server.maximumPoolSize (optional)**:
+
+  Integer. default: available CPU cores * 32
+
+* **param_server.minimumPoolSize (optional)**:
+
+  Integer. default: same as param_server.maximumPoolSize
+
 
 ### When using Redis
 

--- a/digdag-docs/src/operators/param_set.md
+++ b/digdag-docs/src/operators/param_set.md
@@ -41,6 +41,39 @@ The value is 7,776,000 seconds (90days: 60sec * 60min * 24hours * 90days)).
 
   String of the password of the ParamServer
 
+* **param_server.loginTimeout (optional)**:
+
+  Seconds in integer. default: 30
+
+* **param_server.socketTimeout (optional)**:
+
+  Seconds in integer. default: 1800
+
+* **param_server.ssl (optional)**:
+
+  Boolean. default: false
+
+* **param_server.connectionTimeout (optional)**:
+
+  Seconds in integer. default: 30
+
+* **param_server.idleTimeout (optional)**:
+
+  Seconds in integer. default: 600
+
+* **param_server.validationTimeout (optional)**:
+
+  Seconds in integer. default: 5
+
+* **param_server.maximumPoolSize (optional)**:
+
+  Integer. default: available CPU cores * 32
+
+* **param_server.minimumPoolSize (optional)**:
+
+  Integer. default: same as param_server.maximumPoolSize
+
+
 #### Sample
 
     param_server.type=postgresql


### PR DESCRIPTION
I added these configuration description.
```
param_server.loginTimeout
param_server.socketTimeout
param_server.ssl
param_server.connectionTimeout
param_server.idleTimeout
param_server.validationTimeout
param_server.maximumPoolSize
param_server.minimumPoolSize
```

## Ref
I referenced these codes.  
https://github.com/treasure-data/digdag/blob/cfc6cc23b52cc3e1d27f639662f6266ad97d7c38/digdag-standards/src/main/java/io/digdag/standards/operator/param/PostgresqlServerClientConnectionManager.java#L96-L108
https://github.com/treasure-data/digdag/blob/cfc6cc23b52cc3e1d27f639662f6266ad97d7c38/digdag-core/src/main/java/io/digdag/core/database/DatabaseConfig.java#L88-L90