### PR TITLE
Add some timeout configurations to `mail` operators

### DIFF
--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -404,14 +404,14 @@ In the config file, following parameters are available
 * eval.js-engine-type (type of ConfigEvalEngine. "nashorn" or "graal". "nashorn" is default on Java8 and "graal" is default on Java11)
 * eval.extended-syntax (boolean, default: true. Enable or disable extended syntax in graal. If true, nested ``{..}`` is allowed)
 
-Default values in `mail` operators:
+Configurations of `mail` operator's default values
 * config.mail.host (string)
 * config.mail.port (integer)
 * config.mail.username (string)
 * config.mail.password (string)
 * config.mail.from (string)
 * config.mail.subject (string)
-* config.mail.connect_timeout (string. default: 30s)
+* config.mail.connect_timeout (string. default: 60s)
 * config.mail.socket_timeout (string. default: 180s)
 
 Secret Encryption Key

--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -404,6 +404,16 @@ In the config file, following parameters are available
 * eval.js-engine-type (type of ConfigEvalEngine. "nashorn" or "graal". "nashorn" is default on Java8 and "graal" is default on Java11)
 * eval.extended-syntax (boolean, default: true. Enable or disable extended syntax in graal. If true, nested ``{..}`` is allowed)
 
+Default values in `mail` operators:
+* config.mail.host (string)
+* config.mail.port (integer)
+* config.mail.username (string)
+* config.mail.password (string)
+* config.mail.from (string)
+* config.mail.subject (string)
+* config.mail.connect_timeout (string. default: 30s)
+* config.mail.socket_timeout (string. default: 180s)
+
 Secret Encryption Key
 *********************
 

--- a/digdag-docs/src/operators/mail.md
+++ b/digdag-docs/src/operators/mail.md
@@ -219,6 +219,26 @@ When you set those parameters, use [digdag secrets command](https://docs.digdag.
   ssl: false
   ```
 
+* **connect_timeout**: DURATION
+
+  The timeout value used for socket connect operations. If connecting to the server takes longer than this value, the operation fails. *Default*: `60s`(60 seconds).
+
+  Examples:
+
+  ```
+  connect_timeout: 30s
+  ```
+
+* **socket_timeout**: DURATION
+
+  The timeout value used for socket read operations. If reading from the server takes longer than this value, the operation fails. *Default*: `180s`(180 seconds).
+
+  Examples:
+
+  ```
+  socket_timeout: 120s
+  ```
+
 * **html**: BOOLEAN
 
   Uses HTML mail (default: false).

--- a/digdag-docs/src/operators/redshift.md
+++ b/digdag-docs/src/operators/redshift.md
@@ -201,19 +201,19 @@ When you set those parameters, use [digdag secrets command](https://docs.digdag.
   status_table: customized_status_table
   ```
 
-* **connect_timeout**: NAME
+* **connect_timeout**: DURATION
 
-  The timeout value used for socket connect operations. If connecting to the server takes longer than this value, the connection is broken. *Default*: `30s`(30 seconds).
+  The timeout value used for socket connect operations. If connecting to the server takes longer than this value, the operation fails. *Default*: `30s`(30 seconds).
 
   Examples:
 
   ```
   connect_timeout: 30s
   ```
-  
-* **socket_timeout**: NAME
 
-  The timeout value used for socket read operations. If reading from the server takes longer than this value, the connection is closed. *Default*: `1800s`(1800 seconds).
+* **socket_timeout**: DURATION
+
+  The timeout value used for socket read operations. If reading from the server takes longer than this value, the operation fails. *Default*: `1800s`(1800 seconds).
 
   Examples:
 

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/MailOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/MailOperatorFactory.java
@@ -311,8 +311,8 @@ public class MailOperatorFactory
         }
         SmtpConfig config = ImmutableSmtpConfig.builder()
                 .host(userHost.get())
-                // This code expects `params` has `port` field even if `secrets` has the field.
-                // Maybe we need to revisit here later to see whether this is intentional or not.
+                // TODO: This code expects `params` has `port` field even if `secrets` has the field.
+                //       Maybe we need to revisit here later to see whether this behavior is reasonable or not.
                 .port(secrets.getSecretOptional("port").transform(Integer::parseInt).or(params.get("port", int.class)))
                 .startTls(secrets.getSecretOptional("tls").transform(Boolean::parseBoolean).or(params.get("tls", boolean.class, true)))
                 .ssl(secrets.getSecretOptional("ssl").transform(Boolean::parseBoolean).or(params.get("ssl", boolean.class, false)))

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/MailOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/MailOperatorFactory.java
@@ -44,6 +44,11 @@ public class MailOperatorFactory
 {
     private static Logger logger = LoggerFactory.getLogger(MailOperatorFactory.class);
 
+    private static final String CONFIG_KEY_CONNECT_TIMEOUT = "connect_timeout";
+    private static final String CONFIG_KEY_SOCKET_TIMEOUT = "socket_timeout";
+    private static final Duration DEFAULT_CONNECT_TIMEOUT = Duration.ofSeconds(60);
+    private static final Duration DEFAULT_SOCKET_TIMEOUT = Duration.ofSeconds(180);
+
     private final TemplateEngine templateEngine;
     private final MailDefaults mailDefaults;
     private final Optional<SmtpConfig> systemSmtpConfig;
@@ -301,6 +306,8 @@ public class MailOperatorFactory
         }
         SmtpConfig config = ImmutableSmtpConfig.builder()
                 .host(userHost.get())
