### PR TITLE
Limiting the number of tasks/loops in _parallel

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowCompiler.java
+++ b/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowCompiler.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.Map.Entry;
 import java.util.stream.Collectors;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.*;
 import com.google.common.collect.*;
 import io.digdag.core.session.TaskType;
@@ -231,7 +232,8 @@ public class WorkflowCompiler
                     .map(pair -> collect(Optional.of(tb), fullName, pair.getKey(), pair.getValue(), validator))
                     .collect(Collectors.toList());
 
-                if (config.get("_parallel", boolean.class, false)) {
+                ParallelControl pc = new ParallelControl(config);
+                if (pc.isParallel() && pc.getParallelLimit() == 0) {
                     // _after: is valid only when parallel: is true
                     Map<String, TaskBuilder> names = new HashMap<>();
                     for (TaskBuilder subtask : subtasks) {
@@ -247,6 +249,32 @@ public class WorkflowCompiler
                         }
                         subtask.modifyConfig().remove("_after");  // suppress "Parameter '_after' is not used" warning message
                         names.put(subtask.getName(), subtask);
+                    }
+                }
+                else if (pc.isParallel() && pc.getParallelLimit() > 0) {
+                    int limit = pc.getParallelLimit();
+                    List<TaskBuilder> beforeList = new ArrayList<>();
+                    for (List<TaskBuilder> chunkedSubtasks : Lists.partition(subtasks, limit)) {
+                        Map<String, TaskBuilder> names = new HashMap<>();
+                        for (TaskBuilder subtask : chunkedSubtasks) {
+                            if (subtask.getConfig().get("_background", boolean.class, false)) {
+                                throw new ConfigException("Setting \"_background: true\" option is invalid (unnecessary) if its parent task has \"_parallel: true\" option");
+                            }
+                            for (String upName : subtask.getConfig().getListOrEmpty("_after", String.class)) {
+                                TaskBuilder up = names.get(upName);
+                                if (up == null) {
+                                    throw new ConfigException("Dependency task '"+upName+"' does not exist");
+                                }
+                                subtask.addUpstream(up);
+                            }
+                            subtask.modifyConfig().remove("_after");  // suppress "Parameter '_after' is not used" warning message
+                            names.put(subtask.getName(), subtask);
+                            for (TaskBuilder before : beforeList) {
+                                subtask.addUpstream(before);
+                            }
+                        }
+                        beforeList.clear();
+                        beforeList.addAll(chunkedSubtasks);
                     }
                 }
                 else {
@@ -303,5 +331,34 @@ public class WorkflowCompiler
                 .groupingOnly(groupingOnly)
                 .build();
         }
