### PR TITLE
Enhance py> operator error handling

### DIFF
--- a/digdag-standards/src/main/resources/digdag/standards/py/runner.py
+++ b/digdag-standards/src/main/resources/digdag/standards/py/runner.py
@@ -160,8 +160,8 @@ try:
         args = digdag_inspect_arguments(callable_type, False, params)
         result = callable_type(**args)
 except SystemExit as e:
-    # SystemExit only show exit code and it is not kind to user. So create specific error message.
-    # This error will happen if called python module name and method name are equal to standard module. (e.g tokenize.main)
+    # SystemExit only shows an exit code and it is not kind to users. So this block creates a specific error message.
+    # This error will happen if called python module name and method name are equal to those of the standard library module. (e.g. tokenize.main)
     error = Exception("Failed to call python command with code:%d" % e.code, "Possible cause: Ivalid python module call, duplicae module name with standard library")
     error_type, error_value, _tb = sys.exc_info()
     error_message = "%s %s" % (error.args[0], error.args[1])

--- a/digdag-standards/src/main/resources/digdag/standards/py/runner.py
+++ b/digdag-standards/src/main/resources/digdag/standards/py/runner.py
@@ -140,32 +140,37 @@ def digdag_inspect_arguments(callable_type, exclude_self, params):
     else:
         return args
 
-callable_type, method_name = digdag_inspect_command(command)
 error = None
+error_message = None
 error_value = None
 error_traceback = None
+callable_type = None
+method_name = None
 
-if method_name:
-    init_args = digdag_inspect_arguments(callable_type.__init__, True, params)
-    instance = callable_type(**init_args)
+try:
+    callable_type, method_name = digdag_inspect_command(command)
+    if method_name:
+        init_args = digdag_inspect_arguments(callable_type.__init__, True, params)
+        instance = callable_type(**init_args)
 
-    method = getattr(instance, method_name)
-    method_args = digdag_inspect_arguments(method, True, params)
-    try:
+        method = getattr(instance, method_name)
+        method_args = digdag_inspect_arguments(method, True, params)
         result = method(**method_args)
-    except Exception as e:
-        error = e
-        error_type, error_value, _tb = sys.exc_info()
-        error_traceback = traceback.format_exception(error_type, error_value, _tb)
-
-else:
-    args = digdag_inspect_arguments(callable_type, False, params)
-    try:
+    else:
+        args = digdag_inspect_arguments(callable_type, False, params)
         result = callable_type(**args)
