### PR TITLE
WM-867: Introduce retrying logic on curl commands on temporary network outage and/or S3 errors

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -75,7 +75,7 @@ public class EcsCommandExecutor
     private static final String CONFIG_RETRY_TASK_OUTPUT_UPLOADS = ECS_COMMAND_EXECUTOR_SYSTEM_CONFIG_PREFIX + "retry_task_output_uploads";
     private static final int DEFAULT_RETRY_TASK_SCRIPTS_DOWNLOADS = 8;
     private static final int DEFAULT_RETRY_TASK_OUTPUT_UPLOADS = 7;
-    private static final String CONFIG_DISABLE_CURL_FAIL_OPT = ECS_COMMAND_EXECUTOR_SYSTEM_CONFIG_PREFIX + "disable_curl_fail_opt";
+    private static final String CONFIG_DISABLE_CURL_FAIL_OPT_ON_UPLOADS = ECS_COMMAND_EXECUTOR_SYSTEM_CONFIG_PREFIX + "disable_curl_fail_opt_on_uploads";
 
     private final Config systemConfig;
     private final EcsClientFactory ecsClientFactory;
@@ -85,7 +85,7 @@ public class EcsCommandExecutor
     private final CommandLogger clog;
     private final Optional<Duration> defaultCommandTaskTTL;
     private final int retryDownloads, retryUploads;
-    private final boolean curlFailOpt;
+    private final boolean curlFailOptOnUploads; // false by the default
 
     @Inject
     public EcsCommandExecutor(
@@ -107,7 +107,7 @@ public class EcsCommandExecutor
                 .or(Optional.absent());
         this.retryDownloads = systemConfig.get(CONFIG_RETRY_TASK_SCRIPTS_DOWNLOADS, int.class, DEFAULT_RETRY_TASK_SCRIPTS_DOWNLOADS);
         this.retryUploads = systemConfig.get(CONFIG_RETRY_TASK_OUTPUT_UPLOADS, int.class, DEFAULT_RETRY_TASK_OUTPUT_UPLOADS);
-        this.curlFailOpt = systemConfig.get(CONFIG_DISABLE_CURL_FAIL_OPT, boolean.class, false);
+        this.curlFailOptOnUploads = systemConfig.get(CONFIG_DISABLE_CURL_FAIL_OPT_ON_UPLOADS, boolean.class, false);
     }
 
     @Override
@@ -658,7 +658,7 @@ public class EcsCommandExecutor
         bashArguments.add(s("mkdir -p %s", ioDirectoryPath.toString()));
         // retry by exponential backoff 1+2+4+8+16+32+64+128=255 seconds by the default to avoid temporary network outage and/or S3 errors
         // exit 22 on non-transient http errors so that task can be retried
