### PR TITLE
Add a log marker "UNEXPECTED_SERVER_ERROR"

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/agent/MultiThreadAgent.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/MultiThreadAgent.java
@@ -4,6 +4,7 @@ import com.google.common.base.Optional;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.digdag.core.ErrorReporter;
 import io.digdag.core.database.TransactionManager;
+import io.digdag.core.log.LogMarkers;
 import io.digdag.spi.TaskRequest;
 import java.time.Duration;
 import java.util.List;
@@ -131,7 +132,9 @@ public class MultiThreadAgent
                                         runner.run(req);
                                     }
                                     catch (Throwable t) {
-                                        logger.error("Uncaught exception. Task queue will detect this failure and this task will be retried later.", t);
+                                        logger.error(
+                                                LogMarkers.UNEXPECTED_SERVER_ERROR,
+                                                "Uncaught exception. Task queue will detect this failure and this task will be retried later.", t);
                                         errorReporter.reportUncaughtError(t);
                                         metrics.increment(Category.AGENT, "uncaughtErrors");
                                     }
@@ -152,7 +155,9 @@ public class MultiThreadAgent
                 }
             }
             catch (Throwable t) {
-                logger.error("Uncaught exception during acquiring tasks from a server. Ignoring. Agent thread will be retried.", t);
+                logger.error(
+                        LogMarkers.UNEXPECTED_SERVER_ERROR,
+                        "Uncaught exception during acquiring tasks from a server. Ignoring. Agent thread will be retried.", t);
                 errorReporter.reportUncaughtError(t);
                 metrics.increment(Category.AGENT, "uncaughtErrors");
                 try {

--- a/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
@@ -10,6 +10,7 @@ import io.digdag.client.config.ConfigException;
 import io.digdag.client.config.ConfigFactory;
 import io.digdag.core.Limits;
 import io.digdag.core.log.LogLevel;
+import io.digdag.core.log.LogMarkers;
 import io.digdag.core.log.TaskContextLogging;
 import io.digdag.core.log.TaskLogger;
 import io.digdag.core.ErrorReporter;
@@ -170,7 +171,9 @@ public class OperatorManager
                         logger.error("Configuration error at task {}: {}", request.getTaskName(), formatExceptionMessage(ex));
                     }
                     else {
-                        logger.error("Task failed with unexpected error: {}", ex.getMessage(), ex);
+                        logger.error(
+                                LogMarkers.UNEXPECTED_SERVER_ERROR,
+                                "Task failed with unexpected error: {}", ex.getMessage(), ex);
                     }
                     callback.taskFailed(request, agentId, buildExceptionErrorConfig(ex).toConfig(cf));  // no retry
                 }
@@ -179,10 +182,10 @@ public class OperatorManager
         }
         catch (RuntimeException | IOException ex) {
             // exception happened in workspaceManager
-            logger.error("Task failed with unexpected error: {}", ex.getMessage(), ex);
+            logger.error(
+                    LogMarkers.UNEXPECTED_SERVER_ERROR,
+                    "Task failed with unexpected error: {}", ex.getMessage(), ex);
             callback.taskFailed(request, agentId, buildExceptionErrorConfig(ex).toConfig(cf));
-
-
         }
     }
 
@@ -348,7 +351,9 @@ public class OperatorManager
             }
         }
         catch (Throwable t) {
-            logger.error("Uncaught exception during sending task heartbeats to a server. Ignoring. Heartbeat thread will be retried.", t);
+            logger.error(
+                    LogMarkers.UNEXPECTED_SERVER_ERROR,
+                    "Uncaught exception during sending task heartbeats to a server. Ignoring. Heartbeat thread will be retried.", t);
             errorReporter.reportUncaughtError(t);
             metrics.increment(Category.AGENT, "uncaughtErrors");
         }

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseTaskQueueServer.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseTaskQueueServer.java
@@ -18,6 +18,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.digdag.core.ErrorReporter;
+import io.digdag.core.log.LogMarkers;
 import io.digdag.spi.metrics.DigdagMetrics;
 import static io.digdag.spi.metrics.DigdagMetrics.Category;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
@@ -444,7 +445,9 @@ public class DatabaseTaskQueueServer
             }
         }
         catch (Throwable t) {
-            logger.error("An uncaught exception is ignored. This lock expiration thread will be restarted.", t);
+            logger.error(
+                    LogMarkers.UNEXPECTED_SERVER_ERROR,
+                    "An uncaught exception is ignored. This lock expiration thread will be restarted.", t);
             errorReporter.reportUncaughtError(t);
             metrics.increment(Category.DB, "uncaughtErrors");
         }

