### PR TITLE
Added task override validation

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -712,7 +712,13 @@ public class EcsCommandExecutor
             throw new ConfigException("Due to AWS service limitation, the total characters of Environment variables "
                     + "must be less than 8000 but it was " + total);
         } else if(total >= 6000) {
-            logger.warn(s("The total characters of Environment variables are too long %d. We have a hard limit on 8000.", total));
+            try {
+                // logging to WF console
+                log(s("The total characters of Environment variables are too long %d. We have a hard limit on 8000.", total), clog);
+            } catch (IOException e) {
+                // internal logging
+                logger.warn(s("The total characters of Environment variables are too long %d. We have a hard limit on 8000.", total), e);
+            }
         }
     }
 

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -714,10 +714,11 @@ public class EcsCommandExecutor
         } else if(total >= 6000) {
             try {
                 // logging to WF console
-                log(s("The total characters of Environment variables are too long %d. We have a hard limit on 8000.", total), clog);
+                log(s("The total bytes of Environment variables are too long %d. We have a hard limit on 8000. "
+                        + "Please consider reducing the size of environment variables.", total), clog);
             } catch (IOException e) {
                 // internal logging
-                logger.warn(s("The total characters of Environment variables are too long %d. We have a hard limit on 8000.", total), e);
+                logger.warn(s("The total bytes of Environment variables are too long %d. We have a hard limit on 8000.", total), e);
             }
         }
     }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -80,6 +80,7 @@ public class EcsCommandExecutor
     static final String CONFIG_ENABLE_CURL_FAIL_OPT_ON_UPLOADS = ECS_COMMAND_EXECUTOR_SYSTEM_CONFIG_PREFIX + "enable_curl_fail_opt_on_uploads";
     static final String CONFIG_MAX_WAIT_FOR_FETCH_LOG_EVENTS = ECS_COMMAND_EXECUTOR_SYSTEM_CONFIG_PREFIX + "max_wait_for_fetch_log_events";
     private static final long DEFAULT_MAX_WAIT_FOR_FETCH_LOG_EVENTS_IN_SEC = 60L;
+    private static final long ENV_VARS_BYTES_THRESHOLD = 8000;
 
     private final Config systemConfig;
     private final EcsClientFactory ecsClientFactory;
@@ -670,6 +671,7 @@ public class EcsCommandExecutor
         final ContainerOverride containerOverride = new ContainerOverride();
         // Assume that a single container will run in the task.
         final ContainerDefinition cd = td.getContainerDefinitions().get(0);
+        validateTaskOverride(commandContext, commandRequest, cd);
         setEcsContainerOverrideName(commandContext, commandRequest, containerOverride, cd);
         setEcsContainerOverrideCommand(commandContext, commandRequest, containerOverride); // RuntimeException,ConfigException
         setEcsContainerOverrideEnvironment(commandContext, commandRequest, containerOverride);
@@ -681,6 +683,39 @@ public class EcsCommandExecutor
 
         request.withOverrides(taskOverride);
     }
+
+    protected void validateTaskOverride(
+            final CommandContext context,
+            final CommandRequest request,
+            final ContainerDefinition cd)
+            throws ConfigException
+    {
+        // Note: A total of 8192 characters are allowed for overrides. This limit includes
+        // the JSON formatting characters of the override structure.
+        //
+        // see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html#API_RunTask_RequestSyntax
+        //
+        // This is simplified validation. The other payload size to environment variables is not exactly 192.
+        // Not using UTF-8 1-4 bytes per a character.
+        int total = 0;
+        for (Map.Entry<String, String> e : request.getEnvironments().entrySet()) {
+            String k = e.getKey();
+            String v = e.getValue();
+            if(k != null) {
+                total += k.length();
+            }
+            if(v != null) {
+                total += v.length();
+            }
+        }
+        if(total >= ENV_VARS_BYTES_THRESHOLD) {
+            throw new ConfigException("Due to AWS service limitation, the total characters of Environment variables "
+                    + "must be less than 8000 but it was " + total);
+        } else if(total >= 7500) {
+            logger.warn(s("The total characters of Environment variables are too long %d. We have a hard limit on 8000.", total));
+        }
+    }
+
 
     protected void setEcsContainerOverrideName(
             final CommandContext commandContext,

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -711,7 +711,7 @@ public class EcsCommandExecutor
         }
         if (total >= ENV_VARS_BYTES_THRESHOLD)
         {
-            throw new ConfigException(s("Due to AWS service limitation, the total characters of Environment variables "
+            throw new ConfigException(s("Due to AWS service limitation, the total bytes of Environment variables "
                     + "must be less than %d but it was %d", ENV_VARS_BYTES_THRESHOLD, total));
         } else if (total >= ENV_VARS_BYTES_THRESHOLD_WARN)
         {

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -54,6 +54,7 @@ import javax.annotation.Nullable;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -696,22 +697,21 @@ public class EcsCommandExecutor
         // see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html#API_RunTask_RequestSyntax
         //
         // This is simplified validation. The other payload size to environment variables is not exactly 192.
-        // Not using UTF-8 1-4 bytes per a character.
         int total = 0;
         for (Map.Entry<String, String> e : request.getEnvironments().entrySet()) {
             String k = e.getKey();
             String v = e.getValue();
             if(k != null) {
-                total += k.length();
+                total += k.getBytes(StandardCharsets.UTF_8).length;
             }
             if(v != null) {
-                total += v.length();
+                total += v.getBytes(StandardCharsets.UTF_8).length;
             }
         }
         if(total >= ENV_VARS_BYTES_THRESHOLD) {
             throw new ConfigException("Due to AWS service limitation, the total characters of Environment variables "
                     + "must be less than 8000 but it was " + total);
-        } else if(total >= 7500) {
+        } else if(total >= 6000) {
             logger.warn(s("The total characters of Environment variables are too long %d. We have a hard limit on 8000.", total));
         }
     }

--- a/digdag-standards/src/test/java/io/digdag/standards/command/EcsCommandExecutorTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/command/EcsCommandExecutorTest.java
@@ -222,7 +222,7 @@ public class EcsCommandExecutorTest
             fail("expect ConfigException");
         } catch (ConfigException e) {
             assertThat(e.getMessage(), containsString(
-                "The total bytes of Environment variables are too long"));
+                "the total bytes of Environment variables must be less than"));
         }
 
     }

