### PR TITLE
Show error message when tasks failed with config error in WorkflowExecutor

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java
+++ b/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java
@@ -1330,7 +1330,11 @@ public class WorkflowExecutor
         }
         catch (ConfigException ex) {
             // Subtask config or _check task config has a problem (e.g. more than one operator).
-            return taskFailed(lockedTask, buildExceptionErrorConfig(ex).toConfig(cf));
+            Config errorConfig = buildExceptionErrorConfig(ex).toConfig(cf);
+            logger.error("Configuration error at task {}: {}",
+                    lockedTask.get().getFullName(),
+                    errorConfig.get("message", String.class, ""));
+            return taskFailed(lockedTask, errorConfig);
         }
 
         boolean updated;


### PR DESCRIPTION
Follow up of #1413 
Similar to https://github.com/treasure-data/digdag/issues/950

Currently, when an error occurs due to misconfiguration at a subtask, it could silently fail without any messages because of a log with a trace level as follows.
https://github.com/treasure-data/digdag/blob/069ed09f3cac01620eeaaaf6ff931349f7dcf0f6/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java#L1249-L1252

It would be better to output the log at the error level in case of such an error. This PR supports to show error messages as well.