### PR TITLE
Update handling of a task with CANCEL_REQUESTED flag

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
@@ -160,8 +160,13 @@ public class OperatorManager
                         callback.retryTask(request, agentId, ex.getRetryInterval().get(), ex.getStateParams(cf).get(), ex.getError(cf));
                     }
                     else {
-                        logger.error("Task {} failed.\n{}", request.getTaskName(), formatExceptionMessage(ex));
-                        logger.debug("", ex);
+                        if (request.isCancelRequested()) {
+                            logger.warn("Task {} canceled.", request.getTaskName());
+                        }
+                        else {
+                            logger.error("Task {} failed.\n{}", request.getTaskName(), formatExceptionMessage(ex));
+                            logger.debug("", ex);
+                        }
                         // TODO use debug to log stacktrace here
                         callback.taskFailed(request, agentId, ex.getError(cf).get());  // TODO is error set?
                     }
@@ -345,6 +350,10 @@ public class OperatorManager
                 projectPath, mergedRequest, secretProvider, privilegedVariables, limits);
 
         Operator operator = factory.newOperator(context);
+
+        if (mergedRequest.isCancelRequested()) {
+            return operator.cleanup(mergedRequest);
+        }
 
         return operator.run();
     }

--- a/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
@@ -352,7 +352,7 @@ public class OperatorManager
         Operator operator = factory.newOperator(context);
 
         if (mergedRequest.isCancelRequested()) {
-            return operator.cleanup(mergedRequest);
+            operator.cleanup(mergedRequest);
         }
 
         return operator.run();

--- a/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
@@ -50,6 +50,7 @@ import java.util.stream.Collectors;
 
 import static com.google.common.base.Strings.isNullOrEmpty;
 import static io.digdag.spi.TaskExecutionException.buildExceptionErrorConfig;
