### PR TITLE
Implement account routing

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/DigdagEmbed.java
+++ b/digdag-core/src/main/java/io/digdag/core/DigdagEmbed.java
@@ -20,6 +20,7 @@ import com.google.inject.Module;
 import com.google.inject.Scopes;
 import com.google.inject.util.Modules;
 import io.digdag.commons.ThrowablesUtil;
+import io.digdag.core.acroute.AccountRoutingModule;
 import io.digdag.core.database.TransactionManager;
 import io.digdag.core.notification.NotificationModule;
 import io.digdag.core.queue.QueueModule;
@@ -189,6 +190,7 @@ public class DigdagEmbed
                     new NotificationModule(),
                     new StorageModule(),
                     new EnvironmentModule(environment),
+                    new AccountRoutingModule(),
                     (binder) -> {
                         binder.bind(ProjectArchiveLoader.class);
                         binder.bind(ConfigElement.class).toInstance(systemConfig);

--- a/digdag-core/src/main/java/io/digdag/core/acroute/AccountRoutingModule.java
+++ b/digdag-core/src/main/java/io/digdag/core/acroute/AccountRoutingModule.java
@@ -1,0 +1,16 @@
+package io.digdag.core.acroute;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+import com.google.inject.Scopes;
+import io.digdag.spi.AccountRoutingFactory;
+
+public class AccountRoutingModule
+        implements Module
+{
+    @Override
+    public void configure(Binder binder)
+    {
+        binder.bind(AccountRoutingFactory.class).to(DefaultAccountRoutingFactory.class).in(Scopes.SINGLETON);
+    }
+}

--- a/digdag-core/src/main/java/io/digdag/core/acroute/DefaultAccountRouting.java
+++ b/digdag-core/src/main/java/io/digdag/core/acroute/DefaultAccountRouting.java
@@ -1,0 +1,96 @@
+package io.digdag.core.acroute;
+
+import com.google.common.base.Optional;
+import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigException;
+import io.digdag.spi.AccountRouting;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class DefaultAccountRouting implements AccountRouting
+{
+    private final Boolean enabled;
+    private final List<Integer> includeSiteIds;
+    private final List<Integer> excludeSiteIds;
+
+    @Override
+    public Boolean enabled()
+    {
+        return enabled;
+    }
+
+    @Override
+    public String getFilterSQL(String column) {
+        if (enabled) {
+            if (! includeSiteIds.isEmpty()) {
+                return String.format("%s in (%s)",
+                        column,
+                        includeSiteIds.stream().map(i -> i.toString()).collect(Collectors.joining(",")));
+            }
+            else {
+                return String.format("%s not in (%s)",
+                        column,
+                        excludeSiteIds.stream().map(i -> i.toString()).collect(Collectors.joining(",")));
+            }
+        }
+        else {
+            return "true";
+        }
+    }
+
+    /**
+     *
+     * @param config system configuration
+     * @param prefixKey prefix key to load. (e.g. "executor", "agent")
+     * @return
+     */
+    public static DefaultAccountRouting of(Config config, Optional<String> prefixKey)
+    {
+        Optional<Config> cf = prefixKey.isPresent() ? config.getOptionalNested(prefixKey.get() + ".account_routing") : Optional.of(config);
+        if (cf.isPresent()) {
+            Boolean enabled = cf.get().get("enabled", Boolean.class, false);
+            List<Integer> includes = cf.get().getListOrEmpty("include", Integer.class);
+            List<Integer> excludes = cf.get().getListOrEmpty("exclude", Integer.class);
+
+            // validation
+            if (enabled) {
+                if (includes.isEmpty() && excludes.isEmpty()) {
+                    throw new ConfigException("account_routing: include or exclude must be defined exclusively.");
+                }
+                else if (enabled && !includes.isEmpty() && !excludes.isEmpty()) {
+                    throw new ConfigException("account_routing: include or exclude must be defined exclusively.");
+                }
+            }
+            return new DefaultAccountRouting(enabled, includes, excludes);
+        }
+        else {
+            return new DefaultAccountRouting();
+        }
+    }
+
+    public DefaultAccountRouting(Boolean enabled, List<Integer> includeSiteId, List<Integer> excludeSiteId )
+    {
+        this.enabled = enabled;
+        this.includeSiteIds = new ArrayList<>(includeSiteId);
+        this.excludeSiteIds = new ArrayList<>(excludeSiteId);
+    }
+
+    public DefaultAccountRouting()
+    {
+        this.enabled = false;
+        this.includeSiteIds = new ArrayList<>();
+        this.excludeSiteIds = new ArrayList<>();
+    }
+
+    public List<Integer> getIncludeSiteIds()
+    {
+        return includeSiteIds;
+    }
+
+    public List<Integer> getExcludeSiteIds()
+    {
+        return excludeSiteIds;
+    }
+}

--- a/digdag-core/src/main/java/io/digdag/core/acroute/DefaultAccountRoutingFactory.java
+++ b/digdag-core/src/main/java/io/digdag/core/acroute/DefaultAccountRoutingFactory.java
@@ -1,0 +1,71 @@
+package io.digdag.core.acroute;
+
+import com.google.common.base.Optional;
+import com.google.inject.Inject;
+import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigException;
+import io.digdag.spi.AccountRouting;
+import io.digdag.spi.AccountRoutingFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static io.digdag.spi.AccountRouting.ModuleType;
+
+public class DefaultAccountRoutingFactory implements AccountRoutingFactory
+{
+    private final Config systemConfig;
+    private static Logger logger = LoggerFactory.getLogger(DefaultAccountRoutingFactory.class);
+
+    @Inject
+    public DefaultAccountRoutingFactory(Config systemConfig)
+    {
+        this.systemConfig = systemConfig;
+    }
+
+    @Override
+    public String getType()
+    {
+        return "default";
+    }
+
+    @Override
+    public AccountRouting newAccountRouting(ModuleType module)
+    {
+
+        return fromConfig(systemConfig, Optional.of(module.toString()));
+    }
+
+    private static List<Integer> parseIdList(String s)
+    {
+        return Arrays.stream(s.split(","))
+                .filter(x -> !x.equals(""))
+                .map(Integer::valueOf)
+                .collect(Collectors.toList());
+    }
+
+    public static DefaultAccountRouting fromConfig(Config config, Optional<String> prefixKey)
+    {
+        String prefix = prefixKey.transform( x -> x + ".").or("") + "account_routing.";
+        Boolean enabled = config.get(prefix + "enabled", Boolean.class, false);
+        List<Integer> include = parseIdList(config.get(prefix + "include", String.class, ""));
+        List<Integer> exclude = parseIdList(config.get(prefix + "exclude", String.class, ""));
+
+        // validation
+        if (enabled) {
+            if (include.isEmpty() && exclude.isEmpty()) {
+                throw new ConfigException("account_routing: include or exclude must be defined exclusively.");
+            }
+            else if (enabled && !include.isEmpty() && !exclude.isEmpty()) {
+                throw new ConfigException("account_routing: include or exclude must be defined exclusively.");
+            }
+            return new DefaultAccountRouting(enabled, include, exclude);
+        }
+        else {
+            return new DefaultAccountRouting();
+        }
+    }
+}

--- a/digdag-core/src/main/java/io/digdag/core/agent/InProcessTaskServerApi.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/InProcessTaskServerApi.java
@@ -2,6 +2,7 @@ package io.digdag.core.agent;
 
 import com.google.inject.Inject;
 import com.google.common.collect.ImmutableList;
+import io.digdag.spi.AccountRouting;
 import io.digdag.spi.TaskRequest;
 import io.digdag.spi.TaskQueueLock;
 import io.digdag.spi.TaskQueueClient;
@@ -27,9 +28,9 @@ public class InProcessTaskServerApi
     @Override
     public List<TaskRequest> lockSharedAgentTasks(
             int count, AgentId agentId,
-            int lockSeconds, long maxSleepMillis)
+            int lockSeconds, long maxSleepMillis, AccountRouting accountRouting)
     {
-        List<TaskQueueLock> locks = directQueueClient.lockSharedAgentTasks(count, agentId.toString(), lockSeconds, maxSleepMillis);
+        List<TaskQueueLock> locks = directQueueClient.lockSharedAgentTasks(count, agentId.toString(), lockSeconds, maxSleepMillis, accountRouting);
         if (locks.isEmpty()) {
             return ImmutableList.of();
         }

--- a/digdag-core/src/main/java/io/digdag/core/agent/LocalAgentManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/LocalAgentManager.java
@@ -9,6 +9,8 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.digdag.core.BackgroundExecutor;
 import io.digdag.core.ErrorReporter;
 import io.digdag.core.database.TransactionManager;
+import io.digdag.spi.AccountRouting;
+import io.digdag.spi.AccountRoutingFactory;
 import io.digdag.spi.metrics.DigdagMetrics;
 
 public class LocalAgentManager
@@ -17,7 +19,6 @@ public class LocalAgentManager
     private final Supplier<MultiThreadAgent> agentFactory;
     private volatile Thread thread;
     private volatile MultiThreadAgent agent;
-
 
     @Inject(optional = true)
     private ErrorReporter errorReporter = ErrorReporter.empty();
@@ -31,11 +32,12 @@ public class LocalAgentManager
             AgentId agentId,
             TaskServerApi taskServer,
             OperatorManager operatorManager,
-            TransactionManager transactionManager)
+            TransactionManager transactionManager,
+            AccountRoutingFactory acrouteFactory)
     {
         if (config.getEnabled()) {
             this.agentFactory =
-                    () -> new MultiThreadAgent(config, agentId, taskServer, operatorManager, transactionManager, errorReporter, metrics);
+                    () -> new MultiThreadAgent(config, agentId, taskServer, operatorManager, transactionManager, errorReporter, metrics, acrouteFactory);
         }
         else {
             this.agentFactory = null;

--- a/digdag-core/src/main/java/io/digdag/core/agent/TaskServerApi.java
+++ b/digdag-core/src/main/java/io/digdag/core/agent/TaskServerApi.java
@@ -1,13 +1,15 @@
 package io.digdag.core.agent;
 
 import java.util.List;
+
+import io.digdag.spi.AccountRouting;
 import io.digdag.spi.TaskRequest;
 
 public interface TaskServerApi
 {
     List<TaskRequest> lockSharedAgentTasks(
             int count, AgentId agentId,
-            int lockSeconds, long maxSleepMillis);
+            int lockSeconds, long maxSleepMillis, AccountRouting accountRouting);
 
     void interruptLocalWait();
 }

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseScheduleStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseScheduleStoreManager.java
@@ -10,9 +10,9 @@ import io.digdag.core.schedule.ScheduleControlStore;
 import io.digdag.core.schedule.ScheduleStore;
 import io.digdag.core.schedule.ScheduleStoreManager;
 import io.digdag.core.schedule.StoredSchedule;
+import io.digdag.spi.AccountRouting;
 import io.digdag.spi.ScheduleTime;
 import io.digdag.spi.ac.AccessController;
-import org.skife.jdbi.v2.DBI;
 import org.skife.jdbi.v2.Handle;
 import org.skife.jdbi.v2.StatementContext;
 import org.skife.jdbi.v2.sqlobject.Bind;
@@ -22,14 +22,11 @@ import org.skife.jdbi.v2.sqlobject.customizers.Define;
 import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
 
-import javax.sql.DataSource;
-
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class DatabaseScheduleStoreManager
@@ -61,21 +58,30 @@ public class DatabaseScheduleStoreManager
     }
 
     @Override
