### PR TITLE
Introduce `time` command to `EcsCommandExecutor`

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -620,10 +620,16 @@ public class EcsCommandExecutor
         bashArguments.add(s("curl -s -X PUT -T %s -L \"%s\"", outputProjectArchivePathName, outputProjectArchiveDirectUploadUrl));
         bashArguments.add(s("exit $exit_code"));
 
+        final String formattedBashArguments = bashArguments.build().stream().map(Object::toString).collect(Collectors.joining("; "));
         final List<String> bashCommand = ImmutableList.<String>builder()
+                .add("if [ -x /usr/bin/time ]; then")
+                .add("/usr/bin/time -f \"Elapsed time: %E, Memory (Max RSS): %M kb, CPU used: %P\" /bin/bash -c")
+                .add(formattedBashArguments)
+                .add("else")
                 .add("/bin/bash")
                 .add("-c")
-                .add(bashArguments.build().stream().map(Object::toString).collect(Collectors.joining("; ")))
+                .add(formattedBashArguments)
+                .add("fi")
                 .build();
         logger.debug("Submit command line arguments: " + bashCommand);
 


### PR DESCRIPTION
# What does this PR change?
This PR introduces `time` command so that `EcsCommandExecutor` can show the followings on digdag log;
- Elapsed time of python script
- CPU Usage
- Memory Usage