### PR TITLE
Fix polling (ECS) command executors fail to run tasks on retry

### DIFF
--- a/digdag-plugin-utils/src/main/java/io/digdag/util/BaseOperator.java
+++ b/digdag-plugin-utils/src/main/java/io/digdag/util/BaseOperator.java
@@ -51,9 +51,11 @@ public abstract class BaseOperator
 
             boolean doRetry = retry.evaluate();
             if (doRetry) {
+                // Remove command status so that pollable command executors can run tasks on retry
+                Config nextStateParams = retry.getNextRetryStateParams().remove("commandStatus");
                 throw TaskExecutionException.ofNextPollingWithCause(ex,
                         retry.getNextRetryInterval(),
-                        ConfigElement.copyOf(retry.getNextRetryStateParams()));
+                        ConfigElement.copyOf(nextStateParams));
             }
             else {
                 throw ex;

--- a/digdag-plugin-utils/src/test/java/io/digdag/util/BaseOperatorTest.java
+++ b/digdag-plugin-utils/src/test/java/io/digdag/util/BaseOperatorTest.java
@@ -1,6 +1,8 @@
 package io.digdag.util;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigElement;
 import io.digdag.client.config.ConfigFactory;
@@ -99,6 +101,37 @@ public class BaseOperatorTest
             assertThat(e, is(ex));
             assertThat(e.isError(), is(false));
             assertThat(e.getRetryInterval().get(), is(INTERVAL));
+        }
+    }
+
+    @Test
+    public void verifyNonPollingRuntimeExceptionRemovesCommandStatusOnRetry()
+            throws Exception
+    {
+        config.set("_retry", 10);
+
+        ObjectNode commandStatus = new ObjectMapper().createObjectNode().put("foo", "bar");
+        state.set("commandStatus", commandStatus);
+
+        RuntimeException ex = new RuntimeException("Command failed");
+
+        BaseOperator op = new BaseOperator(newContext(temporaryFolder.getRoot().toPath(), request))
+        {
+            @Override
+            public TaskResult runTask()
+            {
+                throw ex;
+            }
+        };
+
+        try {
+            op.run();
+            fail();
+        }
+        catch (TaskExecutionException e) {
+            assertThat(e.isError(), is(true));
+            assertThat(e.getCause(), is(ex));
+            assertThat(e.getStateParams(configFactory).get().has("commandStatus"), is(false));
         }
     }
 


### PR DESCRIPTION
This PR fixes a bug that ECS command executor fails to submit ECS tasks on retry. 

## Reproducible steps

digdag version: v0.10.1 (and some earlier versions probably)

Assuming that ECS command executor is set up correctly:

1. Add and run the following workflow

    ```
    +ecs-retry-test:
      sh>: |
        echo "Task has been executed!"
        exit 1
      _retry: 1
    ```

2. See task logs to confirm that the command executor actually prints `Task has been executed!` once.

### Expected behavior

In the above steps, the command executor should print `Task has been executed!` twice.

## Cause

Each operator runs a command (= submits an ECS task) only when `"commandStatus"` doesn't exist on state params.
However, ECS command executor's polling mechanism persists `"commandStatus"` even on retry, which tries to poll an ECS task that has already exited.

## Approach in this PR

This PR takes minimal change approach and simply removes `"commandStatus"` from state params on retry.

## Considerations

- Maybe we should also use `TaskExecutionException` for commands' failure to propagate state params.
- Currently, each operator tries to remove `"commandStatus"` from state params on failure (e.g. [`sh>` op](https://github.com/treasure-data/digdag/blob/99c38452cfe1dd62042e6e454ba553a26c48c6db/digdag-standards/src/main/java/io/digdag/standards/operator/ShOperatorFactory.java#L120)) but it has no effect on the state params on retry because it just throws `RuntimeException` right after that. Should we remove these confusing lines? 