-    public int lockReadySchedules(Instant currentTime, int limit, ScheduleAction func)
+    public int lockReadySchedules(Instant currentTime, int limit, AccountRouting accountRouting, ScheduleAction func)
     {
         List<RuntimeException> exceptions = new ArrayList<>();
 
         long count = transaction((handle, dao) -> {
             Stream<StoredSchedule> schedStream;
             if (dao instanceof PgDao) {
-                schedStream = ((PgDao) dao).lockReadySchedulesSkipLocked(currentTime.getEpochSecond(), limit)
-                    .stream();
+                if (accountRouting.enabled()) {
+                    schedStream = ((PgDao) dao).lockReadySchedulesSkipLockedWithAccountFilter(currentTime.getEpochSecond(), limit, accountRouting.getFilterSQL()).stream();
+                }
+                else {
+                    schedStream = ((PgDao) dao).lockReadySchedulesSkipLocked(currentTime.getEpochSecond(), limit).stream();
+                }
             }
             else {
                 // H2 database doesn't support JOIN + FOR UPDATE OF
-                schedStream = dao.lockReadyScheduleIds(currentTime.getEpochSecond(), limit)
-                    .stream()
-                    .map(dao::getScheduleByIdInternal);
+                List<Integer> list1;
+                if (accountRouting.enabled()) {
+                    list1 = dao.lockReadyScheduleIdsWithAccountFilter(currentTime.getEpochSecond(), limit, accountRouting.getFilterSQL());
+                }
+                else {
+                    list1 = dao.lockReadyScheduleIds(currentTime.getEpochSecond(), limit);
+                }
+                schedStream = list1.stream().map(dao::getScheduleByIdInternal);
             }
             return schedStream.mapToInt(sched -> {
                     try {
@@ -260,6 +266,16 @@ public class DatabaseScheduleStoreManager
                 " limit :limit" +
                 " for update of s skip locked")
         List<StoredSchedule> lockReadySchedulesSkipLocked(@Bind("currentTime") long currentTime, @Bind("limit") int limit);
+
+        @SqlQuery("select s.*, wd.name as name from schedules s" +
+                " join workflow_definitions wd on wd.id = s.workflow_definition_id" +
+                " where s.next_run_time \\<= :currentTime" +
+                " and s.disabled_at is null" +
+                " and exists ( select site_id from projects p where s.project_id = p.id" +
+                "   and <accountFilter> )" +
+                " limit :limit" +
+                " for update of s skip locked")
+        List<StoredSchedule> lockReadySchedulesSkipLockedWithAccountFilter(@Bind("currentTime") long currentTime, @Bind("limit") int limit, @Define("accountFilter") String accountFilter);
     }
 
     public interface Dao
@@ -334,6 +350,15 @@ public class DatabaseScheduleStoreManager
                 " limit :limit" +
                 " for update")
         List<Integer> lockReadyScheduleIds(@Bind("currentTime") long currentTime, @Bind("limit") int limit);
+
+        @SqlQuery("select id from schedules" +
+                " where next_run_time \\<= :currentTime" +
+                " and disabled_at is null" +
+                " and exists ( select site_id from projects p where schedules.project_id = p.id" +
+                "   and <accountFilter> )" +
+                " limit :limit" +
+                " for update")
+        List<Integer> lockReadyScheduleIdsWithAccountFilter(@Bind("currentTime") long currentTime, @Bind("limit") int limit, @Define("accountFilter") String accountFilter);
 
         @SqlQuery("select * from schedules" +
                 " where id = :id" +

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseTaskQueueServer.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseTaskQueueServer.java
@@ -13,12 +13,14 @@ import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.annotation.Nullable;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.*;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Inject;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.digdag.core.ErrorReporter;
 import io.digdag.core.log.LogMarkers;
+import io.digdag.spi.AccountRouting;
 import io.digdag.spi.metrics.DigdagMetrics;
 import static io.digdag.spi.metrics.DigdagMetrics.Category;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
@@ -26,6 +28,8 @@ import org.skife.jdbi.v2.sqlobject.SqlUpdate;
 import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.GetGeneratedKeys;
 import org.skife.jdbi.v2.StatementContext;
+import org.skife.jdbi.v2.sqlobject.customizers.Define;
+import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
 import org.skife.jdbi.v2.tweak.ResultSetMapper;
 import io.digdag.spi.ImmutableTaskQueueLock;
 import io.digdag.spi.TaskQueueRequest;
@@ -298,9 +302,14 @@ public class DatabaseTaskQueueServer
     }
 
     @Override
-    public List<TaskQueueLock> lockSharedAgentTasks(int count, String agentId, int lockSeconds, long maxSleepMillis)
+    public List<TaskQueueLock> lockSharedAgentTasks(int count, String agentId, int lockSeconds, long maxSleepMillis, AccountRouting accountRouting)
     {
-        List<Integer> siteIds = autoCommit((handle, dao) -> dao.getActiveSiteIdList());
+        Optional<String> accountFilter = accountRouting.getFilterSQLOpt();
+        List<Integer> siteIds = autoCommit((handle, dao) ->
+                accountFilter.isPresent()?
+                        dao.getActiveSiteIdListWithAccountFilter(accountFilter.get()):
+                        dao.getActiveSiteIdList()
+        );
         // Here shuffles siteIds to iterate in random order so that scheduling becomes slightly more fair across sites.
         // It also improves overhead when smaller siteIds tend to have more tasks than its siteMaxConcurrency.
         Collections.shuffle(siteIds);
@@ -468,6 +477,7 @@ public class DatabaseTaskQueueServer
         }
     }
 
+    @UseStringTemplate3StatementLocator
     public interface Dao
     {
         @SqlQuery("select shared_site_id from queues where id = :queueId")
@@ -498,6 +508,33 @@ public class DatabaseTaskQueueServer
                 "select site_id as id from t " +
                 "where site_id is not null")
         List<Integer> getActiveSiteIdList();
+
+        // optimized implementation of
+        //   select distinct site_id as id from queued_task_locks
+        //   where lock_expire_time is null
+        //   and site_id is not null
+        //   order by site_id asc
+        @SqlQuery(
+                "with recursive t (site_id) as (" +
+                        "(" +
+                        "select site_id from queued_task_locks " +
+                        "where lock_expire_time is null " +
+                        "and site_id is not null " +
+                        "order by site_id limit 1" +
+                        ") " +
+                        "union all " +
+                        "select (" +
+                        "select site_id from queued_task_locks " +
+                        "where lock_expire_time is null " +
+                        "and site_id is not null " +
+                        "and site_id > t.site_id " +
+                        "order by site_id limit 1" +
+                        ") from t where t.site_id is not null" +
+                        ") " +
+                        "select site_id as id from t " +
+                        "where site_id is not null " +
+                        "and <accountFilter>")
+        List<Integer> getActiveSiteIdListWithAccountFilter(@Define("accountFilter") String accountFilter);
 
         @SqlUpdate("insert into queued_tasks" +
                 " (site_id, queue_id, unique_name, data, created_at)" +

--- a/digdag-core/src/main/java/io/digdag/core/schedule/ScheduleExecutor.java
+++ b/digdag-core/src/main/java/io/digdag/core/schedule/ScheduleExecutor.java
@@ -28,6 +28,8 @@ import io.digdag.core.session.SessionStore;
 import io.digdag.core.session.SessionStoreManager;
 import io.digdag.core.session.StoredDelayedSessionAttempt;
 import io.digdag.core.session.StoredSessionAttemptWithSession;
+import io.digdag.spi.AccountRouting;
+import io.digdag.spi.AccountRoutingFactory;
 import io.digdag.spi.ScheduleTime;
 import io.digdag.spi.Scheduler;
 import io.digdag.core.session.ImmutableStoredSessionAttempt;
@@ -69,6 +71,9 @@ public class ScheduleExecutor
     private final ConfigFactory cf;
     private final ScheduleConfig scheduleConfig;
     private ScheduledExecutorService executor;
+    private final AccountRoutingFactory accountRoutingFactory;
+    private final AccountRouting accountRouting;
+
 
     @Inject(optional = true)
     private ErrorReporter errorReporter = ErrorReporter.empty();
@@ -86,7 +91,8 @@ public class ScheduleExecutor
             AttemptBuilder attemptBuilder,
             WorkflowExecutor workflowExecutor,
             ConfigFactory cf,
-            ScheduleConfig scheduleConfig)
+            ScheduleConfig scheduleConfig,
+            AccountRoutingFactory accountRoutingFactory)
     {
         this.rm = rm;
         this.sm = sm;
@@ -97,6 +103,9 @@ public class ScheduleExecutor
         this.workflowExecutor = workflowExecutor;
         this.cf = cf;
         this.scheduleConfig = scheduleConfig;
+        this.accountRoutingFactory = accountRoutingFactory;
+        this.accountRouting = this.accountRoutingFactory.newAccountRouting(AccountRouting.ModuleType.SCHEDULER);
+
     }
 
     @VisibleForTesting
@@ -170,7 +179,7 @@ public class ScheduleExecutor
         int count = tm.begin(() -> {
             // here uses limit=1 because selecting multiple rows with FOR UPDATE
             // has risk of too often deadlock.
-            return sm.lockReadySchedules(now, 1, (store, storedSchedule) -> {
+            return sm.lockReadySchedules(now, 1, accountRouting, (store, storedSchedule) -> {
                 runSchedule(new ScheduleControl(store, storedSchedule), now);
             });
         });

--- a/digdag-core/src/main/java/io/digdag/core/schedule/ScheduleStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/schedule/ScheduleStoreManager.java
@@ -3,6 +3,7 @@ package io.digdag.core.schedule;
 import java.time.Instant;
 import java.util.List;
 import com.google.common.base.Optional;
+import io.digdag.spi.AccountRouting;
 import io.digdag.spi.ScheduleTime;
 import io.digdag.core.repository.ResourceConflictException;
 import io.digdag.core.repository.ResourceNotFoundException;
@@ -16,5 +17,5 @@ public interface ScheduleStoreManager
         void schedule(ScheduleControlStore store, StoredSchedule schedule);
     }
 
-    int lockReadySchedules(Instant currentTime, int limit, ScheduleAction func);
+    int lockReadySchedules(Instant currentTime, int limit, AccountRouting accountRouting, ScheduleAction func);
 }

--- a/digdag-core/src/main/java/io/digdag/core/session/SessionStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/session/SessionStoreManager.java
@@ -5,6 +5,7 @@ import java.time.Instant;
 import com.google.common.base.*;
 import io.digdag.client.config.Config;
 import io.digdag.core.repository.ResourceNotFoundException;
+import io.digdag.spi.AccountRouting;
 
 public interface SessionStoreManager
 {
@@ -26,17 +27,13 @@ public interface SessionStoreManager
     // for WorkflowExecutor.runUntilAny
     boolean isAnyNotDoneAttempts();
 
-    // for WorkflowExecutor.enqueueReadyTasks (Keep for compatibility)
-    default List<Long> findAllReadyTaskIds(int maxEntries) { return findAllReadyTaskIds(maxEntries, false); }
-
     /**
      * for WorkflowExecutor.enqueueReadyTasks
      * @param maxEntries  max number to fetch
      * @param randomFetch fetch randomly or not(original behavior)
      * @return
      */
-    List<Long> findAllReadyTaskIds(int maxEntries, boolean randomFetch);
-
+    List<Long> findAllReadyTaskIds(int maxEntries, boolean randomFetch, AccountRouting accountRouting);
 
     // for AttemptTimeoutEnforcer.enforceAttemptTTLs
     List<StoredSessionAttempt> findActiveAttemptsCreatedBefore(Instant createdBefore, long lastId, int limit);
@@ -59,17 +56,17 @@ public interface SessionStoreManager
     List<TaskStateSummary> findRecentlyChangedTasks(Instant updatedSince, long lastId);
 
     // for WorkflowExecutorManager.propagateAllPlannedToDone
-    List<Long> findTasksByState(TaskStateCode state, long lastId);
+    List<Long> findTasksByState(TaskStateCode state, long lastId, AccountRouting accountRouting);
 
     // for WorkflowExecutorManager.propagateSessionArchive
-    List<TaskAttemptSummary> findRootTasksByStates(TaskStateCode[] states, long lastId);
+    List<TaskAttemptSummary> findRootTasksByStates(TaskStateCode[] states, long lastId, AccountRouting accountRouting);
 
-    // for WorkflowExecutorManager.propagateBlockedChildrenToReady
-    List<Long> findDirectParentsOfBlockedTasks(long lastId);
+    // for WorkflowExecutor.propagateBlockedChildrenToReady
+    List<Long> findDirectParentsOfBlockedTasks(long lastId, AccountRouting accountRouting);
 
     boolean requestCancelAttempt(long attemptId);
 
-    int trySetRetryWaitingToReady();
+    int trySetRetryWaitingToReady(AccountRouting accountRouting);
 
     interface TaskLockAction <T>
     {

--- a/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java
+++ b/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java
@@ -36,6 +36,8 @@ import io.digdag.core.session.TaskAttemptSummary;
 import io.digdag.core.session.TaskStateCode;
 import io.digdag.core.session.TaskStateFlags;
 import io.digdag.metrics.DigdagTimed;
+import io.digdag.spi.AccountRouting;
+import io.digdag.spi.AccountRoutingFactory;
 import io.digdag.spi.TaskQueueLock;
 import io.digdag.spi.TaskRequest;
 import io.digdag.spi.TaskResult;
@@ -174,7 +176,8 @@ public class WorkflowExecutor
     private final Config systemConfig;
     private final Limits limits;
     private final DigdagMetrics metrics;
-
+    private final AccountRoutingFactory acroaccountRoutingFactoryuteFactory;
+    private final AccountRouting accountRouting;
     private final Lock propagatorLock = new ReentrantLock();
     private final Condition propagatorCondition = propagatorLock.newCondition();
     private volatile boolean propagatorNotice = false;
@@ -192,7 +195,8 @@ public class WorkflowExecutor
             ObjectMapper archiveMapper,
             Config systemConfig,
             Limits limits,
-            DigdagMetrics metrics)
+            DigdagMetrics metrics,
+            AccountRoutingFactory accountRoutingFactory)
     {
         this.rm = rm;
         this.sm = sm;
@@ -204,6 +208,8 @@ public class WorkflowExecutor
         this.systemConfig = systemConfig;
         this.limits = limits;
         this.metrics = metrics;
+        this.acroaccountRoutingFactoryuteFactory = accountRoutingFactory;
+        this.accountRouting = this.acroaccountRoutingFactoryuteFactory.newAccountRouting(AccountRouting.ModuleType.EXECUTOR);
         this.enqueueRandomFetch = systemConfig.get("executor.enqueue_random_fetch", Boolean.class, false);
         this.enqueueFetchSize = systemConfig.get("executor.enqueue_fetch_size", Integer.class, 100);
     }
@@ -602,13 +608,13 @@ public class WorkflowExecutor
     }
 
     @DigdagTimed(category = "executor", appendMethodName = true)
