### PR TITLE
Avoid potential deadlock on `tasks` table

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/agent/InProcessTaskServerApi.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/InProcessTaskServerApi.java
@@ -24,7 +24,7 @@ public class InProcessTaskServerApi
             return Long.parseLong(tql.getUniqueName());
         }
         catch (Throwable e) {
-            logger.warn("Failed to convert TaskQueueLock.uniqueName to integer", e);
+            logger.warn("Failed to convert TaskQueueLock.uniqueName to integer. The `uniqueName` will be handled as 0", e);
             return 0;
         }
     };

--- a/digdag-core/src/main/java/io/digdag/core/agent/InProcessTaskServerApi.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/InProcessTaskServerApi.java
@@ -18,8 +18,8 @@ import java.util.stream.Collectors;
 public class InProcessTaskServerApi
     implements TaskServerApi
 {
-    private static final Logger logger = LoggerFactory.getLogger(WorkflowExecutor.class);
-    private final ToLongFunction<TaskQueueLock> CONV_FUNC_FROM_TASK_QUEUE_LOCK_TO_INT = taskQueueLock -> {
+    private static final Logger logger = LoggerFactory.getLogger(InProcessTaskServerApi.class);
+    private static final ToLongFunction<TaskQueueLock> CONV_FUNC_FROM_TASK_QUEUE_LOCK_TO_INT = taskQueueLock -> {
         try {
             return WorkflowExecutor.parseTaskIdFromEncodedQueuedTaskName(taskQueueLock.getUniqueName());
         }

--- a/digdag-core/src/main/java/io/digdag/core/agent/InProcessTaskServerApi.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/InProcessTaskServerApi.java
@@ -19,12 +19,9 @@ public class InProcessTaskServerApi
     implements TaskServerApi
 {
     private static final Logger logger = LoggerFactory.getLogger(WorkflowExecutor.class);
-    private final ToLongFunction<TaskQueueLock> CONV_FUNC_FROM_TASK_QUEUE_LOCK_TO_INT = tql -> {
+    private final ToLongFunction<TaskQueueLock> CONV_FUNC_FROM_TASK_QUEUE_LOCK_TO_INT = taskQueueLock -> {
         try {
-            // Retried task's unique name has suffix `.r${retryCount}`.
-            // See io.digdag.core.workflow.WorkflowExecutor.encodeUniqueQueuedTaskName
-            String[] decodedPartsOfUniqueName = tql.getUniqueName().split("\\.");
-            return Long.parseLong(decodedPartsOfUniqueName[0]);
+            return WorkflowExecutor.parseTaskIdFromEncodedQueuedTaskName(taskQueueLock.getUniqueName());
         }
         catch (Throwable e) {
             logger.warn("Failed to convert TaskQueueLock.uniqueName to integer. The `uniqueName` will be handled as 0", e);

--- a/digdag-core/src/main/java/io/digdag/core/agent/InProcessTaskServerApi.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/InProcessTaskServerApi.java
@@ -7,11 +7,28 @@ import io.digdag.spi.TaskQueueLock;
 import io.digdag.spi.TaskQueueClient;
 import io.digdag.core.queue.TaskQueueServerManager;
 import io.digdag.core.workflow.WorkflowExecutor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.function.ToLongFunction;
 
 public class InProcessTaskServerApi
     implements TaskServerApi
 {
+    private static final Logger logger = LoggerFactory.getLogger(WorkflowExecutor.class);
+    private final ToLongFunction<TaskQueueLock> CONV_FUNC_FROM_TASK_QUEUE_LOCK_TO_INT = tql -> {
+        try {
+            return Long.parseLong(tql.getUniqueName());
+        }
+        catch (Throwable e) {
+            logger.warn("Failed to convert TaskQueueLock.uniqueName to integer", e);
+            return 0;
+        }
+    };
+
     private final TaskQueueClient directQueueClient;
     private final WorkflowExecutor workflowExecutor;
 
@@ -30,6 +47,8 @@ public class InProcessTaskServerApi
             int lockSeconds, long maxSleepMillis)
     {
         List<TaskQueueLock> locks = directQueueClient.lockSharedAgentTasks(count, agentId.toString(), lockSeconds, maxSleepMillis);
+        // Sort the list in order to avoid deadlock with other exclusive lock on multiple rows
+        locks.sort(Comparator.comparingLong(CONV_FUNC_FROM_TASK_QUEUE_LOCK_TO_INT));
         if (locks.isEmpty()) {
             return ImmutableList.of();
         }

--- a/digdag-core/src/main/java/io/digdag/core/agent/InProcessTaskServerApi.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/InProcessTaskServerApi.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.ToLongFunction;
+import java.util.stream.Collectors;
 
 public class InProcessTaskServerApi
     implements TaskServerApi
@@ -46,9 +47,10 @@ public class InProcessTaskServerApi
             int count, AgentId agentId,
             int lockSeconds, long maxSleepMillis)
     {
-        List<TaskQueueLock> locks = directQueueClient.lockSharedAgentTasks(count, agentId.toString(), lockSeconds, maxSleepMillis);
         // Sort the list in order to avoid deadlock with other exclusive lock on multiple rows
-        locks.sort(Comparator.comparingLong(CONV_FUNC_FROM_TASK_QUEUE_LOCK_TO_INT));
+        List<TaskQueueLock> locks = directQueueClient.lockSharedAgentTasks(count, agentId.toString(), lockSeconds, maxSleepMillis).stream()
+                .sorted(Comparator.comparingLong(CONV_FUNC_FROM_TASK_QUEUE_LOCK_TO_INT))
+                .collect(Collectors.toList());
         if (locks.isEmpty()) {
             return ImmutableList.of();
         }

--- a/digdag-core/src/main/java/io/digdag/core/agent/InProcessTaskServerApi.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/InProcessTaskServerApi.java
@@ -21,7 +21,10 @@ public class InProcessTaskServerApi
     private static final Logger logger = LoggerFactory.getLogger(WorkflowExecutor.class);
     private final ToLongFunction<TaskQueueLock> CONV_FUNC_FROM_TASK_QUEUE_LOCK_TO_INT = tql -> {
         try {
-            return Long.parseLong(tql.getUniqueName());
+            // Retried task's unique name has suffix `.r${retryCount}`.
+            // See io.digdag.core.workflow.WorkflowExecutor.encodeUniqueQueuedTaskName
+            String[] decodedPartsOfUniqueName = tql.getUniqueName().split("\\.");
+            return Long.parseLong(decodedPartsOfUniqueName[0]);
         }
         catch (Throwable e) {
             logger.warn("Failed to convert TaskQueueLock.uniqueName to integer. The `uniqueName` will be handled as 0", e);

--- a/digdag-core/src/main/java/io/digdag/core/agent/InProcessTaskServerApi.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/InProcessTaskServerApi.java
@@ -10,7 +10,6 @@ import io.digdag.core.workflow.WorkflowExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.ToLongFunction;

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
@@ -1696,9 +1696,18 @@ public class DatabaseSessionStoreManager
                 " for update")
         Long lockTaskIfNotLocked(@Bind("id") long taskId);
 
+        @SqlUpdate("update tasks" +
+                " set updated_at = now(), retry_at = NULL, state = " + TaskStateCode.READY_CODE +
+                " where id in (" +
+                  "select id" +
+                  " where state in (" + TaskStateCode.RETRY_WAITING_CODE +"," + TaskStateCode.GROUP_RETRY_WAITING_CODE + ")" +
+                  " order by id for update" +
+                ")" +
+                " and retry_at \\<= now()")
+        int trySetRetryWaitingToReady();
+
         @SqlQuery("select id from tasks where state = :state order by random() limit :limit")
         List<Long> findAllTaskIdsByStateAtRandom(@Bind("state") short state, @Bind("limit") int limit);
-
     }
 
     @UseStringTemplate3StatementLocator
@@ -1744,6 +1753,18 @@ public class DatabaseSessionStoreManager
                 " where id = :id" +
                 " for update skip locked")
         Long lockTaskIfNotLocked(@Bind("id") long taskId);
+
+        @SqlUpdate("update tasks" +
+                " set updated_at = now(), retry_at = NULL, state = " + TaskStateCode.READY_CODE +
+                " from (" +
+                  "select id from tasks" +
+                  " where state in (" + TaskStateCode.RETRY_WAITING_CODE +"," + TaskStateCode.GROUP_RETRY_WAITING_CODE + ")" +
+                  " and retry_at \\<= now()" +
+                  " order by id for update" +
+                " ) lck" +
+                " where tasks.id = lck.id"
+        )
+        int trySetRetryWaitingToReady();
 
         @SqlQuery("select id from tasks where state = :state order by random() limit :limit")
         List<Long> findAllTaskIdsByStateAtRandom(@Bind("state") short state, @Bind("limit") int limit);
@@ -2168,10 +2189,6 @@ public class DatabaseSessionStoreManager
                 " where id = :id")
         long setSuccessfulReport(@Bind("id") long taskId, @Bind("subtaskConfig") Config subtaskConfig, @Bind("exportParams") Config exportParams, @Bind("resetStoreParams") String resetStoreParams, @Bind("storeParams") Config storeParams, @Bind("report") Config report);
 
-        @SqlUpdate("update tasks" +
-                " set updated_at = now(), retry_at = NULL, state = " + TaskStateCode.READY_CODE +
-                " where state in (" + TaskStateCode.RETRY_WAITING_CODE +"," + TaskStateCode.GROUP_RETRY_WAITING_CODE + ")" +
-                " and retry_at \\<= now()")
         int trySetRetryWaitingToReady();
 
         @SqlQuery("select * from session_monitors" +

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
@@ -1697,13 +1697,13 @@ public class DatabaseSessionStoreManager
         Long lockTaskIfNotLocked(@Bind("id") long taskId);
 
         @SqlUpdate("update tasks" +
-                " set updated_at = now(), retry_at = NULL, state = " + TaskStateCode.READY_CODE +
-                " where id in (" +
+                 " set updated_at = now(), retry_at = NULL, state = " + TaskStateCode.READY_CODE +
+                 " where id in (" +
                   "select id" +
                   " where state in (" + TaskStateCode.RETRY_WAITING_CODE +"," + TaskStateCode.GROUP_RETRY_WAITING_CODE + ")" +
+                  " and retry_at \\<= now()" +
                   " order by id for update" +
-                ")" +
-                " and retry_at \\<= now()")
+                 ")")
         int trySetRetryWaitingToReady();
 
         @SqlQuery("select id from tasks where state = :state order by random() limit :limit")

--- a/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java
+++ b/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java
@@ -1024,6 +1024,7 @@ public class WorkflowExecutor
         }).or(false);
     }
 
+    // TODO? Probably these 2 methods should be moved into TaskQueueLock in the future
     private static String encodeUniqueQueuedTaskName(StoredTask task)
     {
         int retryCount = task.getRetryCount();
@@ -1035,7 +1036,7 @@ public class WorkflowExecutor
         }
     }
 
-    private static long parseTaskIdFromEncodedQueuedTaskName(String encodedUniqueQueuedTaskName)
+    public static long parseTaskIdFromEncodedQueuedTaskName(String encodedUniqueQueuedTaskName)
     {
         int posDot = encodedUniqueQueuedTaskName.indexOf('.');
         if (posDot >= 0) {

--- a/digdag-core/src/test/java/io/digdag/core/agent/InProcessTaskServerApiTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/agent/InProcessTaskServerApiTest.java
@@ -61,10 +61,20 @@ public class InProcessTaskServerApiTest
         TaskQueueLock taskQueueLock4 = mock(TaskQueueLock.class);
         doReturn("5").when(taskQueueLock4).getUniqueName();
 
-        // So the expected order is: 1 or 3 -> 1 or 3 -> 2 -> 4 -> 0
+        // Retried task's unique name has suffix `.r${retryCount}`.
+        // See io.digdag.core.workflow.WorkflowExecutor.encodeUniqueQueuedTaskName
+        TaskQueueLock taskQueueLock5 = mock(TaskQueueLock.class);
+        doReturn("3.r8").when(taskQueueLock5).getUniqueName();
 
-        ImmutableList<TaskQueueLock> taskQueueLocks =
-                ImmutableList.of(taskQueueLock0, taskQueueLock1, taskQueueLock2, taskQueueLock3, taskQueueLock4);
+        // So the expected order is: 1 or 3 -> 1 or 3 -> 2 -> 5 -> 4 -> 0
+
+        ImmutableList<TaskQueueLock> taskQueueLocks = ImmutableList.of(
+                taskQueueLock0,
+                taskQueueLock1,
+                taskQueueLock2,
+                taskQueueLock3,
+                taskQueueLock4,
+                taskQueueLock5);
 
         int fetchTaskCount = 42;
         String agentIdKey = "Hello";
@@ -83,11 +93,12 @@ public class InProcessTaskServerApiTest
         verify(workflowExecutor, times(1)).getTaskRequests(taskQueueLockListCapture.capture());
 
         List<TaskQueueLock> taskQueueLockList = taskQueueLockListCapture.getValue();
-        assertEquals(5, taskQueueLockList.size());
+        assertEquals(6, taskQueueLockList.size());
         assertTrue(taskQueueLockList.get(0) == taskQueueLock1 || taskQueueLockList.get(0) == taskQueueLock3);
         assertTrue(taskQueueLockList.get(1) == taskQueueLock1 || taskQueueLockList.get(1) == taskQueueLock3);
         assertEquals(taskQueueLock2, taskQueueLockList.get(2));
-        assertEquals(taskQueueLock4, taskQueueLockList.get(3));
-        assertEquals(taskQueueLock0, taskQueueLockList.get(4));
+        assertEquals(taskQueueLock5, taskQueueLockList.get(3));
+        assertEquals(taskQueueLock4, taskQueueLockList.get(4));
+        assertEquals(taskQueueLock0, taskQueueLockList.get(5));
     }
 }

--- a/digdag-core/src/test/java/io/digdag/core/agent/InProcessTaskServerApiTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/agent/InProcessTaskServerApiTest.java
@@ -1,0 +1,71 @@
+package io.digdag.core.agent;
+
+import com.google.common.collect.ImmutableList;
+import io.digdag.core.queue.TaskQueueServerManager;
+import io.digdag.core.workflow.WorkflowExecutor;
+import io.digdag.spi.ImmutableTaskQueueLock;
+import io.digdag.spi.TaskQueueClient;
+import io.digdag.spi.TaskQueueLock;
+import io.digdag.spi.TaskRequest;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InProcessTaskServerApiTest
+{
+    @Mock TaskQueueServerManager taskQueueServerManager;
+    @Mock WorkflowExecutor workflowExecutor;
+    @Mock TaskQueueClient taskQueueClient;
+    private InProcessTaskServerApi taskServerApi;
+
+    @Before
+    public void setUp()
+    {
+        taskServerApi = new InProcessTaskServerApi(taskQueueServerManager, workflowExecutor);
+    }
+
+    @Test
+    public void lockSharedAgentTasks()
+    {
+        TaskQueueLock taskQueueLock0 = mock(TaskQueueLock.class);
+        doReturn("10").when(taskQueueLock0).getUniqueName();
+
+        TaskQueueLock taskQueueLock1 = mock(TaskQueueLock.class);
+        doReturn("unknown").when(taskQueueLock1).getUniqueName();
+
+        TaskQueueLock taskQueueLock2 = mock(TaskQueueLock.class);
+        doReturn("1").when(taskQueueLock2).getUniqueName();
+
+        TaskQueueLock taskQueueLock3 = mock(TaskQueueLock.class);
+        doReturn(null).when(taskQueueLock3).getUniqueName();
+
+        TaskQueueLock taskQueueLock4 = mock(TaskQueueLock.class);
+        doReturn("5").when(taskQueueLock4).getUniqueName();
+
+        ImmutableList<TaskQueueLock> taskQueueLocks =
+                ImmutableList.of(taskQueueLock0, taskQueueLock1, taskQueueLock2, taskQueueLock3, taskQueueLock4);
+
+        int expectedCount = 42;
+        AgentId expectedAgentId = AgentId.of("Hello");
+
+        doReturn(taskQueueLocks).when(taskQueueClient)
+                .lockSharedAgentTasks(
+                        eq(expectedCount),
+                        eq(expectedAgentId),
+                        )
+        doReturn(taskQueueClient).when(taskQueueServerManager).getInProcessTaskQueueClient();
+
+        List<TaskRequest> taskRequests = taskServerApi.lockSharedAgentTasks(10, AgentId.of("hello"), 42, 1234);
+    }
+}

--- a/digdag-core/src/test/java/io/digdag/core/agent/InProcessTaskServerApiTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/agent/InProcessTaskServerApiTest.java
@@ -3,23 +3,25 @@ package io.digdag.core.agent;
 import com.google.common.collect.ImmutableList;
 import io.digdag.core.queue.TaskQueueServerManager;
 import io.digdag.core.workflow.WorkflowExecutor;
-import io.digdag.spi.ImmutableTaskQueueLock;
 import io.digdag.spi.TaskQueueClient;
 import io.digdag.spi.TaskQueueLock;
-import io.digdag.spi.TaskRequest;
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.List;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class InProcessTaskServerApiTest
@@ -29,9 +31,13 @@ public class InProcessTaskServerApiTest
     @Mock TaskQueueClient taskQueueClient;
     private InProcessTaskServerApi taskServerApi;
 
+    @Captor
+    private ArgumentCaptor<List<TaskQueueLock>> taskQueueLockListCapture;
+
     @Before
     public void setUp()
     {
+        doReturn(taskQueueClient).when(taskQueueServerManager).getInProcessTaskQueueClient();
         taskServerApi = new InProcessTaskServerApi(taskQueueServerManager, workflowExecutor);
     }
 
@@ -41,31 +47,47 @@ public class InProcessTaskServerApiTest
         TaskQueueLock taskQueueLock0 = mock(TaskQueueLock.class);
         doReturn("10").when(taskQueueLock0).getUniqueName();
 
+        // This should be treated as id:0 to avoid throwing an exception
         TaskQueueLock taskQueueLock1 = mock(TaskQueueLock.class);
         doReturn("unknown").when(taskQueueLock1).getUniqueName();
 
         TaskQueueLock taskQueueLock2 = mock(TaskQueueLock.class);
         doReturn("1").when(taskQueueLock2).getUniqueName();
 
+        // This should be treated as id:0 to avoid throwing an exception
         TaskQueueLock taskQueueLock3 = mock(TaskQueueLock.class);
         doReturn(null).when(taskQueueLock3).getUniqueName();
 
         TaskQueueLock taskQueueLock4 = mock(TaskQueueLock.class);
         doReturn("5").when(taskQueueLock4).getUniqueName();
 
+        // So the expected order is: 1 or 3 -> 1 or 3 -> 2 -> 4 -> 0
+
         ImmutableList<TaskQueueLock> taskQueueLocks =
                 ImmutableList.of(taskQueueLock0, taskQueueLock1, taskQueueLock2, taskQueueLock3, taskQueueLock4);
 
-        int expectedCount = 42;
-        AgentId expectedAgentId = AgentId.of("Hello");
+        int fetchTaskCount = 42;
+        String agentIdKey = "Hello";
+        int lockSeconds = 3;
+        long maxSleepMilli = 1234;
 
         doReturn(taskQueueLocks).when(taskQueueClient)
                 .lockSharedAgentTasks(
-                        eq(expectedCount),
-                        eq(expectedAgentId),
-                        )
-        doReturn(taskQueueClient).when(taskQueueServerManager).getInProcessTaskQueueClient();
+                        eq(fetchTaskCount),
+                        eq(agentIdKey),
+                        eq(lockSeconds),
+                        eq(maxSleepMilli));
 
-        List<TaskRequest> taskRequests = taskServerApi.lockSharedAgentTasks(10, AgentId.of("hello"), 42, 1234);
+        taskServerApi.lockSharedAgentTasks(fetchTaskCount, AgentId.of(agentIdKey),  lockSeconds, maxSleepMilli);
+
+        verify(workflowExecutor, times(1)).getTaskRequests(taskQueueLockListCapture.capture());
+
+        List<TaskQueueLock> taskQueueLockList = taskQueueLockListCapture.getValue();
+        assertEquals(5, taskQueueLockList.size());
+        assertTrue(taskQueueLockList.get(0) == taskQueueLock1 || taskQueueLockList.get(0) == taskQueueLock3);
+        assertTrue(taskQueueLockList.get(1) == taskQueueLock1 || taskQueueLockList.get(1) == taskQueueLock3);
+        assertEquals(taskQueueLock2, taskQueueLockList.get(2));
+        assertEquals(taskQueueLock4, taskQueueLockList.get(3));
+        assertEquals(taskQueueLock0, taskQueueLockList.get(4));
     }
 }


