### PR TITLE
Support task cpu and memory override

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -603,20 +603,6 @@ public class EcsCommandExecutor
         setTaskOverrideResource(clientConfig, taskOverride);
 
         request.withOverrides(taskOverride);
-
-        //final ContainerOverride containerOverride = new ContainerOverride();
-        //containerOverride.withName()
-        //containerOverride.withCommand()
-        //containerOverride.withCpu();
-        //containerOverride.withMemory();
-        //containerOverride.withMemoryReservation();
-        //containerOverride.withResourceRequirements();
-
-        //final TaskOverride taskOverride = new TaskOverride();
-        //taskOverride.withContainerOverrides();
-        //taskOverride.withExecutionRoleArn();
-        //taskOverride.withTaskRoleArn();
-        //request.withOverrides(taskOverride);
     }
 
     protected void setEcsContainerOverrideName(
@@ -812,15 +798,6 @@ public class EcsCommandExecutor
                             .withAssignPublicIp(clientConfig.isAssignPublicIp() ? AssignPublicIp.ENABLED : AssignPublicIp.DISABLED)
             ));
         }
-
-        //final AwsVpcConfiguration awsVpcConfig = new AwsVpcConfiguration();
-        //awsVpcConfig.withAssignPublicIp();
-        //awsVpcConfig.withAssignPublicIp();
-        //awsVpcConfig.withSecurityGroups();
-        //awsVpcConfig.withSubnets();
-        //final NetworkConfiguration config = new NetworkConfiguration();
-        //config.withAwsvpcConfiguration(vpcConfig);
-        //request.withNetworkConfiguration(config);
     }
 
     protected void setCapacityProviderStrategy(final EcsClientConfig clientConfig, final RunTaskRequest request)
@@ -878,7 +855,7 @@ public class EcsCommandExecutor
         return sb.toString();
     }
 