-    protected boolean propagateBlockedChildrenToReady()
+    public boolean propagateBlockedChildrenToReady()
     {
         boolean anyChanged = false;
         long lastParentId = 0;
         while (true) {
             long finalLastParentId = lastParentId;
-            List<Long> parentIds = tm.begin(() -> sm.findDirectParentsOfBlockedTasks(finalLastParentId));
+            List<Long> parentIds = tm.begin(() -> sm.findDirectParentsOfBlockedTasks(finalLastParentId, accountRouting));
 
             if (parentIds.isEmpty()) {
                 break;
@@ -645,7 +651,7 @@ public class WorkflowExecutor
         long lastTaskId = 0;
         while (true) {
             long finalLastTaskId = lastTaskId;
-            List<Long> taskIds = tm.begin(() -> sm.findTasksByState(TaskStateCode.PLANNED, finalLastTaskId));
+            List<Long> taskIds = tm.begin(() -> sm.findTasksByState(TaskStateCode.PLANNED, finalLastTaskId, accountRouting));
             if (taskIds.isEmpty()) {
                 break;
             }
@@ -856,7 +862,7 @@ public class WorkflowExecutor
         while (true) {
             long finalLastTaskId = lastTaskId;
             List<TaskAttemptSummary> tasks =
-                    tm.begin(() -> sm.findRootTasksByStates(TaskStateCode.doneStates(), finalLastTaskId));
+                    tm.begin(() -> sm.findRootTasksByStates(TaskStateCode.doneStates(), finalLastTaskId, accountRouting));
             if (tasks.isEmpty()) {
                 break;
             }
@@ -879,7 +885,7 @@ public class WorkflowExecutor
     @DigdagTimed(category = "executor", appendMethodName = true)
     protected boolean retryRetryWaitingTasks()
     {
-        return tm.begin(() -> sm.trySetRetryWaitingToReady() > 0);
+        return tm.begin(() -> sm.trySetRetryWaitingToReady(accountRouting) > 0);
     }
 
     private class TaskQueuer
@@ -941,7 +947,7 @@ public class WorkflowExecutor
     @DigdagTimed(category = "executor", appendMethodName = true)
     protected void enqueueReadyTasks(TaskQueuer queuer)
     {
-        List<Long> readyTaskIds = tm.begin(() -> sm.findAllReadyTaskIds(enqueueFetchSize, enqueueRandomFetch));
+        List<Long> readyTaskIds = tm.begin(() -> sm.findAllReadyTaskIds(enqueueFetchSize, enqueueRandomFetch, accountRouting));
         logger.trace("readyTaskIds:{}", readyTaskIds);
         for (long taskId : readyTaskIds) {  // TODO randomize this result to achieve concurrency
             catching(()->funcEnqueueTask().apply(taskId), true, "Failed to call enqueueTask. taskId:" + taskId);

--- a/digdag-core/src/test/java/io/digdag/core/acroute/DefaultAccountRoutingFactoryTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/acroute/DefaultAccountRoutingFactoryTest.java
@@ -1,0 +1,67 @@
+package io.digdag.core.acroute;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Optional;
+import io.digdag.client.config.Config;
+import io.digdag.client.config.ConfigException;
+import io.digdag.client.config.ConfigFactory;
+import io.digdag.spi.AccountRouting;
+import io.digdag.spi.AccountRouting.ModuleType;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+public class DefaultAccountRoutingFactoryTest
+{
+    private final ConfigFactory configFactory = new ConfigFactory(new ObjectMapper());
+
+    @Test
+    public void newAccountRoutingTest1()
+    {
+        Config systemConfig = configFactory.create()
+                .set("executor.account_routing.enabled", "true")
+                .set("executor.account_routing.include", "1,2,3,4")
+                .set("agent.account_routing.enabled", "true")
+                .set("agent.account_routing.exclude", "11,12,13,14");
+        {
+            AccountRouting ac = DefaultAccountRoutingFactory.fromConfig(systemConfig, Optional.of(ModuleType.EXECUTOR.toString()));
+            assertTrue("Account routing must be enabled", ac.enabled());
+            assertEquals("site_id in (1,2,3,4)", ac.getFilterSQL());
+        }
+
+        {
+            AccountRouting ac = DefaultAccountRoutingFactory.fromConfig(systemConfig, Optional.of(ModuleType.AGENT.toString()));
+            assertTrue("Account routing must be enabled", ac.enabled());
+            assertEquals("site_id not in (11,12,13,14)", ac.getFilterSQL());
+        }
+
+        {
+            AccountRouting ac = DefaultAccountRoutingFactory.fromConfig(systemConfig, Optional.of(ModuleType.SCHEDULER.toString()));
+            assertFalse("Account routing must be disabled", ac.enabled());
+            assertFalse("Filter SQL must be empty", ac.getFilterSQLOpt().isPresent());
+        }
+
+    }
+
+    @Test
+    public void configValidation()
+    {
+        {
+            // Either 'include' or 'exclude' must be set
+            Config systemConfig = configFactory.create()
+                    .set("agent.account_routing.enabled", "true");
+            assertThrows(ConfigException.class, ()-> DefaultAccountRoutingFactory.fromConfig(systemConfig, Optional.of(ModuleType.AGENT.toString())));
+        }
+        {
+            // Set both 'include' and 'exclude' are not allowed
+            Config systemConfig = configFactory.create()
+                    .set("agent.account_routing.enabled", "true")
+                    .set("agent.account_routing.include", "1,2,3")
+                    .set("agent.account_routing.exclude", "11,12,13");
+            assertThrows(ConfigException.class, ()-> DefaultAccountRoutingFactory.fromConfig(systemConfig, Optional.of(ModuleType.AGENT.toString())));
+        }
+    }
+}

--- a/digdag-core/src/test/java/io/digdag/core/acroute/DummyAccountRoutingFactory.java
+++ b/digdag-core/src/test/java/io/digdag/core/acroute/DummyAccountRoutingFactory.java
@@ -1,0 +1,32 @@
+package io.digdag.core.acroute;
+
+import io.digdag.spi.AccountRouting;
+import io.digdag.spi.AccountRoutingFactory;
+
+public class DummyAccountRoutingFactory implements AccountRoutingFactory
+{
+    @Override
+    public String getType()
+    {
+        return "dummy";
+    }
+
+    @Override
+    public AccountRouting newAccountRouting(AccountRouting.ModuleType module)
+    {
+        return new AccountRouting()
+        {
+            @Override
+            public Boolean enabled()
+            {
+                return false;
+            }
+
+            @Override
+            public String getFilterSQL(String column)
+            {
+                return "true";
+            }
+        };
+    }
+}

--- a/digdag-core/src/test/java/io/digdag/core/database/DatabaseFactory.java
+++ b/digdag-core/src/test/java/io/digdag/core/database/DatabaseFactory.java
@@ -6,6 +6,7 @@ import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigFactory;
 import io.digdag.commons.ThrowablesUtil;
 import io.digdag.core.Limits;
+import io.digdag.core.acroute.DefaultAccountRoutingFactory;
 import io.digdag.core.agent.AgentId;
 import io.digdag.core.workflow.TaskQueueDispatcher;
 import io.digdag.core.workflow.WorkflowCompiler;
@@ -97,6 +98,12 @@ public class DatabaseFactory
     {
         ConfigFactory configFactory = createConfigFactory();
         Config systemConfig = configFactory.create();
+        return getWorkflowExecutor(configFactory, systemConfig);
+
+    }
+
+    public WorkflowExecutor getWorkflowExecutor(ConfigFactory configFactory, Config systemConfig)
+    {
         return new WorkflowExecutor(
                 getProjectStoreManager(),
                 getSessionStoreManager(),
@@ -107,7 +114,8 @@ public class DatabaseFactory
                 objectMapper(),
                 systemConfig,
                 new Limits(systemConfig),
-                StdDigdagMetrics.empty()
+                StdDigdagMetrics.empty(),
+                new DefaultAccountRoutingFactory(systemConfig)
         );
     }
 

--- a/digdag-core/src/test/java/io/digdag/core/schedule/ScheduleExecutorTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/schedule/ScheduleExecutorTest.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableList;
 import io.digdag.client.DigdagClient;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigFactory;
+import io.digdag.core.acroute.DummyAccountRoutingFactory;
 import io.digdag.core.database.ThreadLocalTransactionManager;
 import io.digdag.core.database.TransactionManager;
 import io.digdag.core.repository.ProjectStoreManager;
@@ -15,6 +16,7 @@ import io.digdag.core.session.SessionStoreManager;
 import io.digdag.core.session.StoredSessionAttemptWithSession;
 import io.digdag.core.workflow.AttemptBuilder;
 import io.digdag.core.workflow.WorkflowExecutor;
+import io.digdag.spi.AccountRouting;
 import io.digdag.spi.ScheduleTime;
 import io.digdag.spi.Scheduler;
 import org.junit.Before;
@@ -88,7 +90,8 @@ public class ScheduleExecutorTest
                         attemptBuilder,
                         workflowExecutor,
                         CONFIG_FACTORY,
-                        scheduleConfig
+                        scheduleConfig,
+                        new DummyAccountRoutingFactory()
                 ));
 
         now = Instant.now();
@@ -116,10 +119,10 @@ public class ScheduleExecutorTest
         when(projectStoreManager.getWorkflowDetailsById(WORKFLOW_DEFINITION_ID)).thenReturn(workflowDefinition);
 
         doAnswer(invocation -> {
-            ScheduleStoreManager.ScheduleAction func = invocation.getArgumentAt(2, ScheduleStoreManager.ScheduleAction.class);
+            ScheduleStoreManager.ScheduleAction func = invocation.getArgumentAt(3, ScheduleStoreManager.ScheduleAction.class);
             func.schedule(scs, schedule);
             return null;
-        }).when(scheduleStoreManager).lockReadySchedules(any(Instant.class), eq(1), any(ScheduleStoreManager.ScheduleAction.class));
+        }).when(scheduleStoreManager).lockReadySchedules(any(Instant.class), eq(1), any(AccountRouting.class), any(ScheduleStoreManager.ScheduleAction.class));
     }
 
     @Test

--- a/digdag-core/src/test/java/io/digdag/core/workflow/TaskDependenciesTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/TaskDependenciesTest.java
@@ -306,21 +306,26 @@ public class TaskDependenciesTest {
             assertThat(tasks.get(9).getUpstreams(), is(Collections.singletonList(tasks.get(8).getId())));
             assertThat(tasks.get(10).getUpstreams(), is(Collections.singletonList(tasks.get(9).getId())));
 
-            assertThat(tasks.get(11).getUpstreams(), is(Stream.of(tasks.get(3).getId(), tasks.get(7).getId()).collect(Collectors.toList())));
+            assertThat(sorted(tasks.get(11).getUpstreams()), is(Stream.of(tasks.get(3).getId(), tasks.get(7).getId()).sorted().collect(Collectors.toList())));
             assertThat(tasks.get(12).getUpstreams(), is(Collections.emptyList()));
             assertThat(tasks.get(13).getUpstreams(), is(Collections.singletonList(tasks.get(12).getId())));
             assertThat(tasks.get(14).getUpstreams(), is(Collections.singletonList(tasks.get(13).getId())));
 
-            assertThat(tasks.get(15).getUpstreams(), is(Stream.of(tasks.get(3).getId(), tasks.get(7).getId()).collect(Collectors.toList())));
+            assertThat(sorted(tasks.get(15).getUpstreams()), is(Stream.of(tasks.get(3).getId(), tasks.get(7).getId()).sorted().collect(Collectors.toList())));
             assertThat(tasks.get(16).getUpstreams(), is(Collections.emptyList()));
             assertThat(tasks.get(17).getUpstreams(), is(Collections.singletonList(tasks.get(16).getId())));
             assertThat(tasks.get(18).getUpstreams(), is(Collections.singletonList(tasks.get(17).getId())));
 
-            assertThat(tasks.get(19).getUpstreams(), is(Stream.of(tasks.get(11).getId(), tasks.get(15).getId()).collect(Collectors.toList())));
+            assertThat(sorted(tasks.get(19).getUpstreams()), is(Stream.of(tasks.get(11).getId(), tasks.get(15).getId()).sorted().collect(Collectors.toList())));
             assertThat(tasks.get(20).getUpstreams(), is(Collections.emptyList()));
             assertThat(tasks.get(21).getUpstreams(), is(Collections.singletonList(tasks.get(20).getId())));
             assertThat(tasks.get(22).getUpstreams(), is(Collections.singletonList(tasks.get(21).getId())));
             return null;
         });
+    }
+
+    private static List<Long> sorted(List<Long> ids)
+    {
+        return ids.stream().sorted().collect(Collectors.toList());
     }
 }

