### PR TITLE
Fix documentation title.

### DIFF
--- a/digdag-docs/src/conf.py
+++ b/digdag-docs/src/conf.py
@@ -69,3 +69,5 @@ html_extra_path = ['_extra']
 html_context = {
   'extra_css_files': ['_static/custom.css']
 }
+
+html_title = 'Digdag v0.10.0-SNAPSHOT'


### PR DESCRIPTION
Currently documentation title is generated from a latest tag and it is wrong if we set tags for other purpose (backup and so on).
Current title is `... Digdag 0_10_before_merge_v0_9_38 documentation`
As a workaround, I set fixed title in `conf.py` .
It require additional work in the release, but the release does not happen so often.