--- a/digdag-core/src/main/java/io/digdag/core/log/LogMarkers.java
+++ b/digdag-core/src/main/java/io/digdag/core/log/LogMarkers.java
@@ -1,0 +1,10 @@
+package io.digdag.core.log;
+
+import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
+
+public final class LogMarkers {
+    public static final Marker UNEXPECTED_SERVER_ERROR = MarkerFactory.getMarker("UNEXPECTED_SERVER_ERROR");
+
+    private LogMarkers() {}
+}

--- a/digdag-core/src/main/java/io/digdag/core/session/SessionMonitorExecutor.java
+++ b/digdag-core/src/main/java/io/digdag/core/session/SessionMonitorExecutor.java
@@ -8,10 +8,10 @@ import java.util.concurrent.ScheduledExecutorService;
 import javax.annotation.PreDestroy;
 import com.google.inject.Inject;
 import com.google.common.base.*;
-import com.google.common.collect.*;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.digdag.core.Limits;
 import io.digdag.core.database.TransactionManager;
+import io.digdag.core.log.LogMarkers;
 import io.digdag.spi.metrics.DigdagMetrics;
 import static io.digdag.spi.metrics.DigdagMetrics.Category;
 import org.slf4j.Logger;
@@ -101,7 +101,9 @@ public class SessionMonitorExecutor
             });
         }
         catch (Throwable t) {
-            logger.error("An uncaught exception is ignored. This session monitor scheduling will be retried.", t);
+            logger.error(
+                    LogMarkers.UNEXPECTED_SERVER_ERROR,
+                    "An uncaught exception is ignored. This session monitor scheduling will be retried.", t);
             errorReporter.reportUncaughtError(t);
             metrics.increment(Category.DEFAULT, "uncaughtErrors");
         }

--- a/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java
+++ b/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java
@@ -13,6 +13,7 @@ import io.digdag.client.config.ConfigFactory;
 import io.digdag.core.Limits;
 import io.digdag.core.agent.AgentId;
 import io.digdag.core.database.TransactionManager;
+import io.digdag.core.log.LogMarkers;
 import io.digdag.core.repository.ProjectStoreManager;
 import io.digdag.core.repository.ResourceConflictException;
 import io.digdag.core.repository.ResourceNotFoundException;
@@ -1013,7 +1014,9 @@ public class WorkflowExecutor
             }
             catch (Exception ex) {
                 tm.reset();
-                logger.error("Enqueue error, making this task failed: {}", task, ex);
+                logger.error(
+                        LogMarkers.UNEXPECTED_SERVER_ERROR,
+                        "Enqueue error, making this task failed: {}", task, ex);
                 // TODO retry here?
                 return taskFailed(lockedTask,
                         buildExceptionErrorConfig(ex).toConfig(cf));
@@ -1060,7 +1063,9 @@ public class WorkflowExecutor
             }
             catch (RuntimeException ex) {
                 tm.reset();
-                logger.error("Invalid association of task queue lock id: {}", lock, ex);
+                logger.error(
+                        LogMarkers.UNEXPECTED_SERVER_ERROR,
+                        "Invalid association of task queue lock id: {}", lock, ex);
             }
         }
         return builder.build();

--- a/digdag-server/src/main/java/io/digdag/server/WorkflowExecutionTimeoutEnforcer.java
+++ b/digdag-server/src/main/java/io/digdag/server/WorkflowExecutionTimeoutEnforcer.java
@@ -1,18 +1,15 @@
 package io.digdag.server;
 
 import com.google.common.base.Optional;
-import com.google.common.base.Throwables;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
 import io.digdag.client.config.Config;
-import io.digdag.core.database.Transaction;
 import io.digdag.core.database.TransactionManager;
+import io.digdag.core.log.LogMarkers;
 import io.digdag.core.repository.ProjectStoreManager;
 import io.digdag.core.repository.ResourceNotFoundException;
 import io.digdag.core.repository.StoredProject;
-import io.digdag.core.repository.StoredRevision;
 import io.digdag.core.repository.StoredWorkflowDefinitionWithProject;
-import io.digdag.core.repository.WorkflowDefinition;
 import io.digdag.core.session.AttemptStateFlags;
 import io.digdag.core.session.SessionStoreManager;
 import io.digdag.core.session.StoredSessionAttempt;
@@ -110,14 +107,18 @@ public class WorkflowExecutionTimeoutEnforcer
             enforceAttemptTTLs();
         }
         catch (Throwable t) {
-            logger.error("Uncaught exception when enforcing attempt TTLs. Ignoring. Loop will be retried.", t);
+            logger.error(
+                    LogMarkers.UNEXPECTED_SERVER_ERROR,
+                    "Uncaught exception when enforcing attempt TTLs. Ignoring. Loop will be retried.", t);
         }
 
         try {
             enforceTaskTTLs();
         }
         catch (Throwable t) {
-            logger.error("Uncaught exception when enforcing task TTLs. Ignoring. Loop will be retried.", t);
+            logger.error(
+                    LogMarkers.UNEXPECTED_SERVER_ERROR,
+                    "Uncaught exception when enforcing task TTLs. Ignoring. Loop will be retried.", t);
         }
     }
 
