### PR TITLE
Improved error handling of ECS execution when container task failed to start

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClient.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClient.java
@@ -13,6 +13,8 @@ import io.digdag.client.config.ConfigException;
 import java.io.IOException;
 import java.util.List;
 
+import javax.annotation.Nullable;
+
 public interface EcsClient
         extends AutoCloseable
 {
@@ -39,6 +41,7 @@ public interface EcsClient
 
     void stopTask(String cluster, String taskArn);
 
+    @Nullable
     GetLogEventsResult getLog(String groupName, String streamName, Optional<String> nextToken);
 
     @Override

--- a/digdag-standards/src/test/java/io/digdag/standards/command/ecs/DefaultEcsClientTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/command/ecs/DefaultEcsClientTest.java
@@ -59,7 +59,7 @@ public class DefaultEcsClientTest
     @Before
     public void setUp()
     {
-        ecsClient = spy(new DefaultEcsClient(ecsClientConfig, rawEcsClient, logs, 10, 2, 1, 5));
+        ecsClient = spy(new DefaultEcsClient(ecsClientConfig, rawEcsClient, logs, 10, 5, 2, 1, 5));
     }
 
     @Test


### PR DESCRIPTION
Currently, digdag is trying to fetch Cloudwatch logstream even if container task failed to start (then, no log stream could be happen).

So, improved error handling of ECS execution when container task failed to start.