### PR TITLE
Set selinux label when mounting docker volumes

### DIFF
--- a/digdag-docs/src/command_executor.md
+++ b/digdag-docs/src/command_executor.md
@@ -99,6 +99,7 @@ _export:
     docker: "/usr/local/bin/docker"
     run_options: [ "-m", "1G" ]
     pull_always: true
+    selinux: true
 
 +task1:
   py>: ...
@@ -112,6 +113,7 @@ The sub keys in docker are as follows.
 | docker      | Docker command. default is `docker`     |
 | run_options | Arguments to be passed to `docker run`1 |
 | pull_always | Digdag caches the docker image. If you want to pull the image always, set to `true`. Default is `false` |
+| selinux     | Set to `true` when using SELinux. Default is `false` |
 
 You can build a docker image to be used with `build` parameter.
 

--- a/digdag-standards/src/main/java/io/digdag/standards/command/DockerCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/DockerCommandExecutor.java
@@ -113,7 +113,7 @@ public class DockerCommandExecutor
 
             // mount
             command.add("-v").add(String.format(ENGLISH,
-                        "%s:%s:rw", projectPath, projectPath));  // use projectPath to keep pb.directory() valid
+                        "%s:%s:rw,Z", projectPath, projectPath));  // use projectPath to keep pb.directory() valid
 
             // working directory
             final Path workingDirectory = getAbsoluteWorkingDirectory(context, request); // absolute

--- a/digdag-standards/src/main/java/io/digdag/standards/command/DockerCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/DockerCommandExecutor.java
@@ -112,8 +112,13 @@ public class DockerCommandExecutor
             command.add("--rm");  // remove container when exits
 
             // mount
-            command.add("-v").add(String.format(ENGLISH,
-                        "%s:%s:rw,Z", projectPath, projectPath));  // use projectPath to keep pb.directory() valid
+            if (dockerConfig.get("selinux", Boolean.class, false)) {
+                command.add("-v").add(String.format(ENGLISH,
+                    "%s:%s:rw,Z", projectPath, projectPath));  // use projectPath to keep pb.directory() valid
+            } else {
+                command.add("-v").add(String.format(ENGLISH,
+                    "%s:%s:rw", projectPath, projectPath));  // use projectPath to keep pb.directory() valid
+            }
 
             // working directory
             final Path workingDirectory = getAbsoluteWorkingDirectory(context, request); // absolute


### PR DESCRIPTION
When using SELinux, docker volumes need to be mounted with :Z in order to work properly.

This implements a `selinux` boolean config option in the docker context to enable or disable SELinux support.

Also document new configuration option.

Issue: https://github.com/treasure-data/digdag/issues/1663