### PR TITLE
Stop automatic `releaseSnapshot` from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,18 +66,6 @@ jobs:
       # Build and deploy documents
       - run: ci/push_gh_pages.sh
 
-  release_snapshot:
-    # executor type https://circleci.com/docs/2.0/executor-types/
-    docker:
-      - image: digdag/digdag-build:20191203T225216-c5b7206657c98c728b183634079f0a919ee98f8c
-        # environment Variables in a Job https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-job
-        environment:
-          TERM: dumb
-          TZ: 'UTC'
-    steps:
-      - checkout
-      - run: ./gradlew releaseSnapshot
-
 workflows:
   version: 2
 
@@ -89,10 +77,3 @@ workflows:
             branches:
               only:
                 - master
-      - release_snapshot: # v0_10 branch only
-          requires:
-            - test
-          filters:
-            branches:
-              only:
-                - v0_11


### PR DESCRIPTION
We've executed `gradle releaseSnapshot` on CircleCI to release snapshot artifacts to Bintray for each `v0_11` branch update. But Bintray is closing its service now and our CI recently started failing. We also have a plan to move to Sonatype, but it's only for normal releases not for snapshot releases. So, we don't need this broken automatic `releaseSnapshot` anymore.