+    }
+
+    private static class ParallelControl
+    {
+        private final boolean isParallel;
+        private final int parallelLimit;
+
+        private ParallelControl(Config config)
+        {
+            final JsonNode parallelNode = config.getInternalObjectNode().get("_parallel");
+            if (parallelNode == null) { // not specified, default
+                this.isParallel = false;
+                this.parallelLimit = 0;
+            }
+            else if (parallelNode.isBoolean()) { // _parallel: true/false
+                this.isParallel = config.get("_parallel", boolean.class);
+                this.parallelLimit = 0; // no limit
+            }
+            else if (parallelNode.isObject()) { // _parallel: {limit: N}
+                Config parallel = config.getNested("_parallel");
+                this.isParallel = true; // always true
+                this.parallelLimit = parallel.get("limit", int.class);
+            }
+            else { // unknown format
+                throw new ConfigException(String.format("Invalid _parallel format: %s", parallelNode.toString()));
+            }
+        }
+        public boolean isParallel() { return isParallel; }
+        public int getParallelLimit() { return parallelLimit; }
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowCompiler.java
+++ b/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowCompiler.java
@@ -234,23 +234,25 @@ public class WorkflowCompiler
 
                 ParallelControl pc = new ParallelControl(config);
                 Map<String, TaskBuilder> names = new HashMap<>();
-                if (pc.isParallel() && pc.getParallelLimit() == 0) {
-                    for (TaskBuilder subtask : subtasks) {
-                        parseSubtaskWithParallel(names, subtask);
-                    }
-                }
-                else if (pc.isParallel() && pc.getParallelLimit() > 0) {
-                    int limit = pc.getParallelLimit();
-                    List<TaskBuilder> beforeList = new ArrayList<>();
-                    for (List<TaskBuilder> chunkedSubtasks : Lists.partition(subtasks, limit)) {
-                        for (TaskBuilder subtask : chunkedSubtasks) {
-                            parseSubtaskWithParallel(names, subtask);
-                            for (TaskBuilder before : beforeList) {
-                                subtask.addUpstream(before);
+                if (pc.isParallel()) {
+                    if (pc.getParallelLimit() > 0) {
+                        int limit = pc.getParallelLimit();
+                        List<TaskBuilder> beforeList = new ArrayList<>();
+                        for (List<TaskBuilder> chunkedSubtasks : Lists.partition(subtasks, limit)) {
+                            for (TaskBuilder subtask : chunkedSubtasks) {
+                                parseSubtaskWithParallel(names, subtask);
+                                for (TaskBuilder before : beforeList) {
+                                    subtask.addUpstream(before);
+                                }
                             }
+                            beforeList.clear();
+                            beforeList.addAll(chunkedSubtasks);
                         }
-                        beforeList.clear();
-                        beforeList.addAll(chunkedSubtasks);
+                    }
+                    else {
+                        for (TaskBuilder subtask : subtasks) {
+                            parseSubtaskWithParallel(names, subtask);
+                        }
                     }
                 }
                 else {

--- a/digdag-core/src/test/java/io/digdag/core/workflow/ForEachOperatorFactory.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/ForEachOperatorFactory.java
@@ -72,8 +72,6 @@ public class ForEachOperatorFactory
 
             List<Map<Map.Entry<Integer, String>, Map.Entry<Integer, JsonNode>>> combinations = buildCombinations(entries);
 
-            boolean parallel = params.get("_parallel", boolean.class, false);
-
             Config generated = doConfig.getFactory().create();
             for (Map<Map.Entry<Integer, String>, Map.Entry<Integer, JsonNode>> combination : combinations) {
                 Config combinationConfig = params.getFactory().create();
@@ -88,8 +86,8 @@ public class ForEachOperatorFactory
                         subtask);
             }
 
-            if (parallel) {
-                generated.set("_parallel", parallel);
+            if (params.has("_parallel")) {
+                generated.set("_parallel", params.get("_parallel", JsonNode.class));
             }
 
             return TaskResult.defaultBuilder(request)

--- a/digdag-core/src/test/java/io/digdag/core/workflow/LoopOperatorFactory.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/LoopOperatorFactory.java
@@ -1,6 +1,8 @@
 package io.digdag.core.workflow;
 
 import java.nio.file.Path;
+
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.inject.Inject;
 import io.digdag.core.Limits;
 import io.digdag.spi.OperatorContext;
@@ -54,8 +56,6 @@ public class LoopOperatorFactory
                 throw new ConfigException("Too many loop subtasks. Limit: " + Limits.maxWorkflowTasks());
             }
 
-            boolean parallel = params.get("_parallel", boolean.class, false);
-
             Config generated = doConfig.getFactory().create();
             for (int i = 0; i < count; i++) {
                 Config subtask = params.getFactory().create();
@@ -66,8 +66,8 @@ public class LoopOperatorFactory
                         subtask);
             }
 
-            if (parallel) {
-                generated.set("_parallel", parallel);
+            if (params.has("_parallel")) {
+                generated.set("_parallel", params.get("_parallel", JsonNode.class));
             }
 
             return TaskResult.defaultBuilder(request)

--- a/digdag-core/src/test/java/io/digdag/core/workflow/TaskDependenciesTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/TaskDependenciesTest.java
@@ -236,7 +236,7 @@ public class TaskDependenciesTest {
             //     +step3:
             //       echo>: '${this.task_name}'
             //
-            // id | tasks index   | full_name                                 | expected parent_id | expected upstream_id 　
+            // id | tasks index   | full_name                               | expected parent_id | expected upstream_id 　
             // 1  | tasks.get(0)  | +parallel_limit                         |                    |
             // 2  | tasks.get(1)  | +parallel_limit+repeat                  | 1                  |
             // 3  | tasks.get(2)  | +parallel_limit+repeat^sub              | 2                  |
@@ -245,10 +245,10 @@ public class TaskDependenciesTest {
             // 6  | tasks.get(5)  | +parallel_limit+repeat^sub+loop-0+step2 | 4                  | 5
             // 7  | tasks.get(6)  | +parallel_limit+repeat^sub+loop-0+step3 | 4                  | 6
             // 8  | tasks.get(7)  | +parallel_limit+repeat^sub+loop-1       | 3                  |
-            // 9  | tasks.get(8)  | +parallel_limit+repeat^sub+loop-1+step1 | 8                  | 9
-            // 10 | tasks.get(9)  | +parallel_limit+repeat^sub+loop-1+step2 | 8                  | 10
-            // 11 | tasks.get(10) | +parallel_limit+repeat^sub+loop-1+step3 | 8                  | 4,8
-            // 12 | tasks.get(11) | +parallel_limit+repeat^sub+loop-2       | 3                  |
+            // 9  | tasks.get(8)  | +parallel_limit+repeat^sub+loop-1+step1 | 8                  |
+            // 10 | tasks.get(9)  | +parallel_limit+repeat^sub+loop-1+step2 | 8                  | 9
+            // 11 | tasks.get(10) | +parallel_limit+repeat^sub+loop-1+step3 | 8                  | 10
+            // 12 | tasks.get(11) | +parallel_limit+repeat^sub+loop-2       | 3                  | 4,8
             // 13 | tasks.get(12) | +parallel_limit+repeat^sub+loop-1+step1 | 12                 |
             // 14 | tasks.get(13) | +parallel_limit+repeat^sub+loop-1+step2 | 12                 | 13
             // 15 | tasks.get(14) | +parallel_limit+repeat^sub+loop-1+step3 | 12                 | 14

--- a/digdag-core/src/test/java/io/digdag/core/workflow/TaskDependenciesTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/TaskDependenciesTest.java
@@ -9,7 +9,9 @@ import io.digdag.core.session.StoredSessionAttemptWithSession;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
-import org.junit.After;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -209,6 +211,115 @@ public class TaskDependenciesTest {
             assertThat(tasks.get(21).getUpstreams(), is(Collections.singletonList(tasks.get(19).getId())));
             assertThat(tasks.get(22).getUpstreams(), is(Collections.singletonList(tasks.get(21).getId())));
             assertThat(tasks.get(23).getUpstreams(), is(Collections.emptyList()));
+            return null;
+        });
+    }
+
+    @Test
+    public void testParallelLimitDependencies()
+            throws Exception {
+        StoredSessionAttemptWithSession attempt =
+                runWorkflow(embed, projectPath, "parallel_limit", loadYamlResource("/io/digdag/core/workflow/parallel_limit.dig"));
+        tm.begin(() -> {
+            assertThat(attempt.getStateFlags().isSuccess(), is(true));
+            List<ArchivedTask> tasks = localSite.getSessionStore().getTasksOfAttempt(attempt.getId());
+            // # parallel_limit.dig
+            // +repeat:
+            //   loop>: 5
+            //   _parallel:
+            //     limit: 2
+            //   _do:
+            //     +step1:
+            //       echo>: '${this.task_name}'
+            //     +step2:
+            //       echo>: '${this.task_name}'
+            //     +step3:
+            //       echo>: '${this.task_name}'
+            //
+            // id | tasks index   | full_name                                 | expected parent_id | expected upstream_id 　
+            // 1  | tasks.get(0)  | +parallel_limit                         |                    |
+            // 2  | tasks.get(1)  | +parallel_limit+repeat                  | 1                  |
+            // 3  | tasks.get(2)  | +parallel_limit+repeat^sub              | 2                  |
+            // 4  | tasks.get(3)  | +parallel_limit+repeat^sub+loop-0       | 3                  |
+            // 5  | tasks.get(4)  | +parallel_limit+repeat^sub+loop-0+step1 | 4                  |
+            // 6  | tasks.get(5)  | +parallel_limit+repeat^sub+loop-0+step2 | 4                  | 5
+            // 7  | tasks.get(6)  | +parallel_limit+repeat^sub+loop-0+step3 | 4                  | 6
+            // 8  | tasks.get(7)  | +parallel_limit+repeat^sub+loop-1       | 3                  |
+            // 9  | tasks.get(8)  | +parallel_limit+repeat^sub+loop-1+step1 | 8                  | 9
+            // 10 | tasks.get(9)  | +parallel_limit+repeat^sub+loop-1+step2 | 8                  | 10
+            // 11 | tasks.get(10) | +parallel_limit+repeat^sub+loop-1+step3 | 8                  | 4,8
+            // 12 | tasks.get(11) | +parallel_limit+repeat^sub+loop-2       | 3                  |
+            // 13 | tasks.get(12) | +parallel_limit+repeat^sub+loop-1+step1 | 12                 |
+            // 14 | tasks.get(13) | +parallel_limit+repeat^sub+loop-1+step2 | 12                 | 13
+            // 15 | tasks.get(14) | +parallel_limit+repeat^sub+loop-1+step3 | 12                 | 14
+            // 16 | tasks.get(15) | +parallel_limit+repeat^sub+loop-3       | 3                  | 4,8
+            // 17 | tasks.get(16) | +parallel_limit+repeat^sub+loop-3+step1 | 16                 |
+            // 18 | tasks.get(17) | +parallel_limit+repeat^sub+loop-3+step2 | 16                 | 17
+            // 19 | tasks.get(18) | +parallel_limit+repeat^sub+loop-3+step3 | 16                 | 18
+            // 20 | tasks.get(19) | +parallel_limit+repeat^sub+loop-4       | 3                  | 12,16
+            // 21 | tasks.get(20) | +parallel_limit+repeat^sub+loop-4+step1 | 20                 |
+            // 22 | tasks.get(21) | +parallel_limit+repeat^sub+loop-4+step2 | 20                 | 21
+            // 23 | tasks.get(22) | +parallel_limit+repeat^sub+loop-4+step3 | 20                 | 22
+
+            // parent_id test
+            assertThat(tasks.get(0).getParentId(), is(Optional.absent()));
+            assertThat(tasks.get(1).getParentId(), is(Optional.of(tasks.get(0).getId())));
+            assertThat(tasks.get(2).getParentId(), is(Optional.of(tasks.get(1).getId())));
+
+            assertThat(tasks.get(3).getParentId(), is(Optional.of(tasks.get(2).getId())));
+            assertThat(tasks.get(4).getParentId(), is(Optional.of(tasks.get(3).getId())));
+            assertThat(tasks.get(5).getParentId(), is(Optional.of(tasks.get(3).getId())));
+            assertThat(tasks.get(6).getParentId(), is(Optional.of(tasks.get(3).getId())));
+
+            assertThat(tasks.get(7).getParentId(), is(Optional.of(tasks.get(2).getId())));
+            assertThat(tasks.get(8).getParentId(), is(Optional.of(tasks.get(7).getId())));
+            assertThat(tasks.get(9).getParentId(), is(Optional.of(tasks.get(7).getId())));
+            assertThat(tasks.get(10).getParentId(), is(Optional.of(tasks.get(7).getId())));
+
+            assertThat(tasks.get(11).getParentId(), is(Optional.of(tasks.get(2).getId())));
+            assertThat(tasks.get(12).getParentId(), is(Optional.of(tasks.get(11).getId())));
+            assertThat(tasks.get(13).getParentId(), is(Optional.of(tasks.get(11).getId())));
+            assertThat(tasks.get(14).getParentId(), is(Optional.of(tasks.get(11).getId())));
+
+            assertThat(tasks.get(15).getParentId(), is(Optional.of(tasks.get(2).getId())));
+            assertThat(tasks.get(16).getParentId(), is(Optional.of(tasks.get(15).getId())));
+            assertThat(tasks.get(17).getParentId(), is(Optional.of(tasks.get(15).getId())));
+            assertThat(tasks.get(18).getParentId(), is(Optional.of(tasks.get(15).getId())));
+
+            assertThat(tasks.get(19).getParentId(), is(Optional.of(tasks.get(2).getId())));
+            assertThat(tasks.get(20).getParentId(), is(Optional.of(tasks.get(19).getId())));
+            assertThat(tasks.get(21).getParentId(), is(Optional.of(tasks.get(19).getId())));
+            assertThat(tasks.get(22).getParentId(), is(Optional.of(tasks.get(19).getId())));
+
+            // upstream_id test
+            assertThat(tasks.get(0).getUpstreams(), is(Collections.emptyList()));
+            assertThat(tasks.get(1).getUpstreams(), is(Collections.emptyList()));
+            assertThat(tasks.get(2).getUpstreams(), is(Collections.emptyList()));
+
+            assertThat(tasks.get(3).getUpstreams(), is(Collections.emptyList()));
+            assertThat(tasks.get(4).getUpstreams(), is(Collections.emptyList()));
+            assertThat(tasks.get(5).getUpstreams(), is(Collections.singletonList(tasks.get(4).getId())));
+            assertThat(tasks.get(6).getUpstreams(), is(Collections.singletonList(tasks.get(5).getId())));
+
+            assertThat(tasks.get(7).getUpstreams(), is(Collections.emptyList()));
+            assertThat(tasks.get(8).getUpstreams(), is(Collections.emptyList()));
+            assertThat(tasks.get(9).getUpstreams(), is(Collections.singletonList(tasks.get(8).getId())));
+            assertThat(tasks.get(10).getUpstreams(), is(Collections.singletonList(tasks.get(9).getId())));
+
+            assertThat(tasks.get(11).getUpstreams(), is(Stream.of(tasks.get(3).getId(), tasks.get(7).getId()).collect(Collectors.toList())));
+            assertThat(tasks.get(12).getUpstreams(), is(Collections.emptyList()));
+            assertThat(tasks.get(13).getUpstreams(), is(Collections.singletonList(tasks.get(12).getId())));
+            assertThat(tasks.get(14).getUpstreams(), is(Collections.singletonList(tasks.get(13).getId())));
+
+            assertThat(tasks.get(15).getUpstreams(), is(Stream.of(tasks.get(3).getId(), tasks.get(7).getId()).collect(Collectors.toList())));
+            assertThat(tasks.get(16).getUpstreams(), is(Collections.emptyList()));
+            assertThat(tasks.get(17).getUpstreams(), is(Collections.singletonList(tasks.get(16).getId())));
+            assertThat(tasks.get(18).getUpstreams(), is(Collections.singletonList(tasks.get(17).getId())));
+
+            assertThat(tasks.get(19).getUpstreams(), is(Stream.of(tasks.get(11).getId(), tasks.get(15).getId()).collect(Collectors.toList())));
+            assertThat(tasks.get(20).getUpstreams(), is(Collections.emptyList()));
+            assertThat(tasks.get(21).getUpstreams(), is(Collections.singletonList(tasks.get(20).getId())));
+            assertThat(tasks.get(22).getUpstreams(), is(Collections.singletonList(tasks.get(21).getId())));
             return null;
         });
     }

--- a/digdag-core/src/test/java/io/digdag/core/workflow/TaskDependenciesTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/TaskDependenciesTest.java
@@ -230,11 +230,11 @@ public class TaskDependenciesTest {
             //     limit: 2
             //   _do:
             //     +step1:
-            //       echo>: '${this.task_name}'
+            //       echo>: '${task_name}'
             //     +step2:
-            //       echo>: '${this.task_name}'
+            //       echo>: '${task_name}'
             //     +step3:
-            //       echo>: '${this.task_name}'
+            //       echo>: '${task_name}'
             //
             // id | tasks index   | full_name                               | expected parent_id | expected upstream_id 　
             // 1  | tasks.get(0)  | +parallel_limit                         |                    |

--- a/digdag-core/src/test/resources/io/digdag/core/workflow/parallel_limit.dig
+++ b/digdag-core/src/test/resources/io/digdag/core/workflow/parallel_limit.dig
@@ -1,0 +1,11 @@
++repeat:
+  loop>: 5
+  _parallel:
+    limit: 2
+  _do:
+    +step1:
+      echo>: '${this.task_name}'
+    +step2:
+      echo>: '${this.task_name}'
+    +step3:
+      echo>: '${this.task_name}'

--- a/digdag-core/src/test/resources/io/digdag/core/workflow/parallel_limit.dig
+++ b/digdag-core/src/test/resources/io/digdag/core/workflow/parallel_limit.dig
@@ -4,8 +4,8 @@
     limit: 2
   _do:
     +step1:
-      echo>: '${this.task_name}'
+      echo>: '${task_name}'
     +step2:
-      echo>: '${this.task_name}'
+      echo>: '${task_name}'
     +step3:
-      echo>: '${this.task_name}'
+      echo>: '${task_name}'

--- a/digdag-docs/src/operators/for_each.md
+++ b/digdag-docs/src/operators/for_each.md
@@ -42,7 +42,7 @@
 
   Runs the repeating tasks in parallel.
   If ``_parallel: {limit: N}`` (N is an integer: 1, 2, 3, …) parameter is set,
-  the number of loops running in parallel is limited to N.
+  the number of tasks running in parallel is limited to N.
   Note that the tasks in the loop will be running in serial.
 
   Examples:

--- a/digdag-docs/src/operators/for_each.md
+++ b/digdag-docs/src/operators/for_each.md
@@ -38,14 +38,24 @@
   for_each>: {i: '[1, 2, 3]'}
   ```
 
-* **\_parallel**: BOOLEAN
+* **\_parallel**: BOOLEAN | OBJECT
 
   Runs the repeating tasks in parallel.
+  If ``_parallel: {limit: N}`` (N is an integer: 1, 2, 3, …) parameter is set,
+  the number of loops running in parallel is limited to N.
+  Note that the tasks in the loop will be running in serial.
 
   Examples:
 
   ```
   _parallel: true
+  ```
+
+  Examples:
+
+  ```
+  _parallel:
+    limit: 2
   ```
 
 * **\_do**: TASKS

--- a/digdag-docs/src/operators/for_range.md
+++ b/digdag-docs/src/operators/for_range.md
@@ -63,7 +63,7 @@ This operator exports `${range.from}`, `${range.to}`, and `${range.index}` varia
 
   Runs the repeating tasks in parallel.
   If ``_parallel: {limit: N}`` (N is an integer: 1, 2, 3, …) parameter is set,
-  the number of loops running in parallel is limited to N.
+  the number of tasks running in parallel is limited to N.
   Note that the tasks in the loop will be running in serial.
 
   Examples:

--- a/digdag-docs/src/operators/for_range.md
+++ b/digdag-docs/src/operators/for_range.md
@@ -59,14 +59,24 @@ This operator exports `${range.from}`, `${range.to}`, and `${range.index}` varia
     echo>: from ${range.from} to ${range.to}
   ```
 
-* **\_parallel**: BOOLEAN
+* **\_parallel**: BOOLEAN | OBJECT
 
   Runs the repeating tasks in parallel.
+  If ``_parallel: {limit: N}`` (N is an integer: 1, 2, 3, …) parameter is set,
+  the number of loops running in parallel is limited to N.
+  Note that the tasks in the loop will be running in serial.
 
   Examples:
 
   ```
   _parallel: true
+  ```
+
+  Examples:
+
+  ```
+  _parallel:
+    limit: 2
   ```
 
 * **\_do**: TASKS

--- a/digdag-docs/src/operators/loop.md
+++ b/digdag-docs/src/operators/loop.md
@@ -23,13 +23,24 @@ This operator exports `${i}` variable for the subtasks. Its value begins from 0.
   loop>: 7
   ```
 
-* **\_parallel**: BOOLEAN
+* **\_parallel**: BOOLEAN | OBJECT
+
   Runs the repeating tasks in parallel.
+  If ``_parallel: {limit: N}`` (N is an integer: 1, 2, 3, …) parameter is set,
+  the number of loops running in parallel is limited to N.
+  Note that the tasks in the loop will be running in serial.
 
   Examples:
 
   ```
   _parallel: true
+  ```
+
+  Examples:
+
+  ```
+  _parallel:
+    limit: 2
   ```
 
 * **\_do**: TASKS

--- a/digdag-docs/src/operators/loop.md
+++ b/digdag-docs/src/operators/loop.md
@@ -27,7 +27,7 @@ This operator exports `${i}` variable for the subtasks. Its value begins from 0.
 
   Runs the repeating tasks in parallel.
   If ``_parallel: {limit: N}`` (N is an integer: 1, 2, 3, …) parameter is set,
-  the number of loops running in parallel is limited to N.
+  the number of tasks running in parallel is limited to N.
   Note that the tasks in the loop will be running in serial.
 
   Examples:

--- a/digdag-docs/src/workflow_definition.rst
+++ b/digdag-docs/src/workflow_definition.rst
@@ -243,6 +243,32 @@ If ``_parallel: true`` parameter is set to a group, child tasks in the group run
     +analyze:
       sh>: tasks/analyze_prepared_data_sets.sh
 
+If ``_parallel: {limit: N}`` (N is an integer: 1, 2, 3, …) parameter is set to a group,
+child tasks in the group run in parallel is limited to N  (grandchildren are not affected):
+
+.. code-block:: yaml
+
+    +prepare:
+      # +data1 and +data2 run in parallel, then +data3 and +data4 run in parallel.
+      # (+data1 and +data2 need to be successful.)
+      _parallel:
+        limit: 2
+
+      +data1:
+        sh>: tasks/prepare_data1.sh
+
+      +data2:
+        sh>: tasks/prepare_data2.sh
+
+      +data3:
+        sh>: tasks/prepare_data3.sh
+
+      +data4:
+        sh>: tasks/prepare_data4.sh
+
+    +analyze:
+      sh>: tasks/analyze_prepared_data_sets.sh
+
 If ``_background: true`` parameter is set to a task or group, the task or group run in parallel with previous tasks. Next task wait for the completion of the background task or group.
 
 .. code-block:: yaml

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/ForEachOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/ForEachOperatorFactory.java
@@ -74,8 +74,6 @@ public class ForEachOperatorFactory
 
             List<Map<Map.Entry<Integer, String>, Map.Entry<Integer, JsonNode>>> combinations = buildCombinations(entries);
 
-            boolean parallel = params.get("_parallel", boolean.class, false);
-
             Config generated = doConfig.getFactory().create();
             for (Map<Map.Entry<Integer, String>, Map.Entry<Integer, JsonNode>> combination : combinations) {
                 Config combinationConfig = params.getFactory().create();
@@ -90,9 +88,10 @@ public class ForEachOperatorFactory
                         subtask);
             }
 
-            if (parallel) {
-                generated.set("_parallel", parallel);
+            if (params.has("_parallel")) {
+                generated.set("_parallel", params.get("_parallel", JsonNode.class));
             }
+
 
             return TaskResult.defaultBuilder(request)
                 .subtaskConfig(generated)

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/ForRangeOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/ForRangeOperatorFactory.java
@@ -51,7 +51,6 @@ public class ForRangeOperatorFactory
             Config params = request.getConfig();
 
             Config doConfig = request.getConfig().getNested("_do");
-            boolean parallel = params.get("_parallel", boolean.class, false);
 
             Config rangeConfig = params.parseNested("_command");
             long from = rangeConfig.get("from", long.class);
@@ -97,8 +96,8 @@ public class ForRangeOperatorFactory
 
             enforceTaskCountLimit(index);
 
-            if (parallel) {
-                generated.set("_parallel", parallel);
+            if (params.has("_parallel")) {
+                generated.set("_parallel", params.get("_parallel", JsonNode.class));
             }
 
             return TaskResult.defaultBuilder(request)

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/LoopOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/LoopOperatorFactory.java
@@ -1,6 +1,8 @@
 package io.digdag.standards.operator;
 
 import java.nio.file.Path;
+
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.inject.Inject;
 import io.digdag.core.Limits;
 import io.digdag.spi.OperatorContext;
@@ -58,8 +60,6 @@ public class LoopOperatorFactory
                 throw new ConfigException("Too many loop subtasks. Limit: " + Limits.maxWorkflowTasks());
             }
 
-            boolean parallel = params.get("_parallel", boolean.class, false);
-
             Config generated = doConfig.getFactory().create();
             for (int i = 0; i < count; i++) {
                 Config subtask = params.getFactory().create();
@@ -70,8 +70,8 @@ public class LoopOperatorFactory
                         subtask);
             }
 
-            if (parallel) {
-                generated.set("_parallel", parallel);
+            if (params.has("_parallel")) {
+                generated.set("_parallel", params.get("_parallel", JsonNode.class));
             }
 
             return TaskResult.defaultBuilder(request)

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdForEachOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdForEachOperatorFactory.java
@@ -1,5 +1,6 @@
 package io.digdag.standards.operator.td;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.treasuredata.client.model.TDJob;
@@ -95,8 +96,6 @@ public class TdForEachOperatorFactory
         {
             List<Config> rows = fetchRows(j);
 
-            boolean parallel = params.get("_parallel", boolean.class, false);
-
             Config subtasks = doConfig.getFactory().create();
             for (int i = 0; i < rows.size(); i++) {
                 Config row = rows.get(i);
@@ -106,8 +105,8 @@ public class TdForEachOperatorFactory
                 subtasks.set("+td-for-each-" + i, subtask);
             }
 
-            if (parallel) {
-                subtasks.set("_parallel", true);
+            if (params.has("_parallel")) {
+                subtasks.set("_parallel", params.get("_parallel", JsonNode.class));
             }
 
             return TaskResult.defaultBuilder(request)

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/ForEachOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/ForEachOperatorFactoryTest.java
@@ -1,6 +1,5 @@
 package io.digdag.standards.operator;
 
-import io.digdag.core.database.TransactionManager;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -8,11 +7,9 @@ import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import java.nio.file.Path;
-import java.nio.file.Paths;
 
 import io.digdag.client.config.Config;
 import io.digdag.core.DigdagEmbed;
-import io.digdag.spi.Operator;
 import io.digdag.spi.TaskResult;
 import io.digdag.standards.operator.ForEachOperatorFactory.ForEachOperator;
 
@@ -20,7 +17,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
-import static io.digdag.client.config.ConfigUtils.newConfig;
 import static io.digdag.core.workflow.OperatorTestingUtils.newOperatorFactory;
 import static io.digdag.core.workflow.OperatorTestingUtils.newTaskRequest;
 import static io.digdag.core.workflow.OperatorTestingUtils.newContext;
@@ -89,6 +85,15 @@ public class ForEachOperatorFactoryTest
         assertByResource(
                 "/io/digdag/standards/operator/for_each/parallel_complex.yml",
                 "/io/digdag/standards/operator/for_each/parallel_complex_expected.yml");
+    }
+
+    @Test
+    public void parallelLimitComplex()
+            throws Exception
+    {
+        assertByResource(
+                "/io/digdag/standards/operator/for_each/parallel_limit_complex.yml",
+                "/io/digdag/standards/operator/for_each/parallel_limit_complex_expected.yml");
     }
 
     @Test

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/ForRangeOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/ForRangeOperatorFactoryTest.java
@@ -89,6 +89,16 @@ public class ForRangeOperatorFactoryTest
     }
 
     @Test
+    public void testParallelLimit()
+            throws Exception
+    {
+        assertByResource(
+                "/io/digdag/standards/operator/for_range/parallel_limit.yml",
+                "/io/digdag/standards/operator/for_range/parallel_limit_expected.yml");
+    }
+
+
+    @Test
     public void testParse()
         throws Exception
     {

--- a/digdag-standards/src/test/resources/io/digdag/standards/operator/for_each/parallel_limit_complex.yml
+++ b/digdag-standards/src/test/resources/io/digdag/standards/operator/for_each/parallel_limit_complex.yml
@@ -1,0 +1,7 @@
+_command:
+  a: [1, 2]
+  b: [3, 4]
+_parallel:
+  limit: 2
+_do:
+  echo>: value is ${a} and ${b}

--- a/digdag-standards/src/test/resources/io/digdag/standards/operator/for_each/parallel_limit_complex_expected.yml
+++ b/digdag-standards/src/test/resources/io/digdag/standards/operator/for_each/parallel_limit_complex_expected.yml
@@ -1,0 +1,14 @@
++for-0=a=0=1&1=b=0=3:
+  echo>: value is ${a} and ${b}
+  _export: {a: 1, b: 3}
++for-0=a=0=1&1=b=1=4:
+  echo>: value is ${a} and ${b}
+  _export: {a: 1, b: 4}
++for-0=a=1=2&1=b=0=3:
+  echo>: value is ${a} and ${b}
+  _export: {a: 2, b: 3}
++for-0=a=1=2&1=b=1=4:
+  echo>: value is ${a} and ${b}
+  _export: {a: 2, b: 4}
+_parallel:
+  limit: 2

--- a/digdag-standards/src/test/resources/io/digdag/standards/operator/for_range/parallel_limit.yml
+++ b/digdag-standards/src/test/resources/io/digdag/standards/operator/for_range/parallel_limit.yml
@@ -1,0 +1,8 @@
+_command:
+  from: 0
+  to: 4
+  slices: 4
+_parallel:
+  limit: 2
+_do:
+  echo>: do

--- a/digdag-standards/src/test/resources/io/digdag/standards/operator/for_range/parallel_limit_expected.yml
+++ b/digdag-standards/src/test/resources/io/digdag/standards/operator/for_range/parallel_limit_expected.yml
@@ -1,0 +1,18 @@
++range-from=0&to=1:
+  echo>: do
+  _export:
+    range: {from: 0, to: 1, index: 0}
++range-from=1&to=2:
+  echo>: do
+  _export:
+    range: {from: 1, to: 2, index: 1}
++range-from=2&to=3:
+  echo>: do
+  _export:
+    range: {from: 2, to: 3, index: 2}
++range-from=3&to=4:
+  echo>: do
+  _export:
+    range: {from: 3, to: 4, index: 3}
+_parallel:
+  limit: 2


### PR DESCRIPTION
## Overview
In addition to current `_parallel` features, this PR will introduce the parallel number limitation.

In order to achieve it, this PR makes JSON objects can also be acceptable for `_parallel`, it's for `_parallel: {limit: N}` (N is an integer: 1, 2, 3, …) syntax.

## Use Cases

### For task groups
If ``_parallel: {limit: N}`` parameter is set to a group, child tasks in the group run in parallel is limited to N. 
Note that grandchildren are not affected, same as current behavior.

### For loop operators
If ``_parallel: {limit: N}`` parameter is set, the number of loops running in parallel is limited to N. 
Note that tasks **in the loop** will be running in serial, same as current behavior.

---

## Examples

basic.dig

``_parallel: {limit: N}`` is set to a task group.

```yml
+prepare:
  _parallel:
    limit: 3
  +step1:
    sh>: sleep 2 && echo '${this.task_name}'
  +step2:
    sh>: sleep 2 && echo '${this.task_name}'
  +step3:
    sh>: sleep 2 && echo '${this.task_name}'
  +step4:
    sh>: sleep 2 && echo '${this.task_name}'
  +step5:
    sh>: sleep 2 && echo '${this.task_name}'
```

In this case, from step1, step2 and step3 run in parallel, then step4 and step5 run in parallel. +data1 and +data2 need to be successful.

<details>
<summary>Example task log</summary>
<pre>
<code>
..snip..
2020-06-05 18:12:17 +0900 [INFO] (main): Starting a new session project id=1 workflow name=basic session_time=2020-06-05T00:00:00+00:00
2020-06-05 18:12:18 +0900 [INFO] (0018@[0:default]+basic+prepare+step2): sh>: sleep 2 && echo '+basic+prepare+step2'
2020-06-05 18:12:18 +0900 [INFO] (0019@[0:default]+basic+prepare+step3): sh>: sleep 2 && echo '+basic+prepare+step3'
2020-06-05 18:12:18 +0900 [INFO] (0017@[0:default]+basic+prepare+step1): sh>: sleep 2 && echo '+basic+prepare+step1'
+basic+prepare+step1
+basic+prepare+step3
+basic+prepare+step2
2020-06-05 18:12:20 +0900 [INFO] (0019@[0:default]+basic+prepare+step4): sh>: sleep 2 && echo '+basic+prepare+step4'
2020-06-05 18:12:20 +0900 [INFO] (0018@[0:default]+basic+prepare+step5): sh>: sleep 2 && echo '+basic+prepare+step5'
+basic+prepare+step5
+basic+prepare+step4
Success.
..snip..
</code>
</pre>
</details>

---

repeat.dig

``_parallel: {limit: N}`` is set to loop.

```yml
+repeat:
  loop>: 3
  _parallel:
    limit: 2
  _do:
    +step1:
      sh>: sleep 2 && echo '${this.task_name}'
    +step2:
      sh>: sleep 2 && echo '${this.task_name}'
    +step3:
      sh>: sleep 2 && echo '${this.task_name}'
```

In this case, generates three loops, thus loop0, loop1 run in parallel, and then loop2. But tasks (steps 1 to 3) in the loop run in series.

<details>
<summary>Example task log</summary>
<pre>
<code>
..snip..
2020-06-05 18:00:06 +0900 [INFO] (main): Starting a new session project id=1 workflow name=repeat session_time=2020-06-05T00:00:00+00:00
2020-06-05 18:00:06 +0900 [INFO] (0017@[0:default]+repeat+repeat): loop>: 3
2020-06-05 18:00:06 +0900 [INFO] (0018@[0:default]+repeat+repeat^sub+loop-1+step1): sh>: sleep 2 && echo '+repeat+repeat^sub+loop-1+step1'
2020-06-05 18:00:06 +0900 [INFO] (0017@[0:default]+repeat+repeat^sub+loop-0+step1): sh>: sleep 2 && echo '+repeat+repeat^sub+loop-0+step1'
+repeat+repeat^sub+loop-1+step1
+repeat+repeat^sub+loop-0+step1
2020-06-05 18:00:09 +0900 [INFO] (0018@[0:default]+repeat+repeat^sub+loop-1+step2): sh>: sleep 2 && echo '+repeat+repeat^sub+loop-1+step2'
2020-06-05 18:00:09 +0900 [INFO] (0017@[0:default]+repeat+repeat^sub+loop-0+step2): sh>: sleep 2 && echo '+repeat+repeat^sub+loop-0+step2'
+repeat+repeat^sub+loop-1+step2
+repeat+repeat^sub+loop-0+step2
2020-06-05 18:00:11 +0900 [INFO] (0017@[0:default]+repeat+repeat^sub+loop-0+step3): sh>: sleep 2 && echo '+repeat+repeat^sub+loop-0+step3'
2020-06-05 18:00:11 +0900 [INFO] (0018@[0:default]+repeat+repeat^sub+loop-1+step3): sh>: sleep 2 && echo '+repeat+repeat^sub+loop-1+step3'
+repeat+repeat^sub+loop-0+step3
+repeat+repeat^sub+loop-1+step3
2020-06-05 18:00:13 +0900 [INFO] (0018@[0:default]+repeat+repeat^sub+loop-2+step1): sh>: sleep 2 && echo '+repeat+repeat^sub+loop-2+step1'
+repeat+repeat^sub+loop-2+step1
2020-06-05 18:00:15 +0900 [INFO] (0018@[0:default]+repeat+repeat^sub+loop-2+step2): sh>: sleep 2 && echo '+repeat+repeat^sub+loop-2+step2'
+repeat+repeat^sub+loop-2+step2
2020-06-05 18:00:17 +0900 [INFO] (0018@[0:default]+repeat+repeat^sub+loop-2+step3): sh>: sleep 2 && echo '+repeat+repeat^sub+loop-2+step3'
+repeat+repeat^sub+loop-2+step3
Success.
..snip..
</code>
</pre>
</details>

