### PR TITLE
Resume S3 IT

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,11 +6,14 @@ jobs:
 
     # executor type https://circleci.com/docs/2.0/executor-types/
     docker:
-      - image: digdag/digdag-build:20191203T225216-c5b7206657c98c728b183634079f0a919ee98f8c
+      - image: digdag/digdag-build:20210902T164958-dc911cc971d8656872a988e03926e4e626f10a41
         # environment Variables in a Job https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-job
         environment:
           TERM: dumb
           TZ: 'UTC'
+          TEST_S3_ENDPOINT: http://127.0.0.1:9000
+          TEST_S3_ACCESS_KEY_ID: C0AI42GnKrP5H1yn
+          TEST_S3_SECRET_ACCESS_KEY: w42IbhJJXZt6E71y
     steps:
       - checkout
 
@@ -18,7 +21,7 @@ jobs:
       - run:
           name: setup PostgreSqL
           command: |
-            sudo sed -i 's/max_connections = 1000/max_connections = 2000/' /etc/postgresql/9.5/main/postgresql.conf
+            sudo sed -i 's/max_connections = 1000/max_connections = 2000/' /etc/postgresql/11/main/postgresql.conf
             sudo service postgresql restart
             set -x
             # wait for PostgreSQL container to be available for 2 mins

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,17 @@ jobs:
       # Run tests with dependencies cache
       - restore_cache:
           key: dependency-cache-{{ .Branch }}-{{ .Revision }}
-      - run: ci/run_td_tests.sh
+      - run:
+          name: run IT tests
+          command: |
+            nohup /entrypoint.sh > /dev/null 2>&1 &
+            sleep 10
+            ps -awx
+            ls -l /tmp/
+            . /tmp/minio_credential.txt
+            env
+            curl -v $TEST_S3_ENDPOINT
+            ci/run_td_tests.sh
       - save_cache:
           paths:
             - ~/.gradle

--- a/ci/run_td_tests.sh
+++ b/ci/run_td_tests.sh
@@ -14,7 +14,7 @@ minimumPoolSize = 0
 echo "---TARGET test ---"
 target_src1=`circleci tests glob "digdag-tests/src/test/java/acceptance/**/*IT.java" | circleci tests split --split-by=timings`
 # Exclude some tests due to failure in CircleCI. Will fix them later.
-target_src=`echo $target_src1 | sed -E 's/ digdag-tests\/src\/test\/java\/acceptance\/(S3Wait|S3Storage|Docker)IT.java//g'`
+target_src=`echo $target_src1 | sed -E 's/ digdag-tests\/src\/test\/java\/acceptance\/(Docker)IT.java//g'`
 echo $target_src | xargs -n 1 echo
 echo "------------------"
 


### PR DESCRIPTION
To resume failure IT `S3WaitIT` and `S3StorageIT`, this PR chnages as follows:

- Use new `digdag-build` docker image
- Remove these IT class from exclusion list
- Update CircleCI
