### PR TITLE
Fix test cases to get correct schedule ids

### DIFF
--- a/digdag-tests/src/test/java/acceptance/ServerScheduleIT.java
+++ b/digdag-tests/src/test/java/acceptance/ServerScheduleIT.java
@@ -442,12 +442,10 @@ public class ServerScheduleIT
         Files.createDirectories(projectDir);
         addWorkflow(projectDir, "acceptance/schedule/daily10.dig", "daily10.dig");
         addWorkflow(projectDir, "acceptance/schedule/hourly9.dig", "hourly9.dig");
-        pushProject(server.endpoint(), projectDir);
+        Id projectId = pushProject(server.endpoint(), projectDir);
 
-        List<RestSchedule> schedules = client.getSchedules().getSchedules();
-
-        RestSchedule daily = schedules.get(0);
-        RestSchedule hourly = schedules.get(1);
+        RestSchedule daily = client.getSchedule(projectId, "daily10");
+        RestSchedule hourly = client.getSchedule(projectId, "hourly9");
         Optional<String> skipToTime = Optional.of("2291-02-09T00:01:00Z");
 
         // daily


### PR DESCRIPTION
Follow-up of #1451.

`acceptance.ServerScheduleIT` FAILED with the following error. e.g. https://github.com/treasure-data/digdag/runs/1065603120

```
acceptance.ServerScheduleIT > testSkipAndEnable FAILED
    java.lang.AssertionError: 
    Expected: is <2291-02-09T10:00:00Z>
         but: was <2291-02-09T00:09:00Z>
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
        at org.junit.Assert.assertThat(Assert.java:956)
        at org.junit.Assert.assertThat(Assert.java:923)
        at acceptance.ServerScheduleIT.testSkipAndEnable(ServerScheduleIT.java:461)
```