### PR TITLE
Fix another broken test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,8 @@ workflows:
 
   test_and_docs_deployment:
     jobs:
-      - test: # master and v0_10 branches only
+      - test
+#     - test: # master and v0_10 branches only
 #         filters:
 #           branches:
 #             only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,21 +84,21 @@ workflows:
   test_and_docs_deployment:
     jobs:
       - test: # master and v0_10 branches only
-          filters:
-            branches:
-              only:
-                - master
-                - v0_10
-                - v0_11
-      - docs_deployment: # master branch only
-          filters:
-            branches:
-              only:
-                - master
-      - release_snapshot: # v0_10 branch only
-          requires:
-            - test
-          filters:
-            branches:
-              only:
-                - v0_11
+#         filters:
+#           branches:
+#             only:
+#               - master
+#               - v0_10
+#               - v0_11
+#     - docs_deployment: # master branch only
+#         filters:
+#           branches:
+#             only:
+#               - master
+#     - release_snapshot: # v0_10 branch only
+#         requires:
+#           - test
+#         filters:
+#           branches:
+#             only:
+#               - v0_11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,13 +83,7 @@ workflows:
 
   test_and_docs_deployment:
     jobs:
-      - test: # master and v0_10 branches only
-          filters:
-            branches:
-              only:
-                - master
-                - v0_10
-                - v0_11
+      - test # will be executed for topic branch not only default branches so that we can safely merge it
       - docs_deployment: # master branch only
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,23 +83,22 @@ workflows:
 
   test_and_docs_deployment:
     jobs:
-      - test
-#     - test: # master and v0_10 branches only
-#         filters:
-#           branches:
-#             only:
-#               - master
-#               - v0_10
-#               - v0_11
-#     - docs_deployment: # master branch only
-#         filters:
-#           branches:
-#             only:
-#               - master
-#     - release_snapshot: # v0_10 branch only
-#         requires:
-#           - test
-#         filters:
-#           branches:
-#             only:
-#               - v0_11
+      - test: # master and v0_10 branches only
+          filters:
+            branches:
+              only:
+                - master
+                - v0_10
+                - v0_11
+      - docs_deployment: # master branch only
+          filters:
+            branches:
+              only:
+                - master
+      - release_snapshot: # v0_10 branch only
+          requires:
+            - test
+          filters:
+            branches:
+              only:
+                - v0_11

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,10 @@ on:
     - v0_10
     - v0_11
   pull_request:
-    branches: []
-#   branches:
-#   - master
-#   - v0_10
-#   - v0_11
+    branches:
+    - master
+    - v0_10
+    - v0_11
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,11 @@ on:
     - v0_10
     - v0_11
   pull_request:
-    branches:
-    - master
-    - v0_10
-    - v0_11
+    branches: []
+#   branches:
+#   - master
+#   - v0_10
+#   - v0_11
 
 jobs:
   build:

--- a/digdag-tests/src/test/java/acceptance/td/TdDdlIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/TdDdlIT.java
@@ -235,8 +235,9 @@ public class TdDdlIT
                 }).start();
 
         Files.write(config, asList(
-                "params.td.use_ssl = true",
+                "params.td.use_ssl = false",
                 "params.td.proxy.enabled = true",
+                "params.td.proxy.use_ssl = true",
                 "params.td.proxy.host = " + proxyServer.getListenAddress().getHostString(),
                 "params.td.proxy.port = " + proxyServer.getListenAddress().getPort()
         ), APPEND);

--- a/digdag-tests/src/test/java/acceptance/td/TdDdlIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/TdDdlIT.java
@@ -165,7 +165,7 @@ public class TdDdlIT
     public void testRetries()
             throws Exception
     {
-        int failures = 7;
+        int failures = 3;
 
         Map<String, AtomicInteger> requests = new ConcurrentHashMap<>();
 
@@ -234,7 +234,11 @@ public class TdDdlIT
                     }
                 }).start();
 
+        // In this test, the http proxy doesn't pass any request from `td` operator to TD API.
+        // So `td` operator needs to talk with the proxy over HTTP not HTTPS.
         Files.write(config, asList(
+                "config.td.min_retry_interval = 1s",
+                "config.td.max_retry_interval = 1s",
                 "params.td.use_ssl = false",
                 "params.td.proxy.enabled = true",
                 "params.td.proxy.use_ssl = true",

--- a/digdag-tests/src/test/java/acceptance/td/TdIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/TdIT.java
@@ -425,10 +425,10 @@ public class TdIT
         Files.write(config, asList(
                 "config.td.min_retry_interval = 1s",
                 "config.td.max_retry_interval = 1s",
-                "params.td.use_ssl = true"
-//                "params.td.proxy.enabled = true",
-//                "params.td.proxy.host = " + proxyServer.getListenAddress().getHostString(),
-//                "params.td.proxy.port = " + proxyServer.getListenAddress().getPort()
+                "params.td.use_ssl = true",
+                "params.td.proxy.enabled = true",
+                "params.td.proxy.host = " + proxyServer.getListenAddress().getHostString(),
+                "params.td.proxy.port = " + proxyServer.getListenAddress().getPort()
         ), APPEND);
 
         copyResource("acceptance/td/td/td_inline.dig", projectDir.resolve("workflow.dig"));

--- a/digdag-tests/src/test/java/acceptance/td/TdIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/TdIT.java
@@ -422,6 +422,8 @@ public class TdIT
 
         proxyServer = TestUtils.startRequestFailingProxy(failures, requests);
 
+        // In this test, the http proxy basically passes all requests to real TD API.
+        // So `td` operator needs to use HTTPS not HTTP.
         Files.write(config, asList(
                 "config.td.min_retry_interval = 1s",
                 "config.td.max_retry_interval = 1s",

--- a/digdag-tests/src/test/java/acceptance/td/TdIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/TdIT.java
@@ -425,10 +425,10 @@ public class TdIT
         Files.write(config, asList(
                 "config.td.min_retry_interval = 1s",
                 "config.td.max_retry_interval = 1s",
-                "params.td.use_ssl = true",
-                "params.td.proxy.enabled = true",
-                "params.td.proxy.host = " + proxyServer.getListenAddress().getHostString(),
-                "params.td.proxy.port = " + proxyServer.getListenAddress().getPort()
+                "params.td.use_ssl = true"
+//                "params.td.proxy.enabled = true",
+//                "params.td.proxy.host = " + proxyServer.getListenAddress().getHostString(),
+//                "params.td.proxy.port = " + proxyServer.getListenAddress().getPort()
         ), APPEND);
 
         copyResource("acceptance/td/td/td_inline.dig", projectDir.resolve("workflow.dig"));


### PR DESCRIPTION
We noticed `acceptance.td.TdDdlIT#testRetries` was still broken after merging the previous fix. This PR does
- Fix the broken test
- Test a topic branch on CircleCI to detect CircleCI test failure in advance