### PR TITLE
Fix wrong test workflow which uses unintended arrow function operator 

### DIFF
--- a/digdag-tests/src/test/resources/acceptance/config_eval_engine/invalid1.dig
+++ b/digdag-tests/src/test/resources/acceptance/config_eval_engine/invalid1.dig
@@ -1,5 +1,5 @@
 +test:
-  if>: ${td.last_results.cnt => 3}
+  if>: ${td.last_results.cnt >= 3}
   _do:
     echo>: "A,B,C"
   _else_do:


### PR DESCRIPTION
We saw all CI tests showing this unexpected error message

```
acceptance.ConfigEvalEngineIT > invalidConfigShouldNotInfiniteLoop STANDARD_OUT
    2021-06-07 07:10:45 +0000 [INFO] (XNIO-1 task-8) io.digdag.core.workflow.WorkflowExecutor: Starting a new session project id=1 workflow name=invalid1 session_time=2021-06-07T07:10:44+00:00
Error: 1-06-07 07:10:47 +0000 [ERROR] (0035@[0:config_eval_engine_test]+invalid1+test) io.digdag.core.agent.OperatorManager: Task failed with unexpected error: Unexpected error happened in ConfigEvalEngine: Failed generating bytecode for <function>:4
    java.lang.RuntimeException: Unexpected error happened in ConfigEvalEngine: Failed generating bytecode for <function>:4
      :
```
I checked the test code and it doesn't seem to expect this kind of error.

The cause of this error is that the test workflow uses `=>` as `greater than or equals` operator, but `=>` is JavaScript's `arrow function` operator
