### PR TITLE
Update digdag-build docker image

### DIFF
--- a/docker/bootstrap/dependencies.sh
+++ b/docker/bootstrap/dependencies.sh
@@ -17,12 +17,12 @@ apt-get -y install docker-compose
 
 # Postgres
 sudo apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 7FCC7D46ACCC4CF8 # To fix failure at add-apt-repository
-add-apt-repository "deb https://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main"
+add-apt-repository "deb https://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main"
 wget --quiet -O - https://postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 apt-get -y update
-apt-get -y install postgresql-9.5 postgresql-client-9.5
-cp pg_hba.conf /etc/postgresql/9.5/main/
-cp postgresql.conf /etc/postgresql/9.5/main/
+apt-get -y install postgresql-11 postgresql-client-11
+cp pg_hba.conf /etc/postgresql/11/main/
+cp postgresql.conf /etc/postgresql/11/main/
 /etc/init.d/postgresql start
 sudo -u postgres createuser -s digdag_test
 sudo -u postgres createdb -O digdag_test digdag_test

--- a/docker/bootstrap/postgresql.conf
+++ b/docker/bootstrap/postgresql.conf
@@ -38,15 +38,15 @@
 # The default values of these variables are driven from the -D command-line
 # option or PGDATA environment variable, represented here as ConfigDir.
 
-data_directory = '/var/lib/postgresql/9.5/main'		# use data in another directory
+data_directory = '/var/lib/postgresql/11/main'		# use data in another directory
 					# (change requires restart)
-hba_file = '/etc/postgresql/9.5/main/pg_hba.conf'	# host-based authentication file
+hba_file = '/etc/postgresql/11/main/pg_hba.conf'	# host-based authentication file
 					# (change requires restart)
-ident_file = '/etc/postgresql/9.5/main/pg_ident.conf'	# ident configuration file
+ident_file = '/etc/postgresql/11/main/pg_ident.conf'	# ident configuration file
 					# (change requires restart)
 
 # If external_pid_file is not explicitly set, no extra PID file is written.
-external_pid_file = '/var/run/postgresql/9.5-main.pid'			# write an extra PID file
+external_pid_file = '/var/run/postgresql/11-main.pid'			# write an extra PID file
 					# (change requires restart)
 
 
@@ -443,7 +443,7 @@ log_timezone = 'UTC'
 
 # - Process Title -
 
-cluster_name = '9.5/main'			# added to process titles if nonempty
+cluster_name = '11/main'			# added to process titles if nonempty
 					# (change requires restart)
 #update_process_title = on
 
@@ -459,7 +459,7 @@ cluster_name = '9.5/main'			# added to process titles if nonempty
 #track_io_timing = off
 #track_functions = none			# none, pl, all
 #track_activity_query_size = 1024	# (change requires restart)
-stats_temp_directory = '/var/run/postgresql/9.5-main.pg_stat_tmp'
+stats_temp_directory = '/var/run/postgresql/11-main.pg_stat_tmp'
 
 
 # - Statistics Monitoring -

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,9 +8,17 @@ if [ ! -z "$DIGDAG_TEST_REDIS" ]; then
     redis-server &
 fi
 
-export TEST_S3_ACCESS_KEY_ID=$(cat /dev/urandom | LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
-export TEST_S3_SECRET_ACCESS_KEY=$(cat /dev/urandom | LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
-export TEST_S3_ENDPOINT=http://127.0.0.1:9000
+if [ -z "$TEST_S3_ACCESS_KEY_ID" ]; then
+    export TEST_S3_ACCESS_KEY_ID=$(cat /dev/urandom | LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
+fi
+
+if [ -z "$TEST_S3_SECRET_ACCESS_KEY" ]; then
+    export TEST_S3_SECRET_ACCESS_KEY=$(cat /dev/urandom | LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
+fi
+
+if [ -z "$TEST_S3_ENDPOINT" ]; then
+    export TEST_S3_ENDPOINT=http://127.0.0.1:9000
+fi
 
 export MINIO_ACCESS_KEY=${TEST_S3_ACCESS_KEY_ID}
 export MINIO_SECRET_KEY=${TEST_S3_SECRET_ACCESS_KEY}
@@ -18,4 +26,9 @@ export MINIO_SECRET_KEY=${TEST_S3_SECRET_ACCESS_KEY}
 mkdir -p /tmp/minio
 minio server /tmp/minio/ &
 
+cat <<EOF > /tmp/minio_credential.txt
+export TEST_S3_ENDPOINT=${TEST_S3_ENDPOINT}
+export TEST_S3_ACCESS_KEY_ID=${TEST_S3_ACCESS_KEY_ID}
+export TEST_S3_SECRET_ACCESS_KEY=${TEST_S3_SECRET_ACCESS_KEY}
+EOF
 exec "$@"


### PR DESCRIPTION
I updated digdag-build docker image as follows:

- image: `digdag/digdag-build:20210902T164958-dc911cc971d8656872a988e03926e4e626f10a41`
- Upgrade PostgreSQL from 9.5 (EOL) to 11.
- Improve `entrypoint.sh`
  - Save credential info to `/tmp/minio_credential.txt` to access from `docker exec`
  - Accept environment variables as default credential info
 