+import static java.util.Locale.ENGLISH;
 
 public class OperatorManager
 {
@@ -352,7 +353,13 @@ public class OperatorManager
         Operator operator = factory.newOperator(context);
 
         if (mergedRequest.isCancelRequested()) {
+            // NOTE: In the case of failure to perform cleanup,
+            // target resources continue to remain
             operator.cleanup(mergedRequest);
+            // Throw exception to stop the task
+            throw new TaskExecutionException(String.format(ENGLISH,
+                    "Got a cancel-requested: attempt_id=%d, task_id=%d",
+                    mergedRequest.getAttemptId(), mergedRequest.getTaskId()));
         }
 
         return operator.run();

--- a/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/OperatorManager.java
@@ -161,7 +161,7 @@ public class OperatorManager
                     }
                     else {
                         if (request.isCancelRequested()) {
-                            logger.warn("Task {} canceled.", request.getTaskName());
+                            logger.warn("Task {} is canceled.", request.getTaskName());
                         }
                         else {
                             logger.error("Task {} failed.\n{}", request.getTaskName(), formatExceptionMessage(ex));

--- a/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java
+++ b/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java
@@ -86,8 +86,6 @@ import static java.util.Locale.ENGLISH;
  * READY:
  *   enqueueReadyTasks:
  *     enqueueTask:
- *       (if CANCEL_REQUESTED flag is set) lockedTask.setToCanceled:
- *         : CANCELED
  *       lockedTask.setReadyToRunning:
  *         : RUNNING
  *   NOTE: because updated_at column is used as a part of identifier of
@@ -96,6 +94,8 @@ import static java.util.Locale.ENGLISH;
  *
  * RUNNING:
  *   taskFailed:
+ *     (if CANCEL_REQUESTED flag is set) lockedTask.setToCanceled:
+ *       : CANCELED
  *     (if retryInterval is set) lockedTask.setRunningToRetryWaiting:
  *       : RETRY_WAITING with error
  *     (if error task exists) lockedTask.setRunningToPlannedWithDelayedError:
@@ -104,6 +104,8 @@ import static java.util.Locale.ENGLISH;
  *       : ERROR with error
  *
  *   taskSucceeded:
+ *     (if CANCEL_REQUESTED flag is set) lockedTask.setToCanceled:
+ *       : CANCELED
  *     (if subtasks or check task exist) lockedTask.setRunningToPlannedSuccessful:
  *       : PLANNED
  *     lockedTask.setRunningToShortCircuitSuccess:
@@ -960,9 +962,8 @@ public class WorkflowExecutor
                 return retryGroupingTask(lockedTask);
             }
 
-            if (task.getStateFlags().isCancelRequested()) {
-                return lockedTask.setToCanceled();
-            }
+            // NOTE: Nothing to do here because CANCEL_REQUESTED task will be handled by　an agent.
+            // See also state transitions.
 
             int siteId;
             try {

--- a/digdag-core/src/test/java/io/digdag/core/agent/OperatorManagerTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/agent/OperatorManagerTest.java
@@ -103,6 +103,9 @@ public class OperatorManagerTest
         om.runWithHeartbeat(taskRequest);
         verify(op, times(0)).run();
         verify(op, times(1)).cleanup(any(TaskRequest.class));
+        verify(callback, times(0)).taskSucceeded(any(), any(), any());
+        verify(callback, times(1)).taskFailed(eq(taskRequest), any(), any());
+        verify(callback, times(0)).retryTask(any(), any(), anyInt(), any(), any());
     }
 
     @Test

--- a/digdag-core/src/test/java/io/digdag/core/agent/OperatorManagerTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/agent/OperatorManagerTest.java
@@ -21,7 +21,6 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.io.IOException;
-import java.nio.file.Paths;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
@@ -96,26 +95,14 @@ public class OperatorManagerTest
     {
         TaskRequest taskRequest = OperatorTestingUtils.newTaskRequest(simpleConfig).withIsCancelRequested(true);
 
-        {
-            OperatorManager om = spy(operatorManager);
-            doThrow(new TaskExecutionException("Zzz")).when(om).callExecutor(any(), any(), any());
-            om.runWithHeartbeat(taskRequest);
-            verify(callback, times(0)).taskSucceeded(any(), any(), any());
-            verify(callback, times(1)).taskFailed(eq(taskRequest), any(), any());
-            verify(callback, times(0)).retryTask(any(), any(), anyInt(), any(), any());
-        }
-        {
-            OperatorManager om = spy(operatorManager);
-            Operator op = mock(Operator.class);
-            OperatorFactory of = mock(OperatorFactory.class);
-
-            doReturn(of).when(registry).get(any(), any());
-            doReturn(op).when(of).newOperator(any());
-
-            om.callExecutor(Paths.get("test"), "echo", taskRequest);
-            verify(op, times(1)).cleanup(eq(taskRequest));
-            verify(op, times(0)).run();
-        }
+        OperatorManager om = spy(operatorManager);
+        Operator op = mock(Operator.class);
+        OperatorFactory of = mock(OperatorFactory.class);
+        doReturn(of).when(registry).get(any(), any());
+        doReturn(op).when(of).newOperator(any());
+        om.runWithHeartbeat(taskRequest);
+        verify(op, times(0)).run();
+        verify(op, times(1)).cleanup(any(TaskRequest.class));
     }
 
     @Test

--- a/digdag-spi/src/main/java/io/digdag/spi/CommandExecutor.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/CommandExecutor.java
@@ -23,6 +23,7 @@ public interface CommandExecutor
 
     /**
      * Polls the command status by non-blocking and return CommandStatus.
+     *
      * @param context
      * @param previousStatusJson
      * @return
@@ -33,12 +34,12 @@ public interface CommandExecutor
 
     /**
      * Runs a cleanup script when an attempt gets CANCEL_REQUESTED.
+     *
      * @param context
      * @param state
      * @throws IOException
      */
     default void cleanup(CommandContext context, Config state)
-        throws IOException
-    {
-    }
+            throws IOException
+    { }
 }

--- a/digdag-spi/src/main/java/io/digdag/spi/CommandExecutor.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/CommandExecutor.java
@@ -1,6 +1,8 @@
 package io.digdag.spi;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import io.digdag.client.config.Config;
+
 import java.io.IOException;
 
 public interface CommandExecutor
@@ -28,4 +30,15 @@ public interface CommandExecutor
      */
     CommandStatus poll(CommandContext context, ObjectNode previousStatusJson)
             throws IOException;
+
+    /**
+     * Runs a cleanup script when an attempt gets CANCEL_REQUESTED.
+     * @param context
+     * @param state
+     * @throws IOException
+     */
+    default void cleanup(CommandContext context, Config state)
+        throws IOException
+    {
+    }
 }

--- a/digdag-spi/src/main/java/io/digdag/spi/Operator.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/Operator.java
@@ -3,4 +3,9 @@ package io.digdag.spi;
 public interface Operator
 {
     TaskResult run();
+
+    default TaskResult cleanup(TaskRequest request)
+    {
+        return TaskResult.empty(request);
+    }
 }

--- a/digdag-spi/src/main/java/io/digdag/spi/Operator.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/Operator.java
@@ -1,9 +1,16 @@
 package io.digdag.spi;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public interface Operator
 {
+    Logger logger = LoggerFactory.getLogger(Operator.class);
+
     TaskResult run();
 
     default void cleanup(TaskRequest request)
-    { }
+    {
+        logger.debug("cleanup is called: attempt_id={}, task_id={}", request.getAttemptId(), request.getTaskId());
+    }
 }

