### PR TITLE
Add note about the polling cycle

### DIFF
--- a/digdag-docs/src/operators/s3_wait.md
+++ b/digdag-docs/src/operators/s3_wait.md
@@ -129,5 +129,5 @@ For more information about SSE-C, See the [AWS S3 Documentation](http://docs.aws
           }
         }
 
-Note: The **s3_wait>** operator makes use of polling with *exponential backoff*. As such there might be some time interval between a file being created and the **s3_wait>** operator detecting it.
+Note: The **s3_wait>** operator makes use of polling with *exponential backoff*. As such there might be some time interval between a file being created and the **s3_wait>** operator detecting it. This interval start at 5 seconds and increase to double each cycle, with a maximum interval of 5 minutes.
 


### PR DESCRIPTION
[`s3_wait>` article](https://docs.digdag.io/operators/s3_wait.html) doesn't mention the polling cycle yet.
So, I'd like to mention it in our doc.

https://github.com/treasure-data/digdag/blob/42ea7cb71270957ea6424c2df88dd7c65d248789/digdag-standards/src/main/java/io/digdag/standards/operator/aws/S3WaitOperatorFactory.java#L47