### PR TITLE
Fix wrong usage of TemporaryDigdagServer in IT

### DIFF
--- a/digdag-tests/src/test/java/acceptance/MigrationIT.java
+++ b/digdag-tests/src/test/java/acceptance/MigrationIT.java
@@ -6,6 +6,7 @@ import io.digdag.core.database.migrate.MigrationContext;
 import io.digdag.core.database.migrate.Migration_20151204221156_CreateTables;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
@@ -20,13 +21,8 @@ import static org.junit.Assume.assumeTrue;
 
 public class MigrationIT
 {
-    public TemporaryDigdagServer server = null;
-
-    @Before
-    public void setUp()
-    {
-        server = TemporaryDigdagServer.of();
-    }
+    @Rule
+    public TemporaryDigdagServer server = TemporaryDigdagServer.of();
 
     @After
     public void tearDown()

--- a/digdag-tests/src/test/java/acceptance/MigrationIT.java
+++ b/digdag-tests/src/test/java/acceptance/MigrationIT.java
@@ -6,7 +6,6 @@ import io.digdag.core.database.migrate.MigrationContext;
 import io.digdag.core.database.migrate.Migration_20151204221156_CreateTables;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
@@ -21,8 +20,20 @@ import static org.junit.Assume.assumeTrue;
 
 public class MigrationIT
 {
+    // Shouldn't setup TemporaryDigdagServer using @Rule in this test
+    // since the annotation implicitly calls `apply()` method, but this test
+    // expects the method hasn't been called
+    /*
     @Rule
     public TemporaryDigdagServer server = TemporaryDigdagServer.of();
+    */
+    private TemporaryDigdagServer server = null;
+
+    @Before
+    public void setUp()
+    {
+        server = TemporaryDigdagServer.of();
+    }
 
     @After
     public void tearDown()

--- a/digdag-tests/src/test/java/acceptance/td/PyIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/PyIT.java
@@ -9,8 +9,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import utils.CommandStatus;
 import utils.TemporaryDigdagServer;
 
@@ -32,12 +30,10 @@ public class PyIT
 {
     private static final String ECS_CONFIG = System.getenv("ECS_IT_CONFIG");
 
-    private static final Logger logger = LoggerFactory.getLogger(EmrIT.class);
-
     @Rule
     public TemporaryFolder folder = new TemporaryFolder();
-    @Rule
-    public TemporaryDigdagServer server = TemporaryDigdagServer.of();
+
+    private TemporaryDigdagServer server;
 
     private String accessKeyId;
     private String secretAccessKey;


### PR DESCRIPTION
This PR does
- avoid launching unused  in TemporaryDigdagServer in `acceptance/td/PyIT`
- minor refactoring in `MigrationIT`