### PR TITLE
Fix GraalJS engine shutdown issue

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/agent/GraalJsEngine.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/GraalJsEngine.java
@@ -14,12 +14,12 @@ import org.graalvm.polyglot.HostAccess;
 import org.graalvm.polyglot.PolyglotException;
 import org.graalvm.polyglot.Source;
 import org.graalvm.polyglot.Value;
+
 import static io.digdag.core.agent.ConfigEvalEngine.LIBRARY_JS_CONTENTS;
 
 public class GraalJsEngine
     implements JsEngine
 {
-    private final Engine engine;
     private final Source[] libraryJsSources;
     private final boolean extendedSyntax;
 
@@ -29,15 +29,6 @@ public class GraalJsEngine
 
     public GraalJsEngine(boolean extendedSyntax)
     {
-        this.engine = Engine.newBuilder()
-            .allowExperimentalOptions(true)
-            .option("js.nashorn-compat", "true")
-            .option("js.ecmascript-version", "5")
-            .option("js.syntax-extensions", "false")
-            .option("js.console", "false")
-            .option("js.load", "true")           //Same as default. Should be false?
-            .option("js.load-from-url", "false") //Same as default
-            .build();
         this.extendedSyntax = extendedSyntax;
         try {
             this.libraryJsSources = new Source[LIBRARY_JS_CONTENTS.length];
@@ -56,8 +47,22 @@ public class GraalJsEngine
         return evaluator;
     }
 
+    private static Engine createEngine()
+    {
+        return Engine.newBuilder()
+                .allowExperimentalOptions(true)
+                .option("js.nashorn-compat", "true")
+                .option("js.ecmascript-version", "5")
+                .option("js.syntax-extensions", "false")
+                .option("js.console", "false")
+                .option("js.load", "true")           //Same as default. Should be false?
+                .option("js.load-from-url", "false") //Same as default
+                .build();
+    }
+
     private Supplier<Context> createContextSupplier(Config params)
     {
+        Engine engine = createEngine();
         return () -> {
             Context.Builder contextBuilder = Context.newBuilder()
                     .engine(engine)


### PR DESCRIPTION
Digdag supports graceful shutdown.
But GraalJS engine is unexpectedly closed while Digdag is in shutdown process.
It causes task errors.

To avoid this error, stop sharing engine and create engine for each eval.

This cause performance degradation, but it is still faster 10 times than Nashorn in benchmark.
So I believe it is enough.
