### PR TITLE
Restore skipped `td` operator integration tests

### DIFF
--- a/digdag-tests/src/test/java/acceptance/td/TdIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/TdIT.java
@@ -549,11 +549,8 @@ public class TdIT
     }
 
     private String domainKey(TDApiRequest request)
-            throws IOException
     {
-        Map<String, Object> content = objectMapper().readValue(
-                request.getContent().get(), new TypeReference<Map<String, Object>>() {});
-        return content.get("domain_key").toString();
+        return request.getQueryParams().get("domain_key");
     }
 
     private CommandStatus assertWorkflowRunsSuccessfully(String... params)

--- a/digdag-tests/src/test/java/utils/TestUtils.java
+++ b/digdag-tests/src/test/java/utils/TestUtils.java
@@ -250,7 +250,6 @@ public class TestUtils
             @Override
             public <Result> Result call(TDApiRequest apiRequest, Optional<String> apiKeyCache, final JavaType resultType)
             {
-                // FIXME: Looks POST content isn't saved
                 recorder.record(apiRequest);
                 return super.call(apiRequest, apiKeyCache, resultType);
             }

--- a/digdag-tests/src/test/java/utils/TestUtils.java
+++ b/digdag-tests/src/test/java/utils/TestUtils.java
@@ -20,12 +20,9 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Resources;
-import com.google.inject.Inject;
 import com.google.inject.Injector;
-import com.google.inject.Scopes;
 import com.treasuredata.client.TDApiRequest;
 import com.treasuredata.client.TDClient;
-import com.treasuredata.client.TDClientBuilder;
 import com.treasuredata.client.TDClientConfig;
 import com.treasuredata.client.TDHttpClient;
 import io.digdag.cli.Main;
@@ -39,7 +36,6 @@ import io.digdag.client.api.RestLogFileHandle;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigFactory;
 import io.digdag.core.DigdagEmbed;
-import io.digdag.core.agent.OperatorManager;
 import io.digdag.spi.SecretProvider;
 import io.digdag.standards.operator.td.BaseTDClientFactory;
 import io.digdag.standards.operator.td.TDClientFactory;
@@ -188,149 +184,6 @@ public class TestUtils
         return CommandStatus.of(code, out.toByteArray(), err.toByteArray());
     }
 