-        bashArguments.add(s("curl --retry %d --retry-connrefused%s -s \"%s\" --output %s", retryDownloads, curlFailOpt ? " --fail": "", projectArchiveDirectDownloadUrl, relativeProjectArchivePath.toString()));
+        bashArguments.add(s("curl --retry %d --retry-connrefused --fail -s \"%s\" --output %s", retryDownloads, projectArchiveDirectDownloadUrl, relativeProjectArchivePath.toString()));
         bashArguments.add(s("tar -zxf %s", relativeProjectArchivePath.toString()));
         if (!commandRequest.getWorkingDirectory().toString().isEmpty()) {
             bashArguments.add(s("pushd %s", commandRequest.getWorkingDirectory().toString()));
@@ -674,7 +674,7 @@ public class EcsCommandExecutor
         bashArguments.add(s("tar -zcf %s  --exclude %s --exclude %s .digdag/tmp/", outputProjectArchivePathName, relativeProjectArchivePath.toString(), outputProjectArchivePathName));
         // retry by exponential backoff 1+2+4+8+16+32+64=127 seconds by the default
         // Note that it's intended to curl exit 0 on http errors since it's only for LogWatch logging
-        bashArguments.add(s("curl --retry %d --retry-connrefused -s -X PUT -T %s -L \"%s\"", retryUploads, outputProjectArchivePathName, outputProjectArchiveDirectUploadUrl));
+        bashArguments.add(s("curl --retry %d --retry-connrefused%s -s -X PUT -T %s -L \"%s\"", retryUploads, curlFailOptOnUploads ? " --fail": "", outputProjectArchivePathName, outputProjectArchiveDirectUploadUrl));
         bashArguments.add(s("echo \"%s\"", ECS_END_OF_TASK_LOG_MARK));
         bashArguments.add(s("exit $exit_code"));
 

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -75,6 +75,7 @@ public class EcsCommandExecutor
     private static final String CONFIG_RETRY_TASK_OUTPUT_UPLOADS = ECS_COMMAND_EXECUTOR_SYSTEM_CONFIG_PREFIX + "retry_task_output_uploads";
     private static final int DEFAULT_RETRY_TASK_SCRIPTS_DOWNLOADS = 8;
     private static final int DEFAULT_RETRY_TASK_OUTPUT_UPLOADS = 7;
+    private static final String CONFIG_DISABLE_CURL_FAIL_OPT = ECS_COMMAND_EXECUTOR_SYSTEM_CONFIG_PREFIX + "disable_curl_fail_opt";
 
     private final Config systemConfig;
     private final EcsClientFactory ecsClientFactory;
@@ -84,6 +85,7 @@ public class EcsCommandExecutor
     private final CommandLogger clog;
     private final Optional<Duration> defaultCommandTaskTTL;
     private final int retryDownloads, retryUploads;
+    private final boolean curlFailOpt;
 
     @Inject
     public EcsCommandExecutor(
@@ -105,6 +107,7 @@ public class EcsCommandExecutor
                 .or(Optional.absent());
         this.retryDownloads = systemConfig.get(CONFIG_RETRY_TASK_SCRIPTS_DOWNLOADS, int.class, DEFAULT_RETRY_TASK_SCRIPTS_DOWNLOADS);
         this.retryUploads = systemConfig.get(CONFIG_RETRY_TASK_OUTPUT_UPLOADS, int.class, DEFAULT_RETRY_TASK_OUTPUT_UPLOADS);
+        this.curlFailOpt = systemConfig.has(CONFIG_DISABLE_CURL_FAIL_OPT) == false;
     }
 
     @Override
@@ -655,7 +658,7 @@ public class EcsCommandExecutor
         bashArguments.add(s("mkdir -p %s", ioDirectoryPath.toString()));
         // retry by exponential backoff 1+2+4+8+16+32+64+128=255 seconds by the default to avoid temporary network outage and/or S3 errors
         // exit 22 on non-transient http errors so that task can be retried
-        bashArguments.add(s("curl --retry %d --retry-connrefused --fail -s \"%s\" --output %s", retryDownloads, projectArchiveDirectDownloadUrl, relativeProjectArchivePath.toString()));
+        bashArguments.add(s("curl --retry %d --retry-connrefused%s -s \"%s\" --output %s", retryDownloads, curlFailOpt ? " --fail": "", projectArchiveDirectDownloadUrl, relativeProjectArchivePath.toString()));
         bashArguments.add(s("tar -zxf %s", relativeProjectArchivePath.toString()));
         if (!commandRequest.getWorkingDirectory().toString().isEmpty()) {
             bashArguments.add(s("pushd %s", commandRequest.getWorkingDirectory().toString()));

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -75,7 +75,7 @@ public class EcsCommandExecutor
     private static final String CONFIG_RETRY_TASK_OUTPUT_UPLOADS = ECS_COMMAND_EXECUTOR_SYSTEM_CONFIG_PREFIX + "retry_task_output_uploads";
     private static final int DEFAULT_RETRY_TASK_SCRIPTS_DOWNLOADS = 8;
     private static final int DEFAULT_RETRY_TASK_OUTPUT_UPLOADS = 7;
-    private static final String CONFIG_DISABLE_CURL_FAIL_OPT_ON_UPLOADS = ECS_COMMAND_EXECUTOR_SYSTEM_CONFIG_PREFIX + "disable_curl_fail_opt_on_uploads";
+    private static final String CONFIG_ENABLE_CURL_FAIL_OPT_ON_UPLOADS = ECS_COMMAND_EXECUTOR_SYSTEM_CONFIG_PREFIX + "enable_curl_fail_opt_on_uploads";
 
     private final Config systemConfig;
     private final EcsClientFactory ecsClientFactory;
@@ -107,7 +107,7 @@ public class EcsCommandExecutor
                 .or(Optional.absent());
         this.retryDownloads = systemConfig.get(CONFIG_RETRY_TASK_SCRIPTS_DOWNLOADS, int.class, DEFAULT_RETRY_TASK_SCRIPTS_DOWNLOADS);
         this.retryUploads = systemConfig.get(CONFIG_RETRY_TASK_OUTPUT_UPLOADS, int.class, DEFAULT_RETRY_TASK_OUTPUT_UPLOADS);
-        this.curlFailOptOnUploads = systemConfig.get(CONFIG_DISABLE_CURL_FAIL_OPT_ON_UPLOADS, boolean.class, false);
+        this.curlFailOptOnUploads = systemConfig.get(CONFIG_ENABLE_CURL_FAIL_OPT_ON_UPLOADS, boolean.class, false);
     }
 
     @Override

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -661,7 +661,7 @@ public class EcsCommandExecutor
             bashArguments.add(s("popd"));
         }
         bashArguments.add(s("tar -zcf %s  --exclude %s --exclude %s .digdag/tmp/", outputProjectArchivePathName, relativeProjectArchivePath.toString(), outputProjectArchivePathName));
