### PR TITLE
Add support for skipping past sessions on /api/schedules/{id}/enable

### DIFF
--- a/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
+++ b/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
@@ -26,6 +26,7 @@ import io.digdag.client.api.RestRevisionCollection;
 import io.digdag.client.api.RestSchedule;
 import io.digdag.client.api.RestScheduleCollection;
 import io.digdag.client.api.RestScheduleBackfillRequest;
+import io.digdag.client.api.RestScheduleEnableRequest;
 import io.digdag.client.api.RestScheduleSkipRequest;
 import io.digdag.client.api.RestScheduleSummary;
 import io.digdag.client.api.RestSecret;
@@ -800,6 +801,17 @@ public class DigdagClient implements AutoCloseable
     {
         return doPost(RestScheduleSummary.class,
                 ImmutableMap.of(),
+                target("/api/schedules/{id}/enable")
+                        .resolveTemplate("id", scheduleId));
+    }
+
+    public RestScheduleSummary enableSchedule(Id scheduleId, boolean skipSchedule, Optional<String> nextTime)
+    {
+        return doPost(RestScheduleSummary.class,
+                RestScheduleEnableRequest.builder()
+                    .skipSchedule(skipSchedule)
+                    .nextTime(nextTime)
+                    .build(),
                 target("/api/schedules/{id}/enable")
                         .resolveTemplate("id", scheduleId));
     }

--- a/digdag-client/src/main/java/io/digdag/client/api/RestScheduleEnableRequest.java
+++ b/digdag-client/src/main/java/io/digdag/client/api/RestScheduleEnableRequest.java
@@ -1,0 +1,18 @@
+package io.digdag.client.api;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.base.Optional;
+import org.immutables.value.Value;
+
+@Value.Immutable
+@JsonDeserialize(as = ImmutableRestScheduleEnableRequest.class)
+public interface RestScheduleEnableRequest
+{
+    Optional<Boolean> getSkipSchedule();
+    Optional<String> getNextTime();
+
+    static ImmutableRestScheduleEnableRequest.Builder builder()
+    {
+        return ImmutableRestScheduleEnableRequest.builder();
+    }
+}

--- a/digdag-tests/src/test/java/acceptance/ServerScheduleIT.java
+++ b/digdag-tests/src/test/java/acceptance/ServerScheduleIT.java
@@ -434,4 +434,44 @@ public class ServerScheduleIT
                         .get("last_executed_session_time", String.class))),
                 is(Instant.ofEpochSecond(lastProcessedUnixTime2Epoch)));
     }
+
+    @Test
+    public void testSkipAndEnable()
+            throws Exception
+    {
+        Files.createDirectories(projectDir);
+        addWorkflow(projectDir, "acceptance/schedule/daily10.dig", "daily10.dig");
+        addWorkflow(projectDir, "acceptance/schedule/hourly9.dig", "hourly9.dig");
+        pushProject(server.endpoint(), projectDir);
+
+        List<RestSchedule> schedules = client.getSchedules().getSchedules();
+
+        RestSchedule daily = schedules.get(0);
+        RestSchedule hourly = schedules.get(1);
+        Optional<String> skipToTime = Optional.of("2291-02-09T00:01:00Z");
+
+        // daily
+        // schedule is 10:00:00 every day
+        {
+            client.disableSchedule(daily.getId());
+            client.enableSchedule(daily.getId(), true, skipToTime);
+            // get schedule
+            RestSchedule enabled = client.getSchedule(daily.getId());
+            assertThat(enabled.getDisabledAt(), is(Optional.absent()));
+            assertThat(enabled.getNextRunTime(), is(Instant.parse("2291-02-09T10:00:00Z")));
+            assertThat(enabled.getNextScheduleTime(), is(OffsetDateTime.parse("2291-02-09T00:00Z")));
+        }
+
+        // hourly
+        // schedule is 09:00 every hour
+        {
+            client.disableSchedule(hourly.getId());
+            client.enableSchedule(hourly.getId(), true, skipToTime);
+            // get schedule
+            RestSchedule enabled = client.getSchedule(hourly.getId());
+            assertThat(enabled.getDisabledAt(), is(Optional.absent()));
+            assertThat(enabled.getNextRunTime(), is(Instant.parse("2291-02-09T00:09:00Z")));
+            assertThat(enabled.getNextScheduleTime(), is(OffsetDateTime.parse("2291-02-09T00:00Z")));
+        }
+    }
 }


### PR DESCRIPTION
Add support for skipping past sessions on existing endpoint `/api/schedules/{id}/enable`.
We decided to merge this functionality with the existing endpoints. #1392

Make this endpoint to accept `skipSchedule` and `nextTime` requests when enabling the schedule.

- skipSchedule: false -> re-run all past sessions between paused and resumed. (= same as current behavior)
- skipSchedule: true -> the schedule will be skipped (updated) to currentTime (default) / nextTime (optional, ISO8601 format). It means don't run all previously scheduled sessions.

And I have a plan to update CLI and document as another PR.