### PR TITLE
Profile based on finished at

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/Profile.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Profile.java
@@ -114,8 +114,8 @@ public class Profile
         err.println("Usage: " + programName + " profile the performance by analyzing archived task information (experimental)");
         err.println("  Options:");
         err.println("    -c, --config               <path>           configuration file (required)");
-        err.println("        --from                 <timestamp>      start of profile time range (\"yyyy-MM-dd HH:mm:ss\", required)");
-        err.println("        --to                   <timestamp>      end of profile time range (\"yyyy-MM-dd HH:mm:ss\", default: current timestamp)");
+        err.println("        --from                 <timestamp>      beginning of time range that the profiler scans based on attempts' finish timestamp (\"yyyy-MM-dd HH:mm:ss\", required)");
+        err.println("        --to                   <timestamp>      end of time range that the profiler scans based on attempts' finish timestamp  (\"yyyy-MM-dd HH:mm:ss\", default: current time)");
         err.println("        --fetched-attempts     <attempts-count> number of fetched attempt records at once (default: 1000)");
         err.println("        --partition-size       <partition-size> number of internal partition size (default: 100)");
         err.println("        --database-wait-millis <milliseconds>   internal wait (milliseconds) between database transactions (default: 100)");

--- a/digdag-cli/src/main/java/io/digdag/cli/profile/TaskAnalyzer.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/profile/TaskAnalyzer.java
@@ -47,11 +47,12 @@ public class TaskAnalyzer
         }
     }
 
