### PR TITLE
Add task details as comments automatically to the query run by td operator

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdOperatorFactory.java
@@ -219,7 +219,7 @@ public class TdOperatorFactory
                     throw new ConfigException("Unknown 'engine:' option (available options are: hive and presto): "+engine);
             }
 
-            final String sql = createStmtComment(request) + stmt;
+            final String sql = createStmtComment(request).append(stmt).toString();
 
             TDJobRequest req = new TDJobRequestBuilder()
                     .setResultOutput(resultUrl.transform(t -> t.format(context.getSecrets())).orNull())
@@ -537,14 +537,13 @@ public class TdOperatorFactory
     }
 
     @VisibleForTesting
-    static String createStmtComment(TaskRequest request)
+    static StringBuilder createStmtComment(TaskRequest request)
     {
         return new StringBuilder()
                 .append("-- project_id: ").append(request.getProjectId()).append("\n")
                 .append("-- project_name: ").append(request.getProjectName().or("")).append("\n")
                 .append("-- session_id: ").append(request.getSessionId()).append("\n")
                 .append("-- attempt_id: ").append(request.getAttemptId()).append("\n")
-                .append("-- task_name: ").append(request.getTaskName()).append("\n")
-                .toString();
+                .append("-- task_name: ").append(request.getTaskName()).append("\n");
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdOperatorFactory.java
@@ -542,6 +542,7 @@ public class TdOperatorFactory
         return new StringBuilder()
                 .append("-- project_id: ").append(request.getProjectId()).append("\n")
                 .append("-- project_name: ").append(request.getProjectName().or("")).append("\n")
+                .append("-- workflow_name: ").append(request.getWorkflowName()).append("\n")
                 .append("-- session_id: ").append(request.getSessionId()).append("\n")
                 .append("-- attempt_id: ").append(request.getAttemptId()).append("\n")
                 .append("-- task_name: ").append(request.getTaskName()).append("\n")

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdOperatorFactory.java
@@ -1,6 +1,5 @@
 package io.digdag.standards.operator.td;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
@@ -19,6 +18,7 @@ import io.digdag.core.Environment;
 import io.digdag.spi.Operator;
 import io.digdag.spi.OperatorFactory;
 import io.digdag.spi.OperatorContext;
+import io.digdag.spi.TaskRequest;
 import io.digdag.spi.TaskResult;
 import io.digdag.spi.TemplateEngine;
 import io.digdag.standards.operator.DurationInterval;
@@ -219,11 +219,13 @@ public class TdOperatorFactory
                     throw new ConfigException("Unknown 'engine:' option (available options are: hive and presto): "+engine);
             }
 
+            final String sql = createStmtComment(request) + stmt;
+
             TDJobRequest req = new TDJobRequestBuilder()
                     .setResultOutput(resultUrl.transform(t -> t.format(context.getSecrets())).orNull())
                     .setType(engine)
                     .setDatabase(op.getDatabase())
-                    .setQuery(stmt)
+                    .setQuery(sql)
                     .setRetryLimit(jobRetry)
                     .setPriority(priority)
                     .setPoolName(poolName.orNull())
@@ -235,7 +237,7 @@ public class TdOperatorFactory
                     .createTDJobRequest();
 
             String jobId = op.submitNewJobWithRetry(req);
-            logger.info("Started {} job id={}:\n{}", engine, jobId, stmt);
+            logger.info("Started {} job id={}:\n{}", engine, jobId, sql);
 
             return jobId;
         }
@@ -532,5 +534,17 @@ public class TdOperatorFactory
         else {
             return escapedValue.toString();
         }
+    }
+
+    @VisibleForTesting
+    static String createStmtComment(TaskRequest request)
+    {
+        return new StringBuilder()
+                .append("-- project_id: ").append(request.getProjectId()).append("\n")
+                .append("-- project_name: ").append(request.getProjectName().or("")).append("\n")
+                .append("-- session_id: ").append(request.getSessionId()).append("\n")
+                .append("-- attempt_id: ").append(request.getAttemptId()).append("\n")
+                .append("-- task_name: ").append(request.getTaskName()).append("\n")
+                .toString();
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/td/TdOperatorFactory.java
@@ -219,7 +219,7 @@ public class TdOperatorFactory
                     throw new ConfigException("Unknown 'engine:' option (available options are: hive and presto): "+engine);
             }
 
