### PR TITLE
`pg` operator should check if the status table exists in advance before trying to create the table

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/operator/pg/PgConnection.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/pg/PgConnection.java
@@ -44,6 +44,7 @@ public class PgConnection
                 ResultSet rs = stmt.executeQuery(sql);  // executeQuery throws exception if given query includes multiple statements
                 resultHandler.accept(new PgResultSet(rs));
             }
+            // TODO: This should be moved into `finally`?
             execute("SET TRANSACTION READ WRITE");
         }
         catch (SQLException ex) {
@@ -111,17 +112,30 @@ public class PgConnection
         @Override
         public void prepare(UUID queryId)
         {
-            String sql = buildCreateTable();
-            executeStatement("create a status table " + escapeTableReference(statusTableReference()) + ".\n"
-                            + "hint: if you don't have permission to create tables, "
-                            + "please try one of these options:\n"
-                            + "1. add 'strict_transaction: false' option to disable "
-                            + "exactly-once transaction control that depends on this table.\n"
-                            + "2. ask system administrator to create this table using the following command "
-                            + "and grant SELECT/INSERT/UPDATE/DELETE or ALL privileges to this user: " + sql + ";\n"
-                            + "3. ask system administrator to create a schema that this user can create a table "
-                            + "and set 'status_table_schema' option to it\n"
-                            , sql);
+            try {
+                executeReadOnlyQuery(
+                        String.format("SELECT count(*) FROM %s", escapeTableReference(statusTableReference())),
+                        // Nothing to do for result rows
+                        (result) -> {}
+                );
+            }
+            catch (NotReadOnlyException e) {
+                throw new DatabaseException(
+                        String.format("Unexpected readonly exception occurred: %s", e.getMessage()));
+            }
+            catch (DatabaseException ex) {
+                String sql = buildCreateTable();
+                executeStatement("create a status table " + escapeTableReference(statusTableReference()) + ".\n"
+                                + "hint: if you don't have permission to create tables, "
+                                + "please try one of these options:\n"
+                                + "1. add 'strict_transaction: false' option to disable "
+                                + "exactly-once transaction control that depends on this table.\n"
+                                + "2. ask system administrator to create this table using the following command "
+                                + "and grant SELECT/INSERT/UPDATE/DELETE or ALL privileges to this user: " + sql + ";\n"
+                                + "3. ask system administrator to create a schema that this user can create a table "
+                                + "and set 'status_table_schema' option to it\n"
+                        , sql);
+            }
         }
 
         @Override

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/pg/PgConnection.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/pg/PgConnection.java
@@ -118,7 +118,7 @@ public class PgConnection
                             + "1. add 'strict_transaction: false' option to disable "
                             + "exactly-once transaction control that depends on this table.\n"
                             + "2. ask system administrator to create this table using the following command "
-                            + "and grant INSERT privilege to this user: " + sql + ";\n"
+                            + "and grant SELECT/INSERT/UPDATE/DELETE or ALL privileges to this user: " + sql + ";\n"
                             + "3. ask system administrator to create a schema that this user can create a table "
                             + "and set 'status_table_schema' option to it\n"
                             , sql);

--- a/digdag-standards/src/test/java/io/digdag/standards/operator/pg/PgConnectionTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/operator/pg/PgConnectionTest.java
@@ -26,10 +26,10 @@ import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -115,16 +115,29 @@ public class PgConnectionTest
     }
 
     @Test
-    public void txHelperPrepare()
+    public void txHelperPrepareWhenStatusTableDoesNotExist()
             throws SQLException, NotReadOnlyException
     {
         TransactionHelper txHelper = pgConnection.getStrictTransactionHelper(null, "__digdag_status", Duration.ofDays(1));
+        // Simulate the behaviour of PgConnection.PgPersistentTransactionHelper#prepare in case the status table doesn't exist
         doThrow(DatabaseException.class).when(pgConnection).executeReadOnlyQuery(eq("SELECT count(*) FROM \"__digdag_status\""), any());
         UUID queryId = UUID.randomUUID();
         txHelper.prepare(queryId);
         verify(pgConnection).execute(eq(
                 "CREATE TABLE IF NOT EXISTS \"__digdag_status\"" +
                         " (query_id text NOT NULL UNIQUE, created_at timestamptz NOT NULL, completed_at timestamptz)"));
+    }
+
+    @Test
+    public void txHelperPrepareWhenStatusTableExists()
+            throws SQLException, NotReadOnlyException
+    {
+        TransactionHelper txHelper = pgConnection.getStrictTransactionHelper(null, "__digdag_status", Duration.ofDays(1));
+        // Simulate the behaviour of PgConnection.PgPersistentTransactionHelper#prepare in case the status table already exists
+        doNothing().when(pgConnection).executeReadOnlyQuery(eq("SELECT count(*) FROM \"__digdag_status\""), any());
+        UUID queryId = UUID.randomUUID();
+        txHelper.prepare(queryId);
+        verify(pgConnection, times(0)).execute(any());
     }
 
     private ResultSet setupMockSelectResultSet(UUID queryId)

