### PR TITLE
Fix error of session_time formatting

### DIFF
--- a/digdag-docs/src/operators/require.md
+++ b/digdag-docs/src/operators/require.md
@@ -46,7 +46,7 @@
     loop>: ${moment(last_session_time).daysInMonth()}
     _do:
       require>: daily_workflow
-      session_time: ${moment(last_session_time).add(i, 'day')}
+      session_time: ${moment(last_session_time).add(i, 'day').format()}
   ```
 
 * **project_id**: project_id


### PR DESCRIPTION
Once I have tried documented code, I have saw this error

```
Invalid ISO time format: "2020-10-04T00:00:00.000Z" (json mapping)Text '"2020-10-04T00:00:00.000Z"' could not be parsed at index 0 (date time parse)
```

it works by adding `.format('YYYY-MM-DDTHH:mm:ssZ')` for moment.js 