-    except Exception as e:
-        error = e
-        error_type, error_value, _tb = sys.exc_info()
-        error_traceback = traceback.format_exception(error_type, error_value, _tb)
+except SystemExit as e:
+    # SystemExit only show exit code and it is not kind to user. So create specific error message.
+    # This error will happen if called python module name and method name are equal to standard module. (e.g tokenize.main)
+    error = Exception("Failed to call python command with code:%d" % e.code, "Possible cause: Ivalid python module call, duplicae module name with standard library")
+    error_type, error_value, _tb = sys.exc_info()
+    error_message = "%s %s" % (error.args[0], error.args[1])
+    error_traceback = traceback.format_exception(error_type, error_value, _tb)
+except Exception as e:
+    error = e
+    error_type, error_value, _tb = sys.exc_info()
+    error_message = str(error_value)
+    error_traceback = traceback.format_exception(error_type, error_value, _tb)
 
 out = {
     'subtask_config': digdag_env.subtask_config,
@@ -177,7 +182,7 @@ out = {
 if error:
     out['error'] = {
         'class': error_value.__class__.__name__,
-        'message': str(error_value),
+        'message': error_message,
         'backtrace': error_traceback
     }
 

--- a/digdag-tests/src/test/java/acceptance/PyIT.java
+++ b/digdag-tests/src/test/java/acceptance/PyIT.java
@@ -18,6 +18,7 @@ import java.util.regex.Pattern;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.contains;
@@ -68,41 +69,11 @@ public class PyIT
         copyResource("acceptance/echo_params/scripts/__init__.py", scriptsDir.resolve("__init__.py"));
         copyResource("acceptance/echo_params/scripts/echo_params.py", scriptsDir.resolve("echo_params.py"));
 
-        // Push the project
-        CommandStatus pushStatus = main("push",
-                "--project", projectDir.toString(),
-                "py",
-                "-c", config.toString(),
-                "-e", server.endpoint(),
-                "-r", "4711");
-        assertThat(pushStatus.errUtf8(), pushStatus.code(), is(0));
+        RestSessionAttempt attempt = pushAndStart(projectDir, "echo_params", "4709");
+        assertThat(attempt, notNullValue());
+        assertThat(attempt.getSuccess(), is(true));
 
-        // Start the workflow
-        Id attemptId;
-        {
-            CommandStatus startStatus = main("start",
-                    "-c", config.toString(),
-                    "-e", server.endpoint(),
-                    "py", "echo_params",
-                    "--session", "now");
-            assertThat(startStatus.code(), is(0));
-            attemptId = getAttemptId(startStatus);
-        }
-
-        // Wait for the attempt to complete
-        {
-            RestSessionAttempt attempt = null;
-            for (int i = 0; i < 30; i++) {
-                attempt = client.getSessionAttempt(attemptId);
-                if (attempt.getDone()) {
-                    break;
-                }
-                Thread.sleep(1000);
-            }
-            assertThat(attempt.getSuccess(), is(true));
-        }
-
-        String logs = getAttemptLogs(client, attemptId);
+        String logs = getAttemptLogs(client, attempt.getId());
         assertThat(logs, containsString("digdag params"));
     }
 
@@ -124,36 +95,11 @@ public class PyIT
         copyResource("acceptance/echo_params/scripts/__init__.py", scriptsDir.resolve("__init__.py"));
         copyResource("acceptance/echo_params/scripts/echo_params.py", scriptsDir.resolve("echo_params.py"));
 
-        // Push the project
-        final CommandStatus pushStatus = main("push",
-                "--project", projectDir.toString(),
-                "py",
-                "-c", config.toString(),
-                "-e", server.endpoint(),
-                "-r", "4711");
-        assertThat(pushStatus.errUtf8(), pushStatus.code(), is(0));
-
-        // Start the workflow
-        final CommandStatus startStatus = main("start",
-                "-c", config.toString(),
-                "-e", server.endpoint(),
-                "py", "config_python",
-                "--session", "now");
-        assertThat(startStatus.code(), is(0));
-        final Id attemptId = getAttemptId(startStatus);
-
-        // Wait for the attempt to complete
-        RestSessionAttempt attempt = null;
-        for (int i = 0; i < 30; i++) {
-            attempt = client.getSessionAttempt(attemptId);
-            if (attempt.getDone()) {
-                break;
-            }
-            Thread.sleep(1000);
-        }
+        RestSessionAttempt attempt = pushAndStart(projectDir, "config_python", "4710");
+        assertThat(attempt, notNullValue());
         assertThat(attempt.getSuccess(), is(true));
 
-        final String logs = getAttemptLogs(client, attemptId);
+        final String logs = getAttemptLogs(client, attempt.getId());
         assertThat(logs, containsString("python python"));
         assertThat(logs, containsString("python [u'python', u'-v']"));
     }
@@ -176,37 +122,12 @@ public class PyIT
         copyResource("acceptance/py/scripts/stacktrace.py", scriptsDir.resolve("stacktrace.py"));
         copyResource("acceptance/py/scripts/__init__.py", scriptsDir.resolve("__init__.py"));
 