-    private void setTaskOverrideResource(EcsClientConfig clientConfig, TaskOverride taskOverride)
+    protected void setTaskOverrideResource(EcsClientConfig clientConfig, TaskOverride taskOverride)
     {
         if (clientConfig.getTaskCpu().isPresent()) {
             taskOverride.setCpu(clientConfig.getTaskCpu().get());

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -600,6 +600,8 @@ public class EcsCommandExecutor
 
         final TaskOverride taskOverride = new TaskOverride();
         taskOverride.withContainerOverrides(containerOverride);
+        setTaskOverrideResource(clientConfig, taskOverride);
+
         request.withOverrides(taskOverride);
 
         //final ContainerOverride containerOverride = new ContainerOverride();
@@ -874,5 +876,12 @@ public class EcsCommandExecutor
         }
         sb.append("]");
         return sb.toString();
+    }
+
+    private void setTaskOverrideResource(EcsClientConfig clientConfig, TaskOverride taskOverride)
+    {
+        if (clientConfig.getTaskCpu().isPresent()) {
+            taskOverride.setCpu(clientConfig.getTaskCpu().get());
+        }
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -756,8 +756,8 @@ public class EcsCommandExecutor
         if (clientConfig.getContainerCpu().isPresent()) {
             containerOverride.setCpu(clientConfig.getContainerCpu().get());
         }
-        if (clientConfig.getMemory().isPresent()) {
-            containerOverride.setMemory(clientConfig.getMemory().get());
+        if (clientConfig.getContainerMemory().isPresent()) {
+            containerOverride.setMemory(clientConfig.getContainerMemory().get());
         }
     }
 

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -883,5 +883,9 @@ public class EcsCommandExecutor
         if (clientConfig.getTaskCpu().isPresent()) {
             taskOverride.setCpu(clientConfig.getTaskCpu().get());
         }
+
+        if (clientConfig.getTaskMemory().isPresent()) {
+            taskOverride.setMemory(clientConfig.getTaskMemory().get());
+        }
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -753,8 +753,8 @@ public class EcsCommandExecutor
             final EcsClientConfig clientConfig,
             final ContainerOverride containerOverride)
     {
-        if (clientConfig.getCpu().isPresent()) {
-            containerOverride.setCpu(clientConfig.getCpu().get());
+        if (clientConfig.getContainerCpu().isPresent()) {
+            containerOverride.setCpu(clientConfig.getContainerCpu().get());
         }
         if (clientConfig.getMemory().isPresent()) {
             containerOverride.setMemory(clientConfig.getMemory().get());

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
@@ -60,7 +60,7 @@ public class EcsClientConfig
         // - placementStrategyType (optional/String)
         // - placementStrategyField (optional/String)
         // - task_cpu (optional/String) e.g. `1 vcpu` or `1024` (CPU unit)
-        // - task_memory (optional/String) e.g. `1 GB` or `1024` (Mib)
+        // - task_memory (optional/String) e.g. `1 GB` or `1024` (MiB)
         // For more detail of the value format of `task_cpu` and `task_memory`, please see
         // https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size
         final Config ecsConfig = taskConfig.getNested(TASK_CONFIG_ECS_KEY).deepCopy();

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
@@ -35,6 +35,7 @@ public class EcsClientConfig
         this.placementStrategyType = builder.getPlacementStrategyType();
         this.placementStrategyField = builder.getPlacementStrategyField();
         this.taskCpu = builder.getTaskCpu();
+        this.taskMemory = builder.getTaskMemory();
 
         // All PlacementStrategyFields must be used with a PlacementStrategyType.
         // But some PlacementStrategyTypes can be used without any PlacementStrategyFields.
@@ -113,6 +114,7 @@ public class EcsClientConfig
                 .withPlacementStrategyType(ecsConfig.getOptional("placement_strategy_type", String.class))
                 .withPlacementStrategyField(ecsConfig.getOptional("placement_strategy_field", String.class))
                 .withTaskCpu(ecsConfig.getOptional("task_cpu", String.class))
+                .withTaskMemory(ecsConfig.getOptional("task_memory", String.class))
                 .build();
     }
 
@@ -136,6 +138,7 @@ public class EcsClientConfig
     // https://github.com/aws/aws-sdk-java/blob/1.11.686/aws-java-sdk-ecs/src/main/java/com/amazonaws/services/ecs/model/PlacementStrategy.java#L44-L52
     private final Optional<String> placementStrategyField;
     private final Optional<String> taskCpu;
+    private final Optional<String> taskMemory;
 
     public String getClusterName()
     {
@@ -204,5 +207,10 @@ public class EcsClientConfig
     public Optional<String> getTaskCpu()
     {
         return taskCpu;
+    }
+
+    public Optional<String> getTaskMemory()
+    {
+        return taskMemory;
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
@@ -50,16 +50,19 @@ public class EcsClientConfig
         final String name;
         // `taskConfig` is assumed to have a nested taskConfig with following values
         // at the key of `TASK_CONFIG_ECS_KEY` from `taskConfig`.
-        // - launch_type (optional)
-        // - region
-        // - subnets (optional)
-        // - max_retries (optional)
-        // - capacity_provider_name (optional)
-        // - container_memory (optional)
-        // - container_cpu (optional)
-        // - placementStrategyType (optional)
-        // - placementStrategyField (optional)
-        // - task_cpu
+        // - launch_type (optional/String)
+        // - region (String)
+        // - subnets (optional/String)
+        // - max_retries (optional/int)
+        // - capacity_provider_name (optional/String)
+        // - container_memory (optional/Integer)
+        // - container_cpu (optional/Integer)
+        // - placementStrategyType (optional/String)
+        // - placementStrategyField (optional/String)
+        // - task_cpu (optional/String) e.g. `1 vcpu` or `1024` (CPU unit)
+        // - task_memory (optional/String) e.g. `1 GB` or `1024` (Mib)
+        // For more detail of the value format of `task_cpu` and `task_memory`, please see
+        // https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size
         final Config ecsConfig = taskConfig.getNested(TASK_CONFIG_ECS_KEY).deepCopy();
         if (!clusterName.isPresent()) {
             // Throw ConfigException if 'name' doesn't exist in system ecsConfig.

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
@@ -28,7 +28,7 @@ public class EcsClientConfig
         this.subnets = builder.getSubnets();
         this.maxRetries = builder.getMaxRetries();
         this.capacityProviderName = builder.getCapacityProviderName();
-        this.cpu = builder.getCpu();
+        this.containerCpu = builder.getContainerCpu();
         this.memory = builder.getMemory();
         this.startedBy = builder.getStartedBy();
         this.assignPublicIp = builder.isAssignPublicIp();
@@ -54,7 +54,7 @@ public class EcsClientConfig
         // - max_retries (optional)
         // - capacity_provider_name (optional)
         // - memory (optional)
-        // - cpu (optional)
+        // - container_cpu (optional)
         // - placementStrategyType (optional)
         // - placementStrategyField (optional)
         final Config ecsConfig = taskConfig.getNested(TASK_CONFIG_ECS_KEY).deepCopy();
@@ -101,7 +101,7 @@ public class EcsClientConfig
                 .withSubnets(ecsConfig.getOptional("subnets", String.class))
                 .withMaxRetries(ecsConfig.get("max_retries", int.class, DEFAULT_MAX_RETRIES))
                 .withCapacityProviderName(ecsConfig.getOptional("capacity_provider_name", String.class))
-                .withCpu(ecsConfig.getOptional("cpu", Integer.class))
+                .withContainerCpu(ecsConfig.getOptional("container_cpu", Integer.class))
                 .withMemory(ecsConfig.getOptional("memory", Integer.class))
                 .withStartedBy(ecsConfig.getOptional("startedBy", String.class))
                 // TODO removing default value.
@@ -122,7 +122,7 @@ public class EcsClientConfig
     private final Optional<List<String>> subnets;
     private final Optional<String> launchType;
     private final Optional<String> capacityProviderName;
-    private final Optional<Integer> cpu;
+    private final Optional<Integer> containerCpu;
     private final Optional<Integer> memory;
     private final Optional<String> startedBy;
     // In aws-sdk 1.11.686, only `random`, `spread`, and `binpack` are supported.
@@ -173,7 +173,7 @@ public class EcsClientConfig
         return capacityProviderName;
     }
 
-    public Optional<Integer> getCpu() { return cpu; }
+    public Optional<Integer> getContainerCpu() { return containerCpu; }
 
     public Optional<Integer> getMemory() { return memory; }
 

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
@@ -108,7 +108,7 @@ public class EcsClientConfig
                 .withMaxRetries(ecsConfig.get("max_retries", int.class, DEFAULT_MAX_RETRIES))
                 .withCapacityProviderName(ecsConfig.getOptional("capacity_provider_name", String.class))
                 .withContainerCpu(ecsConfig.getOptional("container_cpu", Integer.class))
-                .withContainerMemory(ecsConfig.getOptional("memory", Integer.class))
+                .withContainerMemory(ecsConfig.getOptional("container_memory", Integer.class))
                 .withStartedBy(ecsConfig.getOptional("startedBy", String.class))
                 // TODO removing default value.
                 // This value was previously hard coded.

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
@@ -132,6 +132,8 @@ public class EcsClientConfig
     private final Optional<String> capacityProviderName;
     private final Optional<Integer> containerCpu;
     private final Optional<Integer> containerMemory;
+    private final Optional<String> taskCpu;
+    private final Optional<String> taskMemory;
     private final Optional<String> startedBy;
     // In aws-sdk 1.11.686, only `random`, `spread`, and `binpack` are supported.
     // https://github.com/aws/aws-sdk-java/blob/1.11.686/aws-java-sdk-ecs/src/main/java/com/amazonaws/services/ecs/model/PlacementStrategyType.java#L23-L25
@@ -140,8 +142,6 @@ public class EcsClientConfig
     // E.g. For the `binpack` placement strategy, valid values are `cpu` and `memory`.
     // https://github.com/aws/aws-sdk-java/blob/1.11.686/aws-java-sdk-ecs/src/main/java/com/amazonaws/services/ecs/model/PlacementStrategy.java#L44-L52
     private final Optional<String> placementStrategyField;
-    private final Optional<String> taskCpu;
-    private final Optional<String> taskMemory;
 
     public String getClusterName()
     {

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
@@ -29,7 +29,7 @@ public class EcsClientConfig
         this.maxRetries = builder.getMaxRetries();
         this.capacityProviderName = builder.getCapacityProviderName();
         this.containerCpu = builder.getContainerCpu();
-        this.memory = builder.getMemory();
+        this.containerMemory = builder.getContainerMemory();
         this.startedBy = builder.getStartedBy();
         this.assignPublicIp = builder.isAssignPublicIp();
         this.placementStrategyType = builder.getPlacementStrategyType();
@@ -53,7 +53,7 @@ public class EcsClientConfig
         // - subnets (optional)
         // - max_retries (optional)
         // - capacity_provider_name (optional)
-        // - memory (optional)
+        // - container_memory (optional)
         // - container_cpu (optional)
         // - placementStrategyType (optional)
         // - placementStrategyField (optional)
@@ -102,7 +102,7 @@ public class EcsClientConfig
                 .withMaxRetries(ecsConfig.get("max_retries", int.class, DEFAULT_MAX_RETRIES))
                 .withCapacityProviderName(ecsConfig.getOptional("capacity_provider_name", String.class))
                 .withContainerCpu(ecsConfig.getOptional("container_cpu", Integer.class))
-                .withMemory(ecsConfig.getOptional("memory", Integer.class))
+                .withContainerMemory(ecsConfig.getOptional("memory", Integer.class))
                 .withStartedBy(ecsConfig.getOptional("startedBy", String.class))
                 // TODO removing default value.
                 // This value was previously hard coded.
@@ -123,7 +123,7 @@ public class EcsClientConfig
     private final Optional<String> launchType;
     private final Optional<String> capacityProviderName;
     private final Optional<Integer> containerCpu;
-    private final Optional<Integer> memory;
+    private final Optional<Integer> containerMemory;
     private final Optional<String> startedBy;
     // In aws-sdk 1.11.686, only `random`, `spread`, and `binpack` are supported.
     // https://github.com/aws/aws-sdk-java/blob/1.11.686/aws-java-sdk-ecs/src/main/java/com/amazonaws/services/ecs/model/PlacementStrategyType.java#L23-L25
@@ -175,7 +175,7 @@ public class EcsClientConfig
 
     public Optional<Integer> getContainerCpu() { return containerCpu; }
 
-    public Optional<Integer> getMemory() { return memory; }
+    public Optional<Integer> getContainerMemory() { return containerMemory; }
 
     public Optional<String> getStartedBy()
     {

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
@@ -34,6 +34,7 @@ public class EcsClientConfig
         this.assignPublicIp = builder.isAssignPublicIp();
         this.placementStrategyType = builder.getPlacementStrategyType();
         this.placementStrategyField = builder.getPlacementStrategyField();
+        this.taskCpu = builder.getTaskCpu();
 
         // All PlacementStrategyFields must be used with a PlacementStrategyType.
         // But some PlacementStrategyTypes can be used without any PlacementStrategyFields.
@@ -57,6 +58,7 @@ public class EcsClientConfig
         // - container_cpu (optional)
         // - placementStrategyType (optional)
         // - placementStrategyField (optional)
+        // - task_cpu
         final Config ecsConfig = taskConfig.getNested(TASK_CONFIG_ECS_KEY).deepCopy();
         if (!clusterName.isPresent()) {
             // Throw ConfigException if 'name' doesn't exist in system ecsConfig.
@@ -110,6 +112,7 @@ public class EcsClientConfig
                 .withAssignPublicIp(ecsConfig.get("assign_public_ip", boolean.class, true))
                 .withPlacementStrategyType(ecsConfig.getOptional("placement_strategy_type", String.class))
                 .withPlacementStrategyField(ecsConfig.getOptional("placement_strategy_field", String.class))
+                .withTaskCpu(ecsConfig.getOptional("task_cpu", String.class))
                 .build();
     }
 
@@ -132,6 +135,7 @@ public class EcsClientConfig
     // E.g. For the `binpack` placement strategy, valid values are `cpu` and `memory`.
     // https://github.com/aws/aws-sdk-java/blob/1.11.686/aws-java-sdk-ecs/src/main/java/com/amazonaws/services/ecs/model/PlacementStrategy.java#L44-L52
     private final Optional<String> placementStrategyField;
+    private final Optional<String> taskCpu;
 
     public String getClusterName()
     {
@@ -195,5 +199,10 @@ public class EcsClientConfig
     public Optional<String> getPlacementStrategyField()
     {
         return placementStrategyField;
+    }
+
+    public Optional<String> getTaskCpu()
+    {
+        return taskCpu;
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
@@ -16,7 +16,7 @@ public class EcsClientConfigBuilder
     private Optional<List<String>> subnets;
     private Optional<String> launchType;
     private Optional<String> capacityProviderName;
-    private Optional<Integer> cpu;
+    private Optional<Integer> containerCpu;
     private Optional<Integer> memory;
     private Optional<String> startedBy;
     private Optional<String> placementStrategyType;
@@ -80,9 +80,9 @@ public class EcsClientConfigBuilder
         return this;
     }
 
-    public EcsClientConfigBuilder withCpu(Optional<Integer> cpu)
+    public EcsClientConfigBuilder withContainerCpu(Optional<Integer> containerCpu)
     {
-        this.cpu = cpu;
+        this.containerCpu = containerCpu;
         return this;
     }
 
@@ -156,9 +156,9 @@ public class EcsClientConfigBuilder
         return capacityProviderName;
     }
 
-    public Optional<Integer> getCpu()
+    public Optional<Integer> getContainerCpu()
     {
-        return cpu;
+        return containerCpu;
     }
 
     public Optional<Integer> getMemory()

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
@@ -17,7 +17,7 @@ public class EcsClientConfigBuilder
     private Optional<String> launchType;
     private Optional<String> capacityProviderName;
     private Optional<Integer> containerCpu;
-    private Optional<Integer> memory;
+    private Optional<Integer> containerMemory;
     private Optional<String> startedBy;
     private Optional<String> placementStrategyType;
     private Optional<String> placementStrategyField;
@@ -86,9 +86,9 @@ public class EcsClientConfigBuilder
         return this;
     }
 
-    public EcsClientConfigBuilder withMemory(Optional<Integer> memory)
+    public EcsClientConfigBuilder withContainerMemory(Optional<Integer> containerMemory)
     {
-        this.memory = memory;
+        this.containerMemory = containerMemory;
         return this;
     }
 
@@ -161,9 +161,9 @@ public class EcsClientConfigBuilder
         return containerCpu;
     }
 
-    public Optional<Integer> getMemory()
+    public Optional<Integer> getContainerMemory()
     {
-        return memory;
+        return containerMemory;
     }
 
     public Optional<String> getStartedBy()

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
@@ -19,6 +19,7 @@ public class EcsClientConfigBuilder
     private Optional<Integer> containerCpu;
     private Optional<Integer> containerMemory;
     private Optional<String> taskCpu;
+    private Optional<String> taskMemory;
     private Optional<String> startedBy;
     private Optional<String> placementStrategyType;
     private Optional<String> placementStrategyField;
@@ -123,6 +124,12 @@ public class EcsClientConfigBuilder
         return this;
     }
 
+    public EcsClientConfigBuilder withTaskMemory(Optional<String> taskMemory)
+    {
+        this.taskMemory = taskMemory;
+        return this;
+    }
+
     public String getClusterName()
     {
         return clusterName;
@@ -196,5 +203,10 @@ public class EcsClientConfigBuilder
     public Optional<String> getTaskCpu()
     {
         return taskCpu;
+    }
+
+    public Optional<String> getTaskMemory()
+    {
+        return taskMemory;
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
@@ -18,6 +18,7 @@ public class EcsClientConfigBuilder
     private Optional<String> capacityProviderName;
     private Optional<Integer> containerCpu;
     private Optional<Integer> containerMemory;
+    private Optional<String> taskCpu;
     private Optional<String> startedBy;
     private Optional<String> placementStrategyType;
     private Optional<String> placementStrategyField;
@@ -116,6 +117,12 @@ public class EcsClientConfigBuilder
         return this;
     }
 
+    public EcsClientConfigBuilder withTaskCpu(Optional<String> taskCpu)
+    {
+        this.taskCpu = taskCpu;
+        return this;
+    }
+
     public String getClusterName()
     {
         return clusterName;
@@ -184,5 +191,10 @@ public class EcsClientConfigBuilder
     public Optional<String> getPlacementStrategyField()
     {
         return placementStrategyField;
+    }
+
+    public Optional<String> getTaskCpu()
+    {
+        return taskCpu;
     }
 }

--- a/digdag-tests/src/test/java/acceptance/DockerIT.java
+++ b/digdag-tests/src/test/java/acceptance/DockerIT.java
@@ -184,7 +184,7 @@ public class DockerIT
         // Wait for the attempt to complete
         {
             RestSessionAttempt attempt = null;
-            for (int i = 0; i < 30; i++) {
+            for (int i = 0; i < 60; i++) {
                 attempt = client.getSessionAttempt(attemptId);
                 if (attempt.getDone()) {
                     break;


### PR DESCRIPTION
# What does this PR change?
1. This PR supports `task_cpu` and `task_memory` override.
1. This PR renames the existing `cpu` and `memory` to `container_cpu` and `container_memory` respectively.

# Background
AWS ECS supports two resource limitation levels
1. Container CPU/Memory
1. Task CPU/Memory

The existing `cpu` and `memory` field in `EcsClientConfig` are used to specify Container CPU/Memory. But we need to specify Task CPU/Memory as well for each task.