### PR TITLE
[WIP] Update key name of task creation timestamp

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -436,7 +436,7 @@ public class EcsCommandExecutor
 
     private boolean isRunningLongerThanTTL(final ObjectNode previousStatus)
     {
-        long creationTimestamp = previousStatus.get("pod_creation_timestamp").asLong();
+        long creationTimestamp = previousStatus.get("task_creation_timestamp").asLong();
         long currentTimestamp = Instant.now().getEpochSecond();
         return currentTimestamp > creationTimestamp + defaultCommandTaskTTL.get().getSeconds();
     }


### PR DESCRIPTION
This PR aligns the key name of the task creation timestamp, it should be `task_creation_timestamp`.
e.g.
https://github.com/treasure-data/digdag/blob/f20567ba7dfa2b2948bd036939fbe828bef09e25/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java#L260-L265