### PR TITLE
Avoid running the same 2 CI tests on AppVayor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,9 +12,10 @@ cache:
   - C:\Users\appveyor\.gradle
 
 environment:
-  NPM: C:\Program Files\nodejs\npm.cmd
+  NPM: C:\Program Files (x86)\nodejs\npm.cmd
   matrix:
   - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+  - JAVA_HOME: C:\Program Files (x86)\Java\jdk1.8.0
 
 install:
   - ps: Install-Product node '12'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,6 @@ environment:
   NPM: C:\Program Files (x86)\nodejs\npm.cmd
   matrix:
   - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
-  - JAVA_HOME: C:\Program Files (x86)\Java\jdk1.8.0
 
 install:
   - ps: Install-Product node '12'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,3 +23,8 @@ install:
   - npm --version
 
 test: off
+
+branches:
+  only:
+    - master
+    - v0_11

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,10 +12,9 @@ cache:
   - C:\Users\appveyor\.gradle
 
 environment:
-  NPM: C:\Program Files (x86)\nodejs\npm.cmd
+  NPM: C:\Program Files\nodejs\npm.cmd
   matrix:
   - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
-  - JAVA_HOME: C:\Program Files (x86)\Java\jdk1.8.0
 
 install:
   - ps: Install-Product node '12'


### PR DESCRIPTION
Current Digdag's CI on AppVayor runs twice as `push` and `pull request` when we push a PR. It doesn't make sense. This PR makes CI on AppVayor be triggered only once as `pull request` for each pull request.