### PR TITLE
Support adding tags on RunTaskRequest

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -565,6 +565,7 @@ public class EcsCommandExecutor
         setEcsTaskOverride(commandContext, commandRequest, td, runTaskRequest, clientConfig); // RuntimeException,ConfigException
         setEcsTaskLaunchType(clientConfig, runTaskRequest);
         setEcsTaskStartedBy(clientConfig, runTaskRequest);
+        setEcsTaskTags(clientConfig, runTaskRequest);
         setEcsNetworkConfiguration(clientConfig, runTaskRequest);
         setCapacityProviderStrategy(clientConfig, runTaskRequest);
         setPlacementStrategy(clientConfig, runTaskRequest);
@@ -789,6 +790,13 @@ public class EcsCommandExecutor
     {
         if (clientConfig.getStartedBy().isPresent()) {
             runTaskRequest.setStartedBy(clientConfig.getStartedBy().get());
+        }
+    }
+
+    protected void setEcsTaskTags(EcsClientConfig clientConfig, RunTaskRequest runTaskRequest)
+    {
+        if (clientConfig.getTags().isPresent()) {
+            runTaskRequest.setTags(clientConfig.getTags().get());
         }
     }
 

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
@@ -1,5 +1,6 @@
 package io.digdag.standards.command.ecs;
 
+import com.amazonaws.services.ecs.model.Tag;
 import com.google.common.base.Optional;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigException;
@@ -38,6 +39,7 @@ public class EcsClientConfig
         this.taskCpu = builder.getTaskCpu();
         this.taskMemory = builder.getTaskMemory();
         this.fargatePlatformVersion = builder.getFargatePlatformVersion();
+        this.tags = builder.getTags();
 
         // All PlacementStrategyFields must be used with a PlacementStrategyType.
         // But some PlacementStrategyTypes can be used without any PlacementStrategyFields.
@@ -131,6 +133,7 @@ public class EcsClientConfig
                 .withTaskCpu(ecsConfig.getOptional("task_cpu", String.class))
                 .withTaskMemory(ecsConfig.getOptional("task_memory", String.class))
                 .withFargatePlatformVersion(ecsConfig.getOptional("fargate_platform_version", String.class))
+                .withTags(ecsConfig.getOptionalNested("tags"))
                 .build();
     }
 
@@ -156,6 +159,7 @@ public class EcsClientConfig
     // https://github.com/aws/aws-sdk-java/blob/1.11.686/aws-java-sdk-ecs/src/main/java/com/amazonaws/services/ecs/model/PlacementStrategy.java#L44-L52
     private final Optional<String> placementStrategyField;
     private final Optional<String> fargatePlatformVersion;
+    private final Optional<List<Tag>> tags;
 
     public String getClusterName()
     {
@@ -234,5 +238,10 @@ public class EcsClientConfig
     public Optional<String> getFargatePlatformVersion()
     {
         return fargatePlatformVersion;
+    }
+
+    public Optional<List<Tag>> getTags()
+    {
+        return tags;
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
@@ -4,9 +4,9 @@ import com.amazonaws.services.ecs.model.Tag;
 import com.google.common.base.Optional;
 import io.digdag.client.config.Config;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class EcsClientConfigBuilder
 {
@@ -146,14 +146,10 @@ public class EcsClientConfigBuilder
     {
         if (tags.isPresent()) {
             final Config tagConfig = tags.get();
-            final List<Tag> tagList = new ArrayList<>();
-            for (String key : tagConfig.getKeys()) {
-                final Tag t = new Tag()
-                        .withKey(key)
-                        .withValue(tagConfig.get(key, String.class));
-                tagList.add(t);
-            }
-            this.tags = Optional.of(tagList);
+            this.tags = Optional.of(
+                    tagConfig.getKeys().stream()
+                            .map(key -> new Tag().withKey(key).withValue(tagConfig.get(key, String.class)))
+                            .collect(Collectors.toList()));
         }
         else {
             this.tags = Optional.absent();

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
@@ -1,7 +1,10 @@
 package io.digdag.standards.command.ecs;
 
+import com.amazonaws.services.ecs.model.Tag;
 import com.google.common.base.Optional;
+import io.digdag.client.config.Config;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -24,6 +27,7 @@ public class EcsClientConfigBuilder
     private Optional<String> placementStrategyType;
     private Optional<String> placementStrategyField;
     private Optional<String> fargatePlatformVersion;
+    private Optional<List<Tag>> tags;
 
     public EcsClientConfig build()
     {
@@ -138,6 +142,26 @@ public class EcsClientConfigBuilder
         return this;
     }
 
+    public EcsClientConfigBuilder withTags(Optional<Config> tags)
+    {
+        if (tags.isPresent()) {
+            final Config tagConfig = tags.get();
+            final List<Tag> tagList = new ArrayList<>();
+            for (String key : tagConfig.getKeys()) {
+                final Tag t = new Tag()
+                        .withKey(key)
+                        .withValue(tagConfig.get(key, String.class));
+                tagList.add(t);
+            }
+            this.tags = Optional.of(tagList);
+        }
+        else {
+            this.tags = Optional.absent();
+        }
+
+        return this;
+    }
+
     public String getClusterName()
     {
         return clusterName;
@@ -221,5 +245,10 @@ public class EcsClientConfigBuilder
     public Optional<String> getFargatePlatformVersion()
     {
         return fargatePlatformVersion;
+    }
+
+    public Optional<List<Tag>> getTags()
+    {
+        return tags;
     }
 }


### PR DESCRIPTION
# What does this PR change?
This PR enables users to specify `Tag` for `RunTaskRequest` on `EcsCommandExecutor`.

# Background
Amazon ECS supports `tag` for ecs tasks as arbitrary meta data of them. It is useful to manage/find ECS tasks on AWS console.

Expected use cases are
- Specifying project name
- Specifying notes