### PR TITLE
Fetch sensitive data from `systemConfig`

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -506,7 +506,7 @@ public class EcsCommandExecutor
             final Config taskConfig)
     {
         if (taskConfig.has(EcsClientConfig.TASK_CONFIG_ECS_KEY)) {
-            return EcsClientConfig.createFromTaskConfig(clusterName, taskConfig);
+            return EcsClientConfig.createFromTaskConfig(clusterName, taskConfig, systemConfig);
         }
         else {
             return EcsClientConfig.createFromSystemConfig(clusterName, systemConfig);


### PR DESCRIPTION
# What will this PR change?
This PR refactors `EcsClientConfig#createFromTaskConfig` so that the method fetches `access_key_id` and `secret_access_key` from `systemConfig` to build a `EcsClientConfig` object.

# Background
Basically `taskConfig` is generated from workflow definition. 
So the object should not have any sensitive data because `taskConfig` is referred as a object without sensitive data.

This PR refactors `EcsClientConfig#createFromTaskConfig` so that the method uses both of `taskConfig` and `systemConfig` to fetch parameters for `EcsClientConfig` object.