### PR TITLE
Fix KubernetesCommandEexecutor part of wait for starting container.

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/KubernetesCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/KubernetesCommandExecutor.java
@@ -246,8 +246,10 @@ public class KubernetesCommandExecutor
 
         final ObjectNode previousExecutorState = (ObjectNode) previousStatusJson.get("executor_state");
         final ObjectNode nextExecutorState = previousExecutorState.deepCopy();
+
         // If the container doesn't start yet, it cannot extract any log messages from the container.
-        if (!client.isWaitingContainerCreation(pod)) { // not 'waiting'
+        final String podPhase = pod.getPhase();
+        if (!podPhase.equals("Pending") && !client.isWaitingContainerCreation(pod)) { // not 'waiting'
             // Read log and write it to CommandLogger
             final long offset = !previousExecutorState.has("log_offset") ? 0L : previousExecutorState.get("log_offset").asLong();
             final String logMessage = client.getLog(podName, offset);
@@ -263,10 +265,9 @@ public class KubernetesCommandExecutor
         final ObjectNode nextStatusJson = previousStatusJson.deepCopy();
         nextStatusJson.set("executor_state", nextExecutorState);
 
-        // If the Pod completed, it needs to create output contents to pass them to the command executor.
-        final String podPhase = pod.getPhase();
-        final boolean isFinished = podPhase.equals("Succeeded") || podPhase.equals("Failed");
 
+        // If the Pod completed, it needs to create output contents to pass them to the command executor.
+        final boolean isFinished = podPhase.equals("Succeeded") || podPhase.equals("Failed");
         if (isFinished) {
             final String outputArchivePathName = "archive-output.tar.gz";
             final String outputArchiveKey = createStorageKey(context.getTaskRequest(), outputArchivePathName); // url format

--- a/digdag-standards/src/main/java/io/digdag/standards/command/KubernetesCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/KubernetesCommandExecutor.java
@@ -265,9 +265,9 @@ public class KubernetesCommandExecutor
         final ObjectNode nextStatusJson = previousStatusJson.deepCopy();
         nextStatusJson.set("executor_state", nextExecutorState);
 
-
         // If the Pod completed, it needs to create output contents to pass them to the command executor.
         final boolean isFinished = podPhase.equals("Succeeded") || podPhase.equals("Failed");
+
         if (isFinished) {
             final String outputArchivePathName = "archive-output.tar.gz";
             final String outputArchiveKey = createStorageKey(context.getTaskRequest(), outputArchivePathName); // url format


### PR DESCRIPTION
Calling the `isWaitingContainerCreation` method while the pod is not scheduled(Pending) will result in an error.
```
java.lang.IndexOutOfBoundsException: Index: 0, Size: 0
	at java.util.ArrayList.rangeCheck(ArrayList.java:657)
	at java.util.ArrayList.get(ArrayList.java:433)
	at io.digdag.standards.command.kubernetes.DefaultKubernetesClient.isWaitingContainerCreation(DefaultKubernetesClient.java:116)
	at io.digdag.standards.command.KubernetesCommandExecutor.getCommandStatusFromKubernetes(KubernetesCommandExecutor.java:250)
	at io.digdag.standards.command.KubernetesCommandExecutor.poll(KubernetesCommandExecutor.java:130)
	at io.digdag.standards.operator.ShOperatorFactory$ShOperator.runCode(ShOperatorFactory.java:112)
	at io.digdag.standards.operator.ShOperatorFactory$ShOperator.runTask(ShOperatorFactory.java:88)
	at io.digdag.util.BaseOperator.run(BaseOperator.java:35)
	at io.digdag.plugin.gke.GkeOperatorFactory$GkeOperator.runTask(GkeOperatorFactory.java:127)
	at io.digdag.util.BaseOperator.run(BaseOperator.java:35)
	at io.digdag.core.agent.OperatorManager.callExecutor(OperatorManager.java:330)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invokeMain(DigdagTimedMethodInterceptor.java:58)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invoke(DigdagTimedMethodInterceptor.java:31)
	at io.digdag.core.agent.OperatorManager.runWithWorkspace(OperatorManager.java:271)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invokeMain(DigdagTimedMethodInterceptor.java:58)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invoke(DigdagTimedMethodInterceptor.java:31)
	at io.digdag.core.agent.OperatorManager.lambda$runWithHeartbeat$2(OperatorManager.java:144)
	at io.digdag.core.agent.ExtractArchiveWorkspaceManager.withExtractedArchive(ExtractArchiveWorkspaceManager.java:77)
	at io.digdag.core.agent.OperatorManager.runWithHeartbeat(OperatorManager.java:142)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invokeMain(DigdagTimedMethodInterceptor.java:58)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invoke(DigdagTimedMethodInterceptor.java:31)
	at io.digdag.core.agent.OperatorManager.run(OperatorManager.java:125)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invokeMain(DigdagTimedMethodInterceptor.java:58)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invoke(DigdagTimedMethodInterceptor.java:31)
	at io.digdag.core.agent.MultiThreadAgent.lambda$null$0(MultiThreadAgent.java:131)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```
So Fix to call `isWaitingContainerCreation` after confirming that the pod is scheduled first.


ref. https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/