### PR TITLE
Enable to fall back to default configuration to support the common configuration for multiple ECS cluster

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
@@ -58,8 +58,10 @@ public class EcsClientConfig
         // - capacity_provider_name (optional/String)
         // - container_memory (optional/Integer)
         // - container_cpu (optional/Integer)
-        // - placementStrategyType (optional/String)
-        // - placementStrategyField (optional/String)
+        // - placement_strategy_type(optional/String)
+        // - placement_strategy_field (optional/String)
+        // - assign_public_ip (optional/boolean)
+        // - started_by (optional/String)
         // - task_cpu (optional/String) e.g. `1 vcpu` or `1024` (CPU unit)
         // - task_memory (optional/String) e.g. `1 GB` or `1024` (MiB)
         // For more detail of the value format of `task_cpu` and `task_memory`, please see

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
@@ -10,7 +10,7 @@ import java.util.List;
 public class EcsClientConfig
 {
     private static final String SYSTEM_CONFIG_PREFIX = "agent.command_executor.ecs.";
-    private static final String SYSTEM_CONFIG_DEFAULT_PREFIX = "agent.command_executor.ecs.__default_config__.";
+    private static final String SYSTEM_CONFIG_DEFAULT_PREFIX = SYSTEM_CONFIG_PREFIX + "__default_config__.";
     public static final String TASK_CONFIG_ECS_KEY = "agent.command_executor.ecs";
     private static final int DEFAULT_MAX_RETRIES = 3;
 

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
@@ -118,7 +118,7 @@ public class EcsClientConfig
                 .withCapacityProviderName(ecsConfig.getOptional("capacity_provider_name", String.class))
                 .withContainerCpu(ecsConfig.getOptional("container_cpu", Integer.class))
                 .withContainerMemory(ecsConfig.getOptional("container_memory", Integer.class))
-                .withStartedBy(ecsConfig.getOptional("startedBy", String.class))
+                .withStartedBy(ecsConfig.getOptional("started_by", String.class))
                 // TODO removing default value.
                 // This value was previously hard coded.
                 // To keep consistency I once set the default value. But it should be removed after migration.

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
@@ -10,6 +10,7 @@ import java.util.List;
 public class EcsClientConfig
 {
     private static final String SYSTEM_CONFIG_PREFIX = "agent.command_executor.ecs.";
+    private static final String SYSTEM_CONFIG_DEFAULT_PREFIX = "agent.command_executor.ecs.__default_config__.";
     public static final String TASK_CONFIG_ECS_KEY = "agent.command_executor.ecs";
     private static final int DEFAULT_MAX_RETRIES = 3;
 
@@ -73,8 +74,16 @@ public class EcsClientConfig
         }
 
         // This method assumes that `access_key_id` and `secret_access_key` are stored at `systemConfig`.
-        ecsConfig.set("access_key_id", systemConfig.get(SYSTEM_CONFIG_PREFIX + name + ".access_key_id", String.class));
-        ecsConfig.set("secret_access_key", systemConfig.get(SYSTEM_CONFIG_PREFIX + name + ".secret_access_key", String.class));
+        // If the `systemConfig` has cluster specific configuration items, they will be fetched.
+        // If not, the default configuration items will be done.
+        if (systemConfig.has(SYSTEM_CONFIG_PREFIX + name + ".access_key_id")) {
+            ecsConfig.set("access_key_id", systemConfig.get(SYSTEM_CONFIG_PREFIX + name + ".access_key_id", String.class));
+            ecsConfig.set("secret_access_key", systemConfig.get(SYSTEM_CONFIG_PREFIX + name + ".secret_access_key", String.class));
+        }
+        else {
+            ecsConfig.set("access_key_id", systemConfig.get(SYSTEM_CONFIG_DEFAULT_PREFIX + "access_key_id", String.class));
+            ecsConfig.set("secret_access_key", systemConfig.get(SYSTEM_CONFIG_DEFAULT_PREFIX + "secret_access_key", String.class));
+        }
 
         return buildEcsClientConfig(name, ecsConfig);
     }

--- a/digdag-standards/src/test/java/io/digdag/standards/command/ecs/EcsClientConfigTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/command/ecs/EcsClientConfigTest.java
@@ -1,0 +1,111 @@
+package io.digdag.standards.command.ecs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Optional;
+import io.digdag.client.DigdagClient;
+import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigException;
+import io.digdag.client.config.ConfigFactory;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+public class EcsClientConfigTest
+{
+    private ObjectMapper om = DigdagClient.objectMapper();
+    private final ConfigFactory cf = new ConfigFactory(om);
+    private Config systemConfig;
+
+    @Before
+    public void setUp()
+    {
+        systemConfig = cf.create()
+                .set("agent.command_executor.ecs.cluster01.access_key_id", "cluster_specific_access_key")
+                .set("agent.command_executor.ecs.cluster01.secret_access_key", "cluster_specific_secret_access_key")
+                .set("agent.command_executor.ecs.__default_config__.access_key_id", "default_custom_access_key")
+                .set("agent.command_executor.ecs.__default_config__.secret_access_key", "default_custom_secret_access_key");
+    }
+
+    @Test
+    public void testCreateFromTaskConfigWithValidPlacementWithClusterSpecificConfig()
+    {
+        final Config taskConfig = cf.create()
+                .set("agent.command_executor.ecs",
+                        cf.create()
+                                .set("region", "us-east-1")
+                                .set("cluster_name", "cluster01")
+                                .set("placement_strategy_type", "random"));
+
+        final EcsClientConfig ecsConfig = EcsClientConfig.createFromTaskConfig(Optional.absent(), taskConfig, systemConfig);
+        assertEquals("cluster_specific_access_key", ecsConfig.getAccessKeyId());
+        assertEquals("cluster_specific_secret_access_key", ecsConfig.getSecretAccessKey());
+    }
+
+    @Test
+    public void testCreateFromTaskConfigWithValidPlacementWithDefaultClusterSpecificConfig()
+    {
+        final Config taskConfig = cf.create()
+                .set("agent.command_executor.ecs",
+                        cf.create()
+                                .set("region", "us-east-1")
+                                .set("cluster_name", "unknown_cluster_name")
+                                .set("placement_strategy_type", "random"));
+
+        final EcsClientConfig ecsConfig = EcsClientConfig.createFromTaskConfig(Optional.absent(), taskConfig, systemConfig);
+        assertEquals("default_custom_access_key", ecsConfig.getAccessKeyId());
+        assertEquals("default_custom_secret_access_key", ecsConfig.getSecretAccessKey());
+    }
+
+    @Test
+    public void testCreateFromTaskConfigWithValidPlacementStrategy()
+    {
+        final Config taskConfig = cf.create()
+                .set("agent.command_executor.ecs",
+                        cf.create()
+                                .set("region", "us-east-1")
+                                .set("cluster_name", "cluster01")
+                                .set("placement_strategy_type", "random"));
+
+        final EcsClientConfig ecsConfig = EcsClientConfig.createFromTaskConfig(Optional.absent(), taskConfig, systemConfig);
+        assertEquals("random", ecsConfig.getPlacementStrategyType().get());
+    }
+
+    @Test
+    public void testCreateFromTaskConfigWithValidPlacementStrategyAndType()
+    {
+        final Config taskConfig = cf.create()
+                .set("agent.command_executor.ecs",
+                        cf.create()
+                                .set("region", "us-east-1")
+                                .set("cluster_name", "cluster01")
+                                .set("placement_strategy_type", Optional.of("binpack"))
+                                .set("placement_strategy_field", Optional.of("memory")));
+
+        final EcsClientConfig ecsConfig = EcsClientConfig.createFromTaskConfig(Optional.absent(), taskConfig, systemConfig);
+        assertEquals("binpack", ecsConfig.getPlacementStrategyType().get());
+        assertEquals("memory", ecsConfig.getPlacementStrategyField().get());
+    }
+
+    @Test
+    public void testCreateFromTaskConfigWithValidPlacementStrategyTypeOnly()
+    {
+        final Config taskConfig = cf.create()
+                .set("agent.command_executor.ecs",
+                        cf.create()
+                                .set("region", "us-east-1")
+                                .set("cluster_name", "cluster01")
+                                .set("placement_strategy_field", Optional.of("memory")));
+
+        try {
+            EcsClientConfig.createFromTaskConfig(Optional.absent(), taskConfig, systemConfig);
+            fail("ConfigException was expected");
+        }
+        catch (Exception e) {
+            assertTrue(e instanceof ConfigException);
+            assertEquals("PlacementStrategyField must be set with PlacementStrategyType", e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
# What does this PR change?
Support falling back to the default configuration prefix for `EcsClientConfig` so that users can use the common configuration items for several ECS cluster names.

# Background

Currently, `access_key_id` and `secret_access_key` are expected to be stored into `systemConfig` with the following keys respectively.

- `agent.command_executor.ecs.#{cluster_name}.access_key_id`
- `agent.command_executor.ecs.#{cluster_name}.secret_access_key`

But in some use cases (e.g. using multiple clusters), we need to specify same `access_key_id` and `secret_access_key` for multiple ECS cluster names.

This PR enables it by falling back to default prefix if specified `cluster_name` does not match to those on `systemConfig`.

e.g. When there are the following keys in `systemConfig` and digdag  user specifies `cluster2` as a cluster name,

- `agent.command_executor.ecs.cluster1.access_key_id`
- `agent.command_executor.ecs.cluster1.secret_access_key`

the following items will be fetched instead.

- `agent.command_executor.ecs.__default_config__.access_key_id`
- `agent.command_executor.ecs.__default_config__.secret_access_key`
