### PR TITLE
Mask debug message in "evaluated config"

### DIFF
--- a/digdag-core/src/test/java/io/digdag/core/agent/OperatorManagerTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/agent/OperatorManagerTest.java
@@ -1,0 +1,53 @@
+package io.digdag.core.agent;
+
+import com.google.common.io.Resources;
+import io.digdag.client.DigdagClient;
+import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigFactory;
+import io.digdag.spi.SecretStoreManager;
+import org.junit.Before;
+import org.junit.Test;
+
+import org.mockito.Mock;
+
+import java.io.IOException;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.junit.Assert.assertEquals;
+
+public class OperatorManagerTest
+{
+    private AgentConfig agentConfig = AgentConfig.defaultBuilder().build();
+    private AgentId agentId = AgentId.of("dummy");
+    @Mock TaskCallbackApi callback;
+    @Mock WorkspaceManager workspaceManager;
+    private ConfigFactory cf = new ConfigFactory(DigdagClient.objectMapper());
+    @Mock ConfigEvalEngine evalEngine;
+    @Mock OperatorRegistry registry;
+    @Mock SecretStoreManager secretStoreManager;
+
+    private OperatorManager operatorManager;
+
+    @Before
+    public void setUp()
+    {
+        operatorManager = new OperatorManager(agentConfig, agentId, callback, workspaceManager, cf, evalEngine, registry, secretStoreManager);
+    }
+
+    @Test
+    public void testFilterConfigForLogging()
+            throws IOException
+    {
+        Config src = cf.fromJsonString(Resources.toString(OperatorManagerTest.class.getResource("/io/digdag/core/agent/operator_manager/filter_config_src.json"), UTF_8));
+        Config srcBackup = src.deepCopy();
+        Config expectedConfig = cf.fromJsonString(Resources.toString(OperatorManagerTest.class.getResource("/io/digdag/core/agent/operator_manager/filter_config_expected.json"), UTF_8));
+
+        Config filteredConfig = operatorManager.filterConfigForLogging(src);
+
+        assertEquals(src, srcBackup); // src must not be modified
+        assertEquals(expectedConfig.getKeys().size(), filteredConfig.getKeys().size());
+        for (String k : expectedConfig.getKeys()) {
+            assertEquals(expectedConfig.get(k, Object.class), filteredConfig.get(k, Object.class));
+        }
+    }
+}

--- a/digdag-core/src/test/resources/io/digdag/core/agent/operator_manager/filter_config_expected.json
+++ b/digdag-core/src/test/resources/io/digdag/core/agent/operator_manager/filter_config_expected.json
@@ -1,0 +1,3 @@
+{ "timezone":"UTC","session_uuid":"5058cce5-f13c-4cd3-bc0c-1604f27dbb4b","session_time":"2020-06-25T08:47:27+00:00",
+  "session_id":7894, "last_executed_session_time":"", "next_session_time":"2020-06-26T00:00:00+00:00",
+  "project_id":180,"attempt_id":8667,"task_name":"+test2+t1" }

--- a/digdag-core/src/test/resources/io/digdag/core/agent/operator_manager/filter_config_src.json
+++ b/digdag-core/src/test/resources/io/digdag/core/agent/operator_manager/filter_config_src.json
@@ -1,0 +1,8 @@
+{ "timezone":"UTC","session_uuid":"5058cce5-f13c-4cd3-bc0c-1604f27dbb4b","session_time":"2020-06-25T08:47:27+00:00",
+  "session_id":7894,"session_date":"2020-06-25","session_date_compact":"20200625",
+  "session_local_time":"2020-06-25 08:47:27","session_tz_offset":"+0000","session_unixtime":1593074847,
+  "last_executed_session_time":"","last_executed_session_date":"","last_executed_session_date_compact":"",
+  "last_executed_session_local_time":"","last_executed_session_tz_offset":"+0000","last_executed_session_unixtime":"",
+  "next_session_time":"2020-06-26T00:00:00+00:00","project_id":180,"attempt_id":8667,"task_name":"+test2+t1",
+  "td":{"database":"sample_datasets"},"td_for_each>":null,"query":"SELECT * FROM www_access limit 3",
+  "_do":{"+show":{"echo>":"row:${td.each.agent}"}} }


### PR DESCRIPTION
Mask "evaluated config" debug message except predefined keys.