--- a/digdag-tests/src/test/java/acceptance/PgIT.java
+++ b/digdag-tests/src/test/java/acceptance/PgIT.java
@@ -128,20 +128,18 @@ public class PgIT
     @After
     public void tearDown()
     {
-        if (user != null) {
-            try {
-                removeTempDatabase();
-            }
-            catch (Throwable e) {
-                logger.error("Failed to remove resources", e);
-            }
+        try {
+            removeTempDatabase();
+        }
+        catch (Throwable e) {
+            logger.error("Failed to remove resources", e);
+        }
 
-            try {
-                removeRestrictedUser();
-            }
-            catch (Throwable e) {
-                logger.error("Failed to remove resources", e);
-            }
+        try {
+            removeRestrictedUser();
+        }
+        catch (Throwable e) {
+            logger.error("Failed to remove resources", e);
         }
     }
 
@@ -651,16 +649,6 @@ public class PgIT
                 "password", password,
                 "database", database
         ).get(key));
-    }
-
-    private void removeCustomStatusTable()
-    {
-        SecretProvider secrets = getDatabaseSecrets();
-
-        try (PgConnection conn = PgConnection.open(PgConnectionConfig.configure(secrets, EMPTY_CONFIG))) {
-            conn.executeUpdate(
-                    String.format("DROP TABLE IF EXISTS %s.%s", CUSTOM_STATUS_TABLE_SCHEMA, CUSTOM_STATUS_TABLE));
-        }
     }
 
     private void createTempDatabase()

--- a/digdag-tests/src/test/java/acceptance/PgIT.java
+++ b/digdag-tests/src/test/java/acceptance/PgIT.java
@@ -49,8 +49,8 @@ public class PgIT
     private static final String RESTRICTED_USER_PASSWORD = "not_admin_password";
     private static final String SRC_TABLE = "src_tbl";
     private static final String DEST_TABLE = "dest_tbl";
-    private static final String DATA_SECHEMA = "data_schema";
-    private static final String STATUS_TABLE_SECHEMA = "status_table_schema";
+    private static final String DATA_SCHEMA = "data_schema";
+    private static final String STATUS_TABLE_SCHEMA = "status_table_schema";
 
     private static final Config EMPTY_CONFIG = configFactory().create();
 
@@ -416,13 +416,13 @@ public class PgIT
         copyResource("acceptance/pg/insert_into_with_schema.dig", root().resolve("pg.dig"));
         copyResource("acceptance/pg/select_table.sql", root().resolve("select_table.sql"));
 
-        dataSchemaName = DATA_SECHEMA;
+        dataSchemaName = DATA_SCHEMA;
         setupSchema(dataSchemaName);
         setupSourceTable();
         setupDestTable();
         grantRestrictedUserOnTheSchema(dataSchemaName);
 
-        String statusTableSchema = STATUS_TABLE_SECHEMA;
+        String statusTableSchema = STATUS_TABLE_SCHEMA;
         setupSchema(statusTableSchema, true);
 
         CommandStatus status = TestUtils.main("run", "-o", root().toString(), "--project", root().toString(),

--- a/digdag-tests/src/test/resources/acceptance/pg/insert_into_with_schema.dig
+++ b/digdag-tests/src/test/resources/acceptance/pg/insert_into_with_schema.dig
@@ -7,4 +7,5 @@ timezone: UTC
   user: ${pg_user}
   schema: ${schema_in_config}
   status_table_schema: ${status_table_schema_in_config}
+  status_table: ${status_table_in_config}
   insert_into: dest_tbl

--- a/digdag-tests/src/test/resources/acceptance/redshift/insert_into_with_schema.dig
+++ b/digdag-tests/src/test/resources/acceptance/redshift/insert_into_with_schema.dig
@@ -7,4 +7,5 @@ timezone: UTC
   user: ${redshift_user}
   schema: ${schema_in_config}
   status_table_schema: ${status_table_schema_in_config}
+  status_table: ${status_table_in_config}
   insert_into: dest_tbl


### PR DESCRIPTION
`pg` operator records the status of workflow tasks in the target PostgreSQL database (a.k.a. `status table`) so that it achieves exactly-once semantics. But this way requires some privileges including CREATE TABLE. For the case DBA doesn't want to give those permissions to the workflow, `pg` operator also provides an option to prepare `status table`  in advance.

We recently noticed it doesn't work expectedly since `pg` operator still issues `CREATE TABLE IF NOT EXISTS` that requires CREATE TABLE privilege and fails even when `status table` is already created in advance.

This PR makes `pg` operator check if `status table` exists in advance before trying to create the table to avoid this issue.