-        // retry by exponential backoff 1+2+4+8+16+32+64+128=127 seconds
+        // retry by exponential backoff 1+2+4+8+16+32+64=127 seconds
         // Note that it's intended to curl exit 0 on http errors since it's only for LogWatch logging
         bashArguments.add(s("curl --retry 7 --retry-connrefused -s -X PUT -T %s -L \"%s\"", outputProjectArchivePathName, outputProjectArchiveDirectUploadUrl));
         bashArguments.add(s("echo \"%s\"", ECS_END_OF_TASK_LOG_MARK));

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -107,7 +107,7 @@ public class EcsCommandExecutor
                 .or(Optional.absent());
         this.retryDownloads = systemConfig.get(CONFIG_RETRY_TASK_SCRIPTS_DOWNLOADS, int.class, DEFAULT_RETRY_TASK_SCRIPTS_DOWNLOADS);
         this.retryUploads = systemConfig.get(CONFIG_RETRY_TASK_OUTPUT_UPLOADS, int.class, DEFAULT_RETRY_TASK_OUTPUT_UPLOADS);
-        this.curlFailOpt = systemConfig.has(CONFIG_DISABLE_CURL_FAIL_OPT) == false;
+        this.curlFailOpt = systemConfig.get(CONFIG_DISABLE_CURL_FAIL_OPT, boolean.class, false);
     }
 
     @Override

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -71,6 +71,11 @@ public class EcsCommandExecutor
     private static final String DEFAULT_COMMAND_TASK_TTL = ECS_COMMAND_EXECUTOR_SYSTEM_CONFIG_PREFIX + "default_command_task_ttl";
     private static final String ECS_END_OF_TASK_LOG_MARK = "--RWNzQ29tbWFuZEV4ZWN1dG9y--"; // base64("EcsCommandExecutor")
 
+    private static final String CONFIG_RETRY_TASK_SCRIPTS_DOWNLOADS = ECS_COMMAND_EXECUTOR_SYSTEM_CONFIG_PREFIX + "retry_task_scripts_downloads";
+    private static final String CONFIG_RETRY_TASK_OUTPUT_UPLOADS = ECS_COMMAND_EXECUTOR_SYSTEM_CONFIG_PREFIX + "retry_task_output_uploads";
+    private static final int DEFAULT_RETRY_TASK_SCRIPTS_DOWNLOADS = 8;
+    private static final int DEFAULT_RETRY_TASK_OUTPUT_UPLOADS = 7;
+
     private final Config systemConfig;
     private final EcsClientFactory ecsClientFactory;
     private final DockerCommandExecutor docker;
@@ -78,6 +83,7 @@ public class EcsCommandExecutor
     private final ProjectArchiveLoader projectArchiveLoader;
     private final CommandLogger clog;
     private final Optional<Duration> defaultCommandTaskTTL;