-        // Push the project
-        final CommandStatus pushStatus = main("push",
-                "--project", projectDir.toString(),
-                "py",
-                "-c", config.toString(),
-                "-e", server.endpoint(),
-                "-r", "4711");
-        assertThat(pushStatus.errUtf8(), pushStatus.code(), is(0));
+        RestSessionAttempt attempt = pushAndStart(projectDir, "stacktrace_python", "4711");
+        assertThat(attempt, notNullValue());
+        assertThat(attempt.getSuccess(), is(false));
 
-        // Start the workflow
-        final CommandStatus startStatus = main("start",
-                "-c", config.toString(),
-                "-e", server.endpoint(),
-                "py", "stacktrace_python",
-                "--session", "now");
-        assertThat(startStatus.code(), is(0));
-        final Id attemptId = getAttemptId(startStatus);
-
-        // Wait for the attempt to complete
-        RestSessionAttempt attempt = null;
-        for (int i = 0; i < 30; i++) {
-            attempt = client.getSessionAttempt(attemptId);
-            if (attempt.getDone()) {
-                break;
-            }
-            Thread.sleep(1000);
-        }
-
-        final String logs = getAttemptLogs(client, attemptId);
-        assertThat(logs, containsString("Task failed with unexpected error: Python command failed with code 1"));
-        assertThat(logs, containsString("my error message (MyError)"));
+        final String logs = getAttemptLogs(client, attempt.getId());
+        assertThat(logs, containsString("Task failed with unexpected error: Python command failed with code 1: my error message (MyError)"));
         assertThat(logs, containsString(", in run"));
         assertThat(logs, containsString("ERROR_MESSAGE_BEGIN Python command failed with code 1"));
     }
@@ -229,20 +150,60 @@ public class PyIT
         copyResource("acceptance/py/scripts/syntax_error.py", scriptsDir.resolve("syntax_error.py"));
         copyResource("acceptance/py/scripts/__init__.py", scriptsDir.resolve("__init__.py"));
 
+        RestSessionAttempt attempt = pushAndStart(projectDir, "syntax_error_python", "4712");
+        assertThat(attempt, notNullValue());
+        assertThat(attempt.getSuccess(), is(false));
+
+        final String logs = getAttemptLogs(client, attempt.getId());
+        assertTrue(logs != null);
+        assertThat(attempt.getSuccess(), is(false));
+        final String regex = "\\[ERROR\\] [^\\n]*Task failed with unexpected error: Python command failed with code 1:[^\\n]*\\(SyntaxError\\)";
+        assertTrue(Pattern.compile(regex).matcher(logs).find());
+    }
+
+    @Test
+    public void verifyLogWithDuplicateModuleError()
+            throws Exception
+    {
+        final Path tempdir = folder.getRoot().toPath().toAbsolutePath();
+        final Path projectDir = tempdir.resolve("py");
+        final Path scriptsDir = projectDir.resolve("scripts");
+
+        // Create new project
+        final CommandStatus initStatus = main("init",
+                "-c", config.toString(),
+                projectDir.toString());
+        assertThat(initStatus.code(), is(0));
+        Files.createDirectories(scriptsDir);
+        copyResource("acceptance/py/dup_module.dig", projectDir.resolve("dup_module.dig"));
+        copyResource("acceptance/py/scripts/tokenize.py", projectDir.resolve("tokenize.py"));
+
+        RestSessionAttempt attempt = pushAndStart(projectDir, "dup_module", "4713");
+        assertThat(attempt, notNullValue());
+        final String logs = getAttemptLogs(client, attempt.getId());
+        assertTrue(logs != null);
+        assertThat(attempt.getSuccess(), is(false));
+        final String regex = "\\[ERROR\\] [^\\n]*Task failed with unexpected error: Python command failed with code 1:[^\\n]*duplicae module name with standard library";
+        assertTrue(Pattern.compile(regex).matcher(logs).find());
+    }
+
+    private RestSessionAttempt pushAndStart(Path projectDir, String workflowName, String revision)
+            throws Exception
+    {
         // Push the project
         final CommandStatus pushStatus = main("push",
                 "--project", projectDir.toString(),
                 "py",
                 "-c", config.toString(),
                 "-e", server.endpoint(),
-                "-r", "4712");
+                "-r", revision);
         assertThat(pushStatus.errUtf8(), pushStatus.code(), is(0));
 
         // Start the workflow
         final CommandStatus startStatus = main("start",
                 "-c", config.toString(),
                 "-e", server.endpoint(),
-                "py", "syntax_error_python",
+                "py", workflowName,
                 "--session", "now");
         assertThat(startStatus.code(), is(0));
         final Id attemptId = getAttemptId(startStatus);
