### PR TITLE
remove column_list parameter from redshift_load

### DIFF
--- a/digdag-docs/src/operators/redshift_load.md
+++ b/digdag-docs/src/operators/redshift_load.md
@@ -23,7 +23,6 @@
         schema: myschema
         table: access_logs
         from: s3://my-app-bucket/access_logs/today
-        column_list: host, path, referer, code, agent, size, method
         manifest: true
         encrypted: true
         region: us-east-1
@@ -195,16 +194,6 @@ When you set those parameters, use [digdag secrets command](https://docs.digdag.
 
   ```
   from: s3://my-app-bucket/access_logs/today
-  ```
-
-* **column_list**: CSV
-
-  Parameter mapped to `COLUMN_LIST` parameter of Redshift's `COPY` statement
-
-  Examples:
-
-  ```
-  column_list: host, path, referer, code, agent, size, method
   ```
 
 * **manifest**: BOOLEAN


### PR DESCRIPTION
column_list parameter has no real implementation yet in redshift_load operator. 
https://github.com/treasure-data/digdag/blob/d1de1e0581cbcc93ebc45bc232c1a28c0fa29698/digdag-standards/src/main/java/io/digdag/standards/operator/redshift/RedshiftConnection.java#L127-L134
