### PR TITLE
Enable to specify system config prefix

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
@@ -50,8 +50,9 @@ public class EcsClientConfig
         final String name;
         // `taskConfig` is assumed to have a nested taskConfig with following values
         // at the key of `TASK_CONFIG_ECS_KEY` from `taskConfig`.
-        // - launch_type (optional/String)
         // - region (String)
+        // - system_config_prefix (optional/String)
+        // - launch_type (optional/String)
         // - subnets (optional/String)
         // - max_retries (optional/int)
         // - capacity_provider_name (optional/String)
@@ -72,9 +73,17 @@ public class EcsClientConfig
             name = clusterName.get();
         }
 
+        String systemConfigPrefix;
+        if (ecsConfig.has("system_config_prefix")) {
+            systemConfigPrefix = ecsConfig.get("system_config_prefix", String.class);
+        }
+        else {
+            systemConfigPrefix = SYSTEM_CONFIG_PREFIX + name + ".";
+        }
+
         // This method assumes that `access_key_id` and `secret_access_key` are stored at `systemConfig`.
-        ecsConfig.set("access_key_id", systemConfig.get(SYSTEM_CONFIG_PREFIX + name + ".access_key_id", String.class));
-        ecsConfig.set("secret_access_key", systemConfig.get(SYSTEM_CONFIG_PREFIX + name + ".secret_access_key", String.class));
+        ecsConfig.set("access_key_id", systemConfig.get(systemConfigPrefix + "access_key_id", String.class));
+        ecsConfig.set("secret_access_key", systemConfig.get(systemConfigPrefix + "secret_access_key", String.class));
 
         return buildEcsClientConfig(name, ecsConfig);
     }

--- a/digdag-standards/src/test/java/io/digdag/standards/command/ecs/EcsClientConfigTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/command/ecs/EcsClientConfigTest.java
@@ -1,0 +1,110 @@
+package io.digdag.standards.command.ecs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Optional;
+import io.digdag.client.DigdagClient;
+import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigException;
+import io.digdag.client.config.ConfigFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class EcsClientConfigTest
+{
+    private ObjectMapper om = DigdagClient.objectMapper();
+    private final ConfigFactory cf = new ConfigFactory(om);
+    private Config systemConfig;
+
+    @Before
+    public void setUp()
+    {
+        systemConfig = cf.create()
+                .set("agent.command_executor.ecs.cluster01.access_key_id", "default_access_key")
+                .set("agent.command_executor.ecs.cluster01.secret_access_key", "default_secret_access_key")
+                .set("custom_ecs_config.access_key_id", "custom_access_key")
+                .set("custom_ecs_config.secret_access_key", "custom_secret_access_key");
+    }
+
+    @Test
+    public void testCreateFromTaskConfigWithoutSystemConfigPrefix()
+    {
+        final Config taskConfig = cf.create()
+                .set("agent.command_executor.ecs",
+                        cf.create()
+                                .set("region", "us-east-1")
+                                .set("cluster_name", "cluster01"));
+
+        final EcsClientConfig ecsConfig = EcsClientConfig.createFromTaskConfig(Optional.absent(), taskConfig, systemConfig);
+        assertEquals("default_access_key", ecsConfig.getAccessKeyId());
+        assertEquals("default_secret_access_key", ecsConfig.getSecretAccessKey());
+    }
+
+    @Test
+    public void testCreateFromTaskConfigWithSystemConfigPrefix()
+    {
+        final Config taskConfig = cf.create()
+                .set("agent.command_executor.ecs",
+                        cf.create()
+                                .set("region", "us-east-1")
+                                .set("cluster_name", "cluster01")
+                                .set("system_config_prefix", "custom_ecs_config."));
+
+        final EcsClientConfig ecsConfig = EcsClientConfig.createFromTaskConfig(Optional.absent(), taskConfig, systemConfig);
+        assertEquals("custom_access_key", ecsConfig.getAccessKeyId());
+        assertEquals("custom_secret_access_key", ecsConfig.getSecretAccessKey());
+    }
+
+    @Test
+    public void testCreateFromTaskConfigWithValidPlacementStrategy()
+    {
+        final Config taskConfig = cf.create()
+                .set("agent.command_executor.ecs",
+                        cf.create()
+                                .set("region", "us-east-1")
+                                .set("cluster_name", "cluster01")
+                                .set("placement_strategy_type", "random"));
+
+        final EcsClientConfig ecsConfig = EcsClientConfig.createFromTaskConfig(Optional.absent(), taskConfig, systemConfig);
+        assertEquals("random", ecsConfig.getPlacementStrategyType().get());
+    }
+
+    @Test
+    public void testCreateFromTaskConfigWithValidPlacementStrategyAndType()
+    {
+        final Config taskConfig = cf.create()
+                .set("agent.command_executor.ecs",
+                        cf.create()
+                                .set("region", "us-east-1")
+                                .set("cluster_name", "cluster01")
+                                .set("placement_strategy_type", Optional.of("binpack"))
+                                .set("placement_strategy_field", Optional.of("memory")));
+
+        final EcsClientConfig ecsConfig = EcsClientConfig.createFromTaskConfig(Optional.absent(), taskConfig, systemConfig);
+        assertEquals("binpack", ecsConfig.getPlacementStrategyType().get());
+        assertEquals("memory", ecsConfig.getPlacementStrategyField().get());
+    }
+
+    @Test
+    public void testCreateFromTaskConfigWithValidPlacementStrategyTypeOnly()
+    {
+        final Config taskConfig = cf.create()
+                .set("agent.command_executor.ecs",
+                        cf.create()
+                                .set("region", "us-east-1")
+                                .set("cluster_name", "cluster01")
+                                .set("placement_strategy_field", Optional.of("memory")));
+
+        try {
+            EcsClientConfig.createFromTaskConfig(Optional.absent(), taskConfig, systemConfig);
+            fail("ConfigException was expected");
+        }
+        catch (Exception e) {
+            assertTrue(e instanceof ConfigException);
+            assertEquals("PlacementStrategyField must be set with PlacementStrategyType", e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
# What does this PR change?
Support `system_config_prefix` option for `EcsClientConfig` so that users can customize the prefix of ecs config.

# Background

Currently, `access_key_id` and `secret_access_key` are expected to be stored into `systemConfig` with the following keys respectively.

- `agent.command_executor.ecs.#{cluster_name}.access_key_id`
- `agent.command_executor.ecs.#{cluster_name}.secret_access_key`

But in some use cases (e.g. using multiple clusters), we need to specify `access_key_id` and `secret_access_key` with static keys as follows;

- `custom_prefix.access_key_id`
- `custom_prefix.secret_access_key`
