### PR TITLE
change URL link for obtaining Unique ID

### DIFF
--- a/digdag-docs/src/operators/td_load.md
+++ b/digdag-docs/src/operators/td_load.md
@@ -23,7 +23,7 @@ When you set those parameters, use [digdag secrets command](https://docs.digdag.
 
 * **td_load>**: FILE.yml
 
-  Path to a YAML template file. This configuration needs to be guessed using td command. If you saved DataConnector job on Treasure Data, you can use [Unique ID](https://support.treasuredata.com/hc/en-us/articles/360001474328-Reference-an-Input-Data-Transfer#Configuring%20your%20Unique%20ID%20Incremental%20Data%20Transfer) instead of YAML path.
+  Path to a YAML template file. This configuration needs to be guessed using td command. If you saved DataConnector job on Treasure Data, you can use [Unique ID](https://tddocs.atlassian.net/wiki/spaces/PD/pages/1083717/Creating+a+YAML+Incremental+Data+Transfer+File#Configuring-your-Unique-ID-Incremental-Data-Transfer) instead of YAML path.
 
   Examples:
 


### PR DESCRIPTION
I changed the URL link for treasure data documentation as the old article is moved to new doc.

current: https://support.treasuredata.com/hc/en-us/articles/360001474328-Reference-an-Input-Data-Transfer#Configuring%20your%20Unique%20ID%20Incremental%20Data%20Transfer

after the change : https://tddocs.atlassian.net/wiki/spaces/PD/pages/1083717/Creating+a+YAML+Incremental+Data+Transfer+File#Configuring-your-Unique-ID-Incremental-Data-Transfer