### PR TITLE
Add a hook for processing AuthenticatedUser

### DIFF
--- a/digdag-server/src/main/java/io/digdag/server/rs/AttemptResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/AttemptResource.java
@@ -261,7 +261,7 @@ public class AttemptResource
                     .or(ImmutableList.of());
 
             Config params = request.getParams();
-            processAuthenticatedUserInfo(authedUser, params);
+            putAdditionalParams(params);
 
             // use the HTTP request time as the runTime
             AttemptRequest ar = attemptBuilder.buildFromStoredWorkflow(
@@ -286,7 +286,8 @@ public class AttemptResource
         }, AttemptLimitExceededException.class, ResourceNotFoundException.class, TaskLimitExceededException.class, AccessControlException.class);
     }
 
-    protected void processAuthenticatedUserInfo(@Nonnull AuthenticatedUser user, @Nonnull Config params)
+    @Nonnull
+    protected void putAdditionalParams(@Nonnull Config params)
     {
         // nop by the default. Override if required
     }

--- a/digdag-server/src/main/java/io/digdag/server/rs/AttemptResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/AttemptResource.java
@@ -285,7 +285,6 @@ public class AttemptResource
         }, AttemptLimitExceededException.class, ResourceNotFoundException.class, TaskLimitExceededException.class, AccessControlException.class);
     }
 
-    @Nonnull
     protected void putAdditionalParams(@Nonnull Config params)
     {
         // nop by the default. Override if required

--- a/digdag-server/src/main/java/io/digdag/server/rs/AttemptResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/AttemptResource.java
@@ -35,7 +35,6 @@ import io.digdag.client.api.*;
 import io.digdag.metrics.DigdagTimed;
 import io.digdag.spi.ac.AccessControlException;
 import io.digdag.spi.ac.AccessController;
-import io.digdag.spi.AuthenticatedUser;
 import io.digdag.spi.ScheduleTime;
 import io.digdag.spi.ac.AttemptTarget;
 import io.digdag.spi.ac.ProjectTarget;

--- a/digdag-server/src/main/java/io/digdag/server/rs/AttemptResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/AttemptResource.java
@@ -249,10 +249,9 @@ public class AttemptResource
             final StoredWorkflowDefinitionWithProject def = rs.getWorkflowDefinitionById( // check NotFound first
                     RestModels.parseWorkflowId(request.getWorkflowId()));
 
-            AuthenticatedUser authedUser = getAuthenticatedUser();
             ac.checkRunWorkflow( // AccessControl
                     WorkflowTarget.of(getSiteId(), def.getName(), def.getProject().getName()),
-                    authedUser);
+                    getAuthenticatedUser());
 
             Optional<Long> resumingAttemptId = request.getResume()
                     .transform(r -> RestModels.parseAttemptId(r.getAttemptId()));


### PR DESCRIPTION
We would like to store WF invoked user information in TD.  So, add hook.

Example usage:

```java
    @Overrided
    protected void putAdditionalParams(@Nonnull Config params)
    {
        AuthenticatedUser user = getAuthenticatedUser();
        final Config info = user.getUserInfo().getNested("td").getNested("user");
        if (info.has("id")) {
            params.set("user_id", info.get("id", Integer.class));
        }
        if (info.has("email")) {
            params.set("user_email", info.get("email", String.class));
        }

        final Config context = user.getUserContext().getNested("td").getNested("user");
        if (context.has("ip_address")) {
            params.set("ip_address", context.get("ip_address", String.class));
        } else if (context.has("ip")) {
            params.set("ip_address", context.get("ip", String.class));
        }
    }
```