-            final String sql = createStmtComment(request).append(stmt).toString();
+            final String sql = wrapStmtWithComment(request, stmt);
 
             TDJobRequest req = new TDJobRequestBuilder()
                     .setResultOutput(resultUrl.transform(t -> t.format(context.getSecrets())).orNull())
@@ -537,13 +537,15 @@ public class TdOperatorFactory
     }
 
     @VisibleForTesting
-    static StringBuilder createStmtComment(TaskRequest request)
+    static String wrapStmtWithComment(TaskRequest request, String stmt)
     {
         return new StringBuilder()
                 .append("-- project_id: ").append(request.getProjectId()).append("\n")
                 .append("-- project_name: ").append(request.getProjectName().or("")).append("\n")
                 .append("-- session_id: ").append(request.getSessionId()).append("\n")
                 .append("-- attempt_id: ").append(request.getAttemptId()).append("\n")
-                .append("-- task_name: ").append(request.getTaskName()).append("\n");
+                .append("-- task_name: ").append(request.getTaskName()).append("\n")
+                .append(stmt)
+                .toString();
     }
 }

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/td/TdOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/td/TdOperatorFactoryTest.java
@@ -251,4 +251,57 @@ public class TdOperatorFactoryTest
         newOperatorFactory(TdOperatorFactory.class)
             .newOperator(newContext(projectPath, newTaskRequest().withConfig(config)));
     }
+
+    @Test
+    public void testWrapStmtWithComment()
+    {
+
+        assertEquals(
+                "-- project_id: 2\n" +
+                        "-- project_name: \n" +
+                        "-- session_id: 5\n" +
+                        "-- attempt_id: 4\n" +
+                        "-- task_name: t\n" +
+                        "select 1",
+                wrapStmtWithComment(taskRequest, "select 1"));
+
+        assertEquals(
+                "-- project_id: 2\n" +
+                        "-- project_name: \n" +
+                        "-- session_id: 5\n" +
+                        "-- attempt_id: 4\n" +
+                        "-- task_name: t\n" +
+                        "-- comment\n" +
+                        "select 1 from test",
+                wrapStmtWithComment(taskRequest, "-- comment\nselect 1 from test"));
+
+        String insertCmdStmt = insertCommandStatement("INSERT",
+                "with a as (select 1)\n" +
+                        "--DIGDAG_INSERT_LINE\n" +
+                        "-- comment\n" +
+                        "select 1");
+        assertEquals(
+                "-- project_id: 2\n" +
+                        "-- project_name: \n" +
+                        "-- session_id: 5\n" +
+                        "-- attempt_id: 4\n" +
+                        "-- task_name: t\n" +
+                        "with a as (select 1)\n" +
+                        "INSERT\n" +
+                        "-- comment\n" +
+                        "select 1",
+                wrapStmtWithComment(taskRequest, insertCmdStmt));
+
+        when(taskRequest.getProjectName()).thenReturn(Optional.of("test_project"));
+        when(taskRequest.getTaskName()).thenReturn("+test_wf+test");
+        assertEquals(
+                "-- project_id: 2\n" +
+                        "-- project_name: test_project\n" +
+                        "-- session_id: 5\n" +
+                        "-- attempt_id: 4\n" +
+                        "-- task_name: +test_wf+test\n" +
+                        "select 1",
+                wrapStmtWithComment(taskRequest, "select 1"));
+    }
+
 }

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/td/TdOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/td/TdOperatorFactoryTest.java
@@ -57,7 +57,7 @@ public class TdOperatorFactoryTest
         when(taskRequest.getProjectName()).thenReturn(Optional.absent());
         when(taskRequest.getSessionId()).thenReturn((long) 5);
         when(taskRequest.getAttemptId()).thenReturn((long) 4);
-        when(taskRequest.getWorkflowName()).thenReturn("test_wf");
+        when(taskRequest.getWorkflowName()).thenReturn("wf");
         when(taskRequest.getTaskName()).thenReturn("t");
     }
 
