### PR TITLE
Fix td_result_export> documents and tests

### DIFF
--- a/digdag-docs/src/operators/td_result_export.md
+++ b/digdag-docs/src/operators/td_result_export.md
@@ -11,11 +11,11 @@
 
     +export_query_result:
       td_result_export>:
-        job_id: 12345
-        result_connection: my_s3_connection
-        result_settings:
-          bucket: my_bucket
-          path: /logs/
+      job_id: 12345
+      result_connection: my_s3_connection
+      result_settings:
+        bucket: my_bucket
+        path: /logs/
 
 ## Options
 

--- a/digdag-tests/src/test/java/acceptance/td/TdResultExportIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/TdResultExportIT.java
@@ -142,9 +142,9 @@ public class TdResultExportIT
         digdagClient.setProjectSecret(projectId, "td.apikey", TD_API_KEY);
 
         Id attemptId = pushAndStart(server.endpoint(), projectDir, "td_result_export", ImmutableMap.of(
-                "job_id", sampleJobId,
-                "result_settings", "{\"user_database_name\":\""+database+"\",\"user_table_name\":\""+table+"\",\"mode\":\"replace\"}",
-                "result_connection", resultConnectorName,
+                "test_job_id", sampleJobId,
+                "test_result_settings", "{\"user_database_name\":\""+database+"\",\"user_table_name\":\""+table+"\",\"mode\":\"replace\"}",
+                "test_result_connection", resultConnectorName,
                 "td.use_ssl", "false")
         );
 

--- a/digdag-tests/src/test/resources/acceptance/td/td_result_export/td_result_export.dig
+++ b/digdag-tests/src/test/resources/acceptance/td/td_result_export/td_result_export.dig
@@ -2,6 +2,6 @@ timezone: UTC
 
 +run:
   td_result_export>:
-    job_id: ${job_id}
-    result_connection: ${result_connection}
-    result_settings: ${result_settings}
+  job_id: ${test_job_id}
+  result_connection: ${test_result_connection}
+  result_settings: ${test_result_settings}


### PR DESCRIPTION
`td_result_export>` operator takes parameters from the top-level, not
from the `td_result_export>` key. This fixes tests and documents to
reflect the actual implementation behavior. This doesn't intend to
confirm appropriacy of current implementation behavior.

Test was working because `job_id` parameter was set as a session parameter.
It was working inappropriately.
