### PR TITLE
[doc] Add server command option description

### DIFF
--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -365,6 +365,7 @@ In the config file, following parameters are available
 * database.idleTimeout (seconds in integer, default: 600)
 * database.validationTimeout (seconds in integer, default: 5)
 * database.maximumPoolSize (integer, default: available CPU cores * 32)
+* database.minimumPoolSize (integer, default: same as database.maximumPoolSize)
 * database.leakDetectionThreshold (HikariCP leakDetectionThreshold milliseconds in integer. default: 0. To enable, set to >= 2000.)
 * database.migrate (enable DB migration. default: true)
 * archive.type (type of project archiving, "db", "s3" or "gcs". default: "db")


### PR DESCRIPTION
I create another PR from https://github.com/treasure-data/digdag/pull/1343.     
I added `database.minimumPoolSize
` configuration description.

## Ref
https://github.com/treasure-data/digdag/pull/1343#pullrequestreview-350541913