@@ -259,7 +259,7 @@ public class TdOperatorFactoryTest
         assertEquals(
                 "-- project_id: 2\n" +
                         "-- project_name: \n" +
-                        "-- workflow_name: test_wf\n" +
+                        "-- workflow_name: wf\n" +
                         "-- session_id: 5\n" +
                         "-- attempt_id: 4\n" +
                         "-- task_name: t\n" +
@@ -269,7 +269,7 @@ public class TdOperatorFactoryTest
         assertEquals(
                 "-- project_id: 2\n" +
                         "-- project_name: \n" +
-                        "-- workflow_name: test_wf\n" +
+                        "-- workflow_name: wf\n" +
                         "-- session_id: 5\n" +
                         "-- attempt_id: 4\n" +
                         "-- task_name: t\n" +
@@ -285,7 +285,7 @@ public class TdOperatorFactoryTest
         assertEquals(
                 "-- project_id: 2\n" +
                         "-- project_name: \n" +
-                        "-- workflow_name: test_wf\n" +
+                        "-- workflow_name: wf\n" +
                         "-- session_id: 5\n" +
                         "-- attempt_id: 4\n" +
                         "-- task_name: t\n" +
@@ -296,6 +296,7 @@ public class TdOperatorFactoryTest
                 wrapStmtWithComment(taskRequest, insertCmdStmt));
 
         when(taskRequest.getProjectName()).thenReturn(Optional.of("test_project"));
+        when(taskRequest.getWorkflowName()).thenReturn("test_wf");
         when(taskRequest.getTaskName()).thenReturn("+test_wf+test");
         assertEquals(
                 "-- project_id: 2\n" +

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/td/TdOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/td/TdOperatorFactoryTest.java
@@ -51,6 +51,16 @@ public class TdOperatorFactoryTest
     @Rule
     public final ExpectedException exception = ExpectedException.none();
 
+    @Before
+    public void setUp()
+    {
+        when(taskRequest.getProjectId()).thenReturn(2);
+        when(taskRequest.getProjectName()).thenReturn(Optional.absent());
+        when(taskRequest.getSessionId()).thenReturn((long) 5);
+        when(taskRequest.getAttemptId()).thenReturn((long) 4);
+        when(taskRequest.getTaskName()).thenReturn("t");
+    }
+
     /**
      *
      * Check config parameters are set to TDJobRequest
@@ -72,9 +82,10 @@ public class TdOperatorFactoryTest
         ArgumentCaptor<TDJobRequest> captor = ArgumentCaptor.forClass(TDJobRequest.class);
 
         TDJobRequest jobRequest = testTDJobRequestParams(projectPath, config);
+        String sql = createStmtComment(taskRequest).append("select 1").toString();
 
         assertEquals("testdb", jobRequest.getDatabase());
-        assertEquals("select 1", jobRequest.getQuery());
+        assertEquals(sql, jobRequest.getQuery());
         assertEquals("presto", jobRequest.getType().toString() );
         assertEquals(Optional.absent(), jobRequest.getEngineVersion());
     }
@@ -99,14 +110,7 @@ public class TdOperatorFactoryTest
         when(op.getDatabase()).thenReturn("testdb");
 
         TDJobRequest jobRequest = testTDJobRequestParams(projectPath, config);
-
-        when(taskRequest.getProjectId()).thenReturn(2);
-        when(taskRequest.getProjectName()).thenReturn(Optional.absent());
-        when(taskRequest.getSessionId()).thenReturn((long) 5);
-        when(taskRequest.getAttemptId()).thenReturn((long) 4);
-        when(taskRequest.getTaskName()).thenReturn("t");
-
-        String sql = createStmtComment(taskRequest) + "select 1";
+        String sql = createStmtComment(taskRequest).append("select 1").toString();
 
         assertEquals("testdb", jobRequest.getDatabase());
         assertEquals(sql, jobRequest.getQuery());

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/td/TdOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/td/TdOperatorFactoryTest.java
@@ -57,6 +57,7 @@ public class TdOperatorFactoryTest
         when(taskRequest.getProjectName()).thenReturn(Optional.absent());
         when(taskRequest.getSessionId()).thenReturn((long) 5);
         when(taskRequest.getAttemptId()).thenReturn((long) 4);
+        when(taskRequest.getWorkflowName()).thenReturn("test_wf");
         when(taskRequest.getTaskName()).thenReturn("t");
     }
 
@@ -258,6 +259,7 @@ public class TdOperatorFactoryTest
         assertEquals(
                 "-- project_id: 2\n" +
                         "-- project_name: \n" +
+                        "-- workflow_name: test_wf\n" +
                         "-- session_id: 5\n" +
                         "-- attempt_id: 4\n" +
                         "-- task_name: t\n" +
@@ -267,6 +269,7 @@ public class TdOperatorFactoryTest
         assertEquals(
                 "-- project_id: 2\n" +
                         "-- project_name: \n" +
+                        "-- workflow_name: test_wf\n" +
                         "-- session_id: 5\n" +
                         "-- attempt_id: 4\n" +
                         "-- task_name: t\n" +
@@ -282,6 +285,7 @@ public class TdOperatorFactoryTest
         assertEquals(
                 "-- project_id: 2\n" +
                         "-- project_name: \n" +
+                        "-- workflow_name: test_wf\n" +
                         "-- session_id: 5\n" +
                         "-- attempt_id: 4\n" +
                         "-- task_name: t\n" +
@@ -296,6 +300,7 @@ public class TdOperatorFactoryTest
         assertEquals(
                 "-- project_id: 2\n" +
                         "-- project_name: test_project\n" +
+                        "-- workflow_name: test_wf\n" +
                         "-- session_id: 5\n" +
                         "-- attempt_id: 4\n" +
                         "-- task_name: +test_wf+test\n" +

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/td/TdOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/td/TdOperatorFactoryTest.java
@@ -5,6 +5,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.treasuredata.client.model.TDJobRequest;
 import io.digdag.core.EnvironmentModule;
+import io.digdag.spi.TaskRequest;
 import io.digdag.standards.td.TdConfigurationModule;
 import org.junit.Before;
 import org.junit.Test;
@@ -23,6 +24,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import static io.digdag.standards.operator.td.TdOperatorFactory.createStmtComment;
 import static io.digdag.standards.operator.td.TdOperatorFactory.insertCommandStatement;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -34,6 +36,7 @@ import static io.digdag.core.workflow.OperatorTestingUtils.newContext;
 import static io.digdag.core.workflow.OperatorTestingUtils.newTaskRequest;
 import static io.digdag.standards.operator.td.TdOperatorTestingUtils.newOperatorFactory;
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -41,6 +44,9 @@ public class TdOperatorFactoryTest
 {
     @Mock
     TDOperator op;
+
+    @Mock
+    TaskRequest taskRequest;
 
     @Rule
     public final ExpectedException exception = ExpectedException.none();
@@ -94,8 +100,16 @@ public class TdOperatorFactoryTest
 
         TDJobRequest jobRequest = testTDJobRequestParams(projectPath, config);
 
+        when(taskRequest.getProjectId()).thenReturn(2);
+        when(taskRequest.getProjectName()).thenReturn(Optional.absent());
+        when(taskRequest.getSessionId()).thenReturn((long) 5);
+        when(taskRequest.getAttemptId()).thenReturn((long) 4);
+        when(taskRequest.getTaskName()).thenReturn("t");
+
+        String sql = createStmtComment(taskRequest) + "select 1";
+
         assertEquals("testdb", jobRequest.getDatabase());
-        assertEquals("select 1", jobRequest.getQuery());
+        assertEquals(sql, jobRequest.getQuery());
         assertEquals("hive", jobRequest.getType().toString() );
         assertTrue(jobRequest.getEngineVersion().isPresent());
         assertEquals("stable", jobRequest.getEngineVersion().get().toString());


### PR DESCRIPTION
Currently, it's hard to identify which the workflow runs the job because we don't have information in the query issued by a workflow.
This PR support to add task details as comments automatically to the top of the query run by td operator, the following information will be added.

- project_id
- project_name
- workflow_name
- session_id
- attempt_id
- task_name

The above information will help the admin/user to identify/debug the workflow from the job results easily.