--- a/digdag-core/src/test/java/io/digdag/core/workflow/WorkflowExecutorCatchingTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/WorkflowExecutorCatchingTest.java
@@ -8,11 +8,11 @@ import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigFactory;
 import io.digdag.core.DigdagEmbed;
 import io.digdag.core.Limits;
+import io.digdag.core.acroute.DefaultAccountRoutingFactory;
 import io.digdag.core.database.TransactionManager;
 import io.digdag.core.repository.ProjectStoreManager;
 import io.digdag.core.session.SessionStoreManager;
 import io.digdag.core.session.TaskAttemptSummary;
-import io.digdag.spi.CommandExecutor;
 import io.digdag.spi.metrics.DigdagMetrics;
 import org.junit.After;
 import org.junit.Before;
@@ -139,7 +139,7 @@ public class WorkflowExecutorCatchingTest
                                                    DigdagMetrics metrics,
                                                    Limits limits)
         {
-            super(rm, sm, tm, dispatcher, compiler, cf, archiveMapper, systemConfig, limits, metrics);
+            super(rm, sm, tm, dispatcher, compiler, cf, archiveMapper, systemConfig, limits, metrics, new DefaultAccountRoutingFactory(systemConfig));
         }
 
         @Override

--- a/digdag-core/src/test/java/io/digdag/core/workflow/WorkflowExecutorTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/WorkflowExecutorTest.java
@@ -15,6 +15,7 @@ import com.google.common.io.Resources;
 import io.digdag.client.config.ConfigElement;
 import io.digdag.client.config.ConfigFactory;
 import io.digdag.core.Limits;
