### PR TITLE
Support name filter at get workflows

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
@@ -594,7 +594,7 @@ public class DatabaseProjectStoreManager
                 // And the index is used for filter by `revision_id` and `name`.
                 // Since this query always limits the records by `revision_id` (the latest revision's one),
                 // partial matching of `name` (e.g. '%test%') can be accepted.
-                " and wd.name like :name" +
+                " and wd.name like :namePattern" +
                 " and <acFilter>" +
                 " order by wd.id" +
                 " limit :limit")
@@ -602,7 +602,7 @@ public class DatabaseProjectStoreManager
                 @Bind("siteId") int siteId,
                 @Bind("limit") int limit,
                 @Bind("lastId") long lastId,
-                @Bind("name") String name,
+                @Bind("namePattern") String namePattern,
                 @Define("acFilter") String acFilter);
     }
 
@@ -643,7 +643,7 @@ public class DatabaseProjectStoreManager
                     // And the index is used for filter by `revision_id` and `name`.
                     // Since this query always limits the records by `revision_id` (the latest revision's one),
                     // partial matching of `name` (e.g. '%test%') can be accepted.
-                    " and wf.name like :name" +
+                    " and wf.name like :namePattern" +
                     " and <acFilter>" +
                     " order by wf.id" +
                     " limit :limit" +
@@ -656,7 +656,7 @@ public class DatabaseProjectStoreManager
                 @Bind("siteId") int siteId,
                 @Bind("limit") int limit,
                 @Bind("lastId") long lastId,
-                @Bind("name") String name,
+                @Bind("namePattern") String namePattern,
                 @Define("acFilter") String acFilter);
     }
 
@@ -760,7 +760,7 @@ public class DatabaseProjectStoreManager
                 " limit 1")
         StoredWorkflowDefinitionWithProject getLatestWorkflowDefinitionByName(@Bind("siteId") int siteId, @Bind("projId") int projId, @Bind("name") String name);
 
-        List<StoredWorkflowDefinitionWithProject> getLatestActiveWorkflowDefinitions(int siteId, int limit, long lastId, String name, String acFilter);
+        List<StoredWorkflowDefinitionWithProject> getLatestActiveWorkflowDefinitions(int siteId, int limit, long lastId, String namePattern, String acFilter);
 
         // getWorkflowDetailsById is same with getWorkflowDetailsByIdInternal
         // excepting site_id check

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
@@ -290,7 +290,7 @@ public class DatabaseProjectStoreManager
         public List<StoredWorkflowDefinitionWithProject> getLatestActiveWorkflowDefinitions(
                 int pageSize,
                 Optional<Long> lastId,
-                Optional<String> name,
+                Optional<String> namePattern,
                 AccessController.ListFilter acFilter)
             throws ResourceNotFoundException
         {
@@ -298,7 +298,7 @@ public class DatabaseProjectStoreManager
                     siteId,
                     pageSize,
                     lastId.or(0L),
-                    generatePartialMatchPattern(name),
+                    generatePartialMatchPattern(namePattern),
                     acFilter.getSql())
             );
         }
@@ -365,10 +365,10 @@ public class DatabaseProjectStoreManager
         {
             // If provided pattern is absent or empty string, just set '%'
             // so that the pattern does not affect to a where clause.
-            return pattern.isPresent() && !pattern.get().isEmpty() ? "%" + escapeLikeParameter(pattern.get()) + "%" : "%";
+            return pattern.isPresent() && !pattern.get().isEmpty() ? "%" + escapeLikePattern(pattern.get()) + "%" : "%";
         }
 
