### PR TITLE
[V0_11] Disable snapshot release of v0_10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,5 +101,4 @@ workflows:
           filters:
             branches:
               only:
-                - v0_10
                 - v0_11


### PR DESCRIPTION
Cherry pick ce6247ea88228e25606183f56bfbfd368aef457e.
Align Circle CI configuration in both `v0_11` and `v0_10` (== future `master`).