### PR TITLE
Add v0_11 as the target of CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,6 +77,7 @@ workflows:
               only:
                 - master
                 - v0_10
+                - v0_11
       - docs_deployment: # master branch only
           filters:
             branches:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,12 @@ on:
     branches:
     - master
     - v0_10
+    - v0_11
   pull_request:
     branches:
     - master
     - v0_10
+    - v0_11
 
 jobs:
   build:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ref: [ v0_10 ]
+        ref: [ v0_10, v0_11 ]
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
We are moving our release branch (a.k.a v0.11.0) to `v0_11` branch.
Add `v0_11` as target of CIs.
We will remove `v0_10` after override of master with `v0_10`. 