### PR TITLE
Fix to fail Resume workflow after Pause

### DIFF
--- a/digdag-ui/model.js
+++ b/digdag-ui/model.js
@@ -450,7 +450,9 @@ export class Model {
     return fetch(this.config.url + url, {
       credentials: 'include',
       method,
-      headers: this.headers()
+      headers: Object.assign({}, this.headers(), {
+        'Content-Type': 'application/json',
+      }),
     }).then(response => {
       if (!response.ok) {
         throw new Error(response.statusText)


### PR DESCRIPTION
This PR fixes a bug that it cannot be resumed paused schedule from digdag UI.

## Reproduce Steps

1. Start latest digdag server
2. Create scheduled workflow
3. Pause schedule from digdagUI
4. Digdag API returns error like below at resume schedule
```
{
	"message": "RESTEASY003200: Could not find message body reader for type: interface io.digdag.client.api.RestScheduleEnableRequest of content type: */*",
	"status": 400
}
```

## Approach in this PR

Error which returned by API represents lacking Content-Type, so add it.
I considered ok to add `application/json`, because digdag API is REST API with Json.

## Workaround Approach

At I resumed workflow from digdag UI.

1. open browser's developer console
2. edit `enable` endpoint request 
3. add Content-Type to HTTP Header 
4. resend to digdag server