### PR DESCRIPTION
We've observed PostgreSQL used by Digdag detected deadlocks.

```
2020-10-26 23:00:55 UTC:xxxx(63248):xxxx@xxxxx:[90713]:ERROR:  deadlock detected
2020-10-26 23:00:55 UTC:xxxx(63248):xxxx@xxxxx:[90713]:DETAIL:  Process 90713 waits for ShareLock on transaction 1911558785; blocked by process 88119.
    Process 88119 waits for ShareLock on transaction 1911558683; blocked by process 90713.
    Process 90713: update tasks set updated_at = now(), retry_at = NULL, state = 1 where state in (2,3) and retry_at <= now()
    Process 88119: select id from tasks where id = $1 for update
```

It looks this happened due to the inconsistent locking orders between
multiple `select id from tasks where id = $1 for update` called by  https://github.com/treasure-data/digdag/blob/2678bf62a17695c4b67af37113a842e94ca09f31/digdag-core/src/main/java/io/digdag/core/agent/InProcessTaskServerApi.java#L32-L37 and `update tasks set state = ${TaskStateCode.READY_CODE} where state in (...) and retry_at <= now()` called by https://github.com/treasure-data/digdag/blob/8baa1e7db395d3a2d441ef1243c1f1da644f3c35/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java#L880.

This PR makes the 2 update operations take a lock in the same order.

A slight drawback of this change is that the new UPDATE statement to move tasks status to READY will be slowed down since the new UPDATE statement uses `UPDATE ... FROM SELECT ... ORDER BY id FOR UPDATE` and I estimate the new version query is a few times slower. But from the metrics of our production environment that executes about 770K tasks per day, the target tasks, in other words "retryable" tasks, is only 6 on average and 22 at most. So I think this doesn't matter.