@@ -154,7 +155,9 @@ public class WorkflowExecutionTimeoutEnforcer
                 }
             }
             catch (Throwable t) {
-                logger.error("Uncaught exception when enforcing attempt TTLs of attempt {}. Ignoring. Loop continues.", attempt.getId(), t);
+                logger.error(
+                        LogMarkers.UNEXPECTED_SERVER_ERROR,
+                        "Uncaught exception when enforcing attempt TTLs of attempt {}. Ignoring. Loop continues.", attempt.getId(), t);
             }
         }
     }
@@ -183,7 +186,9 @@ public class WorkflowExecutionTimeoutEnforcer
                 }
             }
             catch (Throwable t) {
-                logger.error("Uncaught exception when enforcing task TTLs of attempt {}. Ignoring. Loop continues.", entry.getKey(), t);
+                logger.error(
+                        LogMarkers.UNEXPECTED_SERVER_ERROR,
+                        "Uncaught exception when enforcing task TTLs of attempt {}. Ignoring. Loop continues.", entry.getKey(), t);
             }
         }
     }

--- a/digdag-server/src/main/java/io/digdag/server/WorkflowExecutorLoop.java
+++ b/digdag-server/src/main/java/io/digdag/server/WorkflowExecutorLoop.java
@@ -5,6 +5,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import io.digdag.core.BackgroundExecutor;
 import io.digdag.core.ErrorReporter;
+import io.digdag.core.log.LogMarkers;
 import io.digdag.core.workflow.WorkflowExecutor;
 
 import io.digdag.spi.metrics.DigdagMetrics;
@@ -13,7 +14,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.function.Supplier;
-import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 
@@ -59,7 +59,9 @@ public class WorkflowExecutorLoop
                 workflowExecutor.runWhile(() -> !stop);
             }
             catch (Throwable t) {
-                logger.error("Uncaught error during executing workflow state machine. Ignoring. Loop will be retried.", t);
+                logger.error(
+                        LogMarkers.UNEXPECTED_SERVER_ERROR,
+                        "Uncaught error during executing workflow state machine. Ignoring. Loop will be retried.", t);
                 errorReporter.reportUncaughtError(t);
                 metrics.increment(Category.EXECUTOR, "uncaughtErrors");
                 try {

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -15,10 +15,8 @@ import com.amazonaws.services.ecs.model.Task;
 import com.amazonaws.services.ecs.model.TaskDefinition;
 import com.amazonaws.services.ecs.model.TaskOverride;
 import com.amazonaws.services.ecs.model.TaskSetNotFoundException;
-import com.amazonaws.services.logs.model.AWSLogsException;
 import com.amazonaws.services.logs.model.GetLogEventsResult;
 import com.amazonaws.services.logs.model.OutputLogEvent;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
@@ -29,6 +27,7 @@ import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigException;
 import io.digdag.core.archive.ProjectArchiveLoader;
 import io.digdag.core.archive.ProjectArchives;
+import io.digdag.core.log.LogMarkers;
 import io.digdag.core.storage.StorageManager;
 import io.digdag.spi.CommandContext;
 import io.digdag.spi.CommandExecutor;
@@ -43,7 +42,6 @@ import io.digdag.standards.command.ecs.EcsClientFactory;
 import io.digdag.standards.command.ecs.EcsTaskStatus;
 import io.digdag.standards.command.ecs.TemporalProjectArchiveStorage;
 import io.digdag.util.DurationParam;
-import org.apache.commons.codec.binary.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -615,7 +613,7 @@ public class EcsCommandExecutor
         }
         catch (IOException e) {
             final String message = s("Cannot archive the project archive. It will be retried.");
-            logger.error(message, e);
+            logger.error(LogMarkers.UNEXPECTED_SERVER_ERROR, message, e);
             throw new RuntimeException(message, e);
         }
 
@@ -630,7 +628,7 @@ public class EcsCommandExecutor
         }
         catch (IOException e) {
             final String message = s("Cannot upload a temporal project archive '%s'with storage key '%s'. It will be retried.", projectArchivePath.toString(), projectArchiveStorageKey);
-            logger.error(message, e);
+            logger.error(LogMarkers.UNEXPECTED_SERVER_ERROR, message, e);
             throw new RuntimeException(message, e);
         }
         finally {


### PR DESCRIPTION
digdag outputs some log messages as `error` level, but some of them are unexpected and the others are expected. But there is no marker on log messages now to distinct whether it's expected or not. This PR adds a marker on unexpected log messages so that we can handle unexpected ones differently.