### PR TITLE
Enlarged retry timeout to fetch log events for non-zero status

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -54,7 +54,6 @@ import javax.annotation.Nullable;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -364,7 +364,7 @@ public class EcsCommandExecutor
             while (Instant.now().getEpochSecond() < timeout);
 
             if (previousExecutorStatus.get("logging_finished_at") == null) {// case for timeout
-                logger.warn(s("Cannot find logging_finished_at marker in CloudWatch logs.\n"
+                logger.debug(s("Cannot find logging_finished_at marker in CloudWatch logs.\n"
                         + "taskArn=%s, taskStatus=%d, logGroup=%s, logStream=%s",
                     taskArn, statusCode, toLogGroupName(previousStatus), toLogStreamName(previousStatus)));
             }

--- a/digdag-standards/src/test/java/io/digdag/standards/command/EcsCommandExecutorTest2.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/command/EcsCommandExecutorTest2.java
@@ -146,6 +146,7 @@ public class EcsCommandExecutorTest2 {
                                           .put("task_arn", "my_task_arn")
                                           .put("task_finished_at", Instant.now().getEpochSecond())
                                           .put("status_code", 0);
+        previousStatusJson.set("awslogs", om.createObjectNode().put("awslogs-group", "dummy group").put("awslogs-stream", "dummy stream"));
 
         try {
             executor.poll(commandContext, previousStatusJson);


### PR DESCRIPTION
Cloudwatch logs eventually became available.

When stdout/stderr output is too large, 60 wait is not enough to wait EoL marker.
So, enlarged retry timeout to fetch log events for non-zero status from 60 sec to 300 sec.