### PR TITLE
Revised retry logic for getLog

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/DefaultEcsClient.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/DefaultEcsClient.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
@@ -277,7 +278,7 @@ public class DefaultEcsClient
         if (nextToken.isPresent()) {
             request.withNextToken("f/" + nextToken.get());
         }
-        return retryForGetLog(() -> logs.getLogEvents(request), request);
+        return retryForGetLog(r -> logs.getLogEvents(r), request);
     }
 
     @Override
@@ -330,11 +331,11 @@ public class DefaultEcsClient
      * @throws AmazonServiceException
      */
     @VisibleForTesting
-    <T> T retryForGetLog(Supplier<T> func, GetLogEventsRequest request) throws AmazonServiceException
+    <R> R retryForGetLog(Function<GetLogEventsRequest, R> func, GetLogEventsRequest request) throws AmazonServiceException
     {
         for (int i = 0; i < maxRetry; i++) {
             try {
-                return func.get();
+                return func.apply(request);
             }
             catch (AmazonServiceException ex) {
                 if (RetryUtils.isThrottlingException(ex)) {

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/DefaultEcsClient.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/DefaultEcsClient.java
@@ -52,7 +52,7 @@ public class DefaultEcsClient
     private final AWSLogs logs;
 
     private final int maxRetry;
-    private final long maxJitterSecs;   // 0.0 <= jitterSecs < baseJitterSecs
+    private final long maxJitterSecs;
     private final long maxBaseWaitSecs;
     private final long baseIncrementalSecs;
 
@@ -309,7 +309,6 @@ public class DefaultEcsClient
             catch (AmazonServiceException ex) {
                 if (RetryUtils.isThrottlingException(ex)) {
                     logger.debug("Rate exceed: {}. Will be retried.", ex.toString());
-                    // Max of baseWaitSecs is maxBaseWaitSecs
                     final long baseWaitSecs = Math.min(baseIncrementalSecs * i, maxBaseWaitSecs);
                     waitWithRandomJitter(baseWaitSecs, maxJitterSecs);
                 }
@@ -340,7 +339,6 @@ public class DefaultEcsClient
             catch (AmazonServiceException ex) {
                 if (RetryUtils.isThrottlingException(ex)) {
                     logger.debug("Rate exceed: {}. Will be retried.", ex.toString());
-                    // Max of baseWaitSecs is maxBaseWaitSecs
                     final long baseWaitSecs = Math.min(baseIncrementalSecs * i, maxBaseWaitSecs);
                     waitWithRandomJitter(baseWaitSecs, maxJitterSecs);
                 }

--- a/digdag-standards/src/test/java/io/digdag/standards/command/ecs/DefaultEcsClientTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/command/ecs/DefaultEcsClientTest.java
@@ -26,6 +26,7 @@ import org.mockito.stubbing.Answer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static org.hamcrest.Matchers.is;
@@ -171,13 +172,13 @@ public class DefaultEcsClientTest
                 .withLogGroupName("group")
                 .withLogStreamName("stream");
 
-        Supplier<Boolean> func = new Supplier<Boolean>()
+        Function<GetLogEventsRequest, Boolean> func = new Function<GetLogEventsRequest, Boolean>()
         {
             private final int maxError = 3;
             private int current = 0;
 
             @Override
-            public Boolean get()
+            public Boolean apply(GetLogEventsRequest req)
             {
                 current += 1;
                 if (current <= maxError) {
@@ -190,6 +191,7 @@ public class DefaultEcsClientTest
                 }
                 return true;
             }
+
         };
         assertEquals(true, ecsClient.retryForGetLog(func, request));
         Mockito.verify(ecsClient, times(3)).waitWithRandomJitter(anyLong(), anyLong());


### PR DESCRIPTION
Because Cloudwatch log stream became available by an eventually consistency fashion, introduce a retry logic to avoid ResourceNotFoundException.

```
com.amazonaws.services.logs.model.ResourceNotFoundException: The specified log stream does not exist. (Service: AWSLogs; Status Code: 400; Error Code: ResourceNotFoundException; Request ID: xxxx-xxxx-xxx)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleErrorResponse(AmazonHttpClient.java:1712)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeOneRequest(AmazonHttpClient.java:1367)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeHelper(AmazonHttpClient.java:1113)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.doExecute(AmazonHttpClient.java:770)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeWithTimer(AmazonHttpClient.java:744)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.execute(AmazonHttpClient.java:726)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutor.access$500(AmazonHttpClient.java:686)
	at com.amazonaws.http.AmazonHttpClient$RequestExecutionBuilderImpl.execute(AmazonHttpClient.java:668)
	at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:532)
	at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:512)
	at com.amazonaws.services.logs.AWSLogsClient.doInvoke(AWSLogsClient.java:3045)
	at com.amazonaws.services.logs.AWSLogsClient.invoke(AWSLogsClient.java:3012)
	at com.amazonaws.services.logs.AWSLogsClient.invoke(AWSLogsClient.java:3001)
	at com.amazonaws.services.logs.AWSLogsClient.executeGetLogEvents(AWSLogsClient.java:1856)
	at com.amazonaws.services.logs.AWSLogsClient.getLogEvents(AWSLogsClient.java:1827)
	at io.digdag.standards.command.ecs.DefaultEcsClient.lambda$getLog$7(DefaultEcsClient.java:278)
	at io.digdag.standards.command.ecs.DefaultEcsClient.retryOnRateLimit(DefaultEcsClient.java:305)
	at io.digdag.standards.command.ecs.DefaultEcsClient.getLog(DefaultEcsClient.java:278)
	at io.digdag.standards.command.EcsCommandExecutor.fetchLogEvents(EcsCommandExecutor.java:441)
```