### PR TITLE
Add last_attempt_id idx to sessions

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseMigrator.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseMigrator.java
@@ -40,6 +40,7 @@ public class DatabaseMigrator
         new Migration_20170223220127_AddLastSessionTimeAndFlagsToSessions(),
         new Migration_20190318175338_AddIndexToSessionAttempts(),
         new Migration_20191105105927_AddIndexToSessions(),
+        new Migration_20200716114008_AddLastAttemptIdIndexToSessions(),
     })
     .sorted(Comparator.comparing(m -> m.getVersion()))
     .collect(Collectors.toList());

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20200716114008_AddLastAttemptIdIndexToSessions.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20200716114008_AddLastAttemptIdIndexToSessions.java
@@ -1,0 +1,23 @@
+package io.digdag.core.database.migrate;
+
+import org.skife.jdbi.v2.Handle;
+
+public class Migration_20200716114008_AddLastAttemptIdIndexToSessions
+    implements Migration
+{
+    @Override
+    public void migrate(Handle handle, MigrationContext context)
+    {
+        if (context.isPostgres()) {
+            handle.update("create index concurrently sessions_on_last_attempt_id on sessions (last_attempt_id)");
+        } else {
+            handle.update("create index sessions_on_last_attempt_id on sessions (last_attempt_id)");
+        }
+    }
+
+    @Override
+    public boolean noTransaction(MigrationContext context)
+    {
+        return context.isPostgres();
+    }
+}


### PR DESCRIPTION
This index helps to improve performance to get attempts. 
https://github.com/treasure-data/digdag/blob/cefde0d80a6f2a573ac800454da8b4fa7f3e87ad/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java#L1806-L1819

As-Is:
```sql
digdag=# explain select sa.*, s.session_uuid, s.workflow_name, s.session_time from session_attempts sa
join sessions s on s.last_attempt_id = sa.id join projects proj on proj.id = sa.project_id
where sa.site_id = 0 and sa.id < 10000000 and true order by sa.id desc limit 100;
                                                           QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=45.29..80.75 rows=100 width=255)
   ->  Nested Loop  (cost=45.29..275.77 rows=650 width=255)
         ->  Merge Join  (cost=45.14..126.56 rows=650 width=255)
               Merge Cond: (sa.id = s.last_attempt_id)
               ->  Index Scan Backward using session_attempts_pkey on session_attempts sa  (cost=0.28..70.01 rows=772 width=221)
                     Index Cond: (id < 10000000)
                     Filter: (site_id = 0)
               ->  Sort  (cost=44.87..46.49 rows=650 width=42)
                     Sort Key: s.last_attempt_id DESC
                     ->  Seq Scan on sessions s  (cost=0.00..14.50 rows=650 width=42)
         ->  Index Only Scan using projects_pkey on projects proj  (cost=0.15..0.23 rows=1 width=4)
               Index Cond: (id = sa.project_id)
(12 rows)
```

To-Be:
```sql
digdag=# explain select sa.*, s.session_uuid, s.workflow_name, s.session_time from session_attempts sa
join sessions s on s.last_attempt_id = sa.id join projects proj on proj.id = sa.project_id
where sa.site_id = 0 and sa.id < 10000000 and true order by sa.id desc limit 100;
                                                           QUERY PLAN
---------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.70..41.58 rows=100 width=255)
   ->  Nested Loop  (cost=0.70..266.39 rows=650 width=255)
         ->  Merge Join  (cost=0.55..117.18 rows=650 width=255)
               Merge Cond: (sa.id = s.last_attempt_id)
               ->  Index Scan Backward using session_attempts_pkey on session_attempts sa  (cost=0.28..70.01 rows=772 width=221)
                     Index Cond: (id < 10000000)
                     Filter: (site_id = 0)
               ->  Index Scan Backward using sessions_on_last_attempt_id on sessions s  (cost=0.28..37.11 rows=650 width=42)
         ->  Index Only Scan using projects_pkey on projects proj  (cost=0.15..0.23 rows=1 width=4)
               Index Cond: (id = sa.project_id)
(10 rows)
```