### PR TITLE
Support creating EcsClientConfig from taskConfig

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -498,7 +498,7 @@ public class EcsCommandExecutor
         throw new RuntimeException("Submitted task could not be found"); // TODO the message should be improved more understandably.
     }
 
-    protected EcsClientConfig createEcsClientConfig (
+    protected EcsClientConfig createEcsClientConfig(
             final Optional<String> clusterName,
             final Config systemConfig,
             final Config taskConfig)
@@ -525,6 +525,7 @@ public class EcsCommandExecutor
         setEcsTaskCount(runTaskRequest);
         setEcsTaskOverride(commandContext, commandRequest, td, runTaskRequest, clientConfig); // RuntimeException,ConfigException
         setEcsTaskLaunchType(clientConfig, runTaskRequest);
+        setEcsTaskStartedBy(clientConfig, runTaskRequest);
         setEcsNetworkConfiguration(clientConfig, runTaskRequest);
         setCapacityProviderStrategy(clientConfig, runTaskRequest);
         return runTaskRequest;
@@ -729,6 +730,13 @@ public class EcsCommandExecutor
         }
         if (clientConfig.getMemory().isPresent()) {
             containerOverride.setMemory(clientConfig.getMemory().get());
+        }
+    }
+
+    protected void setEcsTaskStartedBy(EcsClientConfig clientConfig, RunTaskRequest runTaskRequest)
+    {
+        if (clientConfig.getStartedBy().isPresent()) {
+            runTaskRequest.setStartedBy(clientConfig.getStartedBy().get());
         }
     }
 

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -518,7 +518,7 @@ public class EcsCommandExecutor
         setEcsGroup(runTaskRequest);
         setEcsTaskDefinition(commandContext, commandRequest, td, runTaskRequest);
         setEcsTaskCount(runTaskRequest);
-        setEcsTaskOverride(commandContext, commandRequest, td, runTaskRequest); // RuntimeException,ConfigException
+        setEcsTaskOverride(commandContext, commandRequest, td, runTaskRequest, clientConfig); // RuntimeException,ConfigException
         setEcsTaskLaunchType(clientConfig, runTaskRequest);
         setEcsNetworkConfiguration(clientConfig, runTaskRequest);
         setCapacityProviderStrategy(clientConfig, runTaskRequest);
@@ -552,7 +552,8 @@ public class EcsCommandExecutor
             final CommandContext commandContext,
             final CommandRequest commandRequest,
             final TaskDefinition td,
-            final RunTaskRequest request)
+            final RunTaskRequest request,
+            final EcsClientConfig clientConfig)
             throws ConfigException
     {
         final ContainerOverride containerOverride = new ContainerOverride();
@@ -561,7 +562,7 @@ public class EcsCommandExecutor
         setEcsContainerOverrideName(commandContext, commandRequest, containerOverride, cd);
         setEcsContainerOverrideCommand(commandContext, commandRequest, containerOverride); // RuntimeException,ConfigException
         setEcsContainerOverrideEnvironment(commandContext, commandRequest, containerOverride);
-        setEcsContainerOverrideResource(commandContext, commandRequest, containerOverride);
+        setEcsContainerOverrideResource(clientConfig, containerOverride);
 
         final TaskOverride taskOverride = new TaskOverride();
         taskOverride.withContainerOverrides(containerOverride);
@@ -715,10 +716,16 @@ public class EcsCommandExecutor
     }
 
     protected void setEcsContainerOverrideResource(
-            final CommandContext commandContext,
-            final CommandRequest commandRequest,
+            final EcsClientConfig clientConfig,
             final ContainerOverride containerOverride)
