### PR TITLE
Logging config

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/Command.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Command.java
@@ -50,6 +50,9 @@ public abstract class Command
     @Parameter(names = {"-l", "--log-level"})
     protected String logLevel = "info";
 
+    @Parameter(names = {"--logback-config"})
+    protected String logbackConfigPath = null;
+
     @DynamicParameter(names = "-X")
     protected Map<String, String> systemProperties = new HashMap<>();
 

--- a/digdag-cli/src/main/resources/digdag/cli/logback-file.xml
+++ b/digdag-cli/src/main/resources/digdag/cli/logback-file.xml
@@ -16,6 +16,7 @@
 
   <logger name="io.netty.util" level="INFO"/>
   <logger name="io.netty.buffer" level="INFO"/>
+  <logger name="com.zaxxer.hikari" level="INFO"/>
 
   <appender name="digdag-context" class="io.digdag.cli.LogbackTaskContextLoggerBridgeAppender">
   </appender>


### PR DESCRIPTION
This PR adds cli option `--logback-config` to specify customized logback xml file.
Digdag set a logback file from predefined logback files (`logback-color.xml`, `logback-console.xml`, `logback-file.xml`) in jar .
So it is difficult to customize logging by ourselves. This PR support it and will be helpful for especially developers.
In addition, exclude noisy debug message of HikariCP as netty.