### PR TITLE
Support task provider strategy

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -536,7 +536,8 @@ public class EcsCommandExecutor
         return runTaskRequest;
     }
 
-    private void setPlacementStrategy(EcsClientConfig clientConfig, RunTaskRequest runTaskRequest) throws ConfigException
+    private void setPlacementStrategy(EcsClientConfig clientConfig, RunTaskRequest runTaskRequest)
+            throws ConfigException
     {
         if (clientConfig.getPlacementStrategyType().isPresent()) {
             final PlacementStrategyType placementStrategyType;

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -9,6 +9,8 @@ import com.amazonaws.services.ecs.model.KeyValuePair;
 import com.amazonaws.services.ecs.model.LaunchType;
 import com.amazonaws.services.ecs.model.LogConfiguration;
 import com.amazonaws.services.ecs.model.NetworkConfiguration;
+import com.amazonaws.services.ecs.model.PlacementStrategy;
+import com.amazonaws.services.ecs.model.PlacementStrategyType;
 import com.amazonaws.services.ecs.model.RunTaskRequest;
 import com.amazonaws.services.ecs.model.RunTaskResult;
 import com.amazonaws.services.ecs.model.Tag;
@@ -530,7 +532,29 @@ public class EcsCommandExecutor
         setEcsTaskStartedBy(clientConfig, runTaskRequest);
         setEcsNetworkConfiguration(clientConfig, runTaskRequest);
         setCapacityProviderStrategy(clientConfig, runTaskRequest);
+        setPlacementStrategy(clientConfig, runTaskRequest);
         return runTaskRequest;
+    }
+
+    private void setPlacementStrategy(EcsClientConfig clientConfig, RunTaskRequest runTaskRequest) throws ConfigException
+    {
+        if (clientConfig.getPlacementStrategyType().isPresent()) {
+            final PlacementStrategyType placementStrategyType;
+            try {
+                placementStrategyType = PlacementStrategyType.fromValue(clientConfig.getPlacementStrategyType().get());
+            }
+            catch (IllegalArgumentException invalidReason) {
+                throw new ConfigException("PlacementStrategyType is invalid", invalidReason);
+            }
+            final PlacementStrategy placementStrategy = new PlacementStrategy();
+            placementStrategy.setType(placementStrategyType);
+
+            if (clientConfig.getPlacementStrategyField().isPresent()) {
+                placementStrategy.setField(clientConfig.getPlacementStrategyField().get());
+            }
+
+            runTaskRequest.setPlacementStrategy(Arrays.asList(placementStrategy));
+        }
     }
 
     protected void setEcsTaskDefinition(

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -543,8 +543,9 @@ public class EcsCommandExecutor
             try {
                 placementStrategyType = PlacementStrategyType.fromValue(clientConfig.getPlacementStrategyType().get());
             }
-            catch (IllegalArgumentException invalidReason) {
-                throw new ConfigException("PlacementStrategyType is invalid", invalidReason);
+            // The message of this exception object has the validation error message.
+            catch (IllegalArgumentException validationError) {
+                throw new ConfigException("PlacementStrategyType is invalid", validationError);
             }
             final PlacementStrategy placementStrategy = new PlacementStrategy();
             placementStrategy.setType(placementStrategyType);

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
@@ -32,6 +32,7 @@ public class EcsClientConfig
         this.startedBy = builder.getStartedBy();
         this.assignPublicIp = builder.isAssignPublicIp();
         this.placementStrategyType = builder.getPlacementStrategyType();
+        this.placementStrategyField = builder.getPlacementStrategyField();
     }
 
     public static EcsClientConfig createFromTaskConfig(final Optional<String> clusterName, final Config taskConfig, final Config systemConfig)
@@ -98,6 +99,7 @@ public class EcsClientConfig
                 // To keep consistency I once set the default value. But it should be removed after migration.
                 .withAssignPublicIp(ecsConfig.get("assign_public_ip", boolean.class, true))
                 .withPlacementStrategyType(ecsConfig.getOptional("placement_strategy_type", String.class))
+                .withPlacementStrategyField(ecsConfig.getOptional("placement_strategy_field", String.class))
                 .build();
     }
 
@@ -114,6 +116,7 @@ public class EcsClientConfig
     private final Optional<Integer> memory;
     private final Optional<String> startedBy;
     private final Optional<String> placementStrategyType;
+    private final Optional<String> placementStrategyField;
 
     public String getClusterName()
     {
@@ -172,5 +175,10 @@ public class EcsClientConfig
     public Optional<String> getPlacementStrategyType()
     {
         return placementStrategyType;
+    }
+
+    public Optional<String> getPlacementStrategyField()
+    {
+        return placementStrategyField;
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
@@ -31,6 +31,7 @@ public class EcsClientConfig
         this.memory = builder.getMemory();
         this.startedBy = builder.getStartedBy();
         this.assignPublicIp = builder.isAssignPublicIp();
+        this.placementStrategyType = builder.getPlacementStrategyType();
     }
 
     public static EcsClientConfig createFromTaskConfig(final Optional<String> clusterName, final Config taskConfig, final Config systemConfig)
@@ -96,6 +97,7 @@ public class EcsClientConfig
                 // This value was previously hard coded.
                 // To keep consistency I once set the default value. But it should be removed after migration.
                 .withAssignPublicIp(ecsConfig.get("assign_public_ip", boolean.class, true))
+                .withPlacementStrategyType(ecsConfig.getOptional("placement_strategy_type", String.class))
                 .build();
     }
 
@@ -111,6 +113,7 @@ public class EcsClientConfig
     private final Optional<Integer> cpu;
     private final Optional<Integer> memory;
     private final Optional<String> startedBy;
+    private final Optional<String> placementStrategyType;
 
     public String getClusterName()
     {
@@ -164,5 +167,10 @@ public class EcsClientConfig
     public boolean isAssignPublicIp()
     {
         return assignPublicIp;
+    }
+
+    public Optional<String> getPlacementStrategyType()
+    {
+        return placementStrategyType;
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
@@ -35,6 +35,9 @@ public class EcsClientConfig
         this.placementStrategyType = builder.getPlacementStrategyType();
         this.placementStrategyField = builder.getPlacementStrategyField();
 
+        // All PlacementStrategyFields must be used with a PlacementStrategyType.
+        // But some PlacementStrategyTypes can be used without any PlacementStrategyFields.
+        // https://github.com/aws/aws-sdk-java/blob/1.11.686/aws-java-sdk-ecs/src/main/java/com/amazonaws/services/ecs/model/PlacementStrategy.java#L44-L52
         if (!placementStrategyType.isPresent() && placementStrategyField.isPresent()) {
             throw new ConfigException("PlacementStrategyField must be set with PlacementStrategyType");
         }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
@@ -20,6 +20,7 @@ public class EcsClientConfigBuilder
     private Optional<Integer> memory;
     private Optional<String> startedBy;
     private Optional<String> placementStrategyType;
+    private Optional<String> placementStrategyField;
 
     public EcsClientConfig build()
     {
@@ -109,6 +110,12 @@ public class EcsClientConfigBuilder
         return this;
     }
 
+    public EcsClientConfigBuilder withPlacementStrategyField(Optional<String> placementStrategyField)
+    {
+        this.placementStrategyField = placementStrategyField;
+        return this;
+    }
+
     public String getClusterName()
     {
         return clusterName;
@@ -172,5 +179,10 @@ public class EcsClientConfigBuilder
     public Optional<String> getPlacementStrategyType()
     {
         return placementStrategyType;
+    }
+
+    public Optional<String> getPlacementStrategyField()
+    {
+        return placementStrategyField;
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
@@ -19,6 +19,7 @@ public class EcsClientConfigBuilder
     private Optional<Integer> cpu;
     private Optional<Integer> memory;
     private Optional<String> startedBy;
+    private Optional<String> placementStrategyType;
 
     public EcsClientConfig build()
     {
@@ -102,6 +103,12 @@ public class EcsClientConfigBuilder
         return this;
     }
 
+    public EcsClientConfigBuilder withPlacementStrategyType(Optional<String> placementStrategyType)
+    {
+        this.placementStrategyType = placementStrategyType;
+        return this;
+    }
+
     public String getClusterName()
     {
         return clusterName;
@@ -160,5 +167,10 @@ public class EcsClientConfigBuilder
     public boolean isAssignPublicIp()
     {
         return assignPublicIp;
+    }
+
+    public Optional<String> getPlacementStrategyType()
+    {
+        return placementStrategyType;
     }
 }


### PR DESCRIPTION
# What does this PR change?
This PR supports `PlacementStrategyType` and `PlacementStrategyField` at `EcsClientConfig` and `EcsCommandExecutor`

# Background
AWS ECS supports `Task Placement Strategies` option to specify a container instance at where an ECS task will run. https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-placement-strategies.html

This PR enables user to specify `TaskPlacementStrategy` and `TaskPlacementField` for each ECS task.