### PR TITLE
Set target_session_id and target_attempt_id when require op is called

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/agent/RequireOperatorFactory.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/RequireOperatorFactory.java
@@ -153,7 +153,9 @@ public class RequireOperatorFactory
             }
             else {
                 // Wait for finish running attempt
-                throw nextPolling(lastStateParams.deepCopy());
+                throw nextPolling(lastStateParams.deepCopy()
+                        .set("target_session_id", attempt.getSessionId())
+                        .set("target_attempt_id", attempt.getId()));
             }
         }
 

--- a/digdag-core/src/main/java/io/digdag/core/agent/RequireOperatorFactory.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/RequireOperatorFactory.java
@@ -106,7 +106,7 @@ public class RequireOperatorFactory
             try {
                 projectIdentifier = Optional.of(makeProjectIdentifier());
 
-                callback.startSession(
+                StoredSessionAttempt kickedAttempt = callback.startSession(
                         context,
                         request.getSiteId(),
                         projectIdentifier.get(),
@@ -114,7 +114,10 @@ public class RequireOperatorFactory
                         instant,
                         retryAttemptName,
                         overrideParams);
-                throw nextPolling(request.getLastStateParams().deepCopy().set("require_kicked", true));
+                throw nextPolling(request.getLastStateParams().deepCopy()
+                        .set("require_kicked", true)
+                        .set("target_session_id", kickedAttempt.getSessionId())
+                        .set("target_attempt_id", kickedAttempt.getId()));
             }
             catch (SessionAttemptConflictException ex) {
                 return processAttempt(ex.getConflictedSession(), lastStateParams, rerunOn, ignoreFailure);

--- a/digdag-tests/src/test/java/acceptance/RequireIT.java
+++ b/digdag-tests/src/test/java/acceptance/RequireIT.java
@@ -451,7 +451,7 @@ public class RequireIT
     }
 
     @Test
-    public void testRequireHasTargetSessionIdEvenWhenJustWaiting()
+    public void testRequireHasTargetSessionIdEvenWhenChildIsNotKicked()
             throws Exception
     {
         // Create new project

--- a/digdag-tests/src/test/java/acceptance/RequireIT.java
+++ b/digdag-tests/src/test/java/acceptance/RequireIT.java
@@ -103,7 +103,7 @@ public class RequireIT
 
         // Wait for the attempt to complete
         boolean success = false;
-        for (int i = 0; i < 30; i++) {
+        for (int i = 0; i < 60; i++) {
             CommandStatus attemptsStatus = main("attempts",
                     "-c", config.toString(),
                     "-e", server.endpoint(),
@@ -503,7 +503,7 @@ public class RequireIT
 
         // Wait for the attempt to complete
         boolean success = false;
-        for (int i = 0; i < 30; i++) {
+        for (int i = 0; i < 60; i++) {
             CommandStatus attemptsStatus = main("attempts",
                     "-c", config.toString(),
                     "-e", server.endpoint(),

--- a/digdag-tests/src/test/java/acceptance/RequireIT.java
+++ b/digdag-tests/src/test/java/acceptance/RequireIT.java
@@ -3,6 +3,7 @@ package acceptance;
 import io.digdag.client.DigdagClient;
 import io.digdag.client.api.Id;
 import io.digdag.client.api.RestSessionAttemptCollection;
+import io.digdag.client.config.Config;
 
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Resources;
@@ -30,6 +31,8 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.fail;
 import static utils.TestUtils.copyResource;
 import static utils.TestUtils.getAttemptId;
+import static utils.TestUtils.getSessionId;
+import static utils.TestUtils.getStateParams;
 import static utils.TestUtils.main;
 
 import static org.hamcrest.Matchers.containsString;
@@ -115,6 +118,27 @@ public class RequireIT
 
         // Verify that the file created by the child workflow is there
         assertThat(Files.exists(childOutFile), is(true));
+
+        CommandStatus attemptTasks = main("tasks",
+                "-c", config.toString(),
+                "-e", server.endpoint(),
+                String.valueOf(attemptId));
+
+        List<Config> stateParams = getStateParams(attemptTasks);
+
+        // It has 2 tasks, +parent and +parent+require.
+        assertThat(stateParams.size(), is(2));
+        Config requireOperatorStateParams = stateParams.get(1);
+
+        Id targetAttemptId = requireOperatorStateParams.get("target_attempt_id", Id.class);
+        CommandStatus targetAttemptStatus = main("attempts",
+                "-c", config.toString(),
+                "-e", server.endpoint(),
+                String.valueOf(targetAttemptId));
+
+        assertThat(targetAttemptStatus.outUtf8().contains("workflow: child"), is(true));
+        assertThat(targetAttemptStatus.outUtf8().contains("status: success"), is(true));
+        assertThat(getSessionId(targetAttemptStatus), is(requireOperatorStateParams.get("target_session_id", Id.class)));
     }
 
     @Test
@@ -424,5 +448,86 @@ public class RequireIT
                     .replace("__FILE__", childOutFile.toString());
             Files.write(projectDir.resolve("child.dig"), child.getBytes("UTF-8"));
         }
+    }
+
+    @Test
+    public void testRequireHasTargetSessionIdEvenWhenJustWaiting()
+            throws Exception
+    {
+        // Create new project
+        CommandStatus initStatus = main("init",
+                "-c", config.toString(),
+                projectDir.toString());
+        assertThat(initStatus.errUtf8(), initStatus.code(), is(0));
+
+        Path childOutFile = projectDir.resolve("child.out").toAbsolutePath().normalize();
+        prepareForChildWF(childOutFile);
+        copyResource("acceptance/require/parent.dig", projectDir.resolve("parent.dig"));
+
+        // Push the project
+        CommandStatus pushStatus = main("push",
+                "--project", projectDir.toString(),
+                "require",
+                "-c", config.toString(),
+                "-e", server.endpoint(),
+                "-r", "4711");
+        assertThat(pushStatus.errUtf8(), pushStatus.code(), is(0));
+
+        // Start the child workflow first.
+        String session = "2016-01-01";
+
+        Id targetAttemptId;
+        Id targetSessionId;
+        {
+            CommandStatus startStatus = main("start",
+                    "-c", config.toString(),
+                    "-e", server.endpoint(),
+                    "require", "child",
+                    "--session", session);
+            assertThat(startStatus.code(), is(0));
+            targetAttemptId = getAttemptId(startStatus);
+            targetSessionId = getSessionId(startStatus);
+        }
+
+        // Start the workflow
+        Id attemptId;
+        {
+            CommandStatus startStatus = main("start",
+                    "-c", config.toString(),
+                    "-e", server.endpoint(),
+                    "require", "parent",
+                    "--session", session);
+            assertThat(startStatus.code(), is(0));
+            attemptId = getAttemptId(startStatus);
+        }
+
+        // Wait for the attempt to complete
+        boolean success = false;
+        for (int i = 0; i < 30; i++) {
+            CommandStatus attemptsStatus = main("attempts",
+                    "-c", config.toString(),
+                    "-e", server.endpoint(),
+                    String.valueOf(attemptId));
+            success = attemptsStatus.outUtf8().contains("status: success");
+            if (success) {
+                break;
+            }
+            Thread.sleep(1000);
+        }
+        assertThat(success, is(true));
+
+        CommandStatus attemptTasks = main("tasks",
+                "-c", config.toString(),
+                "-e", server.endpoint(),
+                String.valueOf(attemptId));
+
+        List<Config> stateParams = getStateParams(attemptTasks);
+
+        // It has 2 tasks, +parent and +parent+require.
+        assertThat(stateParams.size(), is(2));
+        Config requireOperatorStateParams = stateParams.get(1);
+
+        assertThat(requireOperatorStateParams.get("target_attempt_id", Id.class), is(targetAttemptId));
+        assertThat(requireOperatorStateParams.get("target_session_id", Id.class), is(targetSessionId));
     }
 }

--- a/digdag-tests/src/test/java/acceptance/RequireIT.java
+++ b/digdag-tests/src/test/java/acceptance/RequireIT.java
@@ -122,7 +122,7 @@ public class RequireIT
         CommandStatus attemptTasks = main("tasks",
                 "-c", config.toString(),
                 "-e", server.endpoint(),
-                String.valueOf(attemptId));
+                attemptId.toString());
 
         List<Config> stateParams = getStateParams(attemptTasks);
 
@@ -134,7 +134,7 @@ public class RequireIT
         CommandStatus targetAttemptStatus = main("attempts",
                 "-c", config.toString(),
                 "-e", server.endpoint(),
-                String.valueOf(targetAttemptId));
+                targetAttemptId.toString());
 
         assertThat(targetAttemptStatus.outUtf8().contains("workflow: child"), is(true));
         assertThat(targetAttemptStatus.outUtf8().contains("status: success"), is(true));
@@ -507,7 +507,7 @@ public class RequireIT
             CommandStatus attemptsStatus = main("attempts",
                     "-c", config.toString(),
                     "-e", server.endpoint(),
-                    String.valueOf(attemptId));
+                    attemptId.toString());
             success = attemptsStatus.outUtf8().contains("status: success");
             if (success) {
                 break;
@@ -519,7 +519,7 @@ public class RequireIT
         CommandStatus attemptTasks = main("tasks",
                 "-c", config.toString(),
                 "-e", server.endpoint(),
-                String.valueOf(attemptId));
+                attemptId.toString());
 
         List<Config> stateParams = getStateParams(attemptTasks);
 

--- a/digdag-tests/src/test/java/utils/TestUtils.java
+++ b/digdag-tests/src/test/java/utils/TestUtils.java
@@ -24,6 +24,7 @@ import io.digdag.client.DigdagClient;
 import io.digdag.client.api.Id;
 import io.digdag.client.api.JacksonTimeModule;
 import io.digdag.client.api.RestLogFileHandle;
+import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigFactory;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
@@ -118,6 +119,8 @@ public class TestUtils
     public static final Pattern ATTEMPT_ID_PATTERN = Pattern.compile("\\s*attempt id:\\s*(\\d+)\\s*");
 
     public static final Pattern PROJECT_ID_PATTERN = Pattern.compile("\\s*id:\\s*(\\d+)\\s*");
+
+    public static final Pattern STATE_PARAMS_PATTERN = Pattern.compile("\\s*state params:\\s*(.*)\\s*");
 
     public static CommandStatus main(String... args)
     {
@@ -269,6 +272,20 @@ public class TestUtils
         Matcher matcher = PROJECT_ID_PATTERN.matcher(pushStatus.outUtf8());
         assertThat(matcher.find(), is(true));
         return Id.of(matcher.group(1));
+    }
+
+    public static List<Config> getStateParams(CommandStatus pushStatus)
+            throws IOException
+    {
+        Matcher matcher = STATE_PARAMS_PATTERN.matcher(pushStatus.outUtf8());
+        List<Config> l = new ArrayList<>();
+        while(matcher.find()) {
+            l.add(
+                Config.deserializeFromJackson(objectMapper(),
+                        objectMapper().readTree(matcher.group(1)))
+            );
+        }
+        return l;
     }
 
     public static String getAttemptLogs(DigdagClient client, Id attemptId)


### PR DESCRIPTION
I want to know which attempt and which session is required by a `require` operator to understand my attempt dependency. Currently, digdag doesn't have such information. What I can is guessing it by using time.

With this patch, two values, `target_session_id` and `target_attempt_id`, are stored to state param of `require` operator. Then I can use them to find the session and the attempt that were required.