+    private final int retryDownloads, retryUploads;
 
     @Inject
     public EcsCommandExecutor(
@@ -97,6 +103,8 @@ public class EcsCommandExecutor
         this.defaultCommandTaskTTL = systemConfig.getOptional(DEFAULT_COMMAND_TASK_TTL, DurationParam.class)
                 .transform(DurationParam::getDuration)
                 .or(Optional.absent());
+        this.retryDownloads = systemConfig.get(CONFIG_RETRY_TASK_SCRIPTS_DOWNLOADS, int.class, DEFAULT_RETRY_TASK_SCRIPTS_DOWNLOADS);
+        this.retryUploads = systemConfig.get(CONFIG_RETRY_TASK_OUTPUT_UPLOADS, int.class, DEFAULT_RETRY_TASK_OUTPUT_UPLOADS);
     }
 
     @Override
@@ -645,9 +653,9 @@ public class EcsCommandExecutor
         // by the executor and will include pre-signed URLs in the commands.
         //bashArguments.add("set -eux");
         bashArguments.add(s("mkdir -p %s", ioDirectoryPath.toString()));
-        // retry by exponential backoff 1+2+4+8+16+32+64+128=255 seconds to avoid temporary network outage and/or S3 errors
+        // retry by exponential backoff 1+2+4+8+16+32+64+128=255 seconds by the default to avoid temporary network outage and/or S3 errors
         // exit 22 on non-transient http errors so that task can be retried
-        bashArguments.add(s("curl --retry 8 --retry-connrefused --fail -s \"%s\" --output %s", projectArchiveDirectDownloadUrl, relativeProjectArchivePath.toString()));
+        bashArguments.add(s("curl --retry %d --retry-connrefused --fail -s \"%s\" --output %s", retryDownloads, projectArchiveDirectDownloadUrl, relativeProjectArchivePath.toString()));
         bashArguments.add(s("tar -zxf %s", relativeProjectArchivePath.toString()));
         if (!commandRequest.getWorkingDirectory().toString().isEmpty()) {
             bashArguments.add(s("pushd %s", commandRequest.getWorkingDirectory().toString()));
@@ -661,9 +669,9 @@ public class EcsCommandExecutor
             bashArguments.add(s("popd"));
         }
         bashArguments.add(s("tar -zcf %s  --exclude %s --exclude %s .digdag/tmp/", outputProjectArchivePathName, relativeProjectArchivePath.toString(), outputProjectArchivePathName));
-        // retry by exponential backoff 1+2+4+8+16+32+64=127 seconds
+        // retry by exponential backoff 1+2+4+8+16+32+64=127 seconds by the default
         // Note that it's intended to curl exit 0 on http errors since it's only for LogWatch logging
-        bashArguments.add(s("curl --retry 7 --retry-connrefused -s -X PUT -T %s -L \"%s\"", outputProjectArchivePathName, outputProjectArchiveDirectUploadUrl));
+        bashArguments.add(s("curl --retry %d --retry-connrefused -s -X PUT -T %s -L \"%s\"", retryUploads, outputProjectArchivePathName, outputProjectArchiveDirectUploadUrl));
         bashArguments.add(s("echo \"%s\"", ECS_END_OF_TASK_LOG_MARK));
         bashArguments.add(s("exit $exit_code"));
 


### PR DESCRIPTION
We found the following error can be caused due to transient failures (such as temporary network outage and/or S3 errors) on curl command used in the ECS task command (See CS-5095 for detail).

