### PR TITLE
Add workflow to release snapshot via CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,18 @@ jobs:
       # Build and deploy documents
       - run: ci/push_gh_pages.sh
 
+  release_snapshot:
+    # executor type https://circleci.com/docs/2.0/executor-types/
+    docker:
+      - image: digdag/digdag-build:20191203T225216-c5b7206657c98c728b183634079f0a919ee98f8c
+        # environment Variables in a Job https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-job
+        environment:
+          TERM: dumb
+          TZ: 'UTC'
+    steps:
+      - checkout
+      - run: ./gradlew releaseSnapshot
+
 workflows:
   version: 2
 
@@ -82,3 +94,10 @@ workflows:
             branches:
               only:
                 - master
+      - release_snapshot: # v0_10 branch only
+          requires:
+            - test
+          filters:
+            branches:
+              only:
+                - v0_10


### PR DESCRIPTION
Automate releases with CircleCI. As a first step, we'ill enable this feature for `v0_10` branch.