### PR TITLE
Not pass `engine_version` parameter if engine is presto

### DIFF
--- a/digdag-docs/src/operators/td.md
+++ b/digdag-docs/src/operators/td.md
@@ -268,7 +268,7 @@ When you set those parameters, use [digdag secrets command](https://docs.digdag.
 
 * **engine_version**: NAME
 
-  Specify engine version for Hive and Presto.
+  Specify engine version for Hive.
 
   Examples:
 

--- a/digdag-docs/src/operators/td_for_each.md
+++ b/digdag-docs/src/operators/td_for_each.md
@@ -103,7 +103,7 @@ When you set those parameters, use [digdag secrets command](https://docs.digdag.
 
 * **engine_version**: NAME
 
-  Specify engine version for Hive and Presto.
+  Specify engine version for Hive.
 
   Examples:
 

--- a/digdag-docs/src/operators/td_wait.md
+++ b/digdag-docs/src/operators/td_wait.md
@@ -109,7 +109,7 @@ When you set those parameters, use [digdag secrets command](https://docs.digdag.
 
 * **engine_version**: NAME
 
-  Specify engine version for Hive and Presto.
+  Specify engine version for Hive.
 
   Examples:
 

--- a/digdag-docs/src/operators/td_wait_table.md
+++ b/digdag-docs/src/operators/td_wait_table.md
@@ -113,7 +113,7 @@ When you set those parameters, use [digdag secrets command](https://docs.digdag.
 
 * **engine_version**: NAME
 
-  Specify engine version for Hive and Presto.
+  Specify engine version for Hive.
 
   Examples:
 

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdForEachOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdForEachOperatorFactory.java
@@ -121,6 +121,13 @@ public class TdForEachOperatorFactory
                 throw new ConfigException("Unknown 'engine:' option (available options are: hive and presto): " + engine);
             }
 
+            Optional<String> ev = Optional.absent();
+
+            // engine version is effective only for hive.
+            if (engine.equals("hive")) {
+                ev = engineVersion;
+            }
+
             TDJobRequest req = new TDJobRequestBuilder()
                     .setType(engine)
                     .setDatabase(op.getDatabase())
@@ -130,7 +137,7 @@ public class TdForEachOperatorFactory
                     .setPoolName(poolName.orNull())
                     .setDomainKey(domainkey)
                     .setScheduledTime(request.getSessionTime().getEpochSecond())
-                    .setEngineVersion(engineVersion.transform(e -> TDJob.EngineVersion.fromString(e)).orNull())
+                    .setEngineVersion(ev.transform(e -> TDJob.EngineVersion.fromString(e)).orNull())
                     .createTDJobRequest();
 
             String jobId = op.submitNewJobWithRetry(req);

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdOperatorFactory.java
@@ -183,6 +183,8 @@ public class TdOperatorFactory
         protected String startJob(TDOperator op, String domainKey)
         {
             String stmt;
+            Optional<String> ev = Optional.absent();
+
             switch(engine) {
                 case "presto":
                     if (insertInto.isPresent()) {
@@ -213,6 +215,9 @@ public class TdOperatorFactory
                     else {
                         stmt = query;
                     }
+
+                    // engine version is effective only for hive.
+                    ev = engineVersion;
                     break;
 
                 default:
@@ -231,7 +236,7 @@ public class TdOperatorFactory
                     .setResultConnectionId(resultConnection.transform(name -> getResultConnectionId(name, op)))
                     .setResultConnectionSettings(resultSettings.transform(t -> t.format(context.getSecrets())))
                     .setDomainKey(domainKey)
-                    .setEngineVersion(engineVersion.transform(e -> TDJob.EngineVersion.fromString(e)).orNull())
+                    .setEngineVersion(ev.transform(e -> TDJob.EngineVersion.fromString(e)).orNull())
                     .createTDJobRequest();
 
             String jobId = op.submitNewJobWithRetry(req);

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdWaitOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdWaitOperatorFactory.java
@@ -134,6 +134,13 @@ public class TdWaitOperatorFactory
         @VisibleForTesting
         String startJob(TDOperator op, String domainKey)
         {
+            Optional<String> ev = Optional.absent();
+
+            // engine version is effective only for hive.
+            if (engine.equals("hive")) {
+                ev = engineVersion;
+            }
+
             TDJobRequest req = new TDJobRequestBuilder()
                     .setType(engine)
                     .setDatabase(op.getDatabase())
@@ -143,7 +150,7 @@ public class TdWaitOperatorFactory
                     .setScheduledTime(request.getSessionTime().getEpochSecond())
                     .setPoolName(poolName.orNull())
                     .setDomainKey(domainKey)
-                    .setEngineVersion(engineVersion.transform(e -> TDJob.EngineVersion.fromString(e)).orNull())
+                    .setEngineVersion(ev.transform(e -> TDJob.EngineVersion.fromString(e)).orNull())
                     .createTDJobRequest();
 
             String jobId = op.submitNewJobWithRetry(req);

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdWaitTableOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdWaitTableOperatorFactory.java
@@ -200,6 +200,12 @@ public class TdWaitTableOperatorFactory
         String startJob(TDOperator op, String domainKey)
         {
             String query = createQuery();
+            Optional<String> ev = Optional.absent();
+
+            // engine version is effective only for hive.
+            if (engine.equals("hive")) {
+                ev = engineVersion;
+            }
 
             TDJobRequest req = new TDJobRequestBuilder()
                     .setType(engine)
@@ -209,7 +215,7 @@ public class TdWaitTableOperatorFactory
                     .setPriority(priority)
                     .setPoolName(poolName.orNull())
                     .setDomainKey(domainKey)
-                    .setEngineVersion(engineVersion.transform(e -> TDJob.EngineVersion.fromString(e)).orNull())
+                    .setEngineVersion(ev.transform(e -> TDJob.EngineVersion.fromString(e)).orNull())
                     .createTDJobRequest();
 
             String jobId = op.submitNewJobWithRetry(req);

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/td/TdForEachOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/td/TdForEachOperatorFactoryTest.java
@@ -82,6 +82,30 @@ public class TdForEachOperatorFactoryTest
         assertEquals("stable", jobRequest.getEngineVersion().get().toString());
     }
 
+    @Test
+    public void testTDJobRequestParamsWithEngineVersionForPrestoIsIgnored()
+            throws Exception
+    {
+        Path projectPath = Paths.get("").normalize().toAbsolutePath();
+
+        Config config = newConfig()
+                .set("database", "testdb")
+                .set("query", "select 1")
+                .set("engine", "presto")
+                .set("engine_version", "stable")
+                .set("_do", newConfig().set("+show", newConfig().set("echo>", "aaaa")));
+
+        when(op.submitNewJobWithRetry(any(TDJobRequest.class))).thenReturn("");
+        when(op.getDatabase()).thenReturn("testdb");
+
+        TDJobRequest jobRequest = testTDJobRequestParams(projectPath, config);
+
+        assertEquals("testdb", jobRequest.getDatabase());
+        assertEquals("select 1", jobRequest.getQuery());
+        assertEquals("presto", jobRequest.getType().toString());
+        assertFalse(jobRequest.getEngineVersion().isPresent());
+    }
+
     private TDJobRequest testTDJobRequestParams(Path projectPath, Config config)
     {
         ArgumentCaptor<TDJobRequest> captor = ArgumentCaptor.forClass(TDJobRequest.class);

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/td/TdOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/td/TdOperatorFactoryTest.java
@@ -26,6 +26,7 @@ import org.mockito.runners.MockitoJUnitRunner;
 import static io.digdag.standards.operator.td.TdOperatorFactory.insertCommandStatement;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -99,6 +100,29 @@ public class TdOperatorFactoryTest
         assertEquals("hive", jobRequest.getType().toString() );
         assertTrue(jobRequest.getEngineVersion().isPresent());
         assertEquals("stable", jobRequest.getEngineVersion().get().toString());
+    }
+
+    @Test
+    public void testTDJobRequestParamsWithEngineVersionForPrestoIsIgnored()
+            throws Exception
+    {
+        Path projectPath = Paths.get("").normalize().toAbsolutePath();
+
+        Config config = newConfig()
+                .set("database", "testdb")
+                .set("query", "select 1")
+                .set("engine", "presto")
+                .set("engine_version", "stable");
+
+        when(op.submitNewJobWithRetry(any(TDJobRequest.class))).thenReturn("");
+        when(op.getDatabase()).thenReturn("testdb");
+
+        TDJobRequest jobRequest = testTDJobRequestParams(projectPath, config);
+
+        assertEquals("testdb", jobRequest.getDatabase());
+        assertEquals("select 1", jobRequest.getQuery());
+        assertEquals("presto", jobRequest.getType().toString() );
+        assertFalse(jobRequest.getEngineVersion().isPresent());
     }
 
     private TDJobRequest testTDJobRequestParams(Path projectPath, Config config)

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/td/TdWaitOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/td/TdWaitOperatorFactoryTest.java
@@ -81,6 +81,29 @@ public class TdWaitOperatorFactoryTest
 
     }
 
+    @Test
+    public void testTDJobRequestParamsWithEngineVersionForPrestoIsIgnored()
+            throws Exception
+    {
+        Path projectPath = Paths.get("").normalize().toAbsolutePath();
+
+        Config config = newConfig()
+                .set("database", "testdb")
+                .set("query", "select 1")
+                .set("engine", "presto")
+                .set("engine_version", "stable");
+
+        when(op.submitNewJobWithRetry(any(TDJobRequest.class))).thenReturn("");
+        when(op.getDatabase()).thenReturn("testdb");
+
+        TDJobRequest jobRequest = testTDJobRequestParams(projectPath, config);
+
+        assertEquals("testdb", jobRequest.getDatabase());
+        assertEquals("select 1", jobRequest.getQuery());
+        assertEquals("presto", jobRequest.getType().toString());
+        assertFalse(jobRequest.getEngineVersion().isPresent());
+    }
+
     private TDJobRequest testTDJobRequestParams(Path projectPath, Config config)
     {
         ArgumentCaptor<TDJobRequest> captor = ArgumentCaptor.forClass(TDJobRequest.class);

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/td/TdWaitTableOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/td/TdWaitTableOperatorFactoryTest.java
@@ -19,6 +19,7 @@ import static io.digdag.standards.operator.td.TdOperatorTestingUtils.newOperator
 import static io.digdag.client.config.ConfigUtils.newConfig;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
@@ -58,6 +59,29 @@ public class TdWaitTableOperatorFactoryTest
      * Check config parameters are set to TDJobRequest
      */
     @Test
+    public void testTDJobRequestParamsWithEngineVersionForPrestoIsIgnored()
+            throws Exception
+    {
+        Path projectPath = Paths.get("").normalize().toAbsolutePath();
+
+        Config config = newConfig()
+                .set("_command", "target_table_00")
+                .set("database", "testdb")
+                .set("engine", "presto")
+                .set("engine_version", "stable");
+
+        when(op.submitNewJobWithRetry(any(TDJobRequest.class))).thenReturn("");
+        when(op.getDatabase()).thenReturn("testdb");
+
+        TDJobRequest jobRequest = testTDJobRequestParams(projectPath, config);
+
+        assertEquals("testdb", jobRequest.getDatabase());
+        assertTrue(jobRequest.getQuery().length() > 0);
+        assertEquals("presto", jobRequest.getType().toString());
+        assertFalse(jobRequest.getEngineVersion().isPresent());
+    }
+
+    @Test
     public void testTDJobRequestParamsWithEngineVersion()
             throws Exception
     {
@@ -79,7 +103,6 @@ public class TdWaitTableOperatorFactoryTest
         assertEquals("hive", jobRequest.getType().toString());
         assertTrue(jobRequest.getEngineVersion().isPresent());
         assertEquals("stable", jobRequest.getEngineVersion().get().toString());
-
     }
 
     private TDJobRequest testTDJobRequestParams(Path projectPath, Config config)


### PR DESCRIPTION
We manage dig file which includes a lot of `td` operators
and some jobs should be run by presto others should be hive.
Query engine of some jobs are determined dynamically.
In such a case we need to check engine and determine engine_version
if `engine_version` is passed for both presto and hive.

But we can not control presto engine_version via API job creation endpoint.
Then it's useless effort to determine engine_version.
We will need to specify `engine_version` of only hive by this change.