### PR TITLE
correction last_id desc

### DIFF
--- a/digdag-docs/src/_extra/api/swagger.yaml
+++ b/digdag-docs/src/_extra/api/swagger.yaml
@@ -60,7 +60,7 @@ paths:
         type: "boolean"
       - name: "last_id"
         in: "query"
-        description: "list attempts whose id is grater than this id for pagination"
+        description: "list attempts whose id's are lesser than this id for pagination"
         required: false
         type: "integer"
         format: "int64"

--- a/digdag-docs/src/_extra/api/swagger.yaml
+++ b/digdag-docs/src/_extra/api/swagger.yaml
@@ -857,7 +857,7 @@ paths:
       parameters:
       - name: "last_id"
         in: "query"
-        description: "list sessions whose id is grater than this id for pagination"
+        description: "list sessions whose id's are lesser than this id for pagination"
         required: false
         type: "integer"
         format: "int64"

--- a/digdag-docs/src/_extra/api/swagger.yaml
+++ b/digdag-docs/src/_extra/api/swagger.yaml
@@ -911,7 +911,7 @@ paths:
         format: "int64"
       - name: "last_id"
         in: "query"
-        description: "list attempts whose id is grater than this id for pagination"
+        description: "list attempts whose id's are lesser than this id for pagination"
         required: false
         type: "integer"
         format: "int64"


### PR DESCRIPTION
using GET /api/attempts with last_id only returns all attempts less than the specified last_id. But the original description says it returns all id's that are greater. 