### PR TITLE
Remove a link of sample code for td_table_export operator

### DIFF
--- a/digdag-docs/src/operators/td_table_export.md
+++ b/digdag-docs/src/operators/td_table_export.md
@@ -1,6 +1,6 @@
 # td_table_export>: Treasure Data table export to S3
 
-NOTE: We're limiting export capability to only us-east region S3 bucket. In general, please use Result Output to S3 feature using td operator. This workflow example is [here](https://github.com/treasure-data/workflow-examples/tree/master/td/s3).
+NOTE: We're limiting export capability to only us-east region S3 bucket. In general, please use Result Output to S3 feature using td operator.
 
 **td_table_export>** operator exports data from Treasure Data to S3.
 


### PR DESCRIPTION
Documentation of `td_table_export` operator has a link of sample code which links to treasure-boxes. However, the code in the link is not `td_table_export`, it's `td` + `result_connection: s3`.

To avoid misleading people, should remove the link until have the correct sample code.