### PR TITLE
Improve teardown in PgIT and RedshiftIT

### DIFF
--- a/digdag-tests/src/test/java/acceptance/PgIT.java
+++ b/digdag-tests/src/test/java/acceptance/PgIT.java
@@ -128,6 +128,11 @@ public class PgIT
     @After
     public void tearDown()
     {
+        if (host == null) {
+            // Do nothing since all the tests in this class are skipped
+            return;
+        }
+
         try {
             removeTempDatabase();
         }

--- a/digdag-tests/src/test/java/acceptance/td/RedshiftIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/RedshiftIT.java
@@ -180,13 +180,16 @@ public class RedshiftIT
     @After
     public void tearDown()
     {
-        if (database != null) {
-            try {
-                removeTempDatabase();
-            }
-            catch (Throwable e) {
-                logger.error("Failed to remove resources", e);
-            }
+        if (redshiftHost == null) {
+            // Do nothing since all the tests in this class are skipped
+            return;
+        }
+
+        try {
+            removeTempDatabase();
+        }
+        catch (Throwable e) {
+            logger.error("Failed to remove resources", e);
         }
 
         try {


### PR DESCRIPTION
We found CI test showed NPE that happened when those tests were skipped.

```
acceptance.PgIT > createTable STANDARD_OUT
     2021-06-03 09:38:58 +0000 [ERROR] (Test worker) acceptance.PgIT: Failed to remove resources
     java.lang.NullPointerException: null value in entry: host=null
     	at com.google.common.collect.CollectPreconditions.checkEntryNotNull(CollectPreconditions.java:32)
     	at com.google.common.collect.ImmutableMap.of(ImmutableMap.java:107)
     	at acceptance.PgIT.lambda$getAdminDatabaseSecrets$2(PgIT.java:646)
     	at io.digdag.standards.operator.pg.PgConnectionConfig.configure(PgConnectionConfig.java:24)
     	at acceptance.PgIT.removeTempDatabase(PgIT.java:667)
     	at acceptance.PgIT.tearDown(PgIT.java:132)
```

This doesn't make any test failed, but noisy. This PR fixes it.