+                // This code expects `params` has `port` field even if `secrets` has the field.
+                // Maybe we need to revisit here later to see whether this is intentional or not.
                 .port(secrets.getSecretOptional("port").transform(Integer::parseInt).or(params.get("port", int.class)))
                 .startTls(secrets.getSecretOptional("tls").transform(Boolean::parseBoolean).or(params.get("tls", boolean.class, true)))
                 .ssl(secrets.getSecretOptional("ssl").transform(Boolean::parseBoolean).or(params.get("ssl", boolean.class, false)))

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/MailOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/MailOperatorFactoryTest.java
@@ -22,14 +22,11 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 
 import javax.mail.Message;
 import javax.mail.MessagingException;
 import java.io.IOException;
 import java.net.InetSocketAddress;
-import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
@@ -46,9 +43,7 @@ import static io.digdag.core.workflow.OperatorTestingUtils.newContext;
 import static io.digdag.core.workflow.OperatorTestingUtils.newOperatorFactory;
 import static io.digdag.core.workflow.OperatorTestingUtils.newTaskRequest;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -57,13 +52,11 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 
 public class MailOperatorFactoryTest
 {
-
     private static GreenMail greenMail;
     private static int smtpPort;
 
@@ -475,8 +468,8 @@ public class MailOperatorFactoryTest
         assertTrue(smtpConfig.debug());
         assertEquals("hello", smtpConfig.username().get());
         assertEquals("world1234", smtpConfig.password().get());
-        assertEquals(DurationParam.of(Duration.ofSeconds(42)), smtpConfig.connectionTimeout().get());
-        assertEquals(DurationParam.of(Duration.ofMinutes(7)), smtpConfig.socketTimeout().get());
+        assertEquals(DurationParam.of(Duration.ofSeconds(42)), smtpConfig.connectTimeout());
+        assertEquals(DurationParam.of(Duration.ofMinutes(7)), smtpConfig.socketTimeout());
     }
 
     @Test
@@ -494,8 +487,8 @@ public class MailOperatorFactoryTest
         assertFalse(smtpConfig.debug());
         assertFalse(smtpConfig.username().isPresent());
         assertFalse(smtpConfig.password().isPresent());
-        assertFalse(smtpConfig.connectionTimeout().isPresent());
-        assertFalse(smtpConfig.socketTimeout().isPresent());
+        assertEquals(DurationParam.of(Duration.ofSeconds(60)), smtpConfig.connectTimeout());
+        assertEquals(DurationParam.of(Duration.ofSeconds(180)), smtpConfig.socketTimeout());
     }
 
     @Test
@@ -524,8 +517,8 @@ public class MailOperatorFactoryTest
         assertTrue(smtpConfig.debug());
         assertEquals("hello", smtpConfig.username().get());
         assertEquals("world1234", smtpConfig.password().get());
-        assertEquals(DurationParam.of(Duration.ofSeconds(42)), smtpConfig.connectionTimeout().get());
-        assertEquals(DurationParam.of(Duration.ofMinutes(7)), smtpConfig.socketTimeout().get());
+        assertEquals(DurationParam.of(Duration.ofSeconds(42)), smtpConfig.connectTimeout());
+        assertEquals(DurationParam.of(Duration.ofMinutes(7)), smtpConfig.socketTimeout());
     }
 
     private ExecutorService serverSocketConsumer(ServerSocketChannel serverSocketChannel)

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/MailOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/MailOperatorFactoryTest.java
@@ -1,5 +1,6 @@
 package io.digdag.standards.operator;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Resources;
 import com.icegreen.greenmail.server.AbstractServer;
@@ -7,10 +8,13 @@ import com.icegreen.greenmail.util.GreenMail;
 import com.icegreen.greenmail.util.Retriever;
 import com.icegreen.greenmail.util.ServerSetup;
 import com.icegreen.greenmail.util.ServerSetupTest;
+import com.sun.mail.util.MailConnectException;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigException;
 import io.digdag.spi.Operator;
+import io.digdag.spi.SecretProvider;
 import io.digdag.spi.TaskExecutionException;
+import io.digdag.util.DurationParam;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -18,21 +22,43 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 
 import javax.mail.Message;