@@ -256,10 +217,6 @@ public class PyIT
             }
             Thread.sleep(1000);
         }
-
-        final String logs = getAttemptLogs(client, attemptId);
-        assertTrue(logs != null);
-        final String regex = "\\[ERROR\\] [^\\n]*Task failed with unexpected error: Python command failed with code 1:[^\\n]*\\(SyntaxError\\)";
-        assertTrue(Pattern.compile(regex).matcher(logs).find());
+        return attempt;
     }
 }

--- a/digdag-tests/src/test/java/acceptance/PyIT.java
+++ b/digdag-tests/src/test/java/acceptance/PyIT.java
@@ -127,7 +127,7 @@ public class PyIT
         assertThat(attempt.getSuccess(), is(false));
 
         final String logs = getAttemptLogs(client, attempt.getId());
-        assertThat(logs, containsString("Task failed with unexpected error: Python command failed with code 1: my error message (MyError)"));
+        assertThat(logs, containsString("Task failed with unexpected error: Python command failed with code 1"));
         assertThat(logs, containsString(", in run"));
         assertThat(logs, containsString("ERROR_MESSAGE_BEGIN Python command failed with code 1"));
     }
@@ -157,8 +157,8 @@ public class PyIT
         final String logs = getAttemptLogs(client, attempt.getId());
         assertTrue(logs != null);
         assertThat(attempt.getSuccess(), is(false));
-        final String regex = "\\[ERROR\\] [^\\n]*Task failed with unexpected error: Python command failed with code 1:[^\\n]*\\(SyntaxError\\)";
-        assertTrue(Pattern.compile(regex).matcher(logs).find());
+        final String regex = "\\[ERROR\\] [^\\n]*Task failed with unexpected error: Python command failed with code 1.*Error messages from python:[^\\n]*\\(SyntaxError\\)";
+        assertTrue(Pattern.compile(regex, Pattern.DOTALL).matcher(logs).find());
     }
 
     @Test
@@ -183,8 +183,8 @@ public class PyIT
         final String logs = getAttemptLogs(client, attempt.getId());
         assertTrue(logs != null);
         assertThat(attempt.getSuccess(), is(false));
-        final String regex = "\\[ERROR\\] [^\\n]*Task failed with unexpected error: Python command failed with code 1:[^\\n]*duplicae module name with standard library";
-        assertTrue(Pattern.compile(regex).matcher(logs).find());
+        final String regex = "\\[ERROR\\] [^\\n]*Task failed with unexpected error: Python command failed with code 1.*Error messages from python:[^\\n]*duplicae module name with standard library";
+        assertTrue(Pattern.compile(regex, Pattern.DOTALL).matcher(logs).find());
     }
 
     private RestSessionAttempt pushAndStart(Path projectDir, String workflowName, String revision)

--- a/digdag-tests/src/test/java/acceptance/PyIT.java
+++ b/digdag-tests/src/test/java/acceptance/PyIT.java
@@ -3,6 +3,7 @@ package acceptance;
 import io.digdag.client.DigdagClient;
 import io.digdag.client.api.Id;
 import io.digdag.client.api.RestSessionAttempt;
+import org.hamcrest.Matchers;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -12,10 +13,15 @@ import utils.TemporaryDigdagServer;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.contains;
+import static org.mockito.Matchers.isNotNull;
 import static utils.TestUtils.copyResource;
 import static utils.TestUtils.getAttemptId;
 import static utils.TestUtils.getAttemptLogs;
