### PR TITLE
Fix KubernetesCommandExecutor for throw an exception if pod exceeds expire of TemporalConfigStorage.

### DIFF
--- a/digdag-spi/src/main/java/io/digdag/spi/Storage.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/Storage.java
@@ -35,4 +35,8 @@ public interface Storage
     {
         return Optional.absent();
     }
+
+    Long getDirectDownloadExpiration();
+
+    Long getDirectUploadExpiration();
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/KubernetesCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/KubernetesCommandExecutor.java
@@ -256,7 +256,7 @@ public class KubernetesCommandExecutor
             log(logMessage, clog);
             nextExecutorState.set("log_offset", FACTORY.numberNode(offset + logMessage.length())); // update log_offset
         }
-        else if(isWaitLongerThanInConfigStorageExpiration(previousStatusJson)){
+        else if(isWaitingLongerThanInConfigStorageExpiration(previousStatusJson)){
             // Throw error because inTemporalConfigStorage expires
             TaskRequest request = context.getTaskRequest();
             long attemptId = request.getAttemptId();
@@ -326,7 +326,7 @@ public class KubernetesCommandExecutor
         return ImmutableList.of();
     }
 
-    private boolean isWaitLongerThanInConfigStorageExpiration(final ObjectNode previousStatusJson)
+    private boolean isWaitingLongerThanInConfigStorageExpiration(final ObjectNode previousStatusJson)
     {
         long creationTimestamp = previousStatusJson.get("pod_creation_timestamp").asLong();
         long inTemporalConfigStorageExpiration = previousStatusJson.get("in_temporal_config_storage_expiration").asLong();

--- a/digdag-standards/src/main/java/io/digdag/standards/command/kubernetes/TemporalConfigStorage.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/kubernetes/TemporalConfigStorage.java
@@ -54,4 +54,14 @@ public class TemporalConfigStorage
             throw Throwables.propagate(e);
         }
     }
+
+    public Long getDirectDownloadExpiration()
+    {
+        return storage.getDirectDownloadExpiration();
+    }
+
+    public Long getDirectUploadExpiration()
+    {
+        return storage.getDirectUploadExpiration();
+    }
 }

--- a/digdag-storage-s3/src/main/java/io/digdag/storage/s3/S3Storage.java
+++ b/digdag-storage-s3/src/main/java/io/digdag/storage/s3/S3Storage.java
@@ -200,7 +200,7 @@ public class S3Storage
     @Override
     public Optional<DirectDownloadHandle> getDirectDownloadHandle(String key)
     {
-        final long secondsToExpire = getDirectUploadExpiration();
+        final long secondsToExpire = getDirectDownloadExpiration();
 
         GeneratePresignedUrlRequest req = new GeneratePresignedUrlRequest(bucket, key);
         req.setExpiration(Date.from(Instant.now().plusSeconds(secondsToExpire)));

--- a/digdag-storage-s3/src/main/java/io/digdag/storage/s3/S3Storage.java
+++ b/digdag-storage-s3/src/main/java/io/digdag/storage/s3/S3Storage.java
@@ -200,7 +200,7 @@ public class S3Storage
     @Override
     public Optional<DirectDownloadHandle> getDirectDownloadHandle(String key)
     {
-        final long secondsToExpire = config.get("direct_download_expiration", Long.class, 10L*60);
+        final long secondsToExpire = getDirectUploadExpiration();
 
         GeneratePresignedUrlRequest req = new GeneratePresignedUrlRequest(bucket, key);
         req.setExpiration(Date.from(Instant.now().plusSeconds(secondsToExpire)));
@@ -213,7 +213,7 @@ public class S3Storage
     @Override
     public Optional<DirectUploadHandle> getDirectUploadHandle(String key)
     {
-        final long secondsToExpire = config.get("direct_upload_expiration", Long.class, 10L*60);
+        final long secondsToExpire = getDirectUploadExpiration();
 
         GeneratePresignedUrlRequest req = new GeneratePresignedUrlRequest(bucket, key);
         req.setMethod(HttpMethod.PUT);
@@ -222,6 +222,18 @@ public class S3Storage
         String url = client.generatePresignedUrl(req).toString();
 
         return Optional.of(DirectUploadHandle.of(url));
+    }
+
+    @Override
+    public Long getDirectDownloadExpiration()
+    {
+        return config.get("direct_download_expiration", Long.class, 10L*60);
+    }
+
+    @Override
+    public Long getDirectUploadExpiration()
+    {
+        return config.get("direct_upload_expiration", Long.class, 10L*60);
     }
 
     private <T> T getWithRetry(String message, Callable<T> callable)


### PR DESCRIPTION
KubernetesCommandExecutor now throws an exception when the execution time of a pod exceeds the defaultPodTTL.
But we also need to consider that the pod execution time may exceed expiration date of TemporalConfigStorage.
This is because pod error detection can be done early.
For example, if we continue processing when the pod's execution time is beyond the expiration of TemporalConfigStorage, the curl command will raise an error when trying to upload the archive to the expired TemporaryConfigStorage at the end of the operation.