-    { }
+    {
+        if (clientConfig.isCpuSpecified()) {
+            containerOverride.setCpu(clientConfig.getCpu());
+        }
+        if (clientConfig.isMemorySpecified()) {
+            containerOverride.setMemory(clientConfig.getMemory());
+        }
+    }
 
     private static void log(final String message, final CommandLogger to)
             throws IOException

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -775,7 +775,7 @@ public class EcsCommandExecutor
             request.withNetworkConfiguration(new NetworkConfiguration().withAwsvpcConfiguration(
                     new AwsVpcConfiguration()
                             .withSubnets(clientConfig.getSubnets().get())
-                            .withAssignPublicIp(AssignPublicIp.ENABLED) // TODO should be extracted
+                            .withAssignPublicIp(clientConfig.isAssignPublicIp() ? AssignPublicIp.ENABLED : AssignPublicIp.DISABLED)
             ));
         }
 

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -719,11 +719,11 @@ public class EcsCommandExecutor
             final EcsClientConfig clientConfig,
             final ContainerOverride containerOverride)
     {
-        if (clientConfig.isCpuSpecified()) {
-            containerOverride.setCpu(clientConfig.getCpu());
+        if (clientConfig.getCpu().isPresent()) {
+            containerOverride.setCpu(clientConfig.getCpu().get());
         }
-        if (clientConfig.isMemorySpecified()) {
-            containerOverride.setMemory(clientConfig.getMemory());
+        if (clientConfig.getMemory().isPresent()) {
+            containerOverride.setMemory(clientConfig.getMemory().get());
         }
     }
 
@@ -758,10 +758,10 @@ public class EcsCommandExecutor
 
     protected void setEcsNetworkConfiguration(final EcsClientConfig clientConfig, final RunTaskRequest request)
     {
-        if (!clientConfig.getSubnets().isEmpty()) {
+        if (clientConfig.getSubnets().isPresent()) {
             request.withNetworkConfiguration(new NetworkConfiguration().withAwsvpcConfiguration(
                     new AwsVpcConfiguration()
-                            .withSubnets(clientConfig.getSubnets())
+                            .withSubnets(clientConfig.getSubnets().get())
                             .withAssignPublicIp(AssignPublicIp.ENABLED) // TODO should be extracted
             ));
         }
@@ -778,9 +778,9 @@ public class EcsCommandExecutor
 
     protected void setCapacityProviderStrategy(final EcsClientConfig clientConfig, final RunTaskRequest request)
     {
-        if (!clientConfig.getCapacityProviderName().isEmpty()) {
+        if (clientConfig.getCapacityProviderName().isPresent()) {
             CapacityProviderStrategyItem capacityProviderStrategyItem = new CapacityProviderStrategyItem()
-                    .withCapacityProvider(clientConfig.getCapacityProviderName());
+                    .withCapacityProvider(clientConfig.getCapacityProviderName().get());
             request.setCapacityProviderStrategy(Arrays.asList(capacityProviderStrategyItem));
         }
     }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -498,12 +498,17 @@ public class EcsCommandExecutor
         throw new RuntimeException("Submitted task could not be found"); // TODO the message should be improved more understandably.
     }
 
-    EcsClientConfig createEcsClientConfig(
+    protected EcsClientConfig createEcsClientConfig (
             final Optional<String> clusterName,
             final Config systemConfig,
-            final Config config)
+            final Config taskConfig)
     {
-        return EcsClientConfig.of(clusterName, systemConfig, config);
+        if (taskConfig.has(EcsClientConfig.TASK_CONFIG_ECS_KEY)) {
+            return EcsClientConfig.createFromTaskConfig(clusterName, taskConfig);
+        }
+        else {
+            return EcsClientConfig.createFromSystemConfig(clusterName, systemConfig);
+        }
     }
 
     RunTaskRequest buildRunTaskRequest(

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
@@ -10,7 +10,7 @@ public class EcsClientConfig
 {
     private static final String SYSTEM_CONFIG_PREFIX = "agent.command_executor.ecs.";
     public static final String TASK_CONFIG_ECS_KEY = "agent.command_executor.ecs";
-    private static final int DEFAULT_MAX_TRIES = 3;
+    private static final int DEFAULT_MAX_RETRIES = 3;
 
     public static EcsClientConfig of(final Optional<String> clusterName, final Config systemConfig, final Config taskConfig)
     {
@@ -95,10 +95,10 @@ public class EcsClientConfig
                 .withSecretAccessKey(ecsConfig.get("secret_access_key", String.class))
                 .withRegion(ecsConfig.get("region", String.class))
                 .withSubnets(ecsConfig.getOptional("subnets", String.class))
-                .withMaxRetries(ecsConfig.get("max_retries", int.class, DEFAULT_MAX_TRIES))
+                .withMaxRetries(ecsConfig.get("max_retries", int.class, DEFAULT_MAX_RETRIES))
                 .withCapacityProviderName(ecsConfig.getOptional("capacity_provider_name", String.class))
                 .withCpu(ecsConfig.getOptional("cpu", Integer.class))
-                .withCpu(ecsConfig.getOptional("memory", Integer.class))
+                .withMemory(ecsConfig.getOptional("memory", Integer.class))
                 .build();
     }
 

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
@@ -29,6 +29,7 @@ public class EcsClientConfig
         this.capacityProviderName = builder.getCapacityProviderName();
         this.cpu = builder.getCpu();
         this.memory = builder.getMemory();
+        this.startedBy = builder.getStartedBy();
     }
 
     public static EcsClientConfig createFromTaskConfig(final Optional<String> clusterName, final Config config)
@@ -87,6 +88,7 @@ public class EcsClientConfig
                 .withCapacityProviderName(ecsConfig.getOptional("capacity_provider_name", String.class))
                 .withCpu(ecsConfig.getOptional("cpu", Integer.class))
                 .withMemory(ecsConfig.getOptional("memory", Integer.class))
+                .withStartedBy(ecsConfig.getOptional("startedBy", String.class))
                 .build();
     }
 
@@ -100,6 +102,7 @@ public class EcsClientConfig
     private final Optional<String> capacityProviderName;
     private final Optional<Integer> cpu;
     private final Optional<Integer> memory;
+    private final Optional<String> startedBy;
 
     public String getClusterName()
     {
@@ -144,4 +147,9 @@ public class EcsClientConfig
     public Optional<Integer> getCpu() { return cpu; }
 
     public Optional<Integer> getMemory() { return memory; }
+
+    public Optional<String> getStartedBy()
+    {
+        return startedBy;
+    }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
@@ -2,7 +2,6 @@ package io.digdag.standards.command.ecs;
 
 import com.google.common.base.Optional;
 import io.digdag.client.config.Config;
-import io.digdag.client.config.ConfigException;
 import io.digdag.core.storage.StorageManager;
 
 import java.util.Arrays;
@@ -12,6 +11,8 @@ public class EcsClientConfig
 {
     private static final String SYSTEM_CONFIG_PREFIX = "agent.command_executor.ecs.";
     public static final String TASK_CONFIG_ECS_KEY = "agent.command_executor.ecs";
+    private static final int CPU_NOT_SPECIFIED = -1;
+    private static final int MEMORY_NOT_SPECIFIED = -1;
 
     public static EcsClientConfig of(final Optional<String> clusterName, final Config systemConfig, final Config taskConfig)
     {
@@ -30,6 +31,16 @@ public class EcsClientConfig
         return new EcsClientConfigBuilder();
     }
 
+    public boolean isCpuSpecified()
+    {
+        return this.cpu != CPU_NOT_SPECIFIED;
+    }
+
+    public boolean isMemorySpecified()
+    {
+        return this.memory != MEMORY_NOT_SPECIFIED;
+    }
+
     public EcsClientConfig(EcsClientConfigBuilder builder)
     {
         this.clusterName = builder.getClusterName();
@@ -40,6 +51,8 @@ public class EcsClientConfig
         this.subnets = Arrays.asList(builder.getSubnets().split(","));
         this.maxRetries = builder.getMaxRetries();
         this.capacityProviderName = builder.getCapacityProviderName();
+        this.cpu = builder.getCpu();
+        this.memory = builder.getMemory();
     }
 
     private static EcsClientConfig createFromTaskConfig(final Optional<String> clusterName, final Config config)
@@ -94,6 +107,8 @@ public class EcsClientConfig
                 .withSubnets(ecsConfig.get("subnets", String.class, ""))
                 .withMaxRetries(ecsConfig.get("max_retries", int.class, 3))
                 .withCapacityProviderName(ecsConfig.get("capacity_provider_name", String.class, ""))
+                .withCpu(ecsConfig.get("cpu", int.class, CPU_NOT_SPECIFIED))
+                .withCpu(ecsConfig.get("memory", int.class, MEMORY_NOT_SPECIFIED))
                 .build();
     }
 
@@ -105,6 +120,8 @@ public class EcsClientConfig
     private final List<String> subnets;
     private final int maxRetries;
     private final String capacityProviderName;
+    private final int cpu;
+    private final int memory;
 
     public String getClusterName()
     {
@@ -145,4 +162,8 @@ public class EcsClientConfig
     {
         return capacityProviderName;
     }
+
+    public int getCpu() { return cpu; }
+
+    public int getMemory() { return memory; }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
@@ -63,16 +63,7 @@ public class EcsClientConfig
             name = clusterName.get();
         }
 
-        return EcsClientConfig.builder()
-                .withClusterName(name)
-                .withLaunchType(ecsConfig.get("launch_type", String.class))
-                .withAccessKeyId(ecsConfig.get("access_key_id", String.class))
-                .withSecretAccessKey(ecsConfig.get("secret_access_key", String.class))
-                .withRegion(ecsConfig.get("region", String.class))
-                .withSubnets(ecsConfig.get("subnets", String.class, ""))
-                .withMaxRetries(ecsConfig.get("max_retries", int.class, 3))
-                .withCapacityProviderName(ecsConfig.get("capacity_provider_name", String.class, ""))
-                .build();
+        return buildEcsClientConfig(name, ecsConfig);
     }
 
     private static EcsClientConfig createFromSystemConfig(final Optional<String> clusterName, final Config systemConfig)
@@ -88,14 +79,22 @@ public class EcsClientConfig
 
         final String extractedPrefix = SYSTEM_CONFIG_PREFIX + name + ".";
         final Config extracted = StorageManager.extractKeyPrefix(systemConfig, extractedPrefix);
-        return new EcsClientConfig(name,
-                extracted.get("launch_type", String.class),
-                extracted.get("access_key_id", String.class),
-                extracted.get("secret_access_key", String.class),
-                extracted.get("region", String.class),
-                extracted.get("subnets", String.class),
-                extracted.get("max_retries", int.class, 3)
-        );
+
+        return buildEcsClientConfig(name, extracted);
+    }
+
+    private static EcsClientConfig buildEcsClientConfig(String clusterName, Config ecsConfig)
+    {
+        return EcsClientConfig.builder()
+                .withClusterName(clusterName)
+                .withLaunchType(ecsConfig.get("launch_type", String.class))
+                .withAccessKeyId(ecsConfig.get("access_key_id", String.class))
+                .withSecretAccessKey(ecsConfig.get("secret_access_key", String.class))
+                .withRegion(ecsConfig.get("region", String.class))
+                .withSubnets(ecsConfig.get("subnets", String.class, ""))
+                .withMaxRetries(ecsConfig.get("max_retries", int.class, 3))
+                .withCapacityProviderName(ecsConfig.get("capacity_provider_name", String.class, ""))
+                .build();
     }
 
     private final String clusterName;
@@ -106,24 +105,6 @@ public class EcsClientConfig
     private final List<String> subnets;
     private final int maxRetries;
     private final String capacityProviderName;
-
-    private EcsClientConfig(final String clusterName,
-            final String launchType,
-            final String accessKeyId,
-            final String secretAccessKey,
-            final String region,
-            final String subnets,
-            final int maxRetries)
-    {
-        this.clusterName = clusterName;
-        this.launchType = launchType;
-        this.accessKeyId = accessKeyId;
-        this.secretAccessKey = secretAccessKey;
-        this.region = region;
-        this.subnets = Arrays.asList(subnets.split(",")); // TODO more robust
-        this.maxRetries = maxRetries;
-        this.capacityProviderName = "";
-    }
 
     public String getClusterName()
     {

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
@@ -30,6 +30,7 @@ public class EcsClientConfig
         this.cpu = builder.getCpu();
         this.memory = builder.getMemory();
         this.startedBy = builder.getStartedBy();
+        this.assignPublicIp = builder.isAssignPublicIp();
     }
 
     public static EcsClientConfig createFromTaskConfig(final Optional<String> clusterName, final Config config)
@@ -89,6 +90,10 @@ public class EcsClientConfig
                 .withCpu(ecsConfig.getOptional("cpu", Integer.class))
                 .withMemory(ecsConfig.getOptional("memory", Integer.class))
                 .withStartedBy(ecsConfig.getOptional("startedBy", String.class))
+                // TODO removing default value.
+                // This value was previously hard coded.
+                // To keep consistency I once set the default value. But it should be removed after migration.
+                .withAssignPublicIp(ecsConfig.get("assign_public_ip", boolean.class, true))
                 .build();
     }
 
@@ -99,6 +104,7 @@ public class EcsClientConfig
     private final String region;
     private final Optional<List<String>> subnets;
     private final int maxRetries;
+    private boolean assignPublicIp;
     private final Optional<String> capacityProviderName;
     private final Optional<Integer> cpu;
     private final Optional<Integer> memory;
@@ -151,5 +157,10 @@ public class EcsClientConfig
     public Optional<String> getStartedBy()
     {
         return startedBy;
+    }
+
+    public boolean isAssignPublicIp()
+    {
+        return assignPublicIp;
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
@@ -12,18 +12,6 @@ public class EcsClientConfig
     public static final String TASK_CONFIG_ECS_KEY = "agent.command_executor.ecs";
     private static final int DEFAULT_MAX_RETRIES = 3;
 
-    public static EcsClientConfig of(final Optional<String> clusterName, final Config systemConfig, final Config taskConfig)
-    {
-        if (taskConfig.has(TASK_CONFIG_ECS_KEY)) {
-            // from task config
-            return createFromTaskConfig(clusterName, taskConfig);
-        }
-        else {
-            // from system config
-            return createFromSystemConfig(clusterName, systemConfig);
-        }
-    }
-
     public static EcsClientConfigBuilder builder()
     {
         return new EcsClientConfigBuilder();
@@ -43,7 +31,7 @@ public class EcsClientConfig
         this.memory = builder.getMemory();
     }
 
-    private static EcsClientConfig createFromTaskConfig(final Optional<String> clusterName, final Config config)
+    public static EcsClientConfig createFromTaskConfig(final Optional<String> clusterName, final Config config)
     {
         final String name;
         // `config` is assumed to have a nested config with following values
@@ -69,7 +57,7 @@ public class EcsClientConfig
         return buildEcsClientConfig(name, ecsConfig);
     }
 
-    private static EcsClientConfig createFromSystemConfig(final Optional<String> clusterName, final Config systemConfig)
+    public static EcsClientConfig createFromSystemConfig(final Optional<String> clusterName, final Config systemConfig)
     {
         final String name;
         if (!clusterName.isPresent()) {

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
@@ -14,6 +14,7 @@ public class EcsClientConfigBuilder
     private String region;
     private Optional<List<String>> subnets;
     private int maxRetries;
+    private boolean assignPublicIp;
     private Optional<String> capacityProviderName;
     private Optional<Integer> cpu;
     private Optional<Integer> memory;
@@ -95,6 +96,12 @@ public class EcsClientConfigBuilder
         return this;
     }
 
+    public EcsClientConfigBuilder withAssignPublicIp(boolean assignPublicIp)
+    {
+        this.assignPublicIp = assignPublicIp;
+        return this;
+    }
+
     public String getClusterName()
     {
         return clusterName;
@@ -148,5 +155,10 @@ public class EcsClientConfigBuilder
     public Optional<String> getStartedBy()
     {
         return startedBy;
+    }
+
+    public boolean isAssignPublicIp()
+    {
+        return assignPublicIp;
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
@@ -1,0 +1,106 @@
+package io.digdag.standards.command.ecs;
+
+public class EcsClientConfigBuilder
+{
+    private String clusterName;
+    private String launchType;
+    private String accessKeyId;
+    private String secretAccessKey;
+    private String region;
+    private String subnets;
+    private int maxRetries;
+    private String capacityProviderName;
+
+    public EcsClientConfig build()
+    {
+        return new EcsClientConfig(this);
+    }
+
+    public EcsClientConfigBuilder withClusterName(String clusterName)
+    {
+        this.clusterName = clusterName;
+        return this;
+    }
+
+    public EcsClientConfigBuilder withLaunchType(String launchType)
+    {
+        this.launchType = launchType;
+        return this;
+    }
+
+    public EcsClientConfigBuilder withAccessKeyId(String accessKeyId)
+    {
+        this.accessKeyId = accessKeyId;
+        return this;
+    }
+
+    public EcsClientConfigBuilder withSecretAccessKey(String secretAccessKey)
+    {
+        this.secretAccessKey = secretAccessKey;
+        return this;
+    }
+
+    public EcsClientConfigBuilder withRegion(String region)
+    {
+        this.region = region;
+        return this;
+    }
+
+    public EcsClientConfigBuilder withSubnets(String subnets)
+    {
+        this.subnets = subnets;
+        return this;
+    }
+
+    public EcsClientConfigBuilder withMaxRetries(int maxRetries)
+    {
+        this.maxRetries = maxRetries;
+        return this;
+    }
+
+    public EcsClientConfigBuilder withCapacityProviderName(String capacityProviderName)
+    {
+        this.capacityProviderName = capacityProviderName;
+        return this;
+    }
+
+    public String getClusterName()
+    {
+        return clusterName;
+    }
+
+    public String getLaunchType()
+    {
+        return launchType;
+    }
+
+    public String getAccessKeyId()
+    {
+        return accessKeyId;
+    }
+
+    public String getSecretAccessKey()
+    {
+        return secretAccessKey;
+    }
+
+    public String getRegion()
+    {
+        return region;
+    }
+
+    public String getSubnets()
+    {
+        return subnets;
+    }
+
+    public int getMaxRetries()
+    {
+        return maxRetries;
+    }
+
+    public String getCapacityProviderName()
+    {
+        return capacityProviderName;
+    }
+}

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
@@ -1,5 +1,10 @@
 package io.digdag.standards.command.ecs;
 
+import com.google.common.base.Optional;
+
+import java.util.Arrays;
+import java.util.List;
+
 public class EcsClientConfigBuilder
 {
     private String clusterName;
@@ -7,11 +12,11 @@ public class EcsClientConfigBuilder
     private String accessKeyId;
     private String secretAccessKey;
     private String region;
-    private String subnets;
+    private Optional<List<String>> subnets;
     private int maxRetries;
-    private String capacityProviderName;
-    private int cpu;
-    private int memory;
+    private Optional<String> capacityProviderName;
+    private Optional<Integer> cpu;
+    private Optional<Integer> memory;
 
     public EcsClientConfig build()
     {
@@ -48,9 +53,14 @@ public class EcsClientConfigBuilder
         return this;
     }
 
-    public EcsClientConfigBuilder withSubnets(String subnets)
+    public EcsClientConfigBuilder withSubnets(Optional<String> subnets)
     {
-        this.subnets = subnets;
+        if (subnets.isPresent()) {
+            this.subnets = Optional.of(Arrays.asList(subnets.get().split(",")));
+        }
+        else {
+            this.subnets = Optional.absent();
+        }
         return this;
     }
 
@@ -60,19 +70,19 @@ public class EcsClientConfigBuilder
         return this;
     }
 
-    public EcsClientConfigBuilder withCapacityProviderName(String capacityProviderName)
+    public EcsClientConfigBuilder withCapacityProviderName(Optional<String> capacityProviderName)
     {
         this.capacityProviderName = capacityProviderName;
         return this;
     }
 
-    public EcsClientConfigBuilder withCpu(int cpu)
+    public EcsClientConfigBuilder withCpu(Optional<Integer> cpu)
     {
         this.cpu = cpu;
         return this;
     }
 
-    public EcsClientConfigBuilder withMemory(int memory)
+    public EcsClientConfigBuilder withMemory(Optional<Integer> memory)
     {
         this.memory = memory;
         return this;
@@ -103,7 +113,7 @@ public class EcsClientConfigBuilder
         return region;
     }
 
-    public String getSubnets()
+    public Optional<List<String>> getSubnets()
     {
         return subnets;
     }
@@ -113,17 +123,17 @@ public class EcsClientConfigBuilder
         return maxRetries;
     }
 
-    public String getCapacityProviderName()
+    public Optional<String> getCapacityProviderName()
     {
         return capacityProviderName;
     }
 
-    public int getCpu()
+    public Optional<Integer> getCpu()
     {
         return cpu;
     }
 
-    public int getMemory()
+    public Optional<Integer> getMemory()
     {
         return memory;
     }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
@@ -10,6 +10,8 @@ public class EcsClientConfigBuilder
     private String subnets;
     private int maxRetries;
     private String capacityProviderName;
+    private int cpu;
+    private int memory;
 
     public EcsClientConfig build()
     {
@@ -64,6 +66,18 @@ public class EcsClientConfigBuilder
         return this;
     }
 
+    public EcsClientConfigBuilder withCpu(int cpu)
+    {
+        this.cpu = cpu;
+        return this;
+    }
+
+    public EcsClientConfigBuilder withMemory(int memory)
+    {
+        this.memory = memory;
+        return this;
+    }
+
     public String getClusterName()
     {
         return clusterName;
@@ -102,5 +116,15 @@ public class EcsClientConfigBuilder
     public String getCapacityProviderName()
     {
         return capacityProviderName;
+    }
+
+    public int getCpu()
+    {
+        return cpu;
+    }
+
+    public int getMemory()
+    {
+        return memory;
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
@@ -17,6 +17,7 @@ public class EcsClientConfigBuilder
     private Optional<String> capacityProviderName;
     private Optional<Integer> cpu;
     private Optional<Integer> memory;
+    private Optional<String> startedBy;
 
     public EcsClientConfig build()
     {
@@ -88,6 +89,12 @@ public class EcsClientConfigBuilder
         return this;
     }
 
+    public EcsClientConfigBuilder withStartedBy(Optional<String> startedBy)
+    {
+        this.startedBy = startedBy;
+        return this;
+    }
+
     public String getClusterName()
     {
         return clusterName;
@@ -136,5 +143,10 @@ public class EcsClientConfigBuilder
     public Optional<Integer> getMemory()
     {
         return memory;
+    }
+
+    public Optional<String> getStartedBy()
+    {
+        return startedBy;
     }
 }


### PR DESCRIPTION
# What does this PR change?
This PR introduces 
1. a support to create an `EcsClientConfig` instance from taskConfig
1. new properties which can be specified from `EcsClientConfig`
- a support to specify `capacityProvider` on a `RunTaskRequest`
- a support to specify `cpu` on a `ContainerOverride`
- a support to specify `memory` on a `ContainerOverride`

# Background
In the current implementation, we can not create `EcsClientConfig` instances from `taskConfig` (we can create them only from `systemConfig`). 
So it is difficult to execute Ecs tasks with different configurations for each Ecs task. 