+import io.digdag.core.acroute.DefaultAccountRoutingFactory;
 import io.digdag.core.config.YamlConfigLoader;
 import io.digdag.core.database.TransactionManager;
 import io.digdag.core.LocalSite;
@@ -337,7 +338,7 @@ public class WorkflowExecutorTest
         Config systemConfig = configFactory.create();
         Limits limits = new Limits(systemConfig);
 
-        WorkflowExecutor executor = new WorkflowExecutor(rm, sm, tm, dispatcher, compiler, cf, archiveMapper, systemConfig, limits, metrics);
+        WorkflowExecutor executor = new WorkflowExecutor(rm, sm, tm, dispatcher, compiler, cf, archiveMapper, systemConfig, limits, metrics, new DefaultAccountRoutingFactory(systemConfig));
         Config stateParam = cf.create().set("retry_count", "2");
         StoredTask task = mock(StoredTask.class);
 

--- a/digdag-core/src/test/java/io/digdag/core/workflow/WorkflowTestingUtils.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/WorkflowTestingUtils.java
@@ -9,6 +9,7 @@ import io.digdag.client.config.ConfigUtils;
 import io.digdag.commons.ThrowablesUtil;
 import io.digdag.core.DigdagEmbed;
 import io.digdag.core.LocalSite;