--- a/digdag-spi/src/main/java/io/digdag/spi/Operator.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/Operator.java
@@ -4,8 +4,6 @@ public interface Operator
 {
     TaskResult run();
 
-    default TaskResult cleanup(TaskRequest request)
-    {
-        return TaskResult.empty(request);
-    }
+    default void cleanup(TaskRequest request)
+    { }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -38,7 +38,6 @@ import io.digdag.spi.CommandExecutor;
 import io.digdag.spi.CommandLogger;
 import io.digdag.spi.CommandRequest;
 import io.digdag.spi.CommandStatus;
-import io.digdag.spi.TaskExecutionException;
 import io.digdag.spi.TaskRequest;
 import io.digdag.standards.command.ecs.EcsClient;
 import io.digdag.standards.command.ecs.EcsClientConfig;
@@ -299,22 +298,11 @@ public class EcsCommandExecutor
         final EcsClientConfig clientConfig = createEcsClientConfig(Optional.of(clusterName), systemConfig, taskConfig); // ConfigException
 
         try (final EcsClient client = ecsClientFactory.createClient(clientConfig)) { // ConfigException
-            final Task task;
-            try {
-                task = client.getTask(clusterName, taskArn);
-            }
-            catch (TaskSetNotFoundException e) {
-                final String message = s("Cannot get the ECS task status. attemptId=%d, taskId=%d", attemptId, taskId);
-                logger.warn(message);
-                // Throw exception to stop the task
-                throw new TaskExecutionException(message);
-            }
-            final String message = s("Command task execution will be stopped: attemptId=%d, taskId=%d", attemptId, taskId);
+            final Task task = client.getTask(clusterName, taskArn);
+            final String message = s("Command task execution will be stopped: attempt_id=%d, task_id=%d", attemptId, taskId);
             logger.info(message);
-            logger.debug(s("Stop command task %s", task.getTaskArn()));
+            logger.debug(s("Stop command task: %s", task.getTaskArn()));
             client.stopTask(clusterName, task.getTaskArn());
-            // Throw exception to stop the task
-            throw new TaskExecutionException(message);
         }
     }
 

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -309,7 +309,7 @@ public class EcsCommandExecutor
                 // Throw exception to stop the task
                 throw new TaskExecutionException(message);
             }
-            final String message = s("Command task execution cancel requested: attemptId=%d, taskId=%d", attemptId, taskId);
+            final String message = s("Command task execution will be stopped: attemptId=%d, taskId=%d", attemptId, taskId);
             logger.info(message);
             logger.debug(s("Stop command task %s", task.getTaskArn()));
             client.stopTask(clusterName, task.getTaskArn());

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/PyOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/PyOperatorFactory.java
@@ -136,9 +136,11 @@ public class PyOperatorFactory
             if (state.has("commandStatus")) {
                 logger.debug(String.format("Starting cleanup: attemptId=%d, taskId=%d",  attemptId, taskId));
                 try {
+                    // TODO: Need to retry?
                     exec.cleanup(commandContext, state);
-                } catch (IOException ex) {
-                    throw Throwables.propagate(ex);
+                }
+                catch (Throwable e) {
+                    throw Throwables.propagate(e);
                 }
             }
         }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/PyOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/PyOperatorFactory.java
@@ -126,7 +126,7 @@ public class PyOperatorFactory
         }
 
         @Override
-        public TaskResult cleanup(TaskRequest request)
+        public void cleanup(TaskRequest request)
         {
             final Path projectPath = workspace.getProjectPath(); // absolute
             final CommandContext commandContext = buildCommandContext(projectPath);
@@ -141,7 +141,6 @@ public class PyOperatorFactory
                     throw Throwables.propagate(ex);
                 }
             }
-            return TaskResult.empty(request);
         }
 
         private Config runCode(final Config state)


### PR DESCRIPTION
## Overview

Currently, there is a problem with post-processing when a task is canceled.

This PR adds support for handling cleanup when a task is canceled, with the following changes.

### WorkflowExecutor
- Don't `setToCanceled` on enqueueTask and let the OperatorManager do the canceling (= canceled by `taskFailed`).
  - If a task has a CANCEL_REQUESTED flag during/after execution, it is necessary to perform the cleanup process.
  - And task transitions will be changed as follows:
    - As-Is: RETRY_WAITING > READY > CANCELED
    - To-Be: RETRY_WAITING > READY > RUNNING > CANCELED https://github.com/treasure-data/digdag/blob/520baa783235545def0492c98455cad1d56ffd5f/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java#L72-L162
  - ^ This allows cleanup to be performed while the task is running/finished

### OperatorManager
- Changes to execute cleanup when the task is CANCEL_REQUESTED

### CommnadExecutor/Operator
- Adds cleanup functions to the Operator and CommnadExecutor interfaces and implements them in PyOperatorFactory and EcsCommandExecutor.