-
+import javax.mail.MessagingException;
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.SocketTimeoutException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import static io.digdag.client.config.ConfigUtils.newConfig;
 import static io.digdag.core.workflow.OperatorTestingUtils.newContext;
 import static io.digdag.core.workflow.OperatorTestingUtils.newOperatorFactory;
 import static io.digdag.core.workflow.OperatorTestingUtils.newTaskRequest;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
 public class MailOperatorFactoryTest
 {
@@ -352,6 +378,179 @@ public class MailOperatorFactoryTest
         }
         catch (ConfigException ignore) {
         }
+    }
+
+    @Test
+    public void connectionTimeout()
+    {
+        Config config = newConfig()
+                // 192.0.2.0/24 shouldn't be reached since it's used only for test (RFC-1166)
+                .set("host", "192.0.2.0")
+                .set("port", 25)
+                .set("subject", "test")
+                .set("_command", "mail_body.txt")
+                .set("timezone", "Asia/Tokyo")
+                .set("from", "alice@example.com")
+                .set("to", "bob@example.com")
+                .set("connect_timeout", "5s");
+
+        assertWithDuration(() -> {
+                    try {
+                        Operator op = factory.newOperator(newContext(
+                                tempPath,
+                                newTaskRequest().withConfig(config)));
+                        op.run();
+                        fail();
+                    }
+                    catch (TaskExecutionException e) {
+                        Throwable cause = e.getCause();
+                        assertTrue(cause instanceof MailConnectException);
+                    }
+                },
+                // Specified connection timeout is 5 seconds
+                Duration.ofSeconds(5), Duration.ofSeconds(5 * 3)
+        );
+    }
+
+    @Test
+    public void socketTimeout()
+            throws IOException
+    {
+        ServerSocketChannel serverSocketChannel = ServerSocketChannel.open();
+        serverSocketChannel.bind(new InetSocketAddress(0));
+        ExecutorService executorService = serverSocketConsumer(serverSocketChannel);
+
+        Config config = newConfig()
+                .set("host", "localhost")
+                .set("port", serverSocketChannel.socket().getLocalPort())
+                .set("subject", "test")
+                .set("_command", "mail_body.txt")
+                .set("timezone", "Asia/Tokyo")
+                .set("from", "alice@example.com")
+                .set("to", "bob@example.com")
+                .set("socket_timeout", "5s");
+
+        try {
+            assertWithDuration(() -> {
+                        try {
+                            Operator op = factory.newOperator(newContext(
+                                    tempPath,
+                                    newTaskRequest().withConfig(config)));
+                            op.run();
+                            fail();
+                        } catch (TaskExecutionException e) {
+                            Throwable cause = e.getCause();
+                            assertTrue(cause instanceof MessagingException);
+                        }
+                    },
+                    // Specified socket timeout is 5 seconds
+                    Duration.ofSeconds(5), Duration.ofSeconds(5 * 3)
+            );
+        }
+        finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    @Test
+    public void systemSmtpConfig()
+    {
+        Config systemConfig = newConfig()
+                .set("config.mail.host", "mail.digdag.io")
+                .set("config.mail.port", 2525)
+                .set("config.mail.tls", false)
+                .set("config.mail.ssl", true)
+                .set("config.mail.debug", true)
+                .set("config.mail.username", "hello")
+                .set("config.mail.password", "world1234")
+                .set("config.mail.connect_timeout", "42s")
+                .set("config.mail.socket_timeout", "7m");
+
+        MailOperatorFactory.SmtpConfig smtpConfig = MailOperatorFactory.systemSmtpConfig(systemConfig).get();
+        assertEquals("mail.digdag.io", smtpConfig.host());
+        assertEquals(2525, smtpConfig.port());
+        assertFalse(smtpConfig.startTls());
+        assertTrue(smtpConfig.ssl());
+        assertTrue(smtpConfig.debug());
+        assertEquals("hello", smtpConfig.username().get());
+        assertEquals("world1234", smtpConfig.password().get());
+        assertEquals(DurationParam.of(Duration.ofSeconds(42)), smtpConfig.connectionTimeout().get());
+        assertEquals(DurationParam.of(Duration.ofMinutes(7)), smtpConfig.socketTimeout().get());
+    }
+
+    @Test
+    public void defaultSystemSmtpConfig()
+    {
+        Config systemConfig = newConfig()
+                .set("config.mail.host", "mail.digdag.io")
+                .set("config.mail.port", 2525);
+
+        MailOperatorFactory.SmtpConfig smtpConfig = MailOperatorFactory.systemSmtpConfig(systemConfig).get();
+        assertEquals("mail.digdag.io", smtpConfig.host());
+        assertEquals(2525, smtpConfig.port());
+        assertTrue(smtpConfig.startTls());
+        assertFalse(smtpConfig.ssl());
+        assertFalse(smtpConfig.debug());
+        assertFalse(smtpConfig.username().isPresent());
+        assertFalse(smtpConfig.password().isPresent());
+        assertFalse(smtpConfig.connectionTimeout().isPresent());
+        assertFalse(smtpConfig.socketTimeout().isPresent());
+    }
+
+    @Test
+    public void userSmtpConfig()
+    {
+        SecretProvider secretProvider = mock(SecretProvider.class);
+        doReturn(Optional.of("hello")).when(secretProvider).getSecretOptional(eq("username"));
+        doReturn(Optional.of("world1234")).when(secretProvider).getSecretOptional(eq("password"));
+        doReturn(Optional.of("mail.digdag.io")).when(secretProvider).getSecretOptional(eq("host"));
+        doReturn(Optional.of("2525")).when(secretProvider).getSecretOptional(eq("port"));
+        doReturn(Optional.of(false)).when(secretProvider).getSecretOptional(eq("tls"));
+        doReturn(Optional.of(true)).when(secretProvider).getSecretOptional(eq("ssl"));
+        doReturn(Optional.of(true)).when(secretProvider).getSecretOptional(eq("debug"));
+
+        Config params = newConfig()
+                .set("connect_timeout", "42s")
+                .set("socket_timeout", "7m");
+
+        MailOperatorFactory.SmtpConfig smtpConfig = MailOperatorFactory.userSmtpConfig(secretProvider, params).get();
+        assertEquals("mail.digdag.io", smtpConfig.host());
+        assertEquals(2525, smtpConfig.port());
+        assertFalse(smtpConfig.startTls());
+        assertTrue(smtpConfig.ssl());
+        assertTrue(smtpConfig.debug());
+        assertEquals("hello", smtpConfig.username().get());
+        assertEquals("world1234", smtpConfig.password().get());
+        assertEquals(DurationParam.of(Duration.ofSeconds(42)), smtpConfig.connectionTimeout().get());
+        assertEquals(DurationParam.of(Duration.ofMinutes(7)), smtpConfig.socketTimeout().get());
+    }
+
+    private ExecutorService serverSocketConsumer(ServerSocketChannel serverSocketChannel)
+    {
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.execute(() -> {
+            while (!executorService.isShutdown()) {
+                try {
+                    SocketChannel channel = serverSocketChannel.accept();
+                    ByteBuffer buffer = ByteBuffer.allocate(512);
+                    while (!executorService.isShutdown()) {
+                        channel.read(buffer);
+                    }
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        });
+        return executorService;
+    }
+
+    private void assertWithDuration(Runnable task, Duration min, Duration max)
+    {
+        Instant start = Instant.now();
+        task.run();
+        Duration duration = Duration.between(start, Instant.now());
+        assertThat(duration, greaterThanOrEqualTo(min));
+        assertThat(duration, lessThanOrEqualTo(max));
     }
 
     private void receiveCheck(String user, int size)

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/MailOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/MailOperatorFactoryTest.java
@@ -443,6 +443,7 @@ public class MailOperatorFactoryTest
         }
         finally {
             executorService.shutdownNow();
+            serverSocketChannel.close();
         }
     }
 

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/MailOperatorFactoryTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/MailOperatorFactoryTest.java
@@ -55,6 +55,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
@@ -501,15 +502,17 @@ public class MailOperatorFactoryTest
     public void userSmtpConfig()
     {
         SecretProvider secretProvider = mock(SecretProvider.class);
+        doReturn(Optional.absent()).when(secretProvider).getSecretOptional(any());
         doReturn(Optional.of("hello")).when(secretProvider).getSecretOptional(eq("username"));
         doReturn(Optional.of("world1234")).when(secretProvider).getSecretOptional(eq("password"));
         doReturn(Optional.of("mail.digdag.io")).when(secretProvider).getSecretOptional(eq("host"));
-        doReturn(Optional.of("2525")).when(secretProvider).getSecretOptional(eq("port"));
-        doReturn(Optional.of(false)).when(secretProvider).getSecretOptional(eq("tls"));
-        doReturn(Optional.of(true)).when(secretProvider).getSecretOptional(eq("ssl"));
-        doReturn(Optional.of(true)).when(secretProvider).getSecretOptional(eq("debug"));
 
         Config params = newConfig()
+                .set("host", "mail.digdag.io")
+                .set("port", 2525)
+                .set("tls", false)
+                .set("ssl", true)
+                .set("debug", true)
                 .set("connect_timeout", "42s")
                 .set("socket_timeout", "7m");
 


### PR DESCRIPTION
Current `mail` operator's timeout configurations are hard-coded and the values seems a bit too short in production environment.

This PR does
- make it possible to configure `mail` operator's connection timeout and socket timeout
- increase the default timeout values