### PR TITLE
Fix a bug that failed tasks with java.lang.Error retry infinitely

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java
+++ b/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java
@@ -1146,6 +1146,7 @@ public class WorkflowExecutor
                 .attemptId(attempt.getId())
                 .sessionId(attempt.getSessionId())
                 .retryAttemptName(attempt.getRetryAttemptName())
+                .isCancelRequested(task.getStateFlags().isCancelRequested())
                 .taskName(task.getFullName())
                 .lockId(lockId)
                 .timeZone(attempt.getTimeZone())

--- a/digdag-core/src/test/java/io/digdag/core/agent/OperatorManagerTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/agent/OperatorManagerTest.java
@@ -8,7 +8,10 @@ import io.digdag.client.config.ConfigFactory;
 import io.digdag.client.config.ConfigUtils;
 import io.digdag.core.Limits;
 import io.digdag.core.workflow.OperatorTestingUtils;
-import io.digdag.spi.*;
+import io.digdag.spi.SecretStoreManager;
+import io.digdag.spi.TaskExecutionException;
+import io.digdag.spi.TaskRequest;
+import io.digdag.spi.TaskResult;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -20,8 +23,14 @@ import java.io.IOException;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class OperatorManagerTest

--- a/digdag-core/src/test/java/io/digdag/core/workflow/OperatorTestingUtils.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/OperatorTestingUtils.java
@@ -76,6 +76,7 @@ public class OperatorTestingUtils
             .sessionUuid(UUID.randomUUID())
             .sessionTime(Instant.now())
             .createdAt(Instant.now())
+            .isCancelRequested(false)
             .config(newConfig())
             .localConfig(newConfig())
             .lastStateParams(newConfig())

--- a/digdag-core/src/test/java/io/digdag/core/workflow/OperatorTestingUtils.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/OperatorTestingUtils.java
@@ -62,6 +62,11 @@ public class OperatorTestingUtils
 
     public static ImmutableTaskRequest newTaskRequest()
     {
+        return newTaskRequest(newConfig());
+    }
+
+    public static ImmutableTaskRequest newTaskRequest(Config config)
+    {
         return ImmutableTaskRequest.builder()
             .siteId(1)
             .projectId(2)
@@ -78,7 +83,7 @@ public class OperatorTestingUtils
             .createdAt(Instant.now())
             .isCancelRequested(false)
             .config(newConfig())
-            .localConfig(newConfig())
+            .localConfig(config)
             .lastStateParams(newConfig())
             .build();
     }

--- a/digdag-spi/src/main/java/io/digdag/spi/TaskRequest.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/TaskRequest.java
@@ -46,6 +46,8 @@ public interface TaskRequest
 
     Instant getCreatedAt();
 
+    boolean isCancelRequested();
+
     Config getLocalConfig();
 
     Config getConfig();


### PR DESCRIPTION
Current `OperatorManager#runWithHeartbeat` doesn't catch `java.lang.Error` derived objects including `java.lang.OutOfMemoryError`. If a task always fails due to OOM (e.g. internally parse a huge JSON object), the task will be retried infinitely and the task TTL (default: 24 hours) won't work.

This PR fixes the bug by checking if the task is already requested to be canceled by `WorkflowExecutionTimeoutEnforcer` and cancels the task if needed.