### PR TITLE
Add getTaskDefinitionByTags with functional condition

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClient.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClient.java
@@ -7,6 +7,7 @@ import com.amazonaws.services.ecs.model.Task;
 import com.amazonaws.services.ecs.model.TaskDefinition;
 import com.amazonaws.services.logs.model.GetLogEventsResult;
 import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
 import io.digdag.client.config.ConfigException;
 
 import java.io.IOException;
@@ -31,6 +32,8 @@ public interface EcsClient
     List<Tag> getTaskDefinitionTags(final String taskDefinitionArn);
 
     Optional<TaskDefinition> getTaskDefinitionByTags(List<Tag> tags);
+
+    Optional<TaskDefinition> getTaskDefinitionByTags(Predicate<List<Tag>> tags);
 
     Task getTask(String cluster, String taskArn);
 


### PR DESCRIPTION
# What does this PR change?

This PR introduces a method to filters ECS Task definitions by `Predicate` object.
`Optional<TaskDefinition> getTaskDefinitionByTags(final Predicate<List<Tag>> condition)`

# Background

Existing `Optional<TaskDefinition> getTaskDefinitionByTags(final List<Tag> expectedTags)` filters ECS Task definitions by matching all provided Tags.

In order to filter ECS Task definitions more flexibility, we need another method which takes functional interface object as a condition.

One of the expected use case is the following

```java
final Predicate<List<Tag>> condition = tags -> tags.stream().allMatch(t -> t.getKey().startsWith("v2_"));
final Optional<TaskDefinition> v2TaskDefinitions = ecsClient.getTaskDefinitionByTags(condition);
```