### PR TITLE
Improve the partial index on session_attempts

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseMigrator.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseMigrator.java
@@ -41,6 +41,7 @@ public class DatabaseMigrator
         new Migration_20190318175338_AddIndexToSessionAttempts(),
         new Migration_20191105105927_AddIndexToSessions(),
         new Migration_20200716114008_AddLastAttemptIdIndexToSessions(),
+        new Migration_20200803184355_ReplacePartialIndexOnSessionAttempts(),
     })
     .sorted(Comparator.comparing(m -> m.getVersion()))
     .collect(Collectors.toList());

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20200803184355_ReplacePartialIndexOnSessionAttempts.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20200803184355_ReplacePartialIndexOnSessionAttempts.java
@@ -1,0 +1,20 @@
+package io.digdag.core.database.migrate;
+
+import org.skife.jdbi.v2.Handle;
+
+public class Migration_20200803184355_ReplacePartialIndexOnSessionAttempts
+        implements Migration
+{
+    @Override
+    public void migrate(Handle handle, MigrationContext context)
+    {
+        if (context.isPostgres()) {
+            // Don't use "create index concurrently" here since the following "drop index" should be issued after the completion of the index creation
+            handle.update("create index session_attempts_on_state_flags_and_created_at_partial on session_attempts (id, created_at) where state_flags = 0");
+            handle.update("drop index session_attempts_on_state_flags_and_created_at");
+        }
+        else {
+            // H2 does not support partial index
+        }
+    }
+}


### PR DESCRIPTION
We noticed `session_attempts_on_state_flags_and_created_at` index could cause sequential scan on `session_attempts` table since there is a gap in the order of columns between the application and the index. This PR resolves the gap by replacing the old index with new one.