### PR TITLE
Bumpup AWS SDK in order to support ECS capacity provider options.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -126,7 +126,7 @@ subprojects {
     ext {
         jacksonVersion = "2.9.10"
         jacksonDatabindVersion = "2.9.10"
-        awsJavaSdkVersion = "1.11.545"
+        awsJavaSdkVersion = "1.11.686"
         guavaVersion = "19.0"
     }
 


### PR DESCRIPTION
# What does this PR change?
This PR updates AWS SDK to 11.686.

# Background
We need to update AWS SDK to support ECS Capacity Provider options.

https://github.com/aws/aws-sdk-java/blame/1.11.686/aws-java-sdk-ecs/src/main/java/com/amazonaws/services/ecs/model/RunTaskRequest.java#L237-L501