### PR TITLE
Fix ECS task log lost issue

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -60,6 +60,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 public class EcsCommandExecutor
@@ -328,6 +329,14 @@ public class EcsCommandExecutor
                 previousExecutorStatus = fetchLogEvents(client, previousStatus, previousExecutorStatus);
                 if (previousExecutorStatus.get("logging_finished_at") != null) {
                     break;
+                }
+                try {
+                    // Just to avoid DOS attack to ECS endpoint
+                    TimeUnit.SECONDS.sleep(2);
+                }
+                catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(e);
                 }
             }
             while (Instant.now().getEpochSecond() < timeout);

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/DefaultEcsClient.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/DefaultEcsClient.java
@@ -270,6 +270,8 @@ public class DefaultEcsClient
             final Optional<String> nextToken)
     {
         final GetLogEventsRequest request = new GetLogEventsRequest()
+                // This should be true when using `nextToken`. See the doc for details.
+                .withStartFromHead(true)
                 .withLogGroupName(groupName)
                 .withLogStreamName(streamName);
         if (nextToken.isPresent()) {


### PR DESCRIPTION
We've observed occasional missing ECS task logs issue.

I noticed current `DefaultEcsClient` doesn't set `startFromHead` to true which should be true when using `nextToken`. Also this PR includes a few second wait in a loop to avoid DOS-like attack.