### PR TITLE
Fixed NPE bug when statusCode is missing

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -345,7 +345,7 @@ public class EcsCommandExecutor
         // (finished previous poll once considering risk of crushing while running previous actual poll.)
         if (previousStatus.has("task_finished_at")) {
             final long taskFinishedAt = previousStatus.get("task_finished_at").asLong();
-            final int statusCode =  previousStatus.get("status_code").intValue();
+            final int statusCode = previousStatus.get("status_code").intValue(); // null ({@link com.fasterxml.jackson.databind.node.NullNode}) returns 0
 
             long timeout = taskFinishedAt + ((statusCode != 0) ? maxWaitForFetchLogEventsInSecNonZeroStatus : maxWaitForFetchLogEventsInSec);
             do {
@@ -439,7 +439,7 @@ public class EcsCommandExecutor
             // finish this poll once and wait finish marker in head of this method in next poll, considering risk of crushing in this poll.
             nextStatus.put("task_finished_at", Instant.now().getEpochSecond());
             // Set exit code of container finished to nextStatus
-            int containerExitCode = task.getContainers().get(0).getExitCode().intValue();
+            Integer containerExitCode = task.getContainers().get(0).getExitCode(); // could be null
             nextStatus.put("status_code", containerExitCode);
 
             String stopCode = task.getStopCode();
@@ -450,7 +450,7 @@ public class EcsCommandExecutor
                 String stoppedReason = task.getStoppedReason();
                 nextStatus.put("ecs_stopped_reason", stoppedReason);
                 throw new RuntimeException(s(
-                    "ECS Container task failed to start due to temporary AWS issues: stopCode=%s, stoppedReason=%s, containerExitCode=%d\n"
+                    "ECS Container task failed to start due to temporary AWS issues: stopCode=%s, stoppedReason=%s, containerExitCode=%s\n"
                     + "Please retry workflow tasks. Refer https://docs.digdag.io/workflow_definition.html#retrying-failed-tasks-automatically for detail.\n"
                     + "ECS error codes are available on https://docs.aws.amazon.com/AmazonECS/latest/userguide/stopped-task-error-codes.html",
                     stopCode, stoppedReason, containerExitCode));


### PR DESCRIPTION
#1630  introduced a corner case NPE bug as follows.

```
io.digdag.core.agent.OperatorManager: Task failed with unexpected error: null
java.lang.NullPointerException: null
        at io.digdag.standards.command.EcsCommandExecutor.createNextCommandStatus(EcsCommandExecutor.java:442)
        at io.digdag.standards.command.EcsCommandExecutor.poll(EcsCommandExecutor.java:303)
        at com.treasuredata.digdag.command.TdEcsCommandExecutor.pollSuper(TdEcsCommandExecutor.java:237)
        at com.treasuredata.digdag.command.TdEcsCommandExecutor.poll(TdEcsCommandExecutor.java:215)
        at io.digdag.standards.operator.PyOperatorFactory$PyOperator.runCode(PyOperatorFactory.java:170)
        at io.digdag.standards.operator.PyOperatorFactory$PyOperator.runTask(PyOperatorFactory.java:121)
        at io.digdag.util.BaseOperator.run(BaseOperator.java:35)
        at io.digdag.core.agent.OperatorManager.callExecutor(OperatorManager.java:377)
```