```
java.lang.RuntimeException: io.digdag.spi.StorageFileNotFoundException: S3 file not found
at com.google.common.base.Throwables.propagate(Throwables.java:240)
at io.digdag.standards.command.ecs.TemporalProjectArchiveStorage.getContentInputStream(TemporalProjectArchiveStorage.java:55)
at io.digdag.standards.command.EcsCommandExecutor.createNextCommandStatus(EcsCommandExecutor.java:302)
at io.digdag.standards.command.EcsCommandExecutor.poll(EcsCommandExecutor.java:272)
at com.treasuredata.digdag.command.TdEcsCommandExecutor.pollSuper(TdEcsCommandExecutor.java:130)
at com.treasuredata.digdag.command.TdEcsCommandExecutor.poll(TdEcsCommandExecutor.java:108)
at io.digdag.standards.operator.PyOperatorFactory$PyOperator.runCode(PyOperatorFactory.java:143)
at io.digdag.standards.operator.PyOperatorFactory$PyOperator.runTask(PyOperatorFactory.java:114)
at io.digdag.util.BaseOperator.run(BaseOperator.java:35)
at io.digdag.core.agent.OperatorManager.callExecutor(OperatorManager.java:330)
at com.treasuredata.digdag.TdOperatorManager.callExecutor(TdOperatorManager.java:56)
at io.digdag.core.agent.OperatorManager.runWithWorkspace(OperatorManager.java:271)
at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invokeMain(DigdagTimedMethodInterceptor.java:58)
at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invoke(DigdagTimedMethodInterceptor.java:31)
at io.digdag.core.agent.OperatorManager.lambda$runWithHeartbeat$2(OperatorManager.java:144)
at io.digdag.core.agent.ExtractArchiveWorkspaceManager.withExtractedArchive(ExtractArchiveWorkspaceManager.java:77)
at io.digdag.core.agent.OperatorManager.runWithHeartbeat(OperatorManager.java:142)
at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invokeMain(DigdagTimedMethodInterceptor.java:58)
at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invoke(DigdagTimedMethodInterceptor.java:31)
at io.digdag.core.agent.OperatorManager.run(OperatorManager.java:125)
at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invokeMain(DigdagTimedMethodInterceptor.java:58)
at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invoke(DigdagTimedMethodInterceptor.java:31)
at io.digdag.core.agent.MultiThreadAgent.lambda$null$0(MultiThreadAgent.java:131)
at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
at java.base/java.lang.Thread.run(Thread.java:834)
Caused by: io.digdag.spi.StorageFileNotFoundException: S3 file not found
at io.digdag.storage.s3.S3Storage.getWithRetry(S3Storage.java:244)
at io.digdag.storage.s3.S3Storage.open(S3Storage.java:89)
at io.digdag.standards.command.ecs.TemporalProjectArchiveStorage.getContentInputStream(TemporalProjectArchiveStorage.java:52)
... 26 common frames omitted
Caused by: com.amazonaws.services.s3.model.AmazonS3Exception: The specified key does not exist. (Service: Amazon S3; Status Code: 404; Error Code: NoSuchKey; 
```

This PR introduce retry using exponential backoff in curl. 

I verified the retrying logic of [curl command](https://curl.haxx.se/docs/manpage.html) as follows:

```
$ curl --retry 7 --fail https://instability.now.sh?errorRate=99
Warning: Transient problem: HTTP error Will retry in 1 seconds. 7 retries 
Warning: left.
Warning: Transient problem: HTTP error Will retry in 2 seconds. 6 retries 
Warning: left.
Warning: Transient problem: HTTP error Will retry in 4 seconds. 5 retries 
Warning: left.
Warning: Transient problem: HTTP error Will retry in 8 seconds. 4 retries 
Warning: left.
Warning: Transient problem: HTTP error Will retry in 16 seconds. 3 retries 
Warning: left.
Warning: Transient problem: HTTP error Will retry in 32 seconds. 2 retries 
Warning: left.
Warning: Transient problem: HTTP error Will retry in 64 seconds. 1 retries 
Warning: left.
curl: (22) The requested URL returned error: 500 

$ curl --retry 8 --fail https://instability.now.sh?errorRate=99
Warning: Transient problem: HTTP error Will retry in 1 seconds. 7 retries 
Warning: left.
Warning: Transient problem: HTTP error Will retry in 2 seconds. 6 retries 
Warning: left.
Warning: Transient problem: HTTP error Will retry in 4 seconds. 5 retries 
Warning: left.
Warning: Transient problem: HTTP error Will retry in 8 seconds. 4 retries 
Warning: left.
Warning: Transient problem: HTTP error Will retry in 16 seconds. 3 retries 
Warning: left.
Warning: Transient problem: HTTP error Will retry in 32 seconds. 2 retries 
Warning: left.
Warning: Transient problem: HTTP error Will retry in 64 seconds. 1 retries 
Warning: left.
Warning: Transient problem: HTTP error Will retry in 128 seconds. 1 retries 
Warning: left.
curl: (22) The requested URL returned error: 500 

$ curl --retry 7 --fail --retry-connrefused https://instability.now.sh?errorRate=70
Warning: Transient problem: HTTP error Will retry in 1 seconds. 7 retries 
Warning: left.
Warning: Transient problem: HTTP error Will retry in 2 seconds. 6 retries 
Warning: left.
Warning: Transient problem: HTTP error Will retry in 4 seconds. 5 retries 
Warning: left.
{"status":200,"message":"OK"}
```