### PR TITLE
Make launch type optional

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -766,9 +766,10 @@ public class EcsCommandExecutor
 
     protected void setEcsTaskLaunchType(final EcsClientConfig clientConfig, final RunTaskRequest request)
     {
-        final String type = clientConfig.getLaunchType();
-        final LaunchType launchType = LaunchType.fromValue(type);
-        request.withLaunchType(launchType);
+        if (clientConfig.getLaunchType().isPresent()) {
+            final LaunchType launchType = LaunchType.fromValue(clientConfig.getLaunchType().get());
+            request.withLaunchType(launchType);
+        }
     }
 
     protected void setEcsNetworkConfiguration(final EcsClientConfig clientConfig, final RunTaskRequest request)

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -766,6 +766,9 @@ public class EcsCommandExecutor
 
     protected void setEcsTaskLaunchType(final EcsClientConfig clientConfig, final RunTaskRequest request)
     {
+        // Note: `LaunchType` CAN NOT be specified with `CapacityProviderStrategy` in the same time.
+        // So when you specify `CapacityProviderStrategy`, do not specify `LaunchType`.
+        // https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html#ECS-RunTask-request-capacityProviderStrategy
         if (clientConfig.getLaunchType().isPresent()) {
             final LaunchType launchType = LaunchType.fromValue(clientConfig.getLaunchType().get());
             request.withLaunchType(launchType);

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
@@ -80,7 +80,7 @@ public class EcsClientConfig
     {
         return EcsClientConfig.builder()
                 .withClusterName(clusterName)
-                .withLaunchType(ecsConfig.get("launch_type", String.class))
+                .withLaunchType(ecsConfig.getOptional("launch_type", String.class))
                 .withAccessKeyId(ecsConfig.get("access_key_id", String.class))
                 .withSecretAccessKey(ecsConfig.get("secret_access_key", String.class))
                 .withRegion(ecsConfig.get("region", String.class))
@@ -98,13 +98,13 @@ public class EcsClientConfig
     }
 
     private final String clusterName;
-    private final String launchType;
     private final String accessKeyId;
     private final String secretAccessKey;
     private final String region;
-    private final Optional<List<String>> subnets;
     private final int maxRetries;
     private boolean assignPublicIp;
+    private final Optional<List<String>> subnets;
+    private final Optional<String> launchType;
     private final Optional<String> capacityProviderName;
     private final Optional<Integer> cpu;
     private final Optional<Integer> memory;
@@ -115,7 +115,7 @@ public class EcsClientConfig
         return clusterName;
     }
 
-    public String getLaunchType()
+    public Optional<String> getLaunchType()
     {
         return launchType;
     }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
@@ -38,7 +38,7 @@ public class EcsClientConfig
         final String name;
         // `config` is assumed to have a nested config with following values
         // at the key of `TASK_CONFIG_ECS_KEY` from `config`.
-        // - launch_type
+        // - launch_type (optional)
         // - access_key_id
         // - secret_access_key
         // - region

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
@@ -8,13 +8,13 @@ import java.util.List;
 public class EcsClientConfigBuilder
 {
     private String clusterName;
-    private String launchType;
     private String accessKeyId;
     private String secretAccessKey;
     private String region;
-    private Optional<List<String>> subnets;
     private int maxRetries;
     private boolean assignPublicIp;
+    private Optional<List<String>> subnets;
+    private Optional<String> launchType;
     private Optional<String> capacityProviderName;
     private Optional<Integer> cpu;
     private Optional<Integer> memory;
@@ -31,7 +31,7 @@ public class EcsClientConfigBuilder
         return this;
     }
 
-    public EcsClientConfigBuilder withLaunchType(String launchType)
+    public EcsClientConfigBuilder withLaunchType(Optional<String> launchType)
     {
         this.launchType = launchType;
         return this;
@@ -107,7 +107,7 @@ public class EcsClientConfigBuilder
         return clusterName;
     }
 
-    public String getLaunchType()
+    public Optional<String> getLaunchType()
     {
         return launchType;
     }


### PR DESCRIPTION
# What does this PR change?
This PR makes `launchType` `Optional<String>` field from `String`.

# Background
In the specification of AWS ECS API, we can not specify `launchType` {`EC2`/`FARGATE`} and `capacityProviderStragety` at the same time. So `launchType` needs to be `Optional` field.