-        private String escapeLikeParameter(String pattern)
+        private String escapeLikePattern(String pattern)
         {
             return pattern.replace("%", "\\%")
                     .replace("_", "\\_");

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
@@ -589,6 +589,11 @@ public class DatabaseProjectStoreManager
                 " join projects proj on a.project_id = proj.id" +
                 " join workflow_configs wc on wc.id = wd.config_id" +
                 " where wd.id \\> :lastId" +
+                // `workflow_definitions` table has a composite index
+                // for `revision_id` and `name` (`workflow_definitions_on_revision_id_and_name`).
+                // And the index is used for filter by `revision_id` and `name`.
+                // Since this query always limits the records by `revision_id` (the latest revision's one),
+                // partial matching of `name` (e.g. '%test%') can be accepted.
                 " and wd.name like :name" +
                 " and <acFilter>" +
                 " order by wd.id" +
@@ -633,6 +638,11 @@ public class DatabaseProjectStoreManager
                         " group by r.project_id" +
                     " )) " +
                     " and wf.id \\> :lastId" +
+                    // `workflow_definitions` table has a composite index
+                    // for `revision_id` and `name` (`workflow_definitions_on_revision_id_and_name`).
+                    // And the index is used for filter by `revision_id` and `name`.
+                    // Since this query always limits the records by `revision_id` (the latest revision's one),
+                    // partial matching of `name` (e.g. '%test%') can be accepted.
                     " and wf.name like :name" +
                     " and <acFilter>" +
                     " order by wf.id" +

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
@@ -365,7 +365,7 @@ public class DatabaseProjectStoreManager
         {
             // If provided pattern is absent or empty string, just set '%'
             // so that the pattern does not affect to a where clause.
-            return pattern.isPresent() && !pattern.get().isEmpty() ? "%" + escapeLikePattern(pattern.get()) + "%" : "%";
+            return !pattern.or("").isEmpty() ? "%" + escapeLikePattern(pattern.get()) + "%" : "%";
         }
 
         private String escapeLikePattern(String pattern)

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
@@ -39,8 +39,6 @@ import org.skife.jdbi.v2.sqlobject.customizers.Define;
 import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
 
-import javax.activation.DataSource;
-
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -53,8 +51,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-import static java.util.Locale.ENGLISH;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.Locale.ENGLISH;
 
 public class DatabaseProjectStoreManager
         extends BasicDatabaseStoreManager<DatabaseProjectStoreManager.Dao>
@@ -292,6 +290,7 @@ public class DatabaseProjectStoreManager
         public List<StoredWorkflowDefinitionWithProject> getLatestActiveWorkflowDefinitions(
                 int pageSize,
                 Optional<Long> lastId,
+                Optional<String> name,
                 AccessController.ListFilter acFilter)
             throws ResourceNotFoundException
         {

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
@@ -298,7 +298,7 @@ public class DatabaseProjectStoreManager
                     siteId,
                     pageSize,
                     lastId.or(0L),
-                    name.isPresent() && !name.get().isEmpty() ? "%" + escapeLikeParameter(name.get()) + "%" : "%",
+                    generatePartialMatchPattern(name),
                     acFilter.getSql())
             );
         }
@@ -361,9 +361,16 @@ public class DatabaseProjectStoreManager
             return new TimeZoneMap(map);
         }
 
-        private String escapeLikeParameter(String parameter)
+        private String generatePartialMatchPattern(Optional<String> pattern)
         {
-            return parameter.replace("%", "\\%")
+            // If provided pattern is absent or empty string, just set '%'
+            // so that the pattern does not affect to a where clause.
+            return pattern.isPresent() && !pattern.get().isEmpty() ? "%" + escapeLikeParameter(pattern.get()) + "%" : "%";
+        }
+
+        private String escapeLikeParameter(String pattern)
+        {
+            return pattern.replace("%", "\\%")
                     .replace("_", "\\_");
         }
     }

--- a/digdag-core/src/main/java/io/digdag/core/repository/ProjectStore.java
+++ b/digdag-core/src/main/java/io/digdag/core/repository/ProjectStore.java
@@ -62,7 +62,7 @@ public interface ProjectStore
     StoredWorkflowDefinitionWithProject getLatestWorkflowDefinitionByName(int projId, String name)
             throws ResourceNotFoundException;
 
-    List<StoredWorkflowDefinitionWithProject> getLatestActiveWorkflowDefinitions(int pageSize, Optional<Long> lastId, Optional<String> name, AccessController.ListFilter acFilter)
+    List<StoredWorkflowDefinitionWithProject> getLatestActiveWorkflowDefinitions(int pageSize, Optional<Long> lastId, Optional<String> namePattern, AccessController.ListFilter acFilter)
             throws ResourceNotFoundException;
 
     TimeZoneMap getWorkflowTimeZonesByIdList(List<Long> defIdList);

--- a/digdag-core/src/main/java/io/digdag/core/repository/ProjectStore.java
+++ b/digdag-core/src/main/java/io/digdag/core/repository/ProjectStore.java
@@ -1,11 +1,9 @@
 package io.digdag.core.repository;
 
-import java.util.List;
-import java.util.Map;
-import java.time.ZoneId;
-
 import com.google.common.base.Optional;
 import io.digdag.spi.ac.AccessController;
