### PR TITLE
[V0_10] Disable snapshot release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,7 @@ workflows:
               only:
                 - master
                 - v0_10
+                - v0_11
       - docs_deployment: # master branch only
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,3 +102,4 @@ workflows:
             branches:
               only:
                 - v0_10
+                - v0_11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,5 +101,4 @@ workflows:
           filters:
             branches:
               only:
-                - v0_10
                 - v0_11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,12 @@ on:
     branches:
     - master
     - v0_10
+    - v0_11
   pull_request:
     branches:
     - master
     - v0_10
+    - v0_11
 
 jobs:
   build:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ref: [ v0_10 ]
+        ref: [ v0_10, v0_11 ]
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Disable snapshot release for `v0_10` branch. We has moved to `v0_11`.
Include commits for `v0_11` (d9fe89eb7fed03579f8e22ca1432624baacee72b , f8dda610e7a142a96b18719cc03f4b65813b352e)  