-    public static class TDHttpClientRecorder
-    {
-        private final List<TDApiRequest> requests = new ArrayList<>();
-
-        public void record(TDApiRequest request)
-        {
-            requests.add(request);
-        }
-
-        public List<TDApiRequest> requests()
-        {
-            return requests;
-        }
-    }
-
-    static class RecordableTDHttpClient
-            extends TDHttpClient
-    {
-        private final TDHttpClientRecorder recorder;
-
-        public RecordableTDHttpClient(TDClientConfig config, TDHttpClientRecorder recorder)
-        {
-            super(config);
-            this.recorder = recorder;
-        }
-
-        @Override
-        public <Result> Result call(TDApiRequest apiRequest, Optional<String> apiKeyCache, final JavaType resultType)
-        {
-            // FIXME: Looks POST content isn't saved
-            recorder.record(apiRequest);
-            return super.call(apiRequest, apiKeyCache, resultType);
-        }
-    }
-
-    static class RecordableTDClient
-            extends TDClient
-    {
-        public RecordableTDClient(TDClientConfig config, TDHttpClientRecorder recorder)
-        {
-            super(config, new RecordableTDHttpClient(config, recorder), Optional.absent());
-        }
-    }
-
-    static class RecordableTDClientFactory
-        extends TDClientFactory
-    {
-        private final TDHttpClientRecorder recorder;
-
-        public RecordableTDClientFactory(TDHttpClientRecorder recorder)
-        {
-            this.recorder = recorder;
-        }
-
-        @Override
-        public TDClient createClient(TDOperator.SystemDefaultConfig systemDefaultConfig, Map<String, String> env, Config params, SecretProvider secrets)
-        {
-            TDClientConfig clientConfig = clientBuilderFromConfig(systemDefaultConfig, env, params, secrets).buildConfig();
-            return new RecordableTDClient(clientConfig, recorder);
-        }
-    }
-
-    static class RecordableRun
-        extends Run
-    {
-        private TDHttpClientRecorder recorder;
-
-        public void setRecorder(TDHttpClientRecorder recorder)
-        {
-            this.recorder = recorder;
-        }
-
-        @Override
-        protected DigdagEmbed.Bootstrap setupBootstrap(Properties systemProps)
-        {
-            return super.setupBootstrap(systemProps)
-                .overrideModulesWith((binder) ->
-                    binder.bind(BaseTDClientFactory.class).toInstance(new RecordableTDClientFactory(recorder)));
-        }
-    }
-
-    static class CustomMain
-        extends Main
-    {
-        interface CommandAdder
-        {
-            void addCommand(JCommander jc, Injector injector);
-        }
-
-        private final CommandAdder commandAdder;
-
-        public CustomMain(
-                Version version,
-                Map<String, String> env,
-                PrintStream out,
-                PrintStream err,
-                InputStream in,
-                CommandAdder commandAdder)
-        {
-            super(version, env, out, err, in);
-            this.commandAdder = commandAdder;
-        }
-
-        @Override
-        protected void addCommands(JCommander jc, Injector injector)
-        {
-            super.addCommands(jc, injector);
-            commandAdder.addCommand(jc, injector);
-        }
-    }
-
-    public static class CommandStatusAndRecordedApiCalls
-    {
-        public final CommandStatus commandStatus;
-        public final List<TDApiRequest> recordedApiCalls;
-
-        public CommandStatusAndRecordedApiCalls(CommandStatus commandStatus, List<TDApiRequest> recordedApiCalls)
-        {
-            this.commandStatus = commandStatus;
-            this.recordedApiCalls = recordedApiCalls;
-        }
-    }
-
-    public static CommandStatusAndRecordedApiCalls mainWithRecordableRun(Map<String, String> env, Collection<String> args)
-    {
-        InputStream in = new ByteArrayInputStream(new byte[0]);
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
-        ByteArrayOutputStream err = new ByteArrayOutputStream();
-
-        TDHttpClientRecorder recorder = new TDHttpClientRecorder();
-        CustomMain.CommandAdder commandAdder = (jc, injector) -> {
-            RecordableRun instance = injector.getInstance(RecordableRun.class);
-            instance.setRecorder(recorder);
-            jc.addCommand("recordable_run", instance);
-        };
-
-        int code = main(env, LocalVersion.of(), args, out, err, in, commandAdder);
-
-        return new CommandStatusAndRecordedApiCalls(
-                CommandStatus.of(code, out.toByteArray(), err.toByteArray()),
-                recorder.requests());
-    }
-
     public static int main(Map<String, String> env, LocalVersion localVersion, Collection<String> args, OutputStream out, OutputStream err, InputStream in)
     {
         return main(env, localVersion, args, out, err, in, null);
@@ -343,7 +196,7 @@ public class TestUtils
             OutputStream out,
             OutputStream err,
             InputStream in,
-            CustomMain.CommandAdder commandAdder)
+            RecordableWorkflow.CustomMain.CommandAdder commandAdder)
     {
         try (
                 PrintStream outp = new PrintStream(out, true, "UTF-8");
@@ -351,7 +204,7 @@ public class TestUtils
         ) {
             Main main;
             if (commandAdder != null) {
-                main = new CustomMain(localVersion.getVersion(), env, outp, errp, in, commandAdder);
+                main = new RecordableWorkflow.CustomMain(localVersion.getVersion(), env, outp, errp, in, commandAdder);
             }
             else {
                 main = new Main(localVersion.getVersion(), env, outp, errp, in);
@@ -363,6 +216,156 @@ public class TestUtils
             e.printStackTrace();
             Assert.fail();
             throw Throwables.propagate(e);
+        }
+    }
+
+    public static class RecordableWorkflow
+    {
+        public static class TDHttpClientRecorder
+        {
+            private final List<TDApiRequest> requests = new ArrayList<>();
+
+            public void record(TDApiRequest request)
+            {
+                requests.add(request);
+            }
+
+            public List<TDApiRequest> requests()
+            {
+                return requests;
+            }
+        }
+
+        static class RecordableTDHttpClient
+            extends TDHttpClient
+        {
+            private final TDHttpClientRecorder recorder;
+
+            public RecordableTDHttpClient(TDClientConfig config, TDHttpClientRecorder recorder)
+            {
+                super(config);
+                this.recorder = recorder;
+            }
+
+            @Override
+            public <Result> Result call(TDApiRequest apiRequest, Optional<String> apiKeyCache, final JavaType resultType)
+            {
+                // FIXME: Looks POST content isn't saved
+                recorder.record(apiRequest);
+                return super.call(apiRequest, apiKeyCache, resultType);
+            }
+        }
+
+        static class RecordableTDClient
+            extends TDClient
+        {
+            public RecordableTDClient(TDClientConfig config, TDHttpClientRecorder recorder)
+            {
+                super(config, new RecordableTDHttpClient(config, recorder), Optional.absent());
+            }
+        }
+
+        static class RecordableTDClientFactory
+            extends TDClientFactory
+        {
+            private final TDHttpClientRecorder recorder;
+
+            public RecordableTDClientFactory(TDHttpClientRecorder recorder)
+            {
+                this.recorder = recorder;
+            }
+
+            @Override
+            public TDClient createClient(
+                    TDOperator.SystemDefaultConfig systemDefaultConfig,
+                    Map<String, String> env,
+                    Config params,
+                    SecretProvider secrets)
+            {
+                TDClientConfig clientConfig = clientBuilderFromConfig(systemDefaultConfig, env, params, secrets).buildConfig();
+                return new RecordableTDClient(clientConfig, recorder);
+            }
+        }
+
+        static class RecordableRun
+            extends Run
+        {
+            private TDHttpClientRecorder recorder;
+
+            public void setRecorder(TDHttpClientRecorder recorder)
+            {
+                this.recorder = recorder;
+            }
+
+            @Override
+            protected DigdagEmbed.Bootstrap setupBootstrap(Properties systemProps)
+            {
+                return super.setupBootstrap(systemProps)
+                        .overrideModulesWith((binder) ->
+                                binder.bind(BaseTDClientFactory.class).toInstance(new RecordableTDClientFactory(recorder)));
+            }
+        }
+
+        static class CustomMain
+            extends Main
+        {
+            interface CommandAdder
+            {
+                void addCommand(JCommander jc, Injector injector);
+            }
+
+            private final CommandAdder commandAdder;
+
+            public CustomMain(
+                    Version version,
+                    Map<String, String> env,
+                    PrintStream out,
+                    PrintStream err,
+                    InputStream in,
+                    CommandAdder commandAdder)
+            {
+                super(version, env, out, err, in);
+                this.commandAdder = commandAdder;
+            }
+
+            @Override
+            protected void addCommands(JCommander jc, Injector injector)
+            {
+                super.addCommands(jc, injector);
+                commandAdder.addCommand(jc, injector);
+            }
+        }
+
+        public static class CommandStatusAndRecordedApiCalls
+        {
+            public final CommandStatus commandStatus;
+            public final List<TDApiRequest> recordedApiCalls;
+
+            public CommandStatusAndRecordedApiCalls(CommandStatus commandStatus, List<TDApiRequest> recordedApiCalls)
+            {
+                this.commandStatus = commandStatus;
+                this.recordedApiCalls = recordedApiCalls;
+            }
+        }
+
+        public static CommandStatusAndRecordedApiCalls mainWithRecordableRun(Map<String, String> env, Collection<String> args)
+        {
+            InputStream in = new ByteArrayInputStream(new byte[0]);
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            ByteArrayOutputStream err = new ByteArrayOutputStream();
+
+            TDHttpClientRecorder recorder = new TDHttpClientRecorder();
+            CustomMain.CommandAdder commandAdder = (jc, injector) -> {
+                RecordableRun instance = injector.getInstance(RecordableRun.class);
+                instance.setRecorder(recorder);
+                jc.addCommand("recordable_run", instance);
+            };
+
+            int code = TestUtils.main(env, LocalVersion.of(), args, out, err, in, commandAdder);
+
+            return new CommandStatusAndRecordedApiCalls(
+                    CommandStatus.of(code, out.toByteArray(), err.toByteArray()),
+                    recorder.requests());
         }
     }
 


### PR DESCRIPTION
We've commented out some verifications in `td` operator's integration tests that accessed actual Treasure Data endpoint and recently started to fail due to HTTP access decommission https://github.com/treasure-data/digdag/pull/1553 https://github.com/treasure-data/digdag/pull/1557. Those verification internally depended on LittleProxy to see what TD APIs are called, but they didn't work via HTTPS since LittleProxy doesn't support request capture with HTTPS.

This PR introduces `utils.TestUtils.RecordableWorkflow` that inject a custom TDClient recording all API calls instead of depending on LittleProxy and replaces the commented out verifications with it.