+import io.digdag.core.acroute.DummyAccountRoutingFactory;
 import io.digdag.core.config.YamlConfigLoader;
 import io.digdag.core.crypto.SecretCrypto;
 import io.digdag.core.crypto.SecretCryptoProvider;
@@ -24,6 +25,7 @@ import io.digdag.core.repository.ResourceNotFoundException;
 import io.digdag.core.repository.StoredWorkflowDefinition;
 import io.digdag.core.repository.WorkflowDefinitionList;
 import io.digdag.core.session.StoredSessionAttemptWithSession;
+import io.digdag.spi.AccountRoutingFactory;
 import io.digdag.spi.CommandExecutor;
 import io.digdag.spi.OperatorFactory;
 import io.digdag.spi.ScheduleTime;
@@ -75,6 +77,7 @@ public class WorkflowTestingUtils
             })
             .overrideModulesWith((binder) -> {
                 binder.bind(DatabaseConfig.class).toInstance(getEnvironmentDatabaseConfig());
+                binder.bind(AccountRoutingFactory.class).to(DummyAccountRoutingFactory.class);
             })
             ;
         DigdagEmbed embed = customizer.apply(bootstrap).initializeWithoutShutdownHook();

--- a/digdag-spi/src/main/java/io/digdag/spi/AccountRouting.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/AccountRouting.java
@@ -1,0 +1,47 @@
+package io.digdag.spi;
+
+import com.google.common.base.Optional;
+
+public interface AccountRouting
+{
+    enum ModuleType
+    {
+        EXECUTOR("executor"),
+        AGENT("agent"),
+        SCHEDULER("scheduler");
+
+        private final String module;
+
+        ModuleType(String module)
+        {
+            this.module = module;
+        }
+
+        @Override
+        public String toString()
+        {
+            return module;
+        }
+    }
+
+    String DEFAULT_COLUMN = "site_id";
+
+    Boolean enabled();
+
+    String getFilterSQL(String column);
+
+    default String getFilterSQL()
+    {
+        return getFilterSQL(DEFAULT_COLUMN);
+    }
+
+    default Optional<String> getFilterSQLOpt(String column)
+    {
+        return enabled() ? Optional.of(getFilterSQL()) : Optional.absent();
+    }
+
+    default Optional<String> getFilterSQLOpt()
+    {
+        return getFilterSQLOpt(DEFAULT_COLUMN);
+    }
+}

