### PR TITLE
Fix tests for TDDdlIT to adapt to circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,7 @@ workflows:
               only:
                 - master
                 - v0_10
+                - fix-tests
       - docs_deployment: # master branch only
           filters:
             branches:

--- a/digdag-tests/src/test/java/acceptance/td/TdIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/TdIT.java
@@ -385,7 +385,7 @@ public class TdIT
 
             runWorkflow();
 
-            assertTrue(out.toString().contains("apikey will be tried to update by retrying"));
+            assertThat(out.toString(), Matchers.containsString("apikey will be tried to update by retrying"));
         } finally {
             System.setOut(System.out);
         }


### PR DESCRIPTION
There are 2 points, 
1. Matchers.containsString should be used for circleCI for checking STDERR contains some string.
2. https://github.com/treasure-data/digdag/pull/1378 is added, so I added v3/database/list endpoint for mock server.