### PR TITLE
[doc] add embulk option to docs

### DIFF
--- a/digdag-docs/src/operators/embulk.md
+++ b/digdag-docs/src/operators/embulk.md
@@ -7,5 +7,5 @@ Please use `sh>: embulk <options>` instead.
 **embulk>** operator was used to run a [Embulk](http://www.embulk.org) script to transfer data across storages.
 
     +load:
-      sh>: embulk data/load.yml
+      sh>: embulk <option> data/load.yml
 


### PR DESCRIPTION
Sample shows wrong embulk command. It should be have <option> before yml file.