### PR TITLE
Remove jcenter dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,6 @@ allprojects {
 
     repositories {
         mavenCentral()
-        jcenter()
         maven {
             url  "https://dl.bintray.com/digdag/maven"
         }

--- a/digdag-cli/build.gradle
+++ b/digdag-cli/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compile project(':digdag-standards')
     compile 'ch.qos.logback:logback-classic:1.1.5'
     compile 'org.fusesource.jansi:jansi:1.11'
-    compile 'com.beust:jcommander:1.55'
+    compile 'com.beust:jcommander:1.58'
 
     // This line is for including digdag-storage-s3 in CLI (shadow jar) used through
     // dynamic class loading. digdag-cli itself doesn't depend on digdag-storage-s3.

--- a/digdag-guice-rs-server/build.gradle
+++ b/digdag-guice-rs-server/build.gradle
@@ -1,5 +1,5 @@
 dependencies {
-    compile 'org.embulk:guice-bootstrap:0.2.1'
+    compile 'org.embulk:guice-bootstrap:0.3.2'
     compile 'org.weakref:jmxutils:1.19'
     compile 'javax.annotation:javax.annotation-api:1.3.2'
 }

--- a/digdag-tests/src/test/resources/acceptance/plugin/digdag-plugin-example/build.gradle
+++ b/digdag-tests/src/test/resources/acceptance/plugin/digdag-plugin-example/build.gradle
@@ -10,7 +10,6 @@ def digdagVersion = '0.8.18-SNAPSHOT'
 repositories {
     mavenLocal()
     mavenCentral()
-    jcenter()
     maven {
         url  "http://dl.bintray.com/digdag/maven"
     }


### PR DESCRIPTION
# What does this PR change?
This PR removes jcenter dependency since jcenter will be shut down at March 31st 2021 (though packages can be downloaded until February 1st 2022).

For more detail; https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/

And following two libraries need to be updated since the current versions are not published at Maven central.
As far as I checked the diff of each library, there are no breaking change and all tests are green.

# Updated modules

## JCommander 
- https://mvnrepository.com/artifact/com.beust/jcommander
- https://github.com/cbeust/jcommander/compare/1.56...1.58
##  guice-bootstrap 
- https://mvnrepository.com/artifact/org.embulk/guice-bootstrap
- https://github.com/embulk/guice-bootstrap/compare/v0.2.1...v0.3.2