### PR TITLE
Increase polling interval in operators with CommandExecutor

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/operator/EmbulkOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/EmbulkOperatorFactory.java
@@ -77,7 +77,7 @@ public class EmbulkOperatorFactory
             extends BaseOperator
     {
         // TODO extract as config params.
-        final int scriptPollInterval = (int) Duration.ofSeconds(10).getSeconds();
+        final int scriptPollInterval = (int) Duration.ofSeconds(20).getSeconds();
 
         public EmbulkOperator(OperatorContext context)
         {

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/PyOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/PyOperatorFactory.java
@@ -99,7 +99,7 @@ public class PyOperatorFactory
             extends BaseOperator
     {
         // TODO extract as config params.
-        final int scriptPollInterval = (int) Duration.ofSeconds(10).getSeconds();
+        final int scriptPollInterval = (int) Duration.ofSeconds(20).getSeconds();
 
         public PyOperator(OperatorContext context)
         {

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/RbOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/RbOperatorFactory.java
@@ -86,7 +86,7 @@ public class RbOperatorFactory
             extends BaseOperator
     {
         // TODO extract as config params.
-        final int scriptPollInterval = (int) Duration.ofSeconds(10).getSeconds();
+        final int scriptPollInterval = (int) Duration.ofSeconds(20).getSeconds();
 
         public RbOperator(OperatorContext context)
         {

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/ShOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/ShOperatorFactory.java
@@ -73,7 +73,7 @@ public class ShOperatorFactory
             extends BaseOperator
     {
         // TODO extract as config params.
-        final int scriptPollInterval = (int) Duration.ofSeconds(10).getSeconds();
+        final int scriptPollInterval = (int) Duration.ofSeconds(20).getSeconds();
 
         public ShOperator(OperatorContext context)
         {


### PR DESCRIPTION
py>, rb>, sh>, embulk> operators poll the running task in CommandExecutor.
10 seconds has not been long enough for some uses, and can cause rate
limiting errors.