### PR TITLE
Change publish destination from Bintray to OSS Sonatype

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Please check [digdag.io](https://digdag.io) and [docs.digdag.io](https://docs.di
 
 REST API document is available at [docs.digdag.io/api](http://docs.digdag.io/api/).
 
+## Release Notes
+
+The list of release note is [here](https://github.com/treasure-data/digdag/tree/master/digdag-docs/src/releases).
+
+
 ## Development
 
 ### Prerequirements
@@ -63,7 +68,7 @@ Test uses in-memory H2 database by default. To use PostgreSQL, set following env
 $ export DIGDAG_TEST_POSTGRESQL="$(cat config/test_postgresql.properties)"
 ```
 
-## Building CLI executables
+### Building CLI executables
 
 ```
 $ ./gradlew cli
@@ -73,42 +78,6 @@ $ ./gradlew cli -PwithoutUi  # build without integrated UI
 (If the command fails during building UI due to errors from `node` command, you can try to add `-PwithoutUi` argument to exclude the UI from the package).
 
 It makes an executable in `pkg/`, e.g. `pkg/digdag-$VERSION.jar`.
-
-### Releasing a new version
-
-You need to set Bintray user name and API key in `BINTRAY_USER` and `BINTRAY_KEY` environment variables.
-In the following instructions, assumed that `upstream` is set to `treasure-data/digdag` and `origin` is set to your private repository.
-
-1. run `git pull upstream master --tags`.
-1. run `./gradlew setVersion -Pto=<version>` command.
-1. write release notes to `releases/release-<version>.rst` file. It must include at least version (the first line) and release date (the last line).
-1. run `./gradlew clean cli site check releaseCheck`.
-1. make a release branch. `git checkout -b release_v<version>` and commit.
-1. push the release branch to origin and create a PR.
-1. after the PR is merged to master, checkout master and pull latest upstream/master.
-1. run `./gradlew clean cli site check releaseCheck` again.
-1. if it succeeded, run `./gradlew release`.
-1. a few minutes later, run `digdag selfupdate` and confirm the version.
-
-If major version is incremented, also update `version =` and `release =` at [digdag-docs/src/conf.py](digdag-docs/src/conf.py).
-
-If you are expert, skip 5. to 7. and directly update master branch.
-
-### Post-process of new release
-
-You also need following steps after new version has been released.
-
-1. create a tag `git tag -a v<version>` and push `git push upstream v<version>`
-1. create a release in [GitHub releases](https://github.com/treasure-data/digdag/releases).
-1. create next snapshot version, run `./gradlew setVersion -Pto=<next-version>-SNAPSHOT`.
-1. push to master.
-
-
-### Releasing a SNAPSHOT version
-
-```
-./gradlew releaseSnapshot
-```
 
 ### Develop digdag-ui
 
@@ -176,10 +145,6 @@ This might not always update all necessary files (Sphinx doesn't manage update d
 
 It builds index.html at digdag-docs/build/html/index.html.
 
-### Release Notes
-
-The list of release note is [here](https://github.com/treasure-data/digdag/tree/master/digdag-docs/src/releases).
-
 ### Development on IDEs
 
 #### IntelliJ IDEA
@@ -190,4 +155,55 @@ So we'd recommend the followings to avoid those compile errors if you want to de
 1. There's an important configuration option to be enabled to fully have IntelliJ be fully integrated with an existing gradle build configuration: `Delegate IDE build/run actions to gradle` needs to be enabled.
 
 ![](https://user-images.githubusercontent.com/17990895/48221255-9706be80-e35f-11e8-8283-1ca6d713e31c.png)
+
+## Releasing a new version
+This is for committers only.
+### Prerequisite: Sonatype OSSRH
+You need an account in Sonatype OSSRH, and configure it in your `~/.gradle/gradle.properties`.
+
+ossrhUsername=(your Sonatype OSSRH username)
+ossrhPassword=(your Sonatype OSSRH password)
+
+### Prerequisite: PGP signatures
+You need your PGP signatures to release artifacts into Maven Central, and configure Gradle to use your key to sign.
+Configure it in your `~/.gradle/gradle.properties`.
+
+```
+signing.gnupg.executable=gpg
+signing.gnupg.useLegacyGpg=false
+signing.gnupg.keyName=(the last 8 symbols of your keyId)
+signing.gnupg.passphrase=(the passphrase used to protect your private key)
+```
+
+### Release procedure
+1. run `git pull upstream master --tags`.
+1. run `./gradlew setVersion -Pto=<version>` command.
+1. write release notes to `releases/release-<version>.rst` file. It must include at least version (the first line) and release date (the last line).
+1. run `./gradlew clean cli site check releaseCheck`.
+1. make a release branch. `git checkout -b release_v<version>` and commit.
+1. push the release branch to origin and create a PR.
+1. after the PR is merged to master, checkout master and pull latest upstream/master.
+1. run `./gradlew clean cli site check releaseCheck` again.
+1. if it succeeded, run `./gradlew release`.
+1. create a tag `git tag -a v<version>` and push `git push upstream v<version>`
+1. create a release in [GitHub releases](https://github.com/treasure-data/digdag/releases).
+1. upload `pkg/digdag-<version>.jar` to the release
+1. a few minutes later, run `digdag selfupdate` and confirm the version.
+
+If major version is incremented, also update `version =` and `release =` at [digdag-docs/src/conf.py](digdag-docs/src/conf.py).
+
+If you are expert, skip 5. to 7. and directly update master branch.
+
+### Post-process of new release
+
+You also need following steps after new version has been released.
+
+1. create next snapshot version, run `./gradlew setVersion -Pto=<next-version>-SNAPSHOT`.
+1. push to master.
+
+### Releasing a SNAPSHOT version
+
+```
+./gradlew releaseSnapshot
+```
 

--- a/README.md
+++ b/README.md
@@ -206,4 +206,5 @@ You also need following steps after new version has been released.
 ```
 ./gradlew releaseSnapshot
 ```
-
+**Note**
+Snapshot release is not supported currently.

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,11 @@ allprojects {
     apply plugin: 'java'
     apply plugin: 'jacoco'
     apply plugin: 'net.ltgt.apt-idea'
+    // 'maven' plugin is deprecated and replaced by 'maven-publish'.
+    // But it is required for task 'pom' which generates pom.xml in root and subproject root.
+    // ci/validate.sh call the task and run some mvn commands like 'enforcer'.
+    // But there is no enforcer rule definition. So it might be better to remove the task and the plugin.
+    apply plugin: 'maven'
 
     repositories {
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'com.github.johnrengelman.shadow' version '5.2.0'
-    id 'com.jfrog.bintray' version '1.8.4'
     id 'com.github.kt3k.coveralls' version '2.10.1'
     id 'com.github.spotbugs' version '4.0.5'
     id 'net.ltgt.apt-idea' version '0.21'
@@ -11,6 +10,7 @@ apply plugin: 'idea'
 apply plugin: 'maven'
 
 allprojects {
+
     group = 'io.digdag'
     version = '0.10.0'
 
@@ -29,24 +29,13 @@ allprojects {
     apply plugin: 'idea'
     apply plugin: 'java'
     apply plugin: 'jacoco'
-    apply plugin: 'com.jfrog.bintray'
-    apply plugin: 'maven-publish'
     apply plugin: 'net.ltgt.apt-idea'
 
     repositories {
         mavenCentral()
         jcenter()
         maven {
-            url  "https://dl.bintray.com/digdag/maven"
-        }
-        maven {
-            url  "https://dl.bintray.com/digdag/maven-snapshots"
-        }
-        maven {
             url "https://oss.sonatype.org/content/repositories/snapshots"
-        }
-        maven {
-            url "https://dl.bintray.com/yoyama/maven"
         }
     }
 
@@ -54,46 +43,13 @@ allprojects {
         toolVersion = '0.8.5'
     }
 
-    bintray {
-        user = System.getenv('BINTRAY_USER')
-        key = System.getenv('BINTRAY_KEY')
-
-        publications = ['mavenJava']
-
-        filesSpec {
-            // include digdag-<version>.jar built by 'cli' task
-            from "pkg/digdag-${project.version}.jar"
-            into "."
-        }
-
-        dryRun = false
-        publish = true
-
-        pkg {
-            userOrg = 'digdag'
-            if (project.ext.isSnapshotRelease) {
-                repo = 'maven-snapshots'
-                name = 'digdag-snapshots'
-            }
-            else {
-                repo = 'maven'
-                name = 'digdag'
-            }
-            licenses = ['Apache-2.0']
-            publicDownloadNumbers = true
-
-            version {
-                name = project.version
-                released = new Date().format("yyyy-MM-dd'T'HH:mm:ss.SSSZ")
-                vcsTag = "v${project.version}"
-                attributes = ['isCI': System.getenv('CI') ?: false]
-            }
-        }
-    }
 }
+
 
 subprojects {
     apply plugin: 'maven'
+    apply plugin: 'maven-publish'
+    apply plugin: 'signing'
     apply plugin: 'com.github.spotbugs'
 
     sourceCompatibility = 1.8
@@ -298,23 +254,45 @@ subprojects {
         }
     }
 
-    publishing {
-        publications {
-            if (![project(":digdag-docs")].contains(project)) {
+    // digdag-docs is out of target on publish
+    if (![project(":digdag-docs")].contains(project)) {
+        publishing {
+            publications {
                 mavenJava(MavenPublication) {
                     from components.java
                     afterEvaluate {
                         artifact testsJar
                         artifact sourcesJar
                         artifact javadocJar
-
                         pom.withXml(pomXmlModifier)
                     }
                 }
             }
+            repositories {
+                maven {  // publishMavenJavaPublicationToMavenCentralRepository
+                    name = "mavenCentral"
+                    if (project.version.endsWith("-SNAPSHOT")) {
+                        url "https://oss.sonatype.org/content/repositories/snapshots"
+                    } else {
+                        url "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+                    }
+                    credentials {
+                        username = project.hasProperty("ossrhUsername") ? ossrhUsername : ""
+                        password = project.hasProperty("ossrhPassword") ? ossrhPassword : ""
+                    }
+                }
+            }
+        }
+
+        signing {
+            useGpgCmd()
+            sign publishing.publications.mavenJava
         }
     }
+
+
 }
+
 
 jacocoTestReport {
     dependsOn = subprojects.jacocoTestReport
@@ -429,7 +407,6 @@ task cli(dependsOn: ':digdag-cli:shadowJar') {
     }
 }
 
-bintrayUpload.dependsOn('cli')
 
 task classpath(dependsOn: [':digdag-cli:classpath']){
     doLast {
@@ -454,11 +431,9 @@ clean {
 }
 
 task release() {
-    // This is necessary to upload the executable jar to bintray as well.
-    // It makes to run _bintrayRecordingCopy task after cli task.
     release.mustRunAfter cli
-    dependsOn subprojects.publish
-    dependsOn bintrayUpload
+    dependsOn subprojects.findAll{it.name != "digdag-docs" }.publishMavenJavaPublicationToMavenCentralRepository
+    //ToDo upload executable to GitHub
     doLast {
         println "Released ${project.version}."
     }
@@ -545,7 +520,6 @@ task releaseCheck {
 }
 
 // Utility task to release a snapshot version with a fixed version number.
-// Bintray doesn't allow releasing -SNAPSHOT version.
 task releaseSnapshot(type: Exec) {
     commandLine "bash", "-c", "./gradlew -PsnapshotVersion=\$(TZ=UTC git log -n 1 --pretty='format:%ad-%H' --date 'format-local:%Y%m%dT%H%M%S') release"
 }
@@ -564,13 +538,6 @@ task pom {
                     }
                 }
                 repositories {
-                    repository {
-                        id 'jcenter'
-                        url 'https://jcenter.bintray.com'
-                        releases {
-                            enabled 'true'
-                        }
-                    }
                 }
                 modules {
                     subprojects.each {

--- a/build.gradle
+++ b/build.gradle
@@ -272,7 +272,7 @@ subprojects {
             repositories {
                 maven {  // publishMavenJavaPublicationToMavenCentralRepository
                     name = "mavenCentral"
-                    if (project.version.endsWith("-SNAPSHOT")) {
+                    if (project.ext.isSnapshotRelease) {
                         url "https://oss.sonatype.org/content/repositories/snapshots"
                     } else {
                         url "https://oss.sonatype.org/service/local/staging/deploy/maven2"

--- a/build.gradle
+++ b/build.gradle
@@ -284,9 +284,11 @@ subprojects {
                 }
             }
         }
-        signing {
-            useGpgCmd()
-            sign publishing.publications.mavenJava
+        if (project.hasProperty('signing.gnupg.keyName')) {
+            signing {
+                useGpgCmd()
+                sign publishing.publications.mavenJava
+            }
         }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,6 @@ plugins {
 
 apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'idea'
-apply plugin: 'maven'
 
 allprojects {
     group = 'io.digdag'
@@ -45,7 +44,6 @@ allprojects {
 }
 
 subprojects {
-    apply plugin: 'maven'
     apply plugin: 'maven-publish'
     apply plugin: 'signing'
     apply plugin: 'com.github.spotbugs'
@@ -175,15 +173,15 @@ subprojects {
     }
 
     task testsJar(type: Jar) {
-        classifier = 'tests'
+        archiveClassifier = 'tests'
         from sourceSets.test.output
     }
     task sourcesJar(type: Jar) {
-        classifier = 'sources'
+        archiveClassifier = 'sources'
         from sourceSets.main.allSource
     }
     task javadocJar(type: Jar) {
-        classifier = 'javadoc'
+        archiveClassifier = 'javadoc'
         from javadoc
     }
 
@@ -281,7 +279,6 @@ subprojects {
                 }
             }
         }
-
         signing {
             useGpgCmd()
             sign publishing.publications.mavenJava

--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,6 @@ apply plugin: 'idea'
 apply plugin: 'maven'
 
 allprojects {
-
     group = 'io.digdag'
     version = '0.10.0'
 
@@ -44,7 +43,6 @@ allprojects {
     }
 
 }
-
 
 subprojects {
     apply plugin: 'maven'
@@ -289,10 +287,7 @@ subprojects {
             sign publishing.publications.mavenJava
         }
     }
-
-
 }
-
 
 jacocoTestReport {
     dependsOn = subprojects.jacocoTestReport
@@ -536,8 +531,6 @@ task pom {
                             sourceEncoding 'UTF-8'
                         }
                     }
-                }
-                repositories {
                 }
                 modules {
                     subprojects.each {


### PR DESCRIPTION
Because of sunset of Bintray, we move to OSS Sonatype.
As the internal discussion, we stop support of `releaseSnapshot` tasks due to snapshot repository behavior is different between Bintray and sonatype and fix to support will affect to our internal deployment.
In addition, we have never used `releaseSnapshot` for Digdag OSS release so far.
