### PR TITLE
v0_11 fix CI on release of snapshot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,3 +102,4 @@ workflows:
             branches:
               only:
                 - v0_10
+                - v0_11


### PR DESCRIPTION
To release snapshot when a PR has merged, fix CircleCI.