### PR TITLE
Filter out dynamically generated`^sla` task in `digdag profile` command

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/profile/TasksSummary.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/profile/TasksSummary.java
@@ -148,6 +148,7 @@ class TasksSummary
                 // (This case corresponds to #1 in the comment above)
                 if (task.getFullName().endsWith("^check")
                         || task.getFullName().endsWith("^error")
+                        || task.getFullName().endsWith("^sla")
                         || task.getFullName().endsWith("^failure-alert")) {
                     timestampWhenTaskIsReady = Optional.absent();
                 }


### PR DESCRIPTION
`digdag profile` command filters out `^error`, `^check` and `^failure-alert` tasks that are generated dynamically since their tasks' `started_at` don't show actual start delay. But I noticed `^sla` task also needs to be filtered out.