+
+import java.util.List;
 
 public interface ProjectStore
 {
@@ -56,16 +54,16 @@ public interface ProjectStore
     List<StoredWorkflowDefinition> getWorkflowDefinitions(int revId, int pageSize, Optional<Long> lastId, AccessController.ListFilter acFilter);
 
     StoredWorkflowDefinition getWorkflowDefinitionByName(int revId, String name)
-        throws ResourceNotFoundException;
+            throws ResourceNotFoundException;
 
     StoredWorkflowDefinitionWithProject getWorkflowDefinitionById(long wfId)
-        throws ResourceNotFoundException;
+            throws ResourceNotFoundException;
 
     StoredWorkflowDefinitionWithProject getLatestWorkflowDefinitionByName(int projId, String name)
-        throws ResourceNotFoundException;
+            throws ResourceNotFoundException;
 
-    List<StoredWorkflowDefinitionWithProject> getLatestActiveWorkflowDefinitions(int pageSize, Optional<Long> lastId, AccessController.ListFilter acFilter)
-        throws ResourceNotFoundException;
+    List<StoredWorkflowDefinitionWithProject> getLatestActiveWorkflowDefinitions(int pageSize, Optional<Long> lastId, Optional<String> name, AccessController.ListFilter acFilter)
+            throws ResourceNotFoundException;
 
     TimeZoneMap getWorkflowTimeZonesByIdList(List<Long> defIdList);
 }

--- a/digdag-core/src/test/java/io/digdag/core/database/DatabaseProjectStoreManagerTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/database/DatabaseProjectStoreManagerTest.java
@@ -352,6 +352,8 @@ public class DatabaseProjectStoreManagerTest
 
             assertEquals(ImmutableList.of(wfDetails1, wfDetails2, wfDetails3, wfDetails4, wfDetails5, wfDetails6),
                     store.getLatestActiveWorkflowDefinitions(100, Optional.absent(), Optional.absent(), () -> "true"));