--- a/digdag-spi/src/main/java/io/digdag/spi/AccountRoutingFactory.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/AccountRoutingFactory.java
@@ -1,0 +1,10 @@
+package io.digdag.spi;
+
+import static io.digdag.spi.AccountRouting.ModuleType;
+
+public interface AccountRoutingFactory
+{
+    String getType();
+
+    AccountRouting newAccountRouting(ModuleType module);
+}

--- a/digdag-spi/src/main/java/io/digdag/spi/TaskQueueClient.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/TaskQueueClient.java
@@ -1,10 +1,12 @@
 package io.digdag.spi;
 
+import com.google.common.base.Optional;
+
 import java.util.List;
 
 public interface TaskQueueClient
 {
-    List<TaskQueueLock> lockSharedAgentTasks(int count, String agentId, int lockSeconds, long maxSleepMillis);
+    List<TaskQueueLock> lockSharedAgentTasks(int count, String agentId, int lockSeconds, long maxSleepMillis, AccountRouting accountRouting);
 
     // TODO multi-queue is not implemented yet.
     //   List<TaskQueueLock> lockAgentBoundTasks(int queueId)


### PR DESCRIPTION
Implement account routing for workflow processing.

This PR supports account(site_id) routing for the following component.

- Workflow executor
- Agent (worker)
- Scheduler

API is out of scope.
The following configurations are used to enable/disable, set site_id.

```
executor.account_routing.enabled = true
executor.account_routing.include = 0

agent.account_routing.enabled = true
agent.account_routing.exclude = 1,2,3

scheduler.account_routing.enabled = false
``` 

`include` or `exclude` must be exclusively set.
