### PR TITLE
[Doc] Fix a typo in for_range.md

### DIFF
--- a/digdag-docs/src/operators/for_range.md
+++ b/digdag-docs/src/operators/for_range.md
@@ -21,7 +21,7 @@ This operator exports `${range.from}`, `${range.to}`, and `${range.index}` varia
         #  +range-from=40&to=50:
         #    echo>: processing from 40 to 50.
 
-* **for_each>**: object of from, to, and slices or step
+* **for_range>**: object of from, to, and slices or step
 
   This nested object is used to declare a range from **from** to **to**.
 

--- a/digdag-docs/src/operators/for_range.md
+++ b/digdag-docs/src/operators/for_range.md
@@ -12,13 +12,13 @@ This operator exports `${range.from}`, `${range.to}`, and `${range.index}` varia
       _do:
         echo>: processing from ${range.from} to ${range.to}.
         # this will generate 4 tasks:
-        #  +range-from=10&verb=20:
+        #  +range-from=10&to=20:
         #    echo>: processing from 10 to 20.
-        #  +range-from=20&verb=30:
+        #  +range-from=20&to=30:
         #    echo>: processing from 20 to 30.
-        #  +range-from=30&verb=40:
+        #  +range-from=30&to=40:
         #    echo>: processing from 30 to 40.
-        #  +range-from=40&verb=50:
+        #  +range-from=40&to=50:
         #    echo>: processing from 40 to 50.
 
 * **for_each>**: object of from, to, and slices or step


### PR DESCRIPTION
Hi.
I found a typo in your document.
http://docs.digdag.io/operators/for_range.html

# Before
![スクリーンショット 2020-04-26 18 16 49](https://user-images.githubusercontent.com/49683546/80303332-8fa0d280-87ea-11ea-9ffe-2070ecedbe7b.png)

# After
![スクリーンショット 2020-04-30 22 02 43](https://user-images.githubusercontent.com/49683546/80713481-7c656e00-8b2e-11ea-9c25-a7f0a4fdc868.png)

Thank you for your attention.