### PR TITLE
Update filter conditions on AttemptResource

### DIFF
--- a/digdag-server/src/main/java/io/digdag/server/rs/AttemptResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/AttemptResource.java
@@ -23,6 +23,7 @@ import io.digdag.core.session.ArchivedTask;
 import io.digdag.core.session.SessionStore;
 import io.digdag.core.session.SessionStoreManager;
 import io.digdag.core.session.StoredSessionAttemptWithSession;
+import io.digdag.core.session.StoredTask;
 import io.digdag.core.session.TaskRelation;
 import io.digdag.core.session.TaskStateCode;
 import io.digdag.core.workflow.*;
@@ -315,15 +316,15 @@ public class AttemptResource
                 // If a group error has occurred,
                 // exclude the group's child/dynamically generated tasks from successTasks
                 // even if they are in SUCCESS state
-                .filter(task -> !groupRetryErrorTaskIds.contains(task.getParentId().orNull()))
                 .filter(task -> !task.getFullName().contains("^sub"))
                 .filter(task -> task.getState() == TaskStateCode.SUCCESS)
-                .map(task -> {
+                .filter(task -> {
                     if (!task.getParentId().isPresent()) {
                         throw new IllegalArgumentException("Resuming successfully completed attempts is not supported");
                     }
-                    return task.getId();
+                    return !groupRetryErrorTaskIds.contains(task.getParentId().get());
                 })
+                .map(StoredTask::getId)
                 .collect(Collectors.toList());
 
         return ImmutableList.copyOf(successTasks);

--- a/digdag-server/src/main/java/io/digdag/server/rs/AttemptResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/AttemptResource.java
@@ -315,7 +315,7 @@ public class AttemptResource
                 // If a group error has occurred,
                 // exclude the group's child/dynamically generated tasks from successTasks
                 // even if they are in SUCCESS state
-                .filter(task -> task.getParentId().isPresent() && !groupRetryErrorTaskIds.contains(task.getParentId().get()))
+                .filter(task -> !groupRetryErrorTaskIds.contains(task.getParentId().orNull()))
                 .filter(task -> !task.getFullName().contains("^sub"))
                 .filter(task -> task.getState() == TaskStateCode.SUCCESS)
                 .map(task -> {

--- a/digdag-tests/src/test/java/acceptance/GroupRetryIT.java
+++ b/digdag-tests/src/test/java/acceptance/GroupRetryIT.java
@@ -166,6 +166,18 @@ public class GroupRetryIT
         assertOutputExists(retry4 + "3-2a", true);
         assertOutputExists(retry4 + "3-2b", true);
         assertOutputExists(retry4 + "3-2c", true);
+
+        // Retry the previous attempt with the latest fixed revision & resume failed tasks
+        // But the previous attempt was successful, it fails to resume
+        {
+            CommandStatus retryStatus = main("retry",
+                    "-c", config.toString(),
+                    "-e", server.endpoint(),
+                    "--latest-revision",
+                    "--resume",
+                    String.valueOf(retry4));
+            assertThat(retryStatus.errUtf8(), retryStatus.code(), is(1));
+        }
     }
 
     @Test
@@ -289,6 +301,18 @@ public class GroupRetryIT
         assertOutputExists(retry4 + "3-2a", true);
         assertOutputExists(retry4 + "3-2b", true);
         assertOutputExists(retry4 + "3-2c", true);
+
+        // Retry the previous attempt with the latest fixed revision & resume failed tasks
+        // But the previous attempt was successful, it fails to resume
+        {
+            CommandStatus retryStatus = main("retry",
+                    "-c", config.toString(),
+                    "-e", server.endpoint(),
+                    "--latest-revision",
+                    "--resume",
+                    String.valueOf(retry4));
+            assertThat(retryStatus.errUtf8(), retryStatus.code(), is(1));
+        }
     }
 
     @Test


### PR DESCRIPTION
Follow up of #1410
As pointed out [here](https://github.com/treasure-data/digdag/pull/1419/files#r468426935), the filter excluded the task containing the parent ID, but it causes an issue with validation does not work as expected. 