### PR TITLE
Bump-up jquery version, to avoid collapse issue in bootstrap

### DIFF
--- a/digdag-ui/package-lock.json
+++ b/digdag-ui/package-lock.json
@@ -7108,9 +7108,9 @@
       "dev": true
     },
     "jquery": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.0.tgz",
-      "integrity": "sha512-Xb7SVYMvygPxbFMpTFQiHh1J7HClEaThguL15N/Gg37Lri/qKyhRGZYzHRyLH8Stq3Aow0LsHO2O2ci86fCrNQ=="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
+      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
     },
     "js-base64": {
       "version": "2.6.4",

--- a/digdag-ui/package.json
+++ b/digdag-ui/package.json
@@ -26,7 +26,7 @@
     "buffer": "5.0.5",
     "cryptiles": "4.1.2",
     "duration": "^0.2.0",
-    "jquery": "3.5.0",
+    "jquery": "3.5.1",
     "js-untar": "0.1.4",
     "js-yaml": "3.13.1",
     "lodash": "^4.17.21",


### PR DESCRIPTION
Hello,
While testing the project in local, seems collapse in `navbar` seems not working well, due to following issue.
https://github.com/twbs/bootstrap/issues/30553

Could you check?