### PR TITLE
Add digdagignore

### DIFF
--- a/digdag-core/build.gradle
+++ b/digdag-core/build.gradle
@@ -23,6 +23,7 @@ dependencies {
     compile 'org.yaml:snakeyaml:1.23'
     compile 'com.google.code.findbugs:annotations:3.0.1'
     compile 'org.weakref:jmxutils:1.19'
+    compile 'org.eclipse.jgit:org.eclipse.jgit:5.11.1.202105131744-r'
 
     // JavaScript engine
     compile 'org.graalvm.js:js:19.3.1'

--- a/digdag-core/src/main/java/io/digdag/core/archive/DigdagIgnore.java
+++ b/digdag-core/src/main/java/io/digdag/core/archive/DigdagIgnore.java
@@ -33,7 +33,8 @@ public class DigdagIgnore implements DirectoryStream.Filter<Path> {
     @Override
     public boolean accept(Path target) {
         Boolean ignored = this.ignoreNode.checkIgnored(
-                this.projectPath.relativize(target).toString(),
+                // checkIgnored assumes separator to be "/"
+                this.projectPath.relativize(target).toString().replace(File.separatorChar, '/'),
                 target.toFile().isDirectory()
         );
          return ignored == null || ignored == false;

--- a/digdag-core/src/main/java/io/digdag/core/archive/DigdagIgnore.java
+++ b/digdag-core/src/main/java/io/digdag/core/archive/DigdagIgnore.java
@@ -1,0 +1,41 @@
+package io.digdag.core.archive;
+
+import org.eclipse.jgit.ignore.IgnoreNode;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Path;
+import java.util.Optional;
+
+public class DigdagIgnore implements DirectoryStream.Filter<Path> {
+    private Path projectPath;
+    private IgnoreNode ignoreNode;
+
+    private DigdagIgnore(){}
+
+    public static Optional<DigdagIgnore> ofProject(Path projectPath) throws IOException {
+        File digdagIgnoreFile = projectPath.resolve(".digdagignore").toFile();
+        if (!digdagIgnoreFile.exists()) {
+            return Optional.empty();
+        }
+
+        DigdagIgnore instance = new DigdagIgnore();
+        instance.projectPath = projectPath;
+        instance.ignoreNode = new IgnoreNode();
+        try (FileInputStream s = new FileInputStream(digdagIgnoreFile)) {
+            instance.ignoreNode.parse(s);
+            return Optional.of(instance);
+        }
+    }
+
+    @Override
+    public boolean accept(Path target) {
+        Boolean ignored = this.ignoreNode.checkIgnored(
+                this.projectPath.relativize(target).toString(),
+                target.toFile().isDirectory()
+        );
+         return ignored == null || ignored == false;
+    }
+}

--- a/digdag-core/src/main/java/io/digdag/core/archive/ProjectArchive.java
+++ b/digdag-core/src/main/java/io/digdag/core/archive/ProjectArchive.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 import java.nio.file.Path;
 import static java.util.Locale.ENGLISH;
@@ -59,9 +60,9 @@ public class ProjectArchive
     static void listFiles(Path projectPath, PathConsumer consumer)
         throws IOException
     {
+        Optional<DigdagIgnore> digdagIgnore = DigdagIgnore.ofProject(projectPath);
         DirectoryStream.Filter<Path> filter = (target) -> (
-                rejectDotFiles(target) &&
-                DigdagIgnore.ofProject(projectPath)
+                rejectDotFiles(target) && digdagIgnore
                         .map((ignore) -> ignore.accept(target))
                         .orElse(true)
         );

--- a/digdag-core/src/main/java/io/digdag/core/archive/ProjectArchive.java
+++ b/digdag-core/src/main/java/io/digdag/core/archive/ProjectArchive.java
@@ -60,7 +60,9 @@ public class ProjectArchive
     static void listFiles(Path projectPath, PathConsumer consumer)
         throws IOException
     {
+        // parse .digdagignore
         Optional<DigdagIgnore> digdagIgnore = DigdagIgnore.ofProject(projectPath);
+        // filter rejects files / directories match .digdagignore and files / directories start with dot (.)
         DirectoryStream.Filter<Path> filter = (target) -> (
                 rejectDotFiles(target) && digdagIgnore
                         .map((ignore) -> ignore.accept(target))

--- a/digdag-core/src/main/java/io/digdag/core/archive/ProjectArchive.java
+++ b/digdag-core/src/main/java/io/digdag/core/archive/ProjectArchive.java
@@ -6,11 +6,7 @@ import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.Set;
-import java.time.ZoneId;
 import java.nio.file.Path;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.immutables.value.Value;
 import static java.util.Locale.ENGLISH;
 import static com.google.common.base.Preconditions.checkArgument;
 
@@ -63,7 +59,13 @@ public class ProjectArchive
     static void listFiles(Path projectPath, PathConsumer consumer)
         throws IOException
     {
-        listFilesRecursively(projectPath, projectPath, consumer, new HashSet<>());
+        DirectoryStream.Filter<Path> filter = (target) -> (
+                rejectDotFiles(target) &&
+                DigdagIgnore.ofProject(projectPath)
+                        .map((ignore) -> ignore.accept(target))
+                        .orElse(true)
+        );
+        listFilesRecursively(projectPath, projectPath, consumer, filter, new HashSet<>());
     }
 
     public String pathToResourceName(Path path)
@@ -90,16 +92,16 @@ public class ProjectArchive
         return relative.toString().replace(File.separatorChar, '/');
     }
 
-    private static void listFilesRecursively(Path projectPath, Path targetDir, PathConsumer consumer, Set<String> listed)
+    private static void listFilesRecursively(Path projectPath, Path targetDir, PathConsumer consumer, DirectoryStream.Filter<Path> filter, Set<String> listed)
         throws IOException
     {
-        try (DirectoryStream<Path> ds = Files.newDirectoryStream(targetDir, ProjectArchive::rejectDotFiles)) {
+        try (DirectoryStream<Path> ds = Files.newDirectoryStream(targetDir, filter)) {
             for (Path path : ds) {
                 String resourceName = realPathToResourceName(projectPath, path);
                 if (listed.add(resourceName)) {
                     boolean cont = consumer.accept(resourceName, path);
                     if (cont && Files.isDirectory(path)) {
-                        listFilesRecursively(projectPath, path, consumer, listed);
+                        listFilesRecursively(projectPath, path, consumer, filter, listed);
                     }
                 }
             }

--- a/digdag-core/src/test/java/io/digdag/core/archive/ProjectArchiveLoaderTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/archive/ProjectArchiveLoaderTest.java
@@ -1,13 +1,9 @@
 package io.digdag.core.archive;
 
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 
-import com.google.common.base.Optional;
-import com.google.common.base.Throwables;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
 import io.digdag.core.config.ConfigLoaderManager;
@@ -21,7 +17,6 @@ import java.util.Set;
 import static org.junit.Assert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-import io.digdag.client.config.ConfigUtils;
 import static io.digdag.client.config.ConfigUtils.configFactory;
 import static io.digdag.client.config.ConfigUtils.newConfig;
 

--- a/digdag-core/src/test/java/io/digdag/core/archive/ProjectArchiveTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/archive/ProjectArchiveTest.java
@@ -1,19 +1,13 @@
 package io.digdag.core.archive;
 
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
-import com.google.common.base.Optional;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 
-import io.digdag.core.config.ConfigLoaderManager;
-import io.digdag.core.config.YamlConfigLoader;
-import io.digdag.core.repository.WorkflowDefinition;
 import io.digdag.core.repository.WorkflowDefinitionList;
 
 import java.io.File;
@@ -22,15 +16,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.containsString;
 
-import io.digdag.client.config.ConfigUtils;
-import static io.digdag.client.config.ConfigUtils.configFactory;
 import static io.digdag.client.config.ConfigUtils.newConfig;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -124,6 +115,46 @@ public class ProjectArchiveTest
         expected.put("d1", d1);
         expected.put("d1/d2", d2);
         expected.put("d1/d2/d3", d3);
+
+        assertThat(files, is(expected.build()));
+    }
+
+    @Test
+    public void listFilesConsidersDigdagIgnore()
+        throws IOException
+    {
+        Path d1 = Files.createDirectory(path("d1"));
+        Path d2 = Files.createDirectory(path("d1", "d2"));
+        Path d3 = Files.createDirectory(path("d1", "d2", "d3"));
+
+        Path f1 = path("d1", "f1");
+        Path f2 = path("d1", "d2", "f2");
+        Path f3 = path("d1", "d2", "f3");
+        Path f4 = path("d1", "d2", "d3", "f4");
+        Path f5 = path("d1", "d2", "d3", "f5");
+
+        Path digdagIgnore = path(".digdagignore");
+        Files.write(digdagIgnore, (
+                "/d1/d2/d3\n"
+                + "f2"
+        ).getBytes(UTF_8));
+
+        for (Path p : ImmutableList.of(f1, f2, f3, f4, f5)) {
+            Files.write(p, "".getBytes(UTF_8));
+        }
+
+        Map<String, Path> files = new HashMap<>();
+        projectArchive().listFiles((name, path) -> {
+            files.put(name, path);
+            return true;
+        });
+
+        // keys are normalized path names
+        ImmutableMap.Builder<String, Path> expected = ImmutableMap.builder();
+        expected.put("d1", d1);
+        expected.put("d1/d2", d2);
+        expected.put("d1/f1", f1);
+        expected.put("d1/d2/f3", f3);
 
         assertThat(files, is(expected.build()));
     }

--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -843,6 +843,9 @@ Creates a project archive and upload it to the server. This command uploads work
 
   Example: ``--copy-outgoing-symlinks``
 
+Digdag excludes files start with dot (``.``) from project archives.
+If you want to exclude other files, put a file named ``.digdagignore`` in the project root directory and write patterns to ignore in the same way as ``.gitignore``.
+
 download
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Issue: #1092

Reading prior work #1175 , I
- wrote change in `ProjectArchive`.
- use eclipse JGit for implementation.

I still have some worries.
- I don't understand "In your current implementation, `ignoreFileList` method is called every tar entry copying. " in https://github.com/treasure-data/digdag/pull/1175#issuecomment-511006334 yet.
- whether `listFiles` method is good place to parse ignorefile or not.
- where should I write doc about `.digdagignore`