### PR TITLE
Add config option eval.extended-syntax in GraalJS

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/agent/ConfigEvalEngine.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/ConfigEvalEngine.java
@@ -62,7 +62,7 @@ public class ConfigEvalEngine
 
     private static ImmutableList<String> NO_EVALUATE_PARAMETERS = ImmutableList.of("_do",  "_else_do");
 
-    private static enum JsEngineType
+    enum JsEngineType
     {
         NASHORN("nashorn"),
         GRAAL("graal"),
@@ -114,11 +114,13 @@ public class ConfigEvalEngine
     {
         this(systemConfig.getOptional("eval.js-engine-type", String.class)
                 .transform(type -> parseJsEngineType(type))
-                .or(() -> defaultJsEngineType()));
+                .or(() -> defaultJsEngineType()),
+             systemConfig.get("eval.extended-syntax", Boolean.class, true)
+         );
     }
 
     @VisibleForTesting
-    ConfigEvalEngine(JsEngineType jsEngineType)
+    ConfigEvalEngine(JsEngineType jsEngineType, boolean extendedSyntax)
     {
         logger.debug("Using JavaScript engine: {}", jsEngineType.configName);
         this.jsEngineType = jsEngineType;
@@ -129,11 +131,11 @@ public class ConfigEvalEngine
             break;
         case GRAAL:
             this.nashorn = null;
-            this.graal = new GraalJsEngine();
+            this.graal = new GraalJsEngine(extendedSyntax);
             break;
         case NASHORN_GRAAL_CHECK:
             this.nashorn = new NashornJsEngine();
-            this.graal = new GraalJsEngine();
+            this.graal = new GraalJsEngine(extendedSyntax);
             break;
         default:
             throw new UnsupportedOperationException();

--- a/digdag-core/src/main/java/io/digdag/core/agent/NashornJsEngine.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/NashornJsEngine.java
@@ -59,7 +59,7 @@ public class NashornJsEngine
             throw new TemplateException("Failed to serialize parameters to JSON", ex);
         }
         try {
-            return (String) templateInvocable.invokeFunction("template", code, paramsJson);
+            return (String) templateInvocable.invokeFunction("template", code, paramsJson, false);
         }
         catch (ScriptException ex) {
             String message;

--- a/digdag-core/src/main/resources/io/digdag/core/agent/digdag.js
+++ b/digdag-core/src/main/resources/io/digdag/core/agent/digdag.js
@@ -1,4 +1,4 @@
-function template(input, variables)
+function template(input, variables, extendedSyntax)
 {
   var escapes = {
     "'":      "'",
@@ -15,7 +15,7 @@ function template(input, variables)
     return '\\' + escapes[match];
   };
 
-  if (typeof Graal != 'undefined') {
+  if (extendedSyntax) {
     // (?![a-z]+:) => exclude operator-defined templates such as ${secret:sec.ret.key}
     var matcher = /\$\{(?![a-z]+:)([\s\S]+)|$/;
 

--- a/digdag-core/src/test/java/io/digdag/core/agent/ConfigEvalEngineTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/agent/ConfigEvalEngineTest.java
@@ -8,6 +8,8 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
+import java.util.Arrays;
+
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -20,7 +22,7 @@ public class ConfigEvalEngineTest
     @Rule
     public final ExpectedException exception = ExpectedException.none();
 
-    private ConfigEvalEngine engine = new ConfigEvalEngine(ConfigEvalEngine.defaultJsEngineType());
+    private ConfigEvalEngine engine = new ConfigEvalEngine(ConfigEvalEngine.defaultJsEngineType(), false);
 
     private Config params()
     {
@@ -127,5 +129,18 @@ public class ConfigEvalEngineTest
         assertThat(engine.isInvokeTemplateRequired(""), is(false));
         assertThat(engine.isInvokeTemplateRequired("\n"), is(false));
         assertThat(engine.isInvokeTemplateRequired("Digdag Notification\naa${hoge}bb"), is(true));
+    }
+
+    @Test
+    public void testExtendedSyntax()
+            throws Exception
+    {
+        ConfigEvalEngine graal = new ConfigEvalEngine(ConfigEvalEngine.JsEngineType.GRAAL, true);
+        assertThat(
+                graal.eval(
+                    newConfig().set("key", "${v1.map(function(item){return item*5})}"),
+                    params().set("v1", Arrays.asList(1,2,3,4,5))).get("key", String.class),
+                is("[5,10,15,20,25]")
+        );
     }
 }

--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -393,7 +393,7 @@ In the config file, following parameters are available
 * api.max_sessions_page_size (integer. The max number of rows of sessions in api response)
 * api.max_archive_total_size_limit (integer. The maximum size of an archived project. i.e. ``digdag push`` size. default: 2MB(2\*1024\*1024))
 * eval.js-engine-type (type of ConfigEvalEngine. "nashorn" or "graal". "nashorn" is default on Java8 and "graal" is default on Java11)
-* eval.extended-syntax (boolean, default: true. Enable or disable extended syntax in eval.js-engine-type=graal. If true, nested '{..}' is allowed.
+* eval.extended-syntax (boolean, default: true. Enable or disable extended syntax in graal. If true, nested ``{..}`` is allowed)
 
 Secret Encryption Key
 *********************

--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -392,7 +392,8 @@ In the config file, following parameters are available
 * api.max_attempts_page_size (integer. The max number of rows of attempts in api response)
 * api.max_sessions_page_size (integer. The max number of rows of sessions in api response)
 * api.max_archive_total_size_limit (integer. The maximum size of an archived project. i.e. ``digdag push`` size. default: 2MB(2\*1024\*1024))
-
+* eval.js-engine-type (type of ConfigEvalEngine. "nashorn" or "graal". "nashorn" is default on Java8 and "graal" is default on Java11)
+* eval.extended-syntax (boolean, default: true. Enable or disable extended syntax in eval.js-engine-type=graal. If true, nested '{..}' is allowed.
 
 Secret Encryption Key
 *********************


### PR DESCRIPTION
Currently extended syntax (nested {}) is always enabled in graal.
But it is better to have an option to enable/disable it for compatibility enhancement.
This PR introduces _eval.extended-syntax_ (true|false)  option.
The default is true. So the behavior is same.

This PR also includes unit test for extended syntax and document.
