### PR TITLE
Implement /api/schedules/{id}/enable_by_mode

### DIFF
--- a/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
+++ b/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
@@ -26,6 +26,7 @@ import io.digdag.client.api.RestRevisionCollection;
 import io.digdag.client.api.RestSchedule;
 import io.digdag.client.api.RestScheduleCollection;
 import io.digdag.client.api.RestScheduleBackfillRequest;
+import io.digdag.client.api.RestScheduleEnableByModeRequest;
 import io.digdag.client.api.RestScheduleSkipRequest;
 import io.digdag.client.api.RestScheduleSummary;
 import io.digdag.client.api.RestSecret;
@@ -801,6 +802,17 @@ public class DigdagClient implements AutoCloseable
         return doPost(RestScheduleSummary.class,
                 ImmutableMap.of(),
                 target("/api/schedules/{id}/enable")
+                        .resolveTemplate("id", scheduleId));
+    }
+
+    public RestScheduleSummary enableScheduleByMode(Id scheduleId, Optional<String> mode, Optional<String> localTime)
+    {
+        return doPost(RestScheduleSummary.class,
+                RestScheduleEnableByModeRequest.builder()
+                    .mode(mode)
+                    .localTime(localTime)
+                    .build(),
+                target("/api/schedules/{id}/enable_by_mode")
                         .resolveTemplate("id", scheduleId));
     }
 

--- a/digdag-client/src/main/java/io/digdag/client/api/RestScheduleEnableByModeRequest.java
+++ b/digdag-client/src/main/java/io/digdag/client/api/RestScheduleEnableByModeRequest.java
@@ -1,0 +1,18 @@
+package io.digdag.client.api;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.base.Optional;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonDeserialize(as = ImmutableRestScheduleEnableByModeRequest.class)
+public interface RestScheduleEnableByModeRequest
+{
+    Optional<String> getMode();
+    Optional<String> getLocalTime();
+
+    static ImmutableRestScheduleEnableByModeRequest.Builder builder()
+    {
+        return ImmutableRestScheduleEnableByModeRequest.builder();
+    }
+}

--- a/digdag-server/src/main/java/io/digdag/server/rs/WorkflowResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/WorkflowResource.java
@@ -194,7 +194,7 @@ public class WorkflowResource
         }, ResourceNotFoundException.class, AccessControlException.class);
     }
 
-    private Instant truncateSessionTime(
+    static Instant truncateSessionTime(
             Instant sessionTime,
             ZoneId timeZone,
             Supplier<Optional<Scheduler>> schedulerSupplier,


### PR DESCRIPTION
This is the PR for adding a new endpoint `/api/schedules/{id}/enable_by_mode`, which is accepting mode when enabling the schedule. 
If a mode is specified, the schedule will be updated based on the mode. 
If a mode is not specified, re-run all past sessions (= same as current behavior)

For example:
- mode: schedule => Start running as scheduled during the most recent session
- mode: next_schedule => Start running as scheduled during the next session

Note that specifying the `next_schedule` might be different from the actual next schedule, the `schedule` will be the actual one.
Please see also [my comment](https://github.com/treasure-data/digdag/blob/f3e822640cfccc8e3637243331338116d9df3829/digdag-server/src/main/java/io/digdag/server/rs/ScheduleResource.java#L333-L339).