### PR TITLE
WM-1210: Fixed AmazonS3Exception, the specified key does not exist, on ECS task polling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,11 +17,19 @@ pom.xml
 docker/bootstrap/constraints.txt
 docker/bootstrap/requirements.txt
 
+# env
+.node-version
+.java-version
+
 # intellij idea
 *.iml
 *.ipr
 *.iws
 *.idea
+
+# eclipse
+.classpath
+.settings
 
 # VSCode
 .project

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'com.github.kt3k.coveralls' version '2.10.1'
     id 'com.github.spotbugs' version '4.0.5'
     id 'net.ltgt.apt-idea' version '0.21'
+    id 'net.ltgt.apt-eclipse' version '0.21'
 }
 
 apply plugin: 'com.github.johnrengelman.shadow'
@@ -26,9 +27,11 @@ allprojects {
     }
 
     apply plugin: 'idea'
+    apply plugin: 'eclipse'
     apply plugin: 'java'
     apply plugin: 'jacoco'
     apply plugin: 'net.ltgt.apt-idea'
+    apply plugin: 'net.ltgt.apt-eclipse'
     // 'maven' plugin is deprecated and replaced by 'maven-publish'.
     // But it is required for task 'pom' which generates pom.xml in root and subproject root.
     // ci/validate.sh call the task and run some mvn commands like 'enforcer'.

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ plugins {
 
 apply plugin: 'com.github.johnrengelman.shadow'
 apply plugin: 'idea'
+apply plugin: 'eclipse'
 
 allprojects {
     group = 'io.digdag'

--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,8 @@ subprojects {
         testCompile 'org.hamcrest:hamcrest-library:1.3'
         testCompile 'org.mockito:mockito-core:1.10.19'
         testCompile 'pl.pragmatists:JUnitParams:1.0.5'
+        testImplementation 'org.powermock:powermock-api-mockito:1.6.6'
+        testImplementation 'org.powermock:powermock-module-junit4:1.6.6'
     }
 
     ext {

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -772,7 +772,7 @@ public class EcsCommandExecutor
         bashArguments.add("python_exit_code=$?");
         bashArguments.addAll(setEcsContainerOverrideArgumentsAfterCommand());
         if (!commandRequest.getWorkingDirectory().toString().isEmpty()) {
-            bashArguments.add(s("popd"));
+            bashArguments.add("popd");
         }
         bashArguments.add(s("tar -zcf %s  --exclude %s --exclude %s .digdag/tmp/", outputProjectArchivePathName, relativeProjectArchivePath.toString(), outputProjectArchivePathName));
         // retry by exponential backoff 1+2+4+8+16+32+64=127 seconds by the default

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Strings;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import io.digdag.client.config.Config;

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -361,9 +361,9 @@ public class EcsCommandExecutor
                 if (statusCode == 0) {
                     String loggingFinishedAt = previousExecutorStatus.has("logging_finished_at") ? previousExecutorStatus.get("logging_finished_at").asText() : null;
                     // The python script itself finished successful but the following command (e.g. tar zcf or curl -X PUT) failed ?
-                    logger.error(s("Unexpectedly, archive-output.tar.gz does not exist while ECS_END_OF_TASK_LOG_MARK observed. "
+                    logger.error(s("Unexpectedly, archive-output.tar.gz does not exist while container task exits 0. "
                             + "cluster=%s, taskArn=%s, logging_finished_at=%s, errorMessage=%s", cluster, taskArn, loggingFinishedAt, errorMessage.orNull()), ex);
-                    throw new RuntimeException(s("Unexpectedly, archive-output.tar.gz does not exist while ECS_END_OF_TASK_LOG_MARK observed. "
+                    throw new RuntimeException(s("Unexpectedly, archive-output.tar.gz does not exist while container task exits 0. "
                             + "cluster=%s, taskArn=%s, logging_finished_at=%s", cluster, taskArn, loggingFinishedAt), ex); // avoid errorMessage not to leak confidential information
                 } else {
                     // could be happen and can avoid processing outputs (see PythonOperatorFactory#runCode)

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -72,11 +72,13 @@ public class EcsCommandExecutor
     private static final String ECS_COMMAND_EXECUTOR_SYSTEM_CONFIG_PREFIX = "agent.command_executor.ecs.";
     private static final String ECS_END_OF_TASK_LOG_MARK = "--RWNzQ29tbWFuZEV4ZWN1dG9y--"; // base64("EcsCommandExecutor")
 
-    private static final String CONFIG_RETRY_TASK_SCRIPTS_DOWNLOADS = ECS_COMMAND_EXECUTOR_SYSTEM_CONFIG_PREFIX + "retry_task_scripts_downloads";
-    private static final String CONFIG_RETRY_TASK_OUTPUT_UPLOADS = ECS_COMMAND_EXECUTOR_SYSTEM_CONFIG_PREFIX + "retry_task_output_uploads";
+    static final String CONFIG_RETRY_TASK_SCRIPTS_DOWNLOADS = ECS_COMMAND_EXECUTOR_SYSTEM_CONFIG_PREFIX + "retry_task_scripts_downloads";
+    static final String CONFIG_RETRY_TASK_OUTPUT_UPLOADS = ECS_COMMAND_EXECUTOR_SYSTEM_CONFIG_PREFIX + "retry_task_output_uploads";
     private static final int DEFAULT_RETRY_TASK_SCRIPTS_DOWNLOADS = 8;
     private static final int DEFAULT_RETRY_TASK_OUTPUT_UPLOADS = 7;
-    private static final String CONFIG_ENABLE_CURL_FAIL_OPT_ON_UPLOADS = ECS_COMMAND_EXECUTOR_SYSTEM_CONFIG_PREFIX + "enable_curl_fail_opt_on_uploads";
+    static final String CONFIG_ENABLE_CURL_FAIL_OPT_ON_UPLOADS = ECS_COMMAND_EXECUTOR_SYSTEM_CONFIG_PREFIX + "enable_curl_fail_opt_on_uploads";
+    static final String CONFIG_MAX_WAIT_FOR_FETCH_LOG_EVENTS = ECS_COMMAND_EXECUTOR_SYSTEM_CONFIG_PREFIX + "max_wait_for_fetch_log_events";
+    private static final long DEFAULT_MAX_WAIT_FOR_FETCH_LOG_EVENTS_IN_SEC = 60L;
 
     private final Config systemConfig;
     private final EcsClientFactory ecsClientFactory;
@@ -86,6 +88,7 @@ public class EcsCommandExecutor
     private final CommandLogger clog;
     private final int retryDownloads, retryUploads;
     private final boolean curlFailOptOnUploads; // false by the default
+    private final long maxWaitForFetchLogEventsInSec;
 
     @Inject
     public EcsCommandExecutor(
@@ -105,6 +108,7 @@ public class EcsCommandExecutor
         this.retryDownloads = systemConfig.get(CONFIG_RETRY_TASK_SCRIPTS_DOWNLOADS, int.class, DEFAULT_RETRY_TASK_SCRIPTS_DOWNLOADS);
         this.retryUploads = systemConfig.get(CONFIG_RETRY_TASK_OUTPUT_UPLOADS, int.class, DEFAULT_RETRY_TASK_OUTPUT_UPLOADS);
         this.curlFailOptOnUploads = systemConfig.get(CONFIG_ENABLE_CURL_FAIL_OPT_ON_UPLOADS, boolean.class, false);
+        this.maxWaitForFetchLogEventsInSec = systemConfig.get(CONFIG_MAX_WAIT_FOR_FETCH_LOG_EVENTS, long.class, DEFAULT_MAX_WAIT_FOR_FETCH_LOG_EVENTS_IN_SEC);
     }
 
     @Override
@@ -306,13 +310,6 @@ public class EcsCommandExecutor
             logger.debug(s("Stop command task: %s", task.getTaskArn()));
             client.stopTask(clusterName, task.getTaskArn());
         }
-    }
-
-    private long maxWaitForFetchLogEventsInSec = 60L;
-
-    @VisibleForTesting
-    void setMaxWaitForFetchLogEvents(long sec) {
-        this.maxWaitForFetchLogEventsInSec = sec;
     }
 
     CommandStatus createNextCommandStatus(

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -363,8 +363,8 @@ public class EcsCommandExecutor
             try (final InputStream in = temporalStorage.getContentInputStream(outputArchiveKey)) {
                 ProjectArchives.extractTarArchive(commandContext.getLocalProjectPath(), in); // IOException
             } catch (StorageFileNotFoundException ex) {
-                if(statusCode == 0) {
-                    if(foundLoggingFinishedMark == false && previousStatus.has("retry_on_end_of_task_mark_missing") == false) {
+                if (statusCode == 0) {
+                    if (foundLoggingFinishedMark == false && previousStatus.has("retry_on_end_of_task_mark_missing") == false) {
                         logger.warn(s("Scheduled to poll again because "
                                 + "1) archive-output.tar.gz does not exist yet while container task normally exit 0, and "
                                 + "2) no ECS_END_OF_TASK_LOG_MARK observed yet. "

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -357,11 +357,12 @@ public class EcsCommandExecutor
                 ProjectArchives.extractTarArchive(commandContext.getLocalProjectPath(), in); // IOException
             } catch (StorageFileNotFoundException ex) {
                 if(statusCode == 0) {
-                    if(foundLoggingFinishedMark == false) {
+                    if(foundLoggingFinishedMark == false && previousStatus.has("retry_on_end_of_task_mark_missing") == false) {
                         logger.warn(s("Scheduled to poll again because "
                                 + "1) archive-output.tar.gz does not exist yet while container task normally exit 0, and "
                                 + "2) no ECS_END_OF_TASK_LOG_MARK observed yet. "
                                 + "cluster=%s, taskArn=%s, errorMessage=%s", cluster, taskArn, errorMessage.orNull()), ex);
+                        nextStatus.put("retry_on_end_of_task_mark_missing", true);
                         return EcsCommandStatus.of(false, nextStatus); // poll again
                     } else {
                         logger.error(s("Unexpectedly, archive-output.tar.gz does not exist while ECS_END_OF_TASK_LOG_MARK observed. "

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -129,7 +129,7 @@ public class EcsCommandExecutor
             }
         }
         catch (ConfigException e) {
-            logger.debug("Fall back to DockerCommandExecutor: {} {}", e.getMessage(), e.getCause() != null ? e.getCause().getMessage() : "");
+            logger.warn("Fall back to DockerCommandExecutor: {} {}", e.getMessage(), e.getCause() != null ? e.getCause().getMessage() : "");
             return docker.run(commandContext, commandRequest); // fall back to DockerCommandExecutor
         }
     }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -48,6 +48,7 @@ import io.digdag.standards.command.ecs.TemporalProjectArchiveStorage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import java.io.ByteArrayInputStream;
@@ -133,9 +134,18 @@ public class EcsCommandExecutor
             }
         }
         catch (ConfigException e) {
-            logger.warn("Fall back to DockerCommandExecutor: {} {}", e.getMessage(), e.getCause() != null ? e.getCause().getMessage() : "");
-            return docker.run(commandContext, commandRequest); // fall back to DockerCommandExecutor
+            logger.debug("Fall back to DockerCommandExecutor: {} {}", e.getMessage(), e.getCause() != null ? e.getCause().getMessage() : "");
+            return runWithLocalDocker(commandContext, commandRequest);
         }
+    }
+
+    @Nonnull
+    protected CommandStatus runWithLocalDocker(
+            @Nonnull final CommandContext commandContext,
+            @Nonnull final CommandRequest commandRequest)
+                    throws IOException
+    {
+        return docker.run(commandContext, commandRequest);
     }
 
     protected Task submitTask(

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/TemporalProjectArchiveStorage.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/TemporalProjectArchiveStorage.java
@@ -46,13 +46,8 @@ public class TemporalProjectArchiveStorage
         return storage.getDirectUploadHandle(key).get().getUrl().toString();
     }
 
-    public InputStream getContentInputStream(final String key)
+    public InputStream getContentInputStream(final String key) throws StorageFileNotFoundException
     {
-        try {
-            return storage.open(key).getContentInputStream();
-        }
-        catch (StorageFileNotFoundException e) {
-            throw ThrowablesUtil.propagate(e);
-        }
+        return storage.open(key).getContentInputStream();
     }
 }

--- a/digdag-standards/src/test/java/io/digdag/standards/command/EcsCommandExecutorTest2.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/command/EcsCommandExecutorTest2.java
@@ -108,7 +108,7 @@ public class EcsCommandExecutorTest2 {
             fail("should not reach here");
         } catch (RuntimeException e) {
             assertThat(e.getMessage(), containsString(
-                "archive-output.tar.gz does not exist while ECS_END_OF_TASK_LOG_MARK observed"));
+                "archive-output.tar.gz does not exist while container task exits 0"));
         }
     }
 
@@ -152,7 +152,7 @@ public class EcsCommandExecutorTest2 {
             fail("should not reach here");
         } catch (RuntimeException e) {
             assertThat(e.getMessage(), containsString(
-                "archive-output.tar.gz does not exist while ECS_END_OF_TASK_LOG_MARK observed"));
+                "archive-output.tar.gz does not exist while container task exits 0"));
             assertThat(e.getMessage(), containsString("logging_finished_at=null"));
         }
     }
@@ -195,6 +195,5 @@ public class EcsCommandExecutorTest2 {
         CommandStatus cmdStatus = executor.poll(commandContext, previousStatusJson);
         assertTrue(cmdStatus.isFinished());
         assertEquals(1, cmdStatus.getStatusCode());
-        assertFalse(cmdStatus.toJson().has("retry_on_end_of_task_mark_missing"));
     }
 }

--- a/digdag-standards/src/test/java/io/digdag/standards/command/EcsCommandExecutorTest2.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/command/EcsCommandExecutorTest2.java
@@ -1,0 +1,196 @@
+package io.digdag.standards.command;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.powermock.api.support.membermodification.MemberMatcher.method;
+import static org.powermock.api.support.membermodification.MemberModifier.stub;
+
+import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigFactory;
+import io.digdag.core.archive.ProjectArchiveLoader;
+import io.digdag.core.storage.StorageManager;
+import io.digdag.spi.CommandContext;
+import io.digdag.spi.CommandLogger;
+import io.digdag.spi.CommandStatus;
+import io.digdag.spi.StorageFileNotFoundException;
+import io.digdag.spi.TaskRequest;
+import io.digdag.standards.command.ecs.EcsClient;
+import io.digdag.standards.command.ecs.EcsClientConfig;
+import io.digdag.standards.command.ecs.EcsClientFactory;
+import io.digdag.standards.command.ecs.TemporalProjectArchiveStorage;
+
+import java.time.Instant;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.base.Optional;
+
+/**
+ * Uses PowerMockRunner for mocking static methods
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(EcsCommandExecutor.class)
+public class EcsCommandExecutorTest2 {
+    private final ObjectMapper om = new ObjectMapper();
+    private final ConfigFactory configFactory = new ConfigFactory(om);
+
+    private Config systemConfig;
+    @Mock
+    private EcsClientFactory ecsClientFactory;
+    @Mock
+    private DockerCommandExecutor dockerCommandExecutor;
+    @Mock
+    private StorageManager storageManager;
+    @Mock
+    private ProjectArchiveLoader projectArchiveLoader;
+    @Mock
+    private CommandLogger commandLogger;
+
+    @Before
+    public void setUp() throws Exception {
+        this.systemConfig = configFactory.create();
+    }
+
+    @Test
+    public void testPollOutputFileDoesNotExists() throws Exception {
+        final EcsClient ecsClient = mock(EcsClient.class);
+        final CommandContext commandContext = mock(CommandContext.class);
+        final EcsCommandExecutor executor =
+                spy(new EcsCommandExecutor(systemConfig, ecsClientFactory, dockerCommandExecutor,
+                    storageManager, projectArchiveLoader, commandLogger));
+        final ObjectNode previousExecutorStatus =
+                om.createObjectNode().put("logging_finished_at", Instant.now().getEpochSecond());
+
+        doReturn(mock(EcsClientConfig.class)).when(executor)
+                                             .createEcsClientConfig(any(Optional.class),
+                                                 any(Config.class), any(Config.class));
+        doReturn(ecsClient).when(ecsClientFactory).createClient(any(EcsClientConfig.class));
+        doReturn(mock(TaskRequest.class)).when(commandContext).getTaskRequest();
+        doReturn(previousExecutorStatus).when(executor)
+                                        .fetchLogEvents(any(EcsClient.class), any(ObjectNode.class),
+                                            any(ObjectNode.class));
+        stub(method(EcsCommandExecutor.class, "getErrorMessageFromTask")).toReturn(
+            Optional.absent()); // trick for mockStaticPartial 
+
+        final TemporalProjectArchiveStorage temporalStorage =
+                spy(TemporalProjectArchiveStorage.of(storageManager, systemConfig));
+        doThrow(StorageFileNotFoundException.class).when(temporalStorage)
+                                                   .getContentInputStream(anyString());
+
+        doReturn(temporalStorage).when(executor)
+                                 .createTemporalProjectArchiveStorage(any(Config.class));
+
+        ObjectNode previousStatusJson = om.createObjectNode()
+                                          .put("cluster_name", "my_cluster")
+                                          .put("task_arn", "my_task_arn")
+                                          .put("task_finished_at", Instant.now().getEpochSecond())
+                                          .put("status_code", 0);
+
+        try {
+            executor.poll(commandContext, previousStatusJson);
+            fail("should not reach here");
+        } catch (RuntimeException e) {
+            assertThat(e.getMessage(), containsString(
+                "archive-output.tar.gz does not exist while ECS_END_OF_TASK_LOG_MARK observed"));
+        }
+    }
+
+    @Test
+    public void testPollNotLoggingFinishedAt() throws Exception {
+        final EcsClient ecsClient = mock(EcsClient.class);
+        final CommandContext commandContext = mock(CommandContext.class);
+        final EcsCommandExecutor executor =
+                spy(new EcsCommandExecutor(systemConfig, ecsClientFactory, dockerCommandExecutor,
+                    storageManager, projectArchiveLoader, commandLogger));
+        final ObjectNode previousExecutorStatus = om.createObjectNode(); //.put("logging_finished_at", Instant.now().getEpochSecond());
+
+        doReturn(mock(EcsClientConfig.class)).when(executor)
+                                             .createEcsClientConfig(any(Optional.class),
+                                                 any(Config.class), any(Config.class));
+        doReturn(ecsClient).when(ecsClientFactory).createClient(any(EcsClientConfig.class));
+        doReturn(mock(TaskRequest.class)).when(commandContext).getTaskRequest();
+        doReturn(previousExecutorStatus).when(executor)
+                                        .fetchLogEvents(any(EcsClient.class), any(ObjectNode.class),
+                                            any(ObjectNode.class));
+        stub(method(EcsCommandExecutor.class, "getErrorMessageFromTask")).toReturn(
+            Optional.absent()); // trick for mockStaticPartial 
+
+        final TemporalProjectArchiveStorage temporalStorage =
+                spy(TemporalProjectArchiveStorage.of(storageManager, systemConfig));
+        doThrow(StorageFileNotFoundException.class).when(temporalStorage)
+                                                   .getContentInputStream(anyString());
+
+        doReturn(temporalStorage).when(executor)
+                                 .createTemporalProjectArchiveStorage(any(Config.class));
+
+        ObjectNode previousStatusJson = om.createObjectNode()
+                                          .put("cluster_name", "my_cluster")
+                                          .put("task_arn", "my_task_arn")
+                                          .put("task_finished_at", Instant.now().getEpochSecond())
+                                          .put("status_code", 0);
+
+        executor.setMaxWaitForFetchLogEvents(5);
+        CommandStatus cmdStatus = executor.poll(commandContext, previousStatusJson);
+        assertFalse(cmdStatus.isFinished());
+        assertEquals(0, cmdStatus.getStatusCode());
+        assertEquals(true, cmdStatus.toJson().get("retry_on_end_of_task_mark_missing").asBoolean());
+    }
+
+    @Test
+    public void testPollExit1() throws Exception {
+        final EcsClient ecsClient = mock(EcsClient.class);
+        final CommandContext commandContext = mock(CommandContext.class);
+        final EcsCommandExecutor executor =
+                spy(new EcsCommandExecutor(systemConfig, ecsClientFactory, dockerCommandExecutor,
+                    storageManager, projectArchiveLoader, commandLogger));
+        final ObjectNode previousExecutorStatus =
+                om.createObjectNode().put("logging_finished_at", Instant.now().getEpochSecond());
+
+        doReturn(mock(EcsClientConfig.class)).when(executor)
+                                             .createEcsClientConfig(any(Optional.class),
+                                                 any(Config.class), any(Config.class));
+        doReturn(ecsClient).when(ecsClientFactory).createClient(any(EcsClientConfig.class));
+        doReturn(mock(TaskRequest.class)).when(commandContext).getTaskRequest();
+        doReturn(previousExecutorStatus).when(executor)
+                                        .fetchLogEvents(any(EcsClient.class), any(ObjectNode.class),
+                                            any(ObjectNode.class));
+        stub(method(EcsCommandExecutor.class, "getErrorMessageFromTask")).toReturn(
+            Optional.absent()); // trick for mockStaticPartial 
+
+        final TemporalProjectArchiveStorage temporalStorage =
+                spy(TemporalProjectArchiveStorage.of(storageManager, systemConfig));
+        doThrow(StorageFileNotFoundException.class).when(temporalStorage)
+                                                   .getContentInputStream(anyString());
+
+        doReturn(temporalStorage).when(executor)
+                                 .createTemporalProjectArchiveStorage(any(Config.class));
+
+        ObjectNode previousStatusJson = om.createObjectNode()
+                                          .put("cluster_name", "my_cluster")
+                                          .put("task_arn", "my_task_arn")
+                                          .put("task_finished_at", Instant.now().getEpochSecond())
+                                          .put("status_code", 1);
+
+        CommandStatus cmdStatus = executor.poll(commandContext, previousStatusJson);
+        assertTrue(cmdStatus.isFinished());
+        assertEquals(1, cmdStatus.getStatusCode());
+        assertFalse(cmdStatus.toJson().has("retry_on_end_of_task_mark_missing"));
+    }
+}

--- a/digdag-standards/src/test/java/io/digdag/standards/command/EcsCommandExecutorTest2.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/command/EcsCommandExecutorTest2.java
@@ -147,10 +147,15 @@ public class EcsCommandExecutorTest2 {
                                           .put("status_code", 0);
 
         executor.setMaxWaitForFetchLogEvents(5);
-        CommandStatus cmdStatus = executor.poll(commandContext, previousStatusJson);
-        assertFalse(cmdStatus.isFinished());
-        assertEquals(0, cmdStatus.getStatusCode());
-        assertEquals(true, cmdStatus.toJson().get("retry_on_end_of_task_mark_missing").asBoolean());
+
+        try {
+            executor.poll(commandContext, previousStatusJson);
+            fail("should not reach here");
+        } catch (RuntimeException e) {
+            assertThat(e.getMessage(), containsString(
+                "archive-output.tar.gz does not exist while ECS_END_OF_TASK_LOG_MARK observed"));
+            assertThat(e.getMessage(), containsString("logging_finished_at=null"));
+        }
     }
 
     @Test

--- a/digdag-standards/src/test/java/io/digdag/standards/command/EcsCommandExecutorTest2.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/command/EcsCommandExecutorTest2.java
@@ -116,6 +116,7 @@ public class EcsCommandExecutorTest2 {
     public void testPollNotLoggingFinishedAt() throws Exception {
         final EcsClient ecsClient = mock(EcsClient.class);
         final CommandContext commandContext = mock(CommandContext.class);
+        systemConfig.set(EcsCommandExecutor.CONFIG_MAX_WAIT_FOR_FETCH_LOG_EVENTS, 5L);
         final EcsCommandExecutor executor =
                 spy(new EcsCommandExecutor(systemConfig, ecsClientFactory, dockerCommandExecutor,
                     storageManager, projectArchiveLoader, commandLogger));
@@ -145,8 +146,6 @@ public class EcsCommandExecutorTest2 {
                                           .put("task_arn", "my_task_arn")
                                           .put("task_finished_at", Instant.now().getEpochSecond())
                                           .put("status_code", 0);
-
-        executor.setMaxWaitForFetchLogEvents(5);
 
         try {
             executor.poll(commandContext, previousStatusJson);


### PR DESCRIPTION
This PR try to resolve the following exception.

```
task failed with unexpected error: io.digdag.spi.StorageFileNotFoundException: S3 file not found
java.lang.RuntimeException: io.digdag.spi.StorageFileNotFoundException: S3 file not found
	at com.google.common.base.Throwables.propagate(Throwables.java:241)
	at io.digdag.standards.command.ecs.TemporalProjectArchiveStorage.getContentInputStream(TemporalProjectArchiveStorage.java:55)
	at io.digdag.standards.command.EcsCommandExecutor.createNextCommandStatus(EcsCommandExecutor.java:339)
	at io.digdag.standards.command.EcsCommandExecutor.poll(EcsCommandExecutor.java:280)
	at com.treasuredata.digdag.command.TdEcsCommandExecutor.pollSuper(TdEcsCommandExecutor.java:226)
	at com.treasuredata.digdag.command.TdEcsCommandExecutor.poll(TdEcsCommandExecutor.java:204)
	at io.digdag.standards.operator.PyOperatorFactory$PyOperator.runCode(PyOperatorFactory.java:164)
	at io.digdag.standards.operator.PyOperatorFactory$PyOperator.runTask(PyOperatorFactory.java:115)
	at io.digdag.util.BaseOperator.run(BaseOperator.java:35)
	at io.digdag.core.agent.OperatorManager.callExecutor(OperatorManager.java:365)
	at com.treasuredata.digdag.TdOperatorManager.callExecutor(TdOperatorManager.java:57)
	at io.digdag.core.agent.OperatorManager.runWithWorkspace(OperatorManager.java:298)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invokeMain(DigdagTimedMethodInterceptor.java:58)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invoke(DigdagTimedMethodInterceptor.java:31)
	at io.digdag.core.agent.OperatorManager.lambda$runWithHeartbeat$2(OperatorManager.java:151)
	at io.digdag.core.agent.ExtractArchiveWorkspaceManager.withExtractedArchive(ExtractArchiveWorkspaceManager.java:77)
	at io.digdag.core.agent.OperatorManager.runWithHeartbeat(OperatorManager.java:149)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invokeMain(DigdagTimedMethodInterceptor.java:58)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invoke(DigdagTimedMethodInterceptor.java:31)
	at io.digdag.core.agent.OperatorManager.run(OperatorManager.java:132)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invokeMain(DigdagTimedMethodInterceptor.java:58)
	at io.digdag.server.metrics.DigdagTimedMethodInterceptor.invoke(DigdagTimedMethodInterceptor.java:31)
	at io.digdag.core.agent.MultiThreadAgent.lambda$null$0(MultiThreadAgent.java:132)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: io.digdag.spi.StorageFileNotFoundException: S3 file not found
	at io.digdag.storage.s3.S3Storage.getWithRetry(S3Storage.java:244)
	at io.digdag.storage.s3.S3Storage.open(S3Storage.java:89)
	at io.digdag.standards.command.ecs.TemporalProjectArchiveStorage.getContentInputStream(TemporalProjectArchiveStorage.java:52)
	... 26 common frames omitted
Caused by: com.amazonaws.services.s3.model.AmazonS3Exception: The specified key does not exist. (Service: Amazon S3; Status Code: 404; Error Code: NoSuchKey; Request ID: xxxxx; S3 Extended Request ID: xxxxx)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleErrorResponse(AmazonHttpClient.java:1712)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeOneRequest(AmazonHttpClient.java:1367)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeHelper(AmazonHttpClient.java:1113)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.doExecute(AmazonHttpClient.java:770)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeWithTimer(AmazonHttpClient.java:744)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.execute(AmazonHttpClient.java:726)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.access$500(AmazonHttpClient.java:686)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutionBuilderImpl.execute(AmazonHttpClient.java:668)
	at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:532)
	at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:512)
	at com.amazonaws.services.s3.AmazonS3Client.invoke(AmazonS3Client.java:5044)
	at com.amazonaws.services.s3.AmazonS3Client.invoke(AmazonS3Client.java:4990)
	at com.amazonaws.services.s3.AmazonS3Client.getObject(AmazonS3Client.java:1478)
	at io.digdag.storage.s3.S3Storage.lambda$open$0(S3Storage.java:89)
	at io.digdag.storage.s3.S3Storage.lambda$getWithRetry$10(S3Storage.java:236)
	at io.digdag.util.RetryExecutor.run(RetryExecutor.java:166)
	at io.digdag.util.RetryExecutor.runInterruptible(RetryExecutor.java:126)
	at io.digdag.storage.s3.S3Storage.getWithRetry(S3Storage.java:236)
	... 28 common frames omitted
```