### PR TITLE
[Doc] fix invalid tab string

### DIFF
--- a/digdag-docs/src/operators/bq_extract.md
+++ b/digdag-docs/src/operators/bq_extract.md
@@ -66,7 +66,7 @@ When you set those parameters, use [digdag secrets command](https://docs.digdag.
   Examples:
 
   ```
-  field_delimiter: '\\t'
+  field_delimiter: "\t"
   ```
 
 * **destination_format**: CSV | NEWLINE_DELIMITED_JSON | AVRO


### PR DESCRIPTION

Fix invalid delimiter example. The current
 example `\\t` doesn't tab character.

```yaml
_export:
  tab: "\t"
  invalid_tab: '\\t'

+task1:
  echo>: echo ***${tab}***${invalid_tab}***
```

```
echo ***	***\\t***
```


Reported-by: reki_frequent Thanks!

After fixing this issue.

![スクリーンショット 2020-02-28 18 00 56](https://user-images.githubusercontent.com/767650/75533523-f8bcd180-5a57-11ea-8fb3-dcb0bf88e3f5.png)