+            assertEquals(ImmutableList.of(wfDetails1, wfDetails2, wfDetails3, wfDetails4, wfDetails5, wfDetails6),
+                    store.getLatestActiveWorkflowDefinitions(100, Optional.absent(), Optional.fromNullable(""), () -> "true"));
             assertEquals(ImmutableList.of(wfDetails2, wfDetails3),
                     store.getLatestActiveWorkflowDefinitions(100, Optional.absent(), Optional.fromNullable("test"), () -> "true"));
             assertEquals(ImmutableList.of(wfDetails4, wfDetails6),

--- a/digdag-server/src/main/java/io/digdag/server/rs/WorkflowResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/WorkflowResource.java
@@ -115,7 +115,7 @@ public class WorkflowResource
             @ApiParam(value="number of workflows to return", required=false)
             @QueryParam("count") Integer count,
             @ApiParam(value="name pattern to be partially matched", required=false)
-            @QueryParam("name") String name
+            @QueryParam("name_pattern") String namePattern
     )
             throws ResourceNotFoundException, AccessControlException
     {
@@ -126,7 +126,7 @@ public class WorkflowResource
             List<StoredWorkflowDefinitionWithProject> defs =
                     rm.getProjectStore(getSiteId())
                             .getLatestActiveWorkflowDefinitions(Optional.fromNullable(count).or(100), Optional.fromNullable(lastId), // check NotFound first
-                                    Optional.fromNullable(name),
+                                    Optional.fromNullable(namePattern),
                                     ac.getListWorkflowsFilterOfSite(
                                             SiteTarget.of(getSiteId()),
                                             getAuthenticatedUser()));

--- a/digdag-server/src/main/java/io/digdag/server/rs/WorkflowResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/WorkflowResource.java
@@ -113,7 +113,10 @@ public class WorkflowResource
             @ApiParam(value="list workflows whose id is grater than this id for pagination", required=false)
             @QueryParam("last_id") Long lastId,
             @ApiParam(value="number of workflows to return", required=false)
-            @QueryParam("count") Integer count)
+            @QueryParam("count") Integer count,
+            @ApiParam(value="name pattern to be partially matched", required=false)
+            @QueryParam("name") String name
+    )
             throws ResourceNotFoundException, AccessControlException
     {
         final SiteTarget siteTarget = SiteTarget.of(getSiteId());
@@ -123,6 +126,7 @@ public class WorkflowResource
             List<StoredWorkflowDefinitionWithProject> defs =
                     rm.getProjectStore(getSiteId())
                             .getLatestActiveWorkflowDefinitions(Optional.fromNullable(count).or(100), Optional.fromNullable(lastId), // check NotFound first
+                                    Optional.fromNullable(name),
                                     ac.getListWorkflowsFilterOfSite(
                                             SiteTarget.of(getSiteId()),
                                             getAuthenticatedUser()));


### PR DESCRIPTION
# What does this PR change?
This PR introduces `name` parameter into `GET /api/workflows` endpoint so that users can filter workflows by name partial match.

I confirmed that this updates does not change the SQL statement execution plan at PostgreSQL by `explain` command.

# Comparison of SQL statement execution plan

Currently `workflow_definitions_on_revision_id_and_name` index on `workflow_definitions` table is already used.

```Nested Loop  (cost=689.20..894.19 rows=28 width=1481)
   ->  Nested Loop  (cost=688.77..797.66 rows=28 width=162)
         ->  Nested Loop  (cost=688.35..784.73 rows=28 width=104)
               ->  Limit  (cost=687.92..687.99 rows=28 width=31)
                     InitPlan 1 (returns $1)
                       ->  GroupAggregate  (cost=0.71..539.00 rows=294 width=8)
                             Group Key: r_1.project_id
                             ->  Nested Loop  (cost=0.71..534.59 rows=294 width=8)
                                   ->  Index Only Scan using projects_on_site_id_and_id on projects p_1  (cost=0.28..71.50 rows=213 width=4)
                                         Index Cond: (site_id = 1)
                                   ->  Index Only Scan using revisions_on_project_id_and_id on revisions r_1  (cost=0.43..2.08 rows=9 width=8)
                                         Index Cond: (project_id = p_1.id)
                     ->  Sort  (cost=148.92..148.99 rows=28 width=31)
                           Sort Key: wf.id
                           ->  Nested Loop  (cost=1.28..148.24 rows=28 width=31)
                                 ->  Nested Loop  (cost=0.86..135.61 rows=28 width=35)
                                       ->  Index Scan using workflow_definitions_on_revision_id_and_name on workflow_definitions wf  (cost=0.43..39.15 rows=28 width=31)
                                             Index Cond: (revision_id = ANY ($1))
                                             Filter: (id > 0)
                                       ->  Index Scan using revisions_pkey on revisions rev  (cost=0.43..3.45 rows=1 width=8)
                                             Index Cond: (id = wf.revision_id)
                                 ->  Index Only Scan using projects_pkey on projects proj  (cost=0.43..0.45 rows=1 width=4)
                                       Index Cond: (id = rev.project_id)
               ->  Index Scan using revisions_pkey on revisions r  (cost=0.43..3.45 rows=1 width=77)
                     Index Cond: (id = wf.revision_id)
         ->  Index Scan using projects_pkey on projects p  (cost=0.43..0.46 rows=1 width=62)
               Index Cond: (id = r.project_id)
   ->  Index Scan using workflow_configs_pkey on workflow_configs wc  (cost=0.43..3.45 rows=1 width=1323)
         Index Cond: (id = wf.config_id)
```

After modification of this PR, same index is used.

```
 Nested Loop  (cost=583.41..589.50 rows=1 width=1481)
   ->  Nested Loop  (cost=582.98..586.05 rows=1 width=162)
         ->  Nested Loop  (cost=582.56..585.59 rows=1 width=104)
               ->  Limit  (cost=582.13..582.13 rows=1 width=31)
                     InitPlan 1 (returns $1)
                       ->  GroupAggregate  (cost=0.71..539.00 rows=294 width=8)
                             Group Key: r_1.project_id
                             ->  Nested Loop  (cost=0.71..534.59 rows=294 width=8)
                                   ->  Index Only Scan using projects_on_site_id_and_id on projects p_1  (cost=0.28..71.50 rows=213 width=4)
                                         Index Cond: (site_id = 1)
                                   ->  Index Only Scan using revisions_on_project_id_and_id on revisions r_1  (cost=0.43..2.08 rows=9 width=8)
                                         Index Cond: (project_id = p_1.id)
                     ->  Sort  (cost=43.13..43.13 rows=1 width=31)
                           Sort Key: wf.id
                           ->  Nested Loop  (cost=1.28..43.12 rows=1 width=31)
                                 ->  Nested Loop  (cost=0.86..42.66 rows=1 width=35)
                                       ->  Index Scan using workflow_definitions_on_revision_id_and_name on workflow_definitions wf  (cost=0.43..39.22 rows=1 width=31)
                                             Index Cond: (revision_id = ANY ($1))
                                             Filter: ((id > 0) AND (name ~~ '%test%'::text))
                                       ->  Index Scan using revisions_pkey on revisions rev  (cost=0.43..3.45 rows=1 width=8)
                                             Index Cond: (id = wf.revision_id)
                                 ->  Index Only Scan using projects_pkey on projects proj  (cost=0.43..0.45 rows=1 width=4)
                                       Index Cond: (id = rev.project_id)
               ->  Index Scan using revisions_pkey on revisions r  (cost=0.43..3.45 rows=1 width=77)
                     Index Cond: (id = wf.revision_id)
         ->  Index Scan using projects_pkey on projects p  (cost=0.43..0.46 rows=1 width=62)
               Index Cond: (id = r.project_id)
   ->  Index Scan using workflow_configs_pkey on workflow_configs wc  (cost=0.43..3.45 rows=1 width=1323)
         Index Cond: (id = wf.config_id)
```
