### PR TITLE
Fix GraalJS compatibility issue

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/agent/ConfigEvalEngine.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/ConfigEvalEngine.java
@@ -279,8 +279,8 @@ public class ConfigEvalEngine
 
             if (resultText == null && checkText != null ||
                     resultText != null && !resultText.equals(checkText)) {
-                logger.error("Detected incompatibility between Nashorn and GraalJS. Code: {}", code);
-                logger.error("Incompatibility info: Nashorn return:{} exception:{} GraalJS return:{} exception:{}",
+                logger.debug("Detected incompatibility between Nashorn and GraalJS. Code: {}", code);
+                logger.debug("Incompatibility info: Nashorn return:{} exception:{} GraalJS return:{} exception:{}",
                         resultText == null? "null" : resultText,
                         resultEx == null? "null" : resultEx.toString(),
                         checkText == null? "null" : checkText,

--- a/digdag-core/src/test/java/io/digdag/core/agent/ConfigEvalEngineTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/agent/ConfigEvalEngineTest.java
@@ -132,6 +132,21 @@ public class ConfigEvalEngineTest
     }
 
     @Test
+    public void testStringInteroperability()
+            throws Exception
+    {
+        ConfigEvalEngine graal = new ConfigEvalEngine(ConfigEvalEngine.JsEngineType.GRAAL, false);
+        for (ConfigEvalEngine e: Arrays.asList(engine, graal)) {
+            assertThat(
+                    graal.eval(
+                            newConfig().set("key", "${\"aaa\".replaceAll(\"a\", \"A\")}"),
+                            params()).get("key", String.class),
+                    is("AAA")
+            );
+        }
+    }
+
+    @Test
     public void testExtendedSyntax()
             throws Exception
     {


### PR DESCRIPTION
Fix GraalJS String interoperability in GraalJS engine.
java.lang.String methods are available same as Nashorn.

Change log level for nashron-graal-check mode because it is not error.