@@ -203,5 +209,57 @@ public class PyIT
         assertThat(logs, containsString("my error message (MyError)"));
         assertThat(logs, containsString(", in run"));
         assertThat(logs, containsString("ERROR_MESSAGE_BEGIN Python command failed with code 1"));
+    }
+
+    @Test
+    public void verifyLogWithSyntaxError()
+            throws Exception
+    {
+        final Path tempdir = folder.getRoot().toPath().toAbsolutePath();
+        final Path projectDir = tempdir.resolve("py");
+        final Path scriptsDir = projectDir.resolve("scripts");
+
+        // Create new project
+        final CommandStatus initStatus = main("init",
+                "-c", config.toString(),
+                projectDir.toString());
+        assertThat(initStatus.code(), is(0));
+        Files.createDirectories(scriptsDir);
+        copyResource("acceptance/py/syntax_error_python.dig", projectDir.resolve("syntax_error_python.dig"));
+        copyResource("acceptance/py/scripts/syntax_error.py", scriptsDir.resolve("syntax_error.py"));
+        copyResource("acceptance/py/scripts/__init__.py", scriptsDir.resolve("__init__.py"));
+
+        // Push the project
+        final CommandStatus pushStatus = main("push",
+                "--project", projectDir.toString(),
+                "py",
+                "-c", config.toString(),
+                "-e", server.endpoint(),
+                "-r", "4712");
+        assertThat(pushStatus.errUtf8(), pushStatus.code(), is(0));
+
+        // Start the workflow
+        final CommandStatus startStatus = main("start",
+                "-c", config.toString(),
+                "-e", server.endpoint(),
+                "py", "syntax_error_python",
+                "--session", "now");
+        assertThat(startStatus.code(), is(0));
+        final Id attemptId = getAttemptId(startStatus);
+
+        // Wait for the attempt to complete
+        RestSessionAttempt attempt = null;
+        for (int i = 0; i < 60; i++) {
+            attempt = client.getSessionAttempt(attemptId);
+            if (attempt.getDone()) {
+                break;
+            }
+            Thread.sleep(1000);
+        }
+
+        final String logs = getAttemptLogs(client, attemptId);
+        assertTrue(logs != null);
+        final String regex = "\\[ERROR\\] [^\\n]*Task failed with unexpected error: Python command failed with code 1:[^\\n]*\\(SyntaxError\\)";
+        assertTrue(Pattern.compile(regex).matcher(logs).find());
     }
 }

--- a/digdag-tests/src/test/resources/acceptance/py/dup_module.dig
+++ b/digdag-tests/src/test/resources/acceptance/py/dup_module.dig
@@ -1,0 +1,2 @@
++task1:
+  py>: tokenize.main

--- a/digdag-tests/src/test/resources/acceptance/py/scripts/syntax_error.py
+++ b/digdag-tests/src/test/resources/acceptance/py/scripts/syntax_error.py
@@ -1,0 +1,5 @@
+from time import sleep
+
+def func1():
+    print("func1 called)
+    

--- a/digdag-tests/src/test/resources/acceptance/py/scripts/tokenize.py
+++ b/digdag-tests/src/test/resources/acceptance/py/scripts/tokenize.py
@@ -1,0 +1,4 @@
+def func1():
+    print("func1 called")
+
+

--- a/digdag-tests/src/test/resources/acceptance/py/syntax_error_python.dig
+++ b/digdag-tests/src/test/resources/acceptance/py/syntax_error_python.dig
@@ -1,0 +1,2 @@
++task1:
+  py>: scripts.syntax_error.func1


### PR DESCRIPTION
Some of errors does not handling in runner.py of py>. And it cause no generation of output.json and users cannot get information of errors.
To mitigate it, change error handling in runner.py as follows:

- catch exception in whole main code
- handle SystemExit exception because it only show exit code and not kind to users.

