### PR TITLE
Update Guice to 5, JDBC for PostgreSQL

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,7 @@ subprojects {
         jacksonDatabindVersion = "2.9.10"
         awsJavaSdkVersion = "1.11.686"
         guavaVersion = "30.1.1-jre"
+        guiceVersion = "5.0.1"
     }
 
     tasks.withType(JavaCompile) {

--- a/digdag-core/build.gradle
+++ b/digdag-core/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     compile project(':digdag-plugin-utils')
     compile project(':digdag-spi')
 
-    compile ('com.google.inject:guice:4.2.2') {
+    compile ('com.google.inject:guice:5.0.1') {
         exclude group: 'com.google.guava', module: 'guava'
     }
     compile 'org.embulk:guice-bootstrap:0.3.2'

--- a/digdag-core/build.gradle
+++ b/digdag-core/build.gradle
@@ -18,7 +18,7 @@ dependencies {
     runtime 'org.antlr:stringtemplate:3.2.1' // Used by jdbi2's string template v3 at runtime
     compile 'com.zaxxer:HikariCP:2.4.7'
     compile 'com.h2database:h2:1.4.192'
-    compile 'org.postgresql:postgresql:9.4.1211'
+    compile 'org.postgresql:postgresql:42.3.1'
     compile 'org.yaml:snakeyaml:1.23'
     compile 'com.google.code.findbugs:annotations:3.0.1'
     compile 'org.weakref:jmxutils:1.19'

--- a/digdag-core/build.gradle
+++ b/digdag-core/build.gradle
@@ -5,7 +5,7 @@ dependencies {
     compile project(':digdag-plugin-utils')
     compile project(':digdag-spi')
 
-    compile ('com.google.inject:guice:5.0.1') {
+    compile ("com.google.inject:guice:${project.ext.guiceVersion}") {
         exclude group: 'com.google.guava', module: 'guava'
     }
     compile 'org.embulk:guice-bootstrap:0.3.2'

--- a/digdag-guice-rs/build.gradle
+++ b/digdag-guice-rs/build.gradle
@@ -1,7 +1,7 @@
 
 dependencies {
     compile project(':digdag-commons')
-    compile 'com.google.inject:guice:4.2.2'
+    compile "com.google.inject:guice:${project.ext.guiceVersion}"
     compile 'javax.servlet:javax.servlet-api:3.1.0'
     compile 'org.jboss.resteasy:resteasy-jaxrs:3.0.13.Final'
     compile 'org.jboss.resteasy:async-http-servlet-3.0:3.0.13.Final'

--- a/digdag-spi/build.gradle
+++ b/digdag-spi/build.gradle
@@ -1,7 +1,7 @@
 
 dependencies {
     compile project(':digdag-client')
-    compile ('com.google.inject.extensions:guice-multibindings:4.2.2') {
+    compile ("com.google.inject.extensions:guice-multibindings:4.2.3") {
         exclude group: 'com.google.guava', module: 'guava'
     }
 }


### PR DESCRIPTION
This PR update Google Guice from 4 to 5. And JDBC library for Pg to the latest.
This will reduce warning "WARNING: An illegal reflective access operation has occurred" with Java11.

