### PR TITLE
Add code scanning workflow

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,7 +2,8 @@ name: "Code scanning"
 
 on:
   schedule:
-    - cron: '0 7 * * 4'
+    # Friday 8AM UTC / Friday 5PM JST
+    - cron: '0 8 * * 5'
 
 jobs:
   CodeQL-Build:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,10 +8,15 @@ jobs:
   CodeQL-Build:
 
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ref: [master, v0_10]
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
+      with:
+        ref: ${{ matrix.ref }}
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,25 @@
+name: "Code scanning"
+
+on:
+  schedule:
+    - cron: '0 7 * * 4'
+
+jobs:
+  CodeQL-Build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: java
+
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
Adds a workflow to perform code scanning. Initially set to run once a week on schedule.

Results of the scan will appear under the repo "Security" tab for repo owners/contributors.

ref: https://help.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/about-code-scanning