### PR TITLE
Improve error messages when ECS task failed to start

### DIFF
--- a/digdag-standards/src/main/resources/digdag/standards/py/runner.py
+++ b/digdag-standards/src/main/resources/digdag/standards/py/runner.py
@@ -162,7 +162,7 @@ try:
 except SystemExit as e:
     # SystemExit only shows an exit code and it is not kind to users. So this block creates a specific error message.
     # This error will happen if called python module name and method name are equal to those of the standard library module. (e.g. tokenize.main)
-    error = Exception("Failed to call python command with code:%d" % e.code, "Possible cause: Invalid python module call, duplicate module name with standard library")
+    error = Exception("Python command %s terminated with exit code %d" % (command, e.code), "Possible cause: program intentionally/accidentally finished, or module name conflicted with the standard library")
     error_type, error_value, _tb = sys.exc_info()
     error_message = "%s %s" % (error.args[0], error.args[1])
     error_traceback = traceback.format_exception(error_type, error_value, _tb)

--- a/digdag-standards/src/main/resources/digdag/standards/py/runner.py
+++ b/digdag-standards/src/main/resources/digdag/standards/py/runner.py
@@ -162,7 +162,7 @@ try:
 except SystemExit as e:
     # SystemExit only shows an exit code and it is not kind to users. So this block creates a specific error message.
     # This error will happen if called python module name and method name are equal to those of the standard library module. (e.g. tokenize.main)
-    error = Exception("Python command %s terminated with exit code %d" % (command, e.code), "Possible cause: program intentionally/accidentally finished, or module name conflicted with the standard library")
+    error = Exception("Python command '%s' terminated with exit code %d." % (command, e.code), "Possible cause: program intentionally/accidentally finished, or module name conflicted with the standard library")
     error_type, error_value, _tb = sys.exc_info()
     error_message = "%s %s" % (error.args[0], error.args[1])
     error_traceback = traceback.format_exception(error_type, error_value, _tb)

--- a/digdag-standards/src/main/resources/digdag/standards/py/runner.py
+++ b/digdag-standards/src/main/resources/digdag/standards/py/runner.py
@@ -162,7 +162,7 @@ try:
 except SystemExit as e:
     # SystemExit only shows an exit code and it is not kind to users. So this block creates a specific error message.
     # This error will happen if called python module name and method name are equal to those of the standard library module. (e.g. tokenize.main)
-    error = Exception("Failed to call python command with code:%d" % e.code, "Possible cause: Ivalid python module call, duplicae module name with standard library")
+    error = Exception("Failed to call python command with code:%d" % e.code, "Possible cause: Invalid python module call, duplicate module name with standard library")
     error_type, error_value, _tb = sys.exc_info()
     error_message = "%s %s" % (error.args[0], error.args[1])
     error_traceback = traceback.format_exception(error_type, error_value, _tb)

--- a/digdag-tests/src/test/java/acceptance/PyIT.java
+++ b/digdag-tests/src/test/java/acceptance/PyIT.java
@@ -183,7 +183,7 @@ public class PyIT
         final String logs = getAttemptLogs(client, attempt.getId());
         assertTrue(logs != null);
         assertThat(attempt.getSuccess(), is(false));
-        final String regex = "\\[ERROR\\] [^\\n]*Task failed with unexpected error: Python command failed with code 1.*Error messages from python:[^\\n]*duplicae module name with standard library";
+        final String regex = "\\[ERROR\\] [^\\n]*Task failed with unexpected error: Python command failed with code 1.*Error messages from python:[^\\n]*program intentionally/accidentally finished, or module name conflicted with the standard library";
         assertTrue(Pattern.compile(regex, Pattern.DOTALL).matcher(logs).find());
     }
 


### PR DESCRIPTION
The current error message is not enough. 

```
ECS Container task failed to start due to temporary AWS issues: stopCode=TaskFailedToStart, stoppedReason=Task failed to start, containerExitCode=null
Please retry workflow tasks. Refer https://docs.digdag.io/workflow_definition.html#retrying-failed-tasks-automatically for detail.
ECS error codes are available on https://docs.aws.amazon.com/AmazonECS/latest/userguide/stopped-task-error-codes.html
```

So, this PR improves error messages when ECS task failed to start.