### PR TITLE
require> enhancement

### DIFF
--- a/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
+++ b/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
@@ -621,6 +621,13 @@ public class DigdagClient implements AutoCloseable
                 .resolveTemplate("id", attemptId));
     }
 
+    public RestSessionAttemptCollection getSessionAttemptRetries(Id attemptId)
+    {
+        return doGet(RestSessionAttemptCollection.class,
+                target("/api/attempts/{id}/retries")
+                .resolveTemplate("id", attemptId));
+    }
+
     public RestTaskCollection getTasks(Id attemptId)
     {
         return doGet(RestTaskCollection.class,

--- a/digdag-core/src/main/java/io/digdag/core/agent/InProcessTaskCallbackApi.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/InProcessTaskCallbackApi.java
@@ -170,9 +170,9 @@ public class InProcessTaskCallbackApi
             Instant instant,
             Optional<String> retryAttemptName,
             Config overrideParams)
-        throws ResourceNotFoundException, ResourceLimitExceededException
+        throws ResourceNotFoundException, ResourceLimitExceededException, SessionAttemptConflictException
     {
-        return tm.<StoredSessionAttempt, ResourceNotFoundException, ResourceLimitExceededException>begin(() -> {
+        return tm.<StoredSessionAttempt, ResourceNotFoundException, ResourceLimitExceededException, SessionAttemptConflictException>begin(() -> {
                             ProjectStore projectStore = pm.getProjectStore(siteId);
 
                             //TODO check permission by AccessController for 'require' operator over another project.
@@ -196,14 +196,9 @@ public class InProcessTaskCallbackApi
 
                             // TODO FIXME SessionMonitor monitors is not set
                             StoredSessionAttemptWithSession attempt;
-                            try {
-                                attempt = exec.submitWorkflow(siteId, ar, def);
-                            }
-                            catch (SessionAttemptConflictException ex) {
-                                attempt = ex.getConflictedSession();
-                            }
+                            attempt = exec.submitWorkflow(siteId, ar, def);
                             return attempt;
                         },
-                ResourceNotFoundException.class, ResourceLimitExceededException.class);
+                ResourceNotFoundException.class, ResourceLimitExceededException.class, SessionAttemptConflictException.class);
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/agent/InProcessTaskCallbackApi.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/InProcessTaskCallbackApi.java
@@ -165,7 +165,7 @@ public class InProcessTaskCallbackApi
     public StoredSessionAttempt startSession(
             OperatorContext context,
             int siteId,
-            int projectId,
+            ProjectIdentifier projectIdentifier,
             String workflowName,
             Instant instant,
             Optional<String> retryAttemptName,
@@ -177,7 +177,10 @@ public class InProcessTaskCallbackApi
 
                             //TODO check permission by AccessController for 'require' operator over another project.
 
-                            StoredProject proj = projectStore.getProjectById(projectId);
+                            StoredProject proj = projectIdentifier.byId() ?
+                                projectStore.getProjectById(projectIdentifier.getId()) :
+                                projectStore.getProjectByName(projectIdentifier.getName());
+
                             StoredWorkflowDefinitionWithProject def =
                                     projectStore.getLatestWorkflowDefinitionByName(proj.getId(), workflowName);
 

--- a/digdag-core/src/main/java/io/digdag/core/agent/RequireOperatorFactory.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/RequireOperatorFactory.java
@@ -10,6 +10,7 @@ import io.digdag.core.agent.TaskCallbackApi.ProjectIdentifier;
 import io.digdag.core.repository.ResourceLimitExceededException;
 import io.digdag.core.repository.ResourceNotFoundException;
 import io.digdag.core.session.StoredSessionAttempt;
+import io.digdag.core.workflow.SessionAttemptConflictException;
 import io.digdag.spi.Operator;
 import io.digdag.spi.OperatorContext;
 import io.digdag.spi.OperatorFactory;
@@ -20,6 +21,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.time.Instant;
+import java.util.UUID;
 
 import static java.util.Locale.ENGLISH;
 
@@ -64,43 +66,120 @@ public class RequireOperatorFactory
         public TaskResult runTask()
         {
             Config config = request.getConfig();
+            Config localConfig = request.getLocalConfig();
+            Config lastStateParams = request.getLastStateParams();
+            logger.debug("YY lastStateParams: {}", lastStateParams);
             String workflowName = config.get("_command", String.class);
             Instant instant = config.get("session_time", Instant.class);
             boolean ignoreFailure = config.get("ignore_failure", boolean.class, false);
-            Optional<String> retryAttemptName = config.getOptional("retry_attempt_name", String.class);
-            Config overrideParams = config.getNestedOrGetEmpty("params");
-            try {
-                ProjectIdentifier projectIdentifier = makeProjectIdentifier();
+            boolean ignoreNoExistence = config.get("ignore_failure", boolean.class, false);
+            OptionRerunOn rerunOn = OptionRerunOn.of(config.get("rerun_on", String.class, "none"));
 
-                StoredSessionAttempt attempt = callback.startSession(
+            Optional<String> retryAttemptName = localConfig.getOptional("retry_attempt_name", String.class);
+            if (lastStateParams.has("rerun_on_retry_attempt_name")) { // This parameter is set because of rerun_on parameter.
+                retryAttemptName = lastStateParams.getOptional("rerun_on_retry_attempt_name", String.class);
+            }
+            logger.debug("retryAttemptName: {}", retryAttemptName.or("(none)"));
+            Config overrideParams = config.getNestedOrGetEmpty("params");
+
+            Optional<StoredSessionAttempt> attempt = Optional.absent();
+            Optional<ResourceNotFoundException> resourceNotFoundException = Optional.absent();
+            Optional<SessionAttemptConflictException> sessionAttemptConflictException = Optional.absent();
+            Optional<ProjectIdentifier> projectIdentifier = Optional.absent();
+            /**
+             *  First of all, try to start attempt by startSession()
+             *  If no attempt exists (no conflict), it return new StoredSessionAttempt.
+             *    - set state param "require_kicked" to true.
+             *    - wait for done by nextPolling.
+             *  If something errors happen, it will throw following exceptions.
+             *    - ResourceNotFoundException ... workflow ,project name(or id) are wrong. -> process as deterministic error
+             *    - ResourceLimitExceededException ... this exception should be deterministic error
+             *    - SessionAttemptConflictException ... this is not error.
+             *      - If the conflict attempt is still running, wait for until done by nextPolling.
+             *      - If done, check the attempt is kicked by this require> or not by state param "require_kicked".
+             *        - If not kicked by this require>, check result and rerun_on option and determine rerun or not.
+             *          - if need to rerun, generate unique retry_attempt_name and set to "rerun_on_retry_attempt_name"
+             *          - throw nextPolling and in next task, "rerun_on_retry_attempt_name" is used as retry_attempt_name and must succeed to create new attempt because it is unique.
+             *        - Both kicked or not kicked, check the result and ignore_failure option
+             *          - If ignore_failure is true or attempt finished successfully, require> op finished successfully
+             *          - else finished with exception.
+             */
+            try {
+                projectIdentifier = Optional.of(makeProjectIdentifier());
+
+                attempt = Optional.of(callback.startSession(
                         context,
                         request.getSiteId(),
-                        projectIdentifier,
+                        projectIdentifier.get(),
                         workflowName,
                         instant,
                         retryAttemptName,
-                        overrideParams);
+                        overrideParams));
+            }
+            catch (ResourceNotFoundException ex) {
+                resourceNotFoundException = Optional.of(ex);
+            }
+            catch (SessionAttemptConflictException ex) {
+                sessionAttemptConflictException = Optional.of(ex);
+            }
+            catch (ResourceLimitExceededException ex) {
+                throw new TaskExecutionException(ex);
+            }
 
-                boolean isDone = attempt.getStateFlags().isDone();
-                if (isDone) {
-                    if (!ignoreFailure && !attempt.getStateFlags().isSuccess()) {
+            if (sessionAttemptConflictException.isPresent()) { // submit failed and get the conflicted attempt
+                logger.debug("startSession conflicted");
+                StoredSessionAttempt conflictedAttempt = sessionAttemptConflictException.get().getConflictedSession();
+                if (conflictedAttempt.getStateFlags().isDone()) {
+                    // A flag to distinguish the attempt is kicked by require> or previous attempt.
+                    boolean requireKicked = lastStateParams.get("require_kicked", boolean.class, false);
+                    if (!requireKicked) {
+                        // Check rerun_on option
+                        // If we need to run, set last_state_param gen_retry_attempt_name flag and nextPolling
+                        if (rerunOn == OptionRerunOn.ALL ||
+                                rerunOn == OptionRerunOn.FAILED && !conflictedAttempt.getStateFlags().isSuccess()) {
+                            //To force run, set flag gen_retry_attempt_name and do polling
+                            ConfigElement nextState = ConfigElement.copyOf(lastStateParams.deepCopy().set("rerun_on_retry_attempt_name", UUID.randomUUID().toString()));
+                            logger.debug("YY nextState:{}", nextState);
+                            // TODO use exponential-backoff to calculate retry interval
+                            throw TaskExecutionException.ofNextPolling(1, nextState);
+                        }
+                    }
+                    if (!ignoreFailure && !conflictedAttempt.getStateFlags().isSuccess()) {
                         // ignore_failure is false and the attempt is in error state. Make this operator failed.
                         throw new TaskExecutionException(String.format(ENGLISH,
-                                    "Dependent workflow failed. Session id: %d, attempt id: %d",
-                                    attempt.getSessionId(), attempt.getId()));
+                                "Dependent workflow failed. Session id: %d, attempt id: %d",
+                                conflictedAttempt.getSessionId(), conflictedAttempt.getId()));
                     }
                     return TaskResult.empty(cf);
                 }
                 else {
+                    // Wait for finish running attempt
                     // TODO use exponential-backoff to calculate retry interval
                     throw TaskExecutionException.ofNextPolling(1, ConfigElement.copyOf(request.getLastStateParams()));
+
                 }
             }
-            catch (ResourceNotFoundException ex) {
-                throw new ConfigException(ex);
+            else if ( resourceNotFoundException.isPresent()) {
+                if (ignoreNoExistence) {
+                    return TaskResult.empty(cf);
+                }
+                else {
+                    throw new TaskExecutionException(String.format(ENGLISH, "Dependent workflow does not exist. %s, workflowName:%s",
+                            projectIdentifier.transform((p)->p.toString()).or(""), workflowName ));
+                }
             }
-            catch (ResourceLimitExceededException ex) {
-                throw new TaskExecutionException(ex);
+            else if (attempt.isPresent()) { // startSession succeeded and created new attempt
+                ConfigElement nextState = ConfigElement.copyOf(request.getLastStateParams().deepCopy().set("require_kicked", true));
+                // TODO use exponential-backoff to calculate retry interval
+                throw TaskExecutionException.ofNextPolling(1, nextState);
+                // set lastStateParam kickedByRequire
+                // unset gen_retry_attempt_name
+                // nextPolling
+            }
+            else {
+                throw new RuntimeException(String.format(ENGLISH,
+                        "Unexpected condition happened in require> operator.  %s, workflowName:%s",
+                        projectIdentifier.transform((p)->p.toString()).or(""), workflowName));
             }
         }
 
@@ -133,4 +212,28 @@ public class RequireOperatorFactory
             return projectIdentifier;
         }
     }
+
+    enum OptionRerunOn
+    {
+        NONE("none"),
+        FAILED( "failed"),
+        ALL ("all");
+
+        private final String name;
+        OptionRerunOn(String name) { this.name = name; }
+        static OptionRerunOn of(String name) {
+            switch (name) {
+                case "none":
+                    return NONE;
+                case "failed":
+                    return FAILED;
+                case "all":
+                    return ALL;
+                default:
+                    throw new ConfigException("invalid rerun_on option:" + name);
+            }
+        }
+    }
+
+
 }

--- a/digdag-core/src/main/java/io/digdag/core/agent/RequireOperatorFactory.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/RequireOperatorFactory.java
@@ -90,7 +90,7 @@ public class RequireOperatorFactory
              *  First of all, try to start attempt by startSession()
              *  If no attempt exists (no conflict), it return new StoredSessionAttempt.
              *    - set state param "require_kicked" to true.
-             *    - wait for done by nextPolling.
+             *    - task is retried to wait for done by nextPolling.
              *  If something errors happen, it will throw following exceptions.
              *    - ResourceNotFoundException ... workflow ,project name(or id) are wrong. -> process as deterministic error
              *    - ResourceLimitExceededException ... this exception should be deterministic error

--- a/digdag-core/src/main/java/io/digdag/core/agent/RequireOperatorFactory.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/RequireOperatorFactory.java
@@ -68,22 +68,20 @@ public class RequireOperatorFactory
             Config config = request.getConfig();
             Config localConfig = request.getLocalConfig();
             Config lastStateParams = request.getLastStateParams();
-            logger.debug("YY lastStateParams: {}", lastStateParams);
+
             String workflowName = config.get("_command", String.class);
             Instant instant = config.get("session_time", Instant.class);
             boolean ignoreFailure = config.get("ignore_failure", boolean.class, false);
-            boolean ignoreNoExistence = config.get("ignore_failure", boolean.class, false);
             OptionRerunOn rerunOn = OptionRerunOn.of(config.get("rerun_on", String.class, "none"));
 
             Optional<String> retryAttemptName = localConfig.getOptional("retry_attempt_name", String.class);
-            if (lastStateParams.has("rerun_on_retry_attempt_name")) { // This parameter is set because of rerun_on parameter.
+            if (lastStateParams.has("rerun_on_retry_attempt_name")) { // This parameter is set for rerun_on parameter.
                 retryAttemptName = lastStateParams.getOptional("rerun_on_retry_attempt_name", String.class);
             }
-            logger.debug("retryAttemptName: {}", retryAttemptName.or("(none)"));
+
             Config overrideParams = config.getNestedOrGetEmpty("params");
 
             Optional<StoredSessionAttempt> attempt = Optional.absent();
-            Optional<ResourceNotFoundException> resourceNotFoundException = Optional.absent();
             Optional<SessionAttemptConflictException> sessionAttemptConflictException = Optional.absent();
             Optional<ProjectIdentifier> projectIdentifier = Optional.absent();
             /**
@@ -92,14 +90,14 @@ public class RequireOperatorFactory
              *    - set state param "require_kicked" to true.
              *    - task is retried to wait for done by nextPolling.
              *  If something errors happen, it will throw following exceptions.
-             *    - ResourceNotFoundException ... workflow ,project name(or id) are wrong. -> process as deterministic error
+             *    - ResourceNotFoundException ... workflow ,project name(or id) are wrong. -> processed as deterministic error
              *    - ResourceLimitExceededException ... this exception should be deterministic error
              *    - SessionAttemptConflictException ... this is not error.
              *      - If the conflict attempt is still running, wait for until done by nextPolling.
              *      - If done, check the attempt is kicked by this require> or not by state param "require_kicked".
              *        - If not kicked by this require>, check result and rerun_on option and determine rerun or not.
              *          - if need to rerun, generate unique retry_attempt_name and set to "rerun_on_retry_attempt_name"
-             *          - throw nextPolling and in next task, "rerun_on_retry_attempt_name" is used as retry_attempt_name and must succeed to create new attempt because it is unique.
+             *          - throw nextPolling and in next call of runTask(), "rerun_on_retry_attempt_name" is used as retry_attempt_name and must succeed to create new attempt because it is unique.
              *        - Both kicked or not kicked, check the result and ignore_failure option
              *          - If ignore_failure is true or attempt finished successfully, require> op finished successfully
              *          - else finished with exception.
@@ -116,39 +114,36 @@ public class RequireOperatorFactory
                         retryAttemptName,
                         overrideParams));
             }
-            catch (ResourceNotFoundException ex) {
-                resourceNotFoundException = Optional.of(ex);
-            }
             catch (SessionAttemptConflictException ex) {
                 sessionAttemptConflictException = Optional.of(ex);
+            }
+            catch (ResourceNotFoundException ex) {
+                throw new TaskExecutionException(String.format(ENGLISH, "Dependent workflow does not exist. %s, workflowName:%s",
+                        projectIdentifier.transform((p)->p.toString()).or(""), workflowName ));
             }
             catch (ResourceLimitExceededException ex) {
                 throw new TaskExecutionException(ex);
             }
 
-            if (sessionAttemptConflictException.isPresent()) { // submit failed and get the conflicted attempt
-                logger.debug("startSession conflicted");
+            if (sessionAttemptConflictException.isPresent()) {
                 StoredSessionAttempt conflictedAttempt = sessionAttemptConflictException.get().getConflictedSession();
                 if (conflictedAttempt.getStateFlags().isDone()) {
-                    // A flag to distinguish the attempt is kicked by require> or previous attempt.
+                    // A flag to distinguish whether the attempt is kicked by require> or previous attempt.
                     boolean requireKicked = lastStateParams.get("require_kicked", boolean.class, false);
-                    if (!requireKicked) {
-                        // Check rerun_on option
-                        // If we need to run, set last_state_param gen_retry_attempt_name flag and nextPolling
-                        if (rerunOn == OptionRerunOn.ALL ||
-                                rerunOn == OptionRerunOn.FAILED && !conflictedAttempt.getStateFlags().isSuccess()) {
-                            //To force run, set flag gen_retry_attempt_name and do polling
-                            ConfigElement nextState = ConfigElement.copyOf(lastStateParams.deepCopy().set("rerun_on_retry_attempt_name", UUID.randomUUID().toString()));
-                            logger.debug("YY nextState:{}", nextState);
-                            // TODO use exponential-backoff to calculate retry interval
-                            throw TaskExecutionException.ofNextPolling(1, nextState);
-                        }
+                    if (!requireKicked &&  (
+                            rerunOn == OptionRerunOn.ALL ||
+                            rerunOn == OptionRerunOn.FAILED && !conflictedAttempt.getStateFlags().isSuccess())) {
+
+                        //To force run, set flag gen_retry_attempt_name and do polling
+                        ConfigElement nextState = ConfigElement.copyOf(lastStateParams.deepCopy().set("rerun_on_retry_attempt_name", UUID.randomUUID().toString()));
+                        // TODO use exponential-backoff to calculate retry interval
+                        throw TaskExecutionException.ofNextPolling(1, nextState);
                     }
                     if (!ignoreFailure && !conflictedAttempt.getStateFlags().isSuccess()) {
                         // ignore_failure is false and the attempt is in error state. Make this operator failed.
                         throw new TaskExecutionException(String.format(ENGLISH,
-                                "Dependent workflow failed. Session id: %d, attempt id: %d",
-                                conflictedAttempt.getSessionId(), conflictedAttempt.getId()));
+                            "Dependent workflow failed. Session id: %d, attempt id: %d",
+                            conflictedAttempt.getSessionId(), conflictedAttempt.getId()));
                     }
                     return TaskResult.empty(cf);
                 }
@@ -156,25 +151,12 @@ public class RequireOperatorFactory
                     // Wait for finish running attempt
                     // TODO use exponential-backoff to calculate retry interval
                     throw TaskExecutionException.ofNextPolling(1, ConfigElement.copyOf(request.getLastStateParams()));
-
-                }
-            }
-            else if ( resourceNotFoundException.isPresent()) {
-                if (ignoreNoExistence) {
-                    return TaskResult.empty(cf);
-                }
-                else {
-                    throw new TaskExecutionException(String.format(ENGLISH, "Dependent workflow does not exist. %s, workflowName:%s",
-                            projectIdentifier.transform((p)->p.toString()).or(""), workflowName ));
                 }
             }
             else if (attempt.isPresent()) { // startSession succeeded and created new attempt
                 ConfigElement nextState = ConfigElement.copyOf(request.getLastStateParams().deepCopy().set("require_kicked", true));
                 // TODO use exponential-backoff to calculate retry interval
                 throw TaskExecutionException.ofNextPolling(1, nextState);
-                // set lastStateParam kickedByRequire
-                // unset gen_retry_attempt_name
-                // nextPolling
             }
             else {
                 throw new RuntimeException(String.format(ENGLISH,
@@ -182,7 +164,6 @@ public class RequireOperatorFactory
                         projectIdentifier.transform((p)->p.toString()).or(""), workflowName));
             }
         }
-
 
         /**
          * Make ProjectIdentifier from parameters.
@@ -234,6 +215,4 @@ public class RequireOperatorFactory
             }
         }
     }
-
-
 }

--- a/digdag-core/src/main/java/io/digdag/core/agent/RequireOperatorFactory.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/RequireOperatorFactory.java
@@ -150,17 +150,17 @@ public class RequireOperatorFactory
             }
             else {
                 // Wait for finish running attempt
-                throw nextPolling(request.getLastStateParams().deepCopy());
+                throw nextPolling(lastStateParams.deepCopy());
             }
         }
 
         private TaskExecutionException nextPolling(Config stateParams)
         {
             int iteration = stateParams.get("retry", int.class, 0);
-            stateParams.set("retry", iteration+1);
+            stateParams.set("retry", iteration + 1);
             int interval = (int) Math.min(1 * Math.pow(2, iteration), MAX_TASK_RETRY_INTERVAL);
 
-            return TaskExecutionException.ofNextPolling( interval, ConfigElement.copyOf(stateParams));
+            return TaskExecutionException.ofNextPolling(interval, ConfigElement.copyOf(stateParams));
         }
 
         /**
@@ -194,12 +194,8 @@ public class RequireOperatorFactory
 
     enum OptionRerunOn
     {
-        NONE("none"),
-        FAILED( "failed"),
-        ALL ("all");
+        NONE, FAILED, ALL;
 
-        private final String name;
-        OptionRerunOn(String name) { this.name = name; }
         static OptionRerunOn of(String name) {
             switch (name) {
                 case "none":

--- a/digdag-core/src/main/java/io/digdag/core/agent/TaskCallbackApi.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/TaskCallbackApi.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import com.google.common.base.Optional;
 import io.digdag.client.config.Config;
 import io.digdag.core.log.TaskLogger;
+import io.digdag.core.workflow.SessionAttemptConflictException;
 import io.digdag.spi.OperatorContext;
 import io.digdag.spi.TaskResult;
 import io.digdag.spi.TaskRequest;
@@ -39,7 +40,7 @@ public interface TaskCallbackApi
             Instant instant,
             Optional<String> retryAttemptName,
             Config overrideParams)
-            throws ResourceNotFoundException, ResourceLimitExceededException;
+            throws ResourceNotFoundException, ResourceLimitExceededException, SessionAttemptConflictException;
 
     /**
      *  Identifier of Project: id or name
@@ -63,5 +64,15 @@ public interface TaskCallbackApi
 
         public Integer getId() { return projectId.get(); }
         public String getName() { return projectName.get(); }
+
+        @Override
+        public String toString() {
+            if (projectId.isPresent()) {
+                return "projectId: " + projectId.get();
+            }
+            else {
+                return "projectName: " + projectName.get();
+            }
+        }
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/agent/TaskCallbackApi.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/TaskCallbackApi.java
@@ -41,7 +41,11 @@ public interface TaskCallbackApi
             Config overrideParams)
             throws ResourceNotFoundException, ResourceLimitExceededException;
 
-    // Identifier of Project: id or name
+    /**
+     *  Identifier of Project: id or name
+     *
+     *  If this class is used from other than RequireOperator, move to ProjectStore is better.
+     */
     class ProjectIdentifier
     {
         private Optional<Integer> projectId = Optional.absent();

--- a/digdag-core/src/main/java/io/digdag/core/agent/TaskCallbackApi.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/TaskCallbackApi.java
@@ -34,10 +34,30 @@ public interface TaskCallbackApi
     StoredSessionAttempt startSession(
             OperatorContext context,
             int siteId,
-            int projectId,
+            ProjectIdentifier projectIdentifier,
             String workflowName,
             Instant instant,
             Optional<String> retryAttemptName,
             Config overrideParams)
-        throws ResourceNotFoundException, ResourceLimitExceededException;
+            throws ResourceNotFoundException, ResourceLimitExceededException;
+
+    // Identifier of Project: id or name
+    class ProjectIdentifier
+    {
+        private Optional<Integer> projectId = Optional.absent();
+        private Optional<String>  projectName = Optional.absent();
+
+        private ProjectIdentifier(){}
+        private ProjectIdentifier(int projectId) { this.projectId = Optional.of(projectId); }
+        private ProjectIdentifier(String projectName) { this.projectName = Optional.of(projectName); }
+
+        public static ProjectIdentifier ofId(int projectId) { return new ProjectIdentifier(projectId); }
+        public static ProjectIdentifier ofName(String projectName) { return new ProjectIdentifier(projectName); }
+
+        public boolean byId() { return projectId.isPresent(); }
+        public boolean byName() { return projectName.isPresent(); }
+
+        public Integer getId() { return projectId.get(); }
+        public String getName() { return projectName.get(); }
+    }
 }

--- a/digdag-docs/src/operators/require.md
+++ b/digdag-docs/src/operators/require.md
@@ -60,6 +60,17 @@
   project_id: 12345
   ```
 
+* **project_name**: project_name
+
+  Name of another project. You can kick another project's workflow by setting this parameter.
+
+  Examples:
+
+  ```
+  require>: another_project_wf
+  project_name: another_project
+  ```
+
 * **ignore_failure**: BOOLEAN
 
   This operator fails when the dependent workflow finished with errors by default.

--- a/digdag-docs/src/operators/require.md
+++ b/digdag-docs/src/operators/require.md
@@ -70,6 +70,13 @@
   project_name: another_project
   ```
 
+* **rerun_on**: none, failed, all (default: none)
+
+  *rerun_on* control require> really kicks or not if the attempt for the dependent workflow already exists. 
+  * *none* ... Not kick the workflow if the attempt already exists.
+  * *failed* ... Kick the workflow if the attempt exists and its result is not success.
+  * *all* ... require> kick the workflow regardless of the result of the attempt.
+
 * **ignore_failure**: BOOLEAN
 
   This operator fails when the dependent workflow finished with errors by default.
@@ -81,3 +88,8 @@
   ignore_failure: true
   ```
 
+  require> evaluates *ignore_failure* at last of its process. If rerun_on is set and require> run new attempt, the result of new attempt is checked.
+
+## Notes
+- require> has been changed to ignore inherited *retry_attempt_name* parameter. 
+  `digdag retry ` command generates unique retry_attempt_name to run, but it is not passed to require>.

--- a/digdag-docs/src/operators/require.md
+++ b/digdag-docs/src/operators/require.md
@@ -50,21 +50,20 @@
   ```
 
 * **project_id**: project_id
+* **project_name**: project_name
 
-  Id of another project. You can kick another project's workflow by setting this parameter.
+  You can kick another project's workflow by setting project_id or project_name.
+  If the project does not exist, the task will fail.
+  If you set both project_id and project_name, the task will fail.
 
-  Examples:
+  Examples 1:
 
   ```
   require>: another_project_wf
   project_id: 12345
   ```
 
-* **project_name**: project_name
-
-  Name of another project. You can kick another project's workflow by setting this parameter.
-
-  Examples:
+  Examples 2:
 
   ```
   require>: another_project_wf

--- a/digdag-docs/src/operators/require.md
+++ b/digdag-docs/src/operators/require.md
@@ -92,4 +92,4 @@
 
 ## Notes
 - require> has been changed to ignore inherited *retry_attempt_name* parameter. 
-  `digdag retry ` command generates unique retry_attempt_name to run, but it is not passed to require>.
+  `digdag retry` command generates unique retry_attempt_name to run, but it is not passed to require>.

--- a/digdag-tests/src/test/java/acceptance/RequireIT.java
+++ b/digdag-tests/src/test/java/acceptance/RequireIT.java
@@ -235,6 +235,23 @@ public class RequireIT
                 "--session", "now"
         );
         assertThat(startStatus.errUtf8(), startStatus.code(), is(0));
+
+        Id parentAttemptId = getAttemptId(startStatus);
+        // Wait for the attempt to complete
+        boolean success = false;
+        for (int i = 0; i < 120; i++) {
+            CommandStatus attemptsStatus = main("attempts",
+                    "-c", config.toString(),
+                    "-e", server.endpoint(),
+                    String.valueOf(parentAttemptId));
+            success = attemptsStatus.outUtf8().contains("status: success");
+            if (success) {
+                break;
+            }
+            Thread.sleep(1000);
+        }
+        assertThat(success, is(true));
+
     }
 
 

--- a/digdag-tests/src/test/java/acceptance/RequireIT.java
+++ b/digdag-tests/src/test/java/acceptance/RequireIT.java
@@ -219,8 +219,8 @@ public class RequireIT
         // Push parent project
         Files.write(projectDir.resolve("parent_another_project.dig"), asList(Resources.toString(
                 Resources.getResource("acceptance/require/parent_another_project.dig"), UTF_8)
-                .replace("${child_project_id}", childProjectId)
-                .replace("${child_project_name}", childProjectName)));
+                .replace("__CHILD_PROJECT_ID__", childProjectId)
+                .replace("__CHILD_PROJECT_NAME__", childProjectName)));
         CommandStatus pushParentStatus = main("push",
                 "--project", projectDir.toString(),
                 "parent_another",

--- a/digdag-tests/src/test/java/acceptance/RequireIT.java
+++ b/digdag-tests/src/test/java/acceptance/RequireIT.java
@@ -1,18 +1,16 @@
 package acceptance;
 
-import com.google.common.base.Optional;
 import io.digdag.client.DigdagClient;
 import io.digdag.client.api.Id;
+import io.digdag.client.api.RestSessionAttemptCollection;
+
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Resources;
-import io.digdag.client.api.RestSessionAttemptCollection;
 
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import utils.CommandStatus;
 import utils.TemporaryDigdagServer;
 
@@ -42,8 +40,6 @@ import static org.junit.Assert.assertThat;
 
 public class RequireIT
 {
-    private static Logger logger = LoggerFactory.getLogger(RequireIT.class);
-
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
 

--- a/digdag-tests/src/test/java/acceptance/RequireIT.java
+++ b/digdag-tests/src/test/java/acceptance/RequireIT.java
@@ -233,7 +233,7 @@ public class RequireIT
         assertThat(m.find(), is(true));
         String childProjectId = m.group(1);
 
-        // Push parent project with project_id: xxx
+        // Push parent project with project_id: xxx or project_name: yyy based on useProjectId
         String template = Resources.toString(
                 Resources.getResource("acceptance/require/parent_another_project.dig"), UTF_8);
         String content = useProjectId ?

--- a/digdag-tests/src/test/resources/acceptance/require/child_another_project.dig
+++ b/digdag-tests/src/test/resources/acceptance/require/child_another_project.dig
@@ -1,0 +1,2 @@
++hello:
+  echo>: this is child_another_project

--- a/digdag-tests/src/test/resources/acceptance/require/child_rerun_on.dig
+++ b/digdag-tests/src/test/resources/acceptance/require/child_rerun_on.dig
@@ -1,0 +1,6 @@
++t1:
+  if>: ${child_fail==="yes"}
+  _do:
+    fail>: child failed
+  _else_do:
+    echo>: child succeed

--- a/digdag-tests/src/test/resources/acceptance/require/parent_another_project.dig
+++ b/digdag-tests/src/test/resources/acceptance/require/parent_another_project.dig
@@ -1,7 +1,3 @@
-+require_by_project_id:
++require_by_project:
   require>: child_another_project
-  project_id: __CHILD_PROJECT_ID__
-
-+require_by_project_name:
-  require>: child_another_project
-  project_name: __CHILD_PROJECT_NAME__
+  __CHILD_PROJECT__

--- a/digdag-tests/src/test/resources/acceptance/require/parent_another_project.dig
+++ b/digdag-tests/src/test/resources/acceptance/require/parent_another_project.dig
@@ -1,7 +1,7 @@
 +require_by_project_id:
   require>: child_another_project
-  project_id: ${child_project_id}
+  project_id: __CHILD_PROJECT_ID__
 
 +require_by_project_name:
   require>: child_another_project
-  project_name: ${child_project_name}
+  project_name: __CHILD_PROJECT_NAME__

--- a/digdag-tests/src/test/resources/acceptance/require/parent_another_project.dig
+++ b/digdag-tests/src/test/resources/acceptance/require/parent_another_project.dig
@@ -1,0 +1,7 @@
++require_by_project_id:
+  require>: child_another_project
+  project_id: ${child_project_id}
+
++require_by_project_name:
+  require>: child_another_project
+  project_name: ${child_project_name}

--- a/digdag-tests/src/test/resources/acceptance/require/parent_rerun_on.dig
+++ b/digdag-tests/src/test/resources/acceptance/require/parent_rerun_on.dig
@@ -1,0 +1,6 @@
+
++require:
+  require>: child
+  rerun_on: ${param_rerun_on}
+  params:
+    child_fail: ${child_fail}


### PR DESCRIPTION

This PR is follow up PR to #1405 and enhance require> operator.

- Introduce rerun_on: (none,failed,all).
- Ignore retry_attempt_name from out of operator. (fix #712 )
- exponential backoff for task retry (max 10 secs)

To exclude #1405 fix from file changes, following view may be good.
https://github.com/treasure-data/digdag/pull/1409/files/48b9ae47b4554f8b5b1fa0fadcc1a28842cd07b7..ef1f5fdeb1b8f248d281b5fb989f714b5b75649e

Following is the flow chart of require>
![WM_815_Google_Slides](https://user-images.githubusercontent.com/1102265/83604583-5d388100-a5b1-11ea-91ab-ff899e4fd818.jpg)
