### PR TITLE
Support `fargatePlatformVersion` property at `EcsClientConfig`

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -414,7 +414,6 @@ public class EcsCommandExecutor
         }
         catch (TaskSetNotFoundException e) {
             errorMessage = Optional.fromNullable(e.getErrorMessage());
-
         }
         return errorMessage;
     }
@@ -569,6 +568,7 @@ public class EcsCommandExecutor
         setEcsNetworkConfiguration(clientConfig, runTaskRequest);
         setCapacityProviderStrategy(clientConfig, runTaskRequest);
         setPlacementStrategy(clientConfig, runTaskRequest);
+        setFargatePlatformVersion(clientConfig, runTaskRequest);
         return runTaskRequest;
     }
 
@@ -842,6 +842,13 @@ public class EcsCommandExecutor
             CapacityProviderStrategyItem capacityProviderStrategyItem = new CapacityProviderStrategyItem()
                     .withCapacityProvider(clientConfig.getCapacityProviderName().get());
             request.setCapacityProviderStrategy(Arrays.asList(capacityProviderStrategyItem));
+        }
+    }
+
+    protected void setFargatePlatformVersion(final EcsClientConfig clientConfig, final RunTaskRequest request)
+    {
+        if (clientConfig.getFargatePlatformVersion().isPresent()) {
+            request.setPlatformVersion(clientConfig.getFargatePlatformVersion().get());
         }
     }
 

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
@@ -37,6 +37,7 @@ public class EcsClientConfig
         this.placementStrategyField = builder.getPlacementStrategyField();
         this.taskCpu = builder.getTaskCpu();
         this.taskMemory = builder.getTaskMemory();
+        this.fargatePlatformVersion = builder.getFargatePlatformVersion();
 
         // All PlacementStrategyFields must be used with a PlacementStrategyType.
         // But some PlacementStrategyTypes can be used without any PlacementStrategyFields.
@@ -129,6 +130,7 @@ public class EcsClientConfig
                 .withPlacementStrategyField(ecsConfig.getOptional("placement_strategy_field", String.class))
                 .withTaskCpu(ecsConfig.getOptional("task_cpu", String.class))
                 .withTaskMemory(ecsConfig.getOptional("task_memory", String.class))
+                .withFargatePlatformVersion(ecsConfig.getOptional("fargate_platform_version", String.class))
                 .build();
     }
 
@@ -153,6 +155,7 @@ public class EcsClientConfig
     // E.g. For the `binpack` placement strategy, valid values are `cpu` and `memory`.
     // https://github.com/aws/aws-sdk-java/blob/1.11.686/aws-java-sdk-ecs/src/main/java/com/amazonaws/services/ecs/model/PlacementStrategy.java#L44-L52
     private final Optional<String> placementStrategyField;
+    private final Optional<String> fargatePlatformVersion;
 
     public String getClusterName()
     {
@@ -226,5 +229,10 @@ public class EcsClientConfig
     public Optional<String> getTaskMemory()
     {
         return taskMemory;
+    }
+
+    public Optional<String> getFargatePlatformVersion()
+    {
+        return fargatePlatformVersion;
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
@@ -23,6 +23,7 @@ public class EcsClientConfigBuilder
     private Optional<String> startedBy;
     private Optional<String> placementStrategyType;
     private Optional<String> placementStrategyField;
+    private Optional<String> fargatePlatformVersion;
 
     public EcsClientConfig build()
     {
@@ -130,6 +131,13 @@ public class EcsClientConfigBuilder
         return this;
     }
 
+    // see https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html#platform-version-migration
+    public EcsClientConfigBuilder withFargatePlatformVersion(Optional<String> fargatePlatformVersion)
+    {
+        this.fargatePlatformVersion = fargatePlatformVersion;
+        return this;
+    }
+
     public String getClusterName()
     {
         return clusterName;
@@ -208,5 +216,10 @@ public class EcsClientConfigBuilder
     public Optional<String> getTaskMemory()
     {
         return taskMemory;
+    }
+
+    public Optional<String> getFargatePlatformVersion()
+    {
+        return fargatePlatformVersion;
     }
 }

--- a/digdag-standards/src/test/java/io/digdag/standards/command/ecs/EcsClientConfigTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/command/ecs/EcsClientConfigTest.java
@@ -108,4 +108,14 @@ public class EcsClientConfigTest
             assertEquals("PlacementStrategyField must be set with PlacementStrategyType", e.getMessage());
         }
     }
+
+    @Test
+    public void testCreateFromSystemConfigWithFargatePlatformVersion() {
+        Config sys = systemConfig.deepCopy();
+        sys.set("agent.command_executor.ecs.name", "cluster01");
+        sys.set("agent.command_executor.ecs.cluster01.fargate_platform_version", "1.4.0");
+        sys.set("agent.command_executor.ecs.cluster01.region", "us-east-1");
+        EcsClientConfig ecsConfig = EcsClientConfig.createFromSystemConfig(Optional.absent(), sys);
+        assertEquals("1.4.0", ecsConfig.getFargatePlatformVersion().get());
+    }
 }


### PR DESCRIPTION
# What does this PR do?
This PR introduces `fargatePlatformVersion`[1]  property for `EcsClientConfig`. This property is expected to be provided by SystemConfig.

- [1] https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html#platform-version-migration