--- a/digdag-standards/src/test/java/io/digdag/standards/command/EcsCommandExecutorTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/command/EcsCommandExecutorTest.java
@@ -1,12 +1,15 @@
 package io.digdag.standards.command;
 
 import com.amazonaws.services.ecs.model.Container;
+import com.amazonaws.services.ecs.model.ContainerDefinition;
 import com.amazonaws.services.ecs.model.Task;
 import com.amazonaws.services.ecs.model.TaskSetNotFoundException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Optional;
+
 import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigException;
 import io.digdag.client.config.ConfigFactory;
 import io.digdag.core.archive.ProjectArchiveLoader;
 import io.digdag.core.storage.StorageManager;
@@ -14,6 +17,7 @@ import io.digdag.spi.CommandContext;
 import io.digdag.spi.CommandLogger;
 import io.digdag.spi.CommandRequest;
 import io.digdag.spi.CommandStatus;
+import io.digdag.spi.ImmutableCommandRequest;
 import io.digdag.spi.TaskRequest;
 import io.digdag.standards.command.ecs.EcsClient;
 import io.digdag.standards.command.ecs.EcsClientConfig;
@@ -25,9 +29,15 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.eq;
@@ -185,5 +195,35 @@ public class EcsCommandExecutorTest
                 fail("Unexpected Exception happened. " + e.toString());
             }
         }
+    }
+
+    @Test
+    public void testValidateTaskOverride()
+    {
+        final EcsCommandExecutor executor =
+                spy(new EcsCommandExecutor(systemConfig, ecsClientFactory, dockerCommandExecutor,
+                    storageManager, projectArchiveLoader, commandLogger));
+
+        Map<String, String> env = new HashMap<>();
+        for (int i = 0; i < 100; i++) {
+            env.put(String.join("", Collections.nCopies(40, "k")) + i,
+                String.join("", Collections.nCopies(40, "v")));
+        }
+
+        CommandRequest request = ImmutableCommandRequest.builder()
+                                                        .environments(env)
+                                                        .commandLine(Collections.emptyList())
+                                                        .ioDirectory(mock(Path.class))
+                                                        .workingDirectory(mock(Path.class))
+                                                        .build();
+        try {
+            executor.validateTaskOverride(mock(CommandContext.class), request,
+                mock(ContainerDefinition.class));
+            fail("expect ConfigException");
+        } catch (ConfigException e) {
+            assertThat(e.getMessage(), containsString(
+                "the total characters of Environment variables must be less than 8000"));
+        }
+
     }
 }

--- a/digdag-standards/src/test/java/io/digdag/standards/command/EcsCommandExecutorTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/command/EcsCommandExecutorTest.java
@@ -222,7 +222,7 @@ public class EcsCommandExecutorTest
             fail("expect ConfigException");
         } catch (ConfigException e) {
             assertThat(e.getMessage(), containsString(
-                "the total characters of Environment variables must be less than 8000"));
+                "The total bytes of Environment variables are too long"));
         }
 
     }


### PR DESCRIPTION
Add validation for the total environment variable size.

ECS has 8192 bytes limitation for task override.
see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html#API_RunTask_RequestSyntax