-    public WholeTasksSummary run(Instant createdFrom,
-                            Instant createdTo,
-                            int fetchedAttempts,
-                            int partitionSize,
-                            int databaseWaitMillis)
+    public WholeTasksSummary run(
+            Instant finishedFrom,
+            Instant finishedTo,
+            int fetchedAttempts,
+            int partitionSize,
+            int databaseWaitMillis)
     {
         TransactionManager tm = injector.getInstance(TransactionManager.class);
         SessionStoreManager sm = injector.getInstance(SessionStoreManager.class);
@@ -66,7 +67,7 @@ public class TaskAnalyzer
             // Partition target attempts to avoid a too long transaction later
             List<List<AttemptIdWithSiteId>> attemptIdsList = tm.begin(() ->
                     Lists.partition(
-                            sm.findFinishedAttemptsWithSessions(createdFrom, createdTo, lastId.get(), fetchedAttempts).stream()
+                            sm.findFinishedAttemptsWithSessions(finishedFrom, finishedTo, lastId.get(), fetchedAttempts).stream()
                                     .map(attempt -> {
                                         lastId.set(Math.max(lastId.get(), attempt.getId()));
                                         return new AttemptIdWithSiteId(attempt.getSiteId(), attempt.getId());

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
@@ -1695,7 +1695,7 @@ public class DatabaseSessionStoreManager
                 " from session_attempts sa" +
                 " join sessions s on s.id = sa.session_id" +
                 " where bitand(state_flags, " + AttemptStateFlags.DONE_CODE + ") != 0" +
-                " and sa.finished_at >= :finishedFrom and sa.finished_at < :finishedTo" +
+                " and sa.finished_at \\>= :finishedFrom and sa.finished_at \\< :finishedTo" +
                 " and sa.id \\> :lastId" +
                 " order by sa.id asc" +
                 " limit :limit";
@@ -1758,7 +1758,7 @@ public class DatabaseSessionStoreManager
                         " from session_attempts sa" +
                         " join sessions s on s.id = sa.session_id" +
                         " where state_flags & " + AttemptStateFlags.DONE_CODE + " != 0" +
-                        " and sa.finished_at >= :finishedFrom and sa.finished_at < :finishedTo" +
+                        " and sa.finished_at \\>= :finishedFrom and sa.finished_at \\< :finishedTo" +
                         " and sa.id \\> :lastId" +
                         " order by sa.id asc" +
                         " limit :limit";

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSessionStoreManager.java
@@ -304,10 +304,10 @@ public class DatabaseSessionStoreManager
 
     @DigdagTimed(value = "dssm_", category = "db", appendMethodName = true)
     @Override
-    public List<StoredSessionAttemptWithSession> findFinishedAttemptsWithSessions(Instant createdFrom, Instant createdTo, long lastId, int limit)
+    public List<StoredSessionAttemptWithSession> findFinishedAttemptsWithSessions(Instant finishedFrom, Instant finishedTo, long lastId, int limit)
     {
         return autoCommit((handle, dao) ->
-                dao.findFinishedAttemptsWithSessionsInternal(sqlTimestampOf(createdFrom), sqlTimestampOf(createdTo), lastId, limit));
+                dao.findFinishedAttemptsWithSessionsInternal(sqlTimestampOf(finishedFrom), sqlTimestampOf(finishedTo), lastId, limit));
     }
 
     @DigdagTimed(value = "dssm_", category = "db", appendMethodName = true)
@@ -1695,14 +1695,14 @@ public class DatabaseSessionStoreManager
                 " from session_attempts sa" +
                 " join sessions s on s.id = sa.session_id" +
                 " where bitand(state_flags, " + AttemptStateFlags.DONE_CODE + ") != 0" +
-                " and sa.created_at between :createdFrom and :createdTo" +
+                " and sa.finished_at >= :finishedFrom and sa.finished_at < :finishedTo" +
                 " and sa.id \\> :lastId" +
                 " order by sa.id asc" +
                 " limit :limit";
         @SqlQuery(SQL_FIND_FINISHED_ATTEMPTS_WITH_SESSIONS_INTERNAL)
         List<StoredSessionAttemptWithSession> findFinishedAttemptsWithSessionsInternal(
-                @Bind("createdFrom") Timestamp createdFrom,
-                @Bind("createdTo") Timestamp createdTo,
+                @Bind("finishedFrom") Timestamp finishedFrom,
+                @Bind("finishedTo") Timestamp finishedTo,
                 @Bind("lastId") long lastId,
                 @Bind("limit") int limit);
 
@@ -1758,14 +1758,14 @@ public class DatabaseSessionStoreManager
                         " from session_attempts sa" +
                         " join sessions s on s.id = sa.session_id" +
                         " where state_flags & " + AttemptStateFlags.DONE_CODE + " != 0" +
-                        " and sa.created_at between :createdFrom and :createdTo" +
+                        " and sa.finished_at >= :finishedFrom and sa.finished_at < :finishedTo" +
                         " and sa.id \\> :lastId" +
                         " order by sa.id asc" +
                         " limit :limit";
         @SqlQuery(SQL_FIND_FINISHED_ATTEMPTS_WITH_SESSIONS_INTERNAL)
         List<StoredSessionAttemptWithSession> findFinishedAttemptsWithSessionsInternal(
-                @Bind("createdFrom") Timestamp createdFrom,
-                @Bind("createdTo") Timestamp createdTo,
+                @Bind("finishedFrom") Timestamp finishedFrom,
+                @Bind("finishedTo") Timestamp finishedTo,
                 @Bind("lastId") long lastId,
                 @Bind("limit") int limit);
 
@@ -2041,10 +2041,10 @@ public class DatabaseSessionStoreManager
         List<StoredSessionAttempt> findActiveAttemptsCreatedBefore(@Bind("createdBefore") Timestamp createdBefore, @Bind("lastId") long lastId, @Bind("limit") int limit);
 
         List<StoredSessionAttemptWithSession> findFinishedAttemptsWithSessionsInternal(
-                @Bind("createdFrom") Timestamp createdFrom,
-                @Bind("createdTo") Timestamp createdTo,
-                @Bind("lastId") long lastId,
-                @Bind("limit") int limit);
+                Timestamp finishedFrom,
+                Timestamp finishedTo,
+                long lastId,
+                int limit);
 
         @SqlQuery("select site_id from tasks" +
                 " join session_attempts sa on sa.id = tasks.attempt_id" +

--- a/digdag-core/src/main/java/io/digdag/core/session/SessionStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/session/SessionStoreManager.java
@@ -42,7 +42,7 @@ public interface SessionStoreManager
     List<StoredSessionAttempt> findActiveAttemptsCreatedBefore(Instant createdBefore, long lastId, int limit);
 
     // for profiling
-    List<StoredSessionAttemptWithSession> findFinishedAttemptsWithSessions(Instant createdFrom, Instant createdTo, long lastId, int limit);
+    List<StoredSessionAttemptWithSession> findFinishedAttemptsWithSessions(Instant finishedFrom, Instant finishedTo, long lastId, int limit);
 
     // for AttemptTimeoutEnforcer.enforceTaskTTLs
     List<TaskAttemptSummary> findTasksStartedBeforeWithState(TaskStateCode[] states, Instant startedBefore, long lastId, int limit);

--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -1017,13 +1017,13 @@ Profile the performance by analyzing archived information (experimental). The re
 
 :command:`--from TIMESTAMP`
 
-  The beginning of time range that the profiler scans. The timestamp format is `yyyy-MM-dd HH:mm:ss`.
+  The beginning of time range that the profiler scans based on attempts' finish timestamp. The timestamp format is `yyyy-MM-dd HH:mm:ss`.
 
   Example: ``--from '2020-12-30 00:00:00'``
 
 :command:`--to TIMESTAMP`
 
-  The end of time range that the profiler scans. The timestamp format is `yyyy-MM-dd HH:mm:ss`. Current time is used if it's not set.
+  The end of time range that the profiler scans based on attempts' finish timestamp. The timestamp format is `yyyy-MM-dd HH:mm:ss`. Current time is used if it's not set.
 
   Example: ``--to '2020-12-31 00:00:00'``
 


### PR DESCRIPTION
The original implementation of `digdag profile` collect archived task metrics based on `session_attempts.created_at`, but it's hard to handle since the following situation easily happens:
- Attempt A started 4 hours ago and is still running
- digdag profile is triggered and captures all attempts that have finished since 4 hours ago based on the command option. Attempt A isn't included in the result
- 1 hour later, digdag profile is triggered again with the same options, but attempt A started 5 hours ago and it won't be captured

So in this PR, we'll make `digdag profile` command from `created_at`-based to `finished_at`-based so we won't miss any archived attempt.