### PR TITLE
`hive_engine_version` options for `td` operators

### DIFF
--- a/digdag-docs/src/operators/td.md
+++ b/digdag-docs/src/operators/td.md
@@ -277,6 +277,18 @@ When you set those parameters, use [digdag secrets command](https://docs.digdag.
   engine_version: stable
   ```
 
+* **hive_engine_version**: NAME
+
+  Specify engine version for Hive.
+  This option overrides ``engine_version`` if ``engine`` is ``hive``.
+
+  Examples:
+
+  ```
+  engine: hive
+  hive_engine_version: stable
+  ```
+
 ## Output parameters
 
 * **td.last_job_id** or **td.last_job.id**

--- a/digdag-docs/src/operators/td_for_each.md
+++ b/digdag-docs/src/operators/td_for_each.md
@@ -112,6 +112,18 @@ When you set those parameters, use [digdag secrets command](https://docs.digdag.
   engine_version: stable
   ```
 
+* **hive_engine_version**: NAME
+
+  Specify engine version for Hive.
+  This option overrides ``engine_version`` if ``engine`` is ``hive``.
+
+  Examples:
+
+  ```
+  engine: hive
+  hive_engine_version: stable
+  ```
+
 ## Output parameters
 
 * **td.last_job_id** or **td.last_job.id**

--- a/digdag-docs/src/operators/td_wait.md
+++ b/digdag-docs/src/operators/td_wait.md
@@ -118,6 +118,18 @@ When you set those parameters, use [digdag secrets command](https://docs.digdag.
   engine_version: stable
   ```
 
+* **hive_engine_version**: NAME
+
+  Specify engine version for Hive.
+  This option overrides ``engine_version`` if ``engine`` is ``hive``.
+
+  Examples:
+
+  ```
+  engine: hive
+  hive_engine_version: stable
+  ```
+
 ## Output parameters
 
 * **td.last_job_id** or **td.last_job.id**

--- a/digdag-docs/src/operators/td_wait_table.md
+++ b/digdag-docs/src/operators/td_wait_table.md
@@ -122,3 +122,14 @@ When you set those parameters, use [digdag secrets command](https://docs.digdag.
   engine_version: stable
   ```
 
+* **hive_engine_version**: NAME
+
+  Specify engine version for Hive.
+  This option overrides ``engine_version`` if ``engine`` is ``hive``.
+
+  Examples:
+
+  ```
+  engine: hive
+  hive_engine_version: stable
+  ```

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/td/TdForEachOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/td/TdForEachOperatorFactoryTest.java
@@ -82,6 +82,83 @@ public class TdForEachOperatorFactoryTest
         assertEquals("stable", jobRequest.getEngineVersion().get().toString());
     }
 
+    @Test
+    public void testTDJobRequestParamsWithHiveEngineVersion()
+            throws Exception
+    {
+        Path projectPath = Paths.get("").normalize().toAbsolutePath();
+
+        Config config = newConfig()
+                .set("database", "testdb")
+                .set("query", "select 1")
+                .set("engine", "hive")
+                .set("hive_engine_version", "stable")
+                .set("_do", newConfig().set("+show", newConfig().set("echo>", "aaaa")));
+
+        when(op.submitNewJobWithRetry(any(TDJobRequest.class))).thenReturn("");
+        when(op.getDatabase()).thenReturn("testdb");
+
+        TDJobRequest jobRequest = testTDJobRequestParams(projectPath, config);
+
+        assertEquals("testdb", jobRequest.getDatabase());
+        assertEquals("select 1", jobRequest.getQuery());
+        assertEquals("hive", jobRequest.getType().toString());
+        assertTrue(jobRequest.getEngineVersion().isPresent());
+        assertEquals("stable", jobRequest.getEngineVersion().get().toString());
+    }
+
+    @Test
+    public void testHiveEngineVersionOverridesEngineVersion()
+            throws Exception
+    {
+        Path projectPath = Paths.get("").normalize().toAbsolutePath();
+
+        Config config = newConfig()
+                .set("database", "testdb")
+                .set("query", "select 1")
+                .set("engine", "hive")
+                .set("engine_version", "stable")
+                .set("hive_engine_version", "current")
+                .set("_do", newConfig().set("+show", newConfig().set("echo>", "aaaa")));
+
+        when(op.submitNewJobWithRetry(any(TDJobRequest.class))).thenReturn("");
+        when(op.getDatabase()).thenReturn("testdb");
+
+        TDJobRequest jobRequest = testTDJobRequestParams(projectPath, config);
+
+        assertEquals("testdb", jobRequest.getDatabase());
+        assertEquals("select 1", jobRequest.getQuery());
+        assertEquals("hive", jobRequest.getType().toString());
+        assertTrue(jobRequest.getEngineVersion().isPresent());
+        assertEquals("current", jobRequest.getEngineVersion().get().toString());
+    }
+
+    @Test
+    public void testHiveEngineVersionNotOverridesEngineVersionIfEngineIsPresto()
+            throws Exception
+    {
+        Path projectPath = Paths.get("").normalize().toAbsolutePath();
+
+        Config config = newConfig()
+                .set("database", "testdb")
+                .set("query", "select 1")
+                .set("engine", "presto")
+                .set("engine_version", "stable")
+                .set("hive_engine_version", "current")
+                .set("_do", newConfig().set("+show", newConfig().set("echo>", "aaaa")));
+
+        when(op.submitNewJobWithRetry(any(TDJobRequest.class))).thenReturn("");
+        when(op.getDatabase()).thenReturn("testdb");
+
+        TDJobRequest jobRequest = testTDJobRequestParams(projectPath, config);
+
+        assertEquals("testdb", jobRequest.getDatabase());
+        assertEquals("select 1", jobRequest.getQuery());
+        assertEquals("presto", jobRequest.getType().toString());
+        assertTrue(jobRequest.getEngineVersion().isPresent());
+        assertEquals("stable", jobRequest.getEngineVersion().get().toString());
+    }
+
     private TDJobRequest testTDJobRequestParams(Path projectPath, Config config)
     {
         ArgumentCaptor<TDJobRequest> captor = ArgumentCaptor.forClass(TDJobRequest.class);

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/td/TdOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/td/TdOperatorFactoryTest.java
@@ -119,6 +119,83 @@ public class TdOperatorFactoryTest
         assertEquals("stable", jobRequest.getEngineVersion().get().toString());
     }
 
+    @Test
+    public void testTDJobRequestParamsWithHiveEngineVersion()
+            throws Exception
+    {
+        Path projectPath = Paths.get("").normalize().toAbsolutePath();
+        String stmt = "select 1";
+
+        Config config = newConfig()
+                .set("database", "testdb")
+                .set("query", stmt)
+                .set("engine", "hive")
+                .set("hive_engine_version", "stable");
+
+        when(op.submitNewJobWithRetry(any(TDJobRequest.class))).thenReturn("");
+        when(op.getDatabase()).thenReturn("testdb");
+
+        TDJobRequest jobRequest = testTDJobRequestParams(projectPath, config);
+
+        assertEquals("testdb", jobRequest.getDatabase());
+        assertEquals(wrapStmtWithComment(taskRequest, stmt), jobRequest.getQuery());
+        assertEquals("hive", jobRequest.getType().toString() );
+        assertTrue(jobRequest.getEngineVersion().isPresent());
+        assertEquals("stable", jobRequest.getEngineVersion().get().toString());
+    }
+
+    @Test
+    public void testHiveEngineVersionOverridesEngineVersion()
+            throws Exception
+    {
+        Path projectPath = Paths.get("").normalize().toAbsolutePath();
+        String stmt = "select 1";
+
+        Config config = newConfig()
+                .set("database", "testdb")
+                .set("query", stmt)
+                .set("engine", "hive")
+                .set("engine_version", "stable")
+                .set("hive_engine_version", "current");
+
+        when(op.submitNewJobWithRetry(any(TDJobRequest.class))).thenReturn("");
+        when(op.getDatabase()).thenReturn("testdb");
+
+        TDJobRequest jobRequest = testTDJobRequestParams(projectPath, config);
+
+        assertEquals("testdb", jobRequest.getDatabase());
+        assertEquals(wrapStmtWithComment(taskRequest, stmt), jobRequest.getQuery());
+        assertEquals("hive", jobRequest.getType().toString() );
+        assertTrue(jobRequest.getEngineVersion().isPresent());
+        assertEquals("current", jobRequest.getEngineVersion().get().toString());
+    }
+
+    @Test
+    public void testHiveEngineVersionNotOverridesEngineVersionIfEngineIsPresto()
+            throws Exception
+    {
+        Path projectPath = Paths.get("").normalize().toAbsolutePath();
+        String stmt = "select 1";
+
+        Config config = newConfig()
+                .set("database", "testdb")
+                .set("query", stmt)
+                .set("engine", "presto")
+                .set("engine_version", "stable")
+                .set("hive_engine_version", "current");
+
+        when(op.submitNewJobWithRetry(any(TDJobRequest.class))).thenReturn("");
+        when(op.getDatabase()).thenReturn("testdb");
+
+        TDJobRequest jobRequest = testTDJobRequestParams(projectPath, config);
+
+        assertEquals("testdb", jobRequest.getDatabase());
+        assertEquals(wrapStmtWithComment(taskRequest, stmt), jobRequest.getQuery());
+        assertEquals("presto", jobRequest.getType().toString() );
+        assertTrue(jobRequest.getEngineVersion().isPresent());
+        assertEquals("stable", jobRequest.getEngineVersion().get().toString());
+    }
+
     private TDJobRequest testTDJobRequestParams(Path projectPath, Config config)
     {
         when(op.submitNewJobWithRetry(any(TDJobRequest.class))).thenReturn("");

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/td/TdWaitOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/td/TdWaitOperatorFactoryTest.java
@@ -81,6 +81,80 @@ public class TdWaitOperatorFactoryTest
 
     }
 
+    @Test
+    public void testTDJobRequestParamsWithHiveEngineVersion()
+            throws Exception
+    {
+        Path projectPath = Paths.get("").normalize().toAbsolutePath();
+
+        Config config = newConfig()
+                .set("database", "testdb")
+                .set("query", "select 1")
+                .set("engine", "hive")
+                .set("hive_engine_version", "stable");
+
+        when(op.submitNewJobWithRetry(any(TDJobRequest.class))).thenReturn("");
+        when(op.getDatabase()).thenReturn("testdb");
+
+        TDJobRequest jobRequest = testTDJobRequestParams(projectPath, config);
+
+        assertEquals("testdb", jobRequest.getDatabase());
+        assertEquals("select 1", jobRequest.getQuery());
+        assertEquals("hive", jobRequest.getType().toString());
+        assertTrue(jobRequest.getEngineVersion().isPresent());
+        assertEquals("stable", jobRequest.getEngineVersion().get().toString());
+    }
+
+    @Test
+    public void testHiveEngineVersionOverridesEngineVersion()
+            throws Exception
+    {
+        Path projectPath = Paths.get("").normalize().toAbsolutePath();
+
+        Config config = newConfig()
+                .set("database", "testdb")
+                .set("query", "select 1")
+                .set("engine", "hive")
+                .set("engine_version", "stable")
+                .set("hive_engine_version", "current");
+
+        when(op.submitNewJobWithRetry(any(TDJobRequest.class))).thenReturn("");
+        when(op.getDatabase()).thenReturn("testdb");
+
+        TDJobRequest jobRequest = testTDJobRequestParams(projectPath, config);
+
+        assertEquals("testdb", jobRequest.getDatabase());
+        assertEquals("select 1", jobRequest.getQuery());
+        assertEquals("hive", jobRequest.getType().toString());
+        assertTrue(jobRequest.getEngineVersion().isPresent());
+        assertEquals("current", jobRequest.getEngineVersion().get().toString());
+    }
+
+    @Test
+    public void testHiveEngineVersionNotOverridesEngineVersionIfEngineIsPresto()
+            throws Exception
+    {
+        Path projectPath = Paths.get("").normalize().toAbsolutePath();
+
+        Config config = newConfig()
+                .set("database", "testdb")
+                .set("query", "select 1")
+                .set("engine", "presto")
+                .set("engine_version", "stable")
+                .set("hive_engine_version", "current");
+
+        when(op.submitNewJobWithRetry(any(TDJobRequest.class))).thenReturn("");
+        when(op.getDatabase()).thenReturn("testdb");
+
+        TDJobRequest jobRequest = testTDJobRequestParams(projectPath, config);
+
+        assertEquals("testdb", jobRequest.getDatabase());
+        assertEquals("select 1", jobRequest.getQuery());
+        assertEquals("presto", jobRequest.getType().toString());
+        assertTrue(jobRequest.getEngineVersion().isPresent());
+        assertEquals("stable", jobRequest.getEngineVersion().get().toString());
+    }
+
     private TDJobRequest testTDJobRequestParams(Path projectPath, Config config)
     {
         ArgumentCaptor<TDJobRequest> captor = ArgumentCaptor.forClass(TDJobRequest.class);

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/td/TdWaitTableOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/td/TdWaitTableOperatorFactoryTest.java
@@ -82,6 +82,80 @@ public class TdWaitTableOperatorFactoryTest
 
     }
 
+    @Test
+    public void testTDJobRequestParamsWithHiveEngineVersion()
+            throws Exception
+    {
+        Path projectPath = Paths.get("").normalize().toAbsolutePath();
+
+        Config config = newConfig()
+                .set("_command", "target_table_00")
+                .set("database", "testdb")
+                .set("engine", "hive")
+                .set("hive_engine_version", "stable");
+
+        when(op.submitNewJobWithRetry(any(TDJobRequest.class))).thenReturn("");
+        when(op.getDatabase()).thenReturn("testdb");
+
+        TDJobRequest jobRequest = testTDJobRequestParams(projectPath, config);
+
+        assertEquals("testdb", jobRequest.getDatabase());
+        assertTrue(jobRequest.getQuery().length() > 0);
+        assertEquals("hive", jobRequest.getType().toString());
+        assertTrue(jobRequest.getEngineVersion().isPresent());
+        assertEquals("stable", jobRequest.getEngineVersion().get().toString());
+    }
+
+    @Test
+    public void testHiveEngineVersionOverridesEngineVersion()
+            throws Exception
+    {
+        Path projectPath = Paths.get("").normalize().toAbsolutePath();
+
+        Config config = newConfig()
+                .set("_command", "target_table_00")
+                .set("database", "testdb")
+                .set("engine", "hive")
+                .set("engine_version", "stable")
+                .set("hive_engine_version", "current");
+
+        when(op.submitNewJobWithRetry(any(TDJobRequest.class))).thenReturn("");
+        when(op.getDatabase()).thenReturn("testdb");
+
+        TDJobRequest jobRequest = testTDJobRequestParams(projectPath, config);
+
+        assertEquals("testdb", jobRequest.getDatabase());
+        assertTrue(jobRequest.getQuery().length() > 0);
+        assertEquals("hive", jobRequest.getType().toString());
+        assertTrue(jobRequest.getEngineVersion().isPresent());
+        assertEquals("current", jobRequest.getEngineVersion().get().toString());
+    }
+
+    @Test
+    public void testHiveEngineVersionNotOverridesEngineVersionIfEngineIsPresto()
+            throws Exception
+    {
+        Path projectPath = Paths.get("").normalize().toAbsolutePath();
+
+        Config config = newConfig()
+                .set("_command", "target_table_00")
+                .set("database", "testdb")
+                .set("engine", "presto")
+                .set("engine_version", "stable")
+                .set("hive_engine_version", "current");
+
+        when(op.submitNewJobWithRetry(any(TDJobRequest.class))).thenReturn("");
+        when(op.getDatabase()).thenReturn("testdb");
+
+        TDJobRequest jobRequest = testTDJobRequestParams(projectPath, config);
+
+        assertEquals("testdb", jobRequest.getDatabase());
+        assertTrue(jobRequest.getQuery().length() > 0);
+        assertEquals("presto", jobRequest.getType().toString());
+        assertTrue(jobRequest.getEngineVersion().isPresent());
+        assertEquals("stable", jobRequest.getEngineVersion().get().toString());
+    }
+
     private TDJobRequest testTDJobRequestParams(Path projectPath, Config config)
     {
         ArgumentCaptor<TDJobRequest> captor = ArgumentCaptor.forClass(TDJobRequest.class);


### PR DESCRIPTION
We manage dig file which includes a lot of `td` operators and some jobs should be run by presto others should be hive.
We want to define engine_version of hive on only one place by using `_export:` and `td:`.
In such case `engine_version` is not enough because we need to switch engine_version value based on query engine.
Introducing `hive_engine_version` option reduces our management cost of engine_versions.