### PR TITLE
Improve the error handling of invalid `sla` definition in SessionMonitorExecutor

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/session/SessionMonitorExecutor.java
+++ b/digdag-core/src/main/java/io/digdag/core/session/SessionMonitorExecutor.java
@@ -9,9 +9,11 @@ import javax.annotation.PreDestroy;
 import com.google.inject.Inject;
 import com.google.common.base.*;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
+import io.digdag.client.config.ConfigException;
 import io.digdag.core.Limits;
 import io.digdag.core.database.TransactionManager;
 import io.digdag.core.log.LogMarkers;
+import io.digdag.core.repository.ModelValidationException;
 import io.digdag.spi.metrics.DigdagMetrics;
 import static io.digdag.spi.metrics.DigdagMetrics.Category;
 import org.slf4j.Logger;
@@ -99,6 +101,10 @@ public class SessionMonitorExecutor
                 });
                 return null;
             });
+        }
+        catch (ModelValidationException | ConfigException e) {
+            logger.error(
+                    "Failed to schedule a session monitor task. This will be retried.", e);
         }
         catch (Throwable t) {
             logger.error(

--- a/digdag-core/src/test/java/io/digdag/core/session/SessionMonitorExecutorTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/session/SessionMonitorExecutorTest.java
@@ -1,0 +1,88 @@
+package io.digdag.core.session;
+
+import com.google.inject.Guice;
+import io.digdag.client.config.ConfigException;
+import io.digdag.client.config.ConfigFactory;
+import io.digdag.core.ErrorReporter;
+import io.digdag.core.Limits;
+import io.digdag.core.database.TransactionManager;
+import io.digdag.core.repository.ModelValidationException;
+import io.digdag.core.workflow.WorkflowExecutor;
+import io.digdag.spi.metrics.DigdagMetrics;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SessionMonitorExecutorTest
+{
+    @Mock
+    ConfigFactory configFactory;
+    @Mock
+    SessionStoreManager sessionStoreManager;
+    @Mock
+    TransactionManager transactionManager;
+    @Mock
+    WorkflowExecutor workflowExecutor;
+    @Mock
+    Limits limits;
+    @Mock
+    ErrorReporter errorReporter;
+    @Mock
+    DigdagMetrics digdagMetrics;
+
+    private SessionMonitorExecutor sessionMonitorExecutor;
+
+    @Before
+    public void setUp()
+    {
+        sessionMonitorExecutor = spy(Guice.createInjector(binder -> {
+            binder.bind(ConfigFactory.class).toInstance(configFactory);
+            binder.bind(SessionStoreManager.class).toInstance(sessionStoreManager);
+            binder.bind(TransactionManager.class).toInstance(transactionManager);
+            binder.bind(WorkflowExecutor.class).toInstance(workflowExecutor);
+            binder.bind(Limits.class).toInstance(limits);
+            binder.bind(ErrorReporter.class).toInstance(errorReporter);
+            binder.bind(DigdagMetrics.class).toInstance(digdagMetrics);
+        }).getInstance(SessionMonitorExecutor.class));
+
+    }
+
+    @Test
+    public void handleUnexpectedExceptionInRun()
+    {
+        doThrow(RuntimeException.class).when(transactionManager).begin(any());
+
+        sessionMonitorExecutor.run();
+
+        verify(errorReporter, times(1)).reportUncaughtError(any(RuntimeException.class));
+    }
+
+    @Test
+    public void handleConfigExceptionInRun()
+    {
+        doThrow(ConfigException.class).when(transactionManager).begin(any());
+
+        sessionMonitorExecutor.run();
+
+        verify(errorReporter, times(0)).reportUncaughtError(any(RuntimeException.class));
+    }
+
+    @Test
+    public void handleModelValidationExceptionInRun()
+    {
+        doThrow(ModelValidationException.class).when(transactionManager).begin(any());
+
+        sessionMonitorExecutor.run();
+
+        verify(errorReporter, times(0)).reportUncaughtError(any(RuntimeException.class));
+    }
+}


### PR DESCRIPTION
Digdag basically validates a workflow when it's pushed, but there is lack of validation to dynamically generated tasks by `sla`.

So Digdag users can push invalid workflow like this (`+mail>:` is invalid)
```
sla:
  duration: 01:00:00
  alert: true
  +notice:
    +mail>:
      data: FOO BAR
```
and it'll finally be handled as an unexpected system error here https://github.com/treasure-data/digdag/blob/v0_10/digdag-core/src/main/java/io/digdag/core/session/SessionMonitorExecutor.java#L104-L108.

Current implementation causes 2 problems.

1. When an invalid `sla` definition is evaluated, the deterministic exception is repeatedly thrown and the session monitor is retried until the attempt finishes and other session monitors aren't evaluated for a while. It means an invalid `sla` causes the delay of other workflows `sla`.

2. Invalid `sla` definition shouldn't be handled as unexpected system error. Digdag has some extension points like `io.digdag.core.ErrorReporter` and `io.digdag.spi.metrics.DigdagMetrics` and they may be integrated with alerting and monitoring systems in production environment. Current implementation of the error handling could cause confusing alerts and/or metrics.

This PR addresses the 2 problems.
