### PR TITLE
Disable shared engine in Graaljs

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/agent/ConfigEvalEngine.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/ConfigEvalEngine.java
@@ -1,5 +1,7 @@
 package io.digdag.core.agent;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.Map;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -396,6 +398,18 @@ public class ConfigEvalEngine
         }
         else {
             return resultText;
+        }
+    }
+
+    @VisibleForTesting
+    static String stackTraceAsString(Throwable e)
+    {
+        try (StringWriter sw = new StringWriter(); PrintWriter pw = new PrintWriter(sw)) {
+            e.printStackTrace(pw);
+            return sw.toString();
+        }
+        catch (IOException ioe) {
+            return "";
         }
     }
 }

--- a/digdag-core/src/test/java/io/digdag/core/agent/ConfigEvalEngineTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/agent/ConfigEvalEngineTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static io.digdag.core.workflow.WorkflowTestingUtils.loadYamlResource;
 import static io.digdag.client.config.ConfigUtils.newConfig;
@@ -198,5 +199,19 @@ public class ConfigEvalEngineTest
                     params().set("v1", Arrays.asList(1,2,3,4,5))).get("key", String.class),
                 is("[5,10,15,20,25]")
         );
+    }
+
+    @Test
+    public void testStackTraceAsString()
+    {
+        String stackTrace = null;
+        try {
+            String str = null;
+            str.length();
+        }
+        catch (RuntimeException ex) {
+            stackTrace = ConfigEvalEngine.stackTraceAsString(ex);
+        }
+        assertThat(stackTrace, notNullValue());
     }
 }


### PR DESCRIPTION
We faced NullPointerException in Graaljs and Graaljs has some NPE issues when using shared engine.
To avoid the possibility of NPE. Stop using shared engine.
In addition, to get more info when PolyglotException is thrown, logging stacktrace.

Ref.
https://github.com/graalvm/graaljs/issues?q=is%3Aissue+NullPointerException