### PR TITLE
Add index to sessions

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseMigrator.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseMigrator.java
@@ -40,6 +40,7 @@ public class DatabaseMigrator
         new Migration_20170223220127_AddLastSessionTimeAndFlagsToSessions(),
         new Migration_20190318175338_AddIndexToSessionAttempts(),
         new Migration_20191105105927_AddIndexToSessions(),
+        new Migration_20201107103915_AddIndexToSessions(),
     })
     .sorted(Comparator.comparing(m -> m.getVersion()))
     .collect(Collectors.toList());

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20201107103915_AddIndexToSessions.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20201107103915_AddIndexToSessions.java
@@ -1,0 +1,24 @@
+package io.digdag.core.database.migrate;
+
+import org.skife.jdbi.v2.Handle;
+
+public class Migration_20201107103915_AddIndexToSessions
+        implements Migration
+{
+
+    @Override
+    public void migrate(Handle handle, MigrationContext context)
+    {
+        if (context.isPostgres()) {
+            handle.update("create index concurrently sessions_on_last_attempt_id on sessions (last_attempt_id)");
+        } else {
+            handle.update("create index sessions_on_last_attempt_id on sessions (last_attempt_id)");
+        }
+    }
+
+    @Override
+    public boolean noTransaction(MigrationContext context)
+    {
+        return context.isPostgres();
+    }
+}


### PR DESCRIPTION
# Approach
- We have came up a critical problem that made workflow schedules do not run.
  - 2 causes
    - Data volumes (sessions and session_attempts).
    - missing index
- This commit does not correspond to data volumes problem.
- Add index for last_attempt_id on sessions
  - Although the column is used as a join clause, there is no index.
  - As a result, a lot of tuples are scanned as follows query plan.

# Investigation
## Slow query
We immediately realized that this problem caused by PostgreSQL.
And a following slow query were output a lot of times to logs.
```sql
select sa.*, s.session_uuid, s.workflow_name, s.session_time from session_attempts sa join sessions s on s.last_attempt_id = sa.id where s.project_id = $1 and s.workflow_name = $2 and sa.state_flags = 0 and sa.site_id = $3 and sa.id < $4 order by sa.id desc limit $5;
```
This corresponds with
https://github.com/treasure-data/digdag/blob/63b0339c88a62663f2890047b612cc0433b81442/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java#L1689
## Query planing (Current v0.9.42)
Actually, this plan has already benefit from an improvement that delete older records like #809.
<details>
<summary>display</summary>

```sql
Limit  (cost=12678.71..12678.71 rows=1 width=282) (actual time=786.722..786.722 rows=0 loops=1)
   ->  Sort  (cost=12678.71..12678.71 rows=1 width=282) (actual time=786.720..786.720 rows=0 loops=1)
         Sort Key: sa.id DESC
         Sort Method: quicksort  Memory: 25kB
         ->  Nested Loop  (cost=0.69..12678.70 rows=1 width=282) (actual time=786.699..786.700 rows=0 loops=1)
               Join Filter: (sa.id = s.last_attempt_id)
               Rows Removed by Join Filter: 672995
               ->  Index Scan using session_attempts_on_state_flags_and_created_at on session_attempts sa  (cost=0.14..23.76 rows=1 width=223) (actual time=0.
006..0.029 rows=5 loops=1)
                     Filter: (site_id = 0)
               ->  Index Scan using sessions_on_project_id_and_workflow_name_and_last_attempt_creat on sessions s  (cost=0.56..12582.98 rows=5756 width=67) (a
ctual time=0.022..107.179 rows=134599 loops=5)
                     Index Cond: ((project_id = a) AND (workflow_name = 'b'::text))
```
</details>