### PR TITLE
CI improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,17 +11,15 @@ jobs:
         environment:
           TERM: dumb
           TZ: 'UTC'
-      - image: circleci/postgres:9.5-alpine
-        environment:
-          POSTGRES_USER: digdag_test
-          POSTGRES_DB: digdag_test
-
     steps:
       - checkout
 
       # Set up Digdag database
       - run:
+          name: setup PostgreSqL
           command: |
+            sudo sed -i 's/max_connections = 1000/max_connections = 2000/' /etc/postgresql/9.5/main/postgresql.conf
+            sudo service postgresql restart
             set -x
             # wait for PostgreSQL container to be available for 2 mins
             for i in $(seq 1 120); do

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,11 +6,14 @@ jobs:
 
     # executor type https://circleci.com/docs/2.0/executor-types/
     docker:
-      - image: digdag/digdag-build:20210121T160201-c21ea363746ab5ef7f7503a1a6212a37b79a9943
+      - image: digdag/digdag-build:20210902T164958-dc911cc971d8656872a988e03926e4e626f10a41
         # environment Variables in a Job https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-job
         environment:
           TERM: dumb
           TZ: 'UTC'
+          TEST_S3_ENDPOINT: http://127.0.0.1:9000
+          TEST_S3_ACCESS_KEY_ID: C0AI42GnKrP5H1yn
+          TEST_S3_SECRET_ACCESS_KEY: w42IbhJJXZt6E71y
     steps:
       - checkout
 
@@ -18,7 +21,7 @@ jobs:
       - run:
           name: setup PostgreSqL
           command: |
-            sudo sed -i 's/max_connections = 1000/max_connections = 2000/' /etc/postgresql/9.5/main/postgresql.conf
+            sudo sed -i 's/max_connections = 1000/max_connections = 2000/' /etc/postgresql/11/main/postgresql.conf
             sudo service postgresql restart
             set -x
             # wait for PostgreSQL container to be available for 2 mins
@@ -32,7 +35,17 @@ jobs:
       # Run tests with dependencies cache
       - restore_cache:
           key: dependency-cache-{{ .Branch }}-{{ .Revision }}
-      - run: ci/run_td_tests.sh
+      - run:
+          name: run IT tests
+          command: |
+            nohup /entrypoint.sh > /dev/null 2>&1 &
+            sleep 10
+            ps -awx
+            ls -l /tmp/
+            . /tmp/minio_credential.txt
+            env
+            curl -v $TEST_S3_ENDPOINT
+            ci/run_td_tests.sh
       - save_cache:
           paths:
             - ~/.gradle

--- a/ci/run_td_tests.sh
+++ b/ci/run_td_tests.sh
@@ -14,7 +14,7 @@ minimumPoolSize = 0
 echo "---TARGET test ---"
 target_src1=`circleci tests glob "digdag-tests/src/test/java/acceptance/**/*IT.java" | circleci tests split --split-by=timings`
 # Exclude some tests due to failure in CircleCI. Will fix them later.
-target_src=`echo $target_src1 | sed -E 's/ digdag-tests\/src\/test\/java\/acceptance\/(S3Wait|S3Storage|Docker)IT.java//g'`
+target_src=`echo $target_src1 | sed -E 's/ digdag-tests\/src\/test\/java\/acceptance\/(Docker)IT.java//g'`
 echo $target_src | xargs -n 1 echo
 echo "------------------"
 

--- a/ci/run_td_tests.sh
+++ b/ci/run_td_tests.sh
@@ -12,15 +12,16 @@ minimumPoolSize = 0
 "
 
 echo "---TARGET test ---"
-target_src=`circleci tests glob "digdag-tests/src/test/java/acceptance/td/**/*IT.java" | circleci tests split --split-by=timings`
+target_src1=`circleci tests glob "digdag-tests/src/test/java/acceptance/**/*IT.java" | circleci tests split --split-by=timings`
+# Exclude some tests due to failure in CircleCI. Will fix them later.
+target_src=`echo $target_src1 | sed -E 's/ digdag-tests\/src\/test\/java\/acceptance\/(S3Wait|S3Storage|Docker)IT.java//g'`
 echo $target_src | xargs -n 1 echo
 echo "------------------"
 
 
 export CI_ACCEPTANCE_TEST=true
 
-./gradlew clean cleanTest test --info --no-daemon -p digdag-tests --tests 'acceptance.td.*' \
+./gradlew clean cleanTest test --info --no-daemon -p digdag-tests --tests 'acceptance.*' \
 	  -PtestFilter="$target_src"
-#	  -PtestFilter='`circleci tests glob "digdag-tests/src/test/java/acceptance/td/**/*.java" | circleci tests split --split-by=timings`'
 
 

--- a/digdag-tests/build.gradle
+++ b/digdag-tests/build.gradle
@@ -36,13 +36,13 @@ test {
         }
     }
 
-  if (project.hasProperty("testFilter")) {
-    List<String> props = project.getProperties().get("testFilter").split("\\s+")
-    println("testFilter: " + props)
-    props.each {
-      String converted = it.replace("digdag-tests/src/test/java/acceptance/td/", "**/").replace(".java", "*.class")
-      println("target: " + converted)
-      include(converted)
+    if (project.hasProperty("testFilter")) {
+        List<String> props = project.getProperties().get("testFilter").split("\\s+")
+        println("testFilter: " + props)
+        props.each {
+            String converted = it.replace("digdag-tests/src/test/java/", "").replace(".java", "*.class")
+            println("target: " + converted)
+            include(converted)
+        }
     }
-  }
 }

--- a/digdag-tests/src/test/java/acceptance/td/PyIT.java
+++ b/digdag-tests/src/test/java/acceptance/td/PyIT.java
@@ -153,7 +153,7 @@ public class PyIT
             }
             assertThat(attempt.getSuccess(), is(true));
         }
-
+        Thread.sleep(60 * 1000); // Log will be delayed
         String logs = getAttemptLogs(client, attemptId);
         assertThat(logs, containsString("digdag params"));
         assertThat(logs, containsString("{'VAR_A': 'aaa'}")); // via _env in echo_params.dig

--- a/docker/bootstrap/dependencies.sh
+++ b/docker/bootstrap/dependencies.sh
@@ -17,12 +17,12 @@ apt-get -y install docker-compose
 
 # Postgres
 sudo apt-key adv --recv-keys --keyserver keyserver.ubuntu.com 7FCC7D46ACCC4CF8 # To fix failure at add-apt-repository
-add-apt-repository "deb https://apt.postgresql.org/pub/repos/apt/ trusty-pgdg main"
+add-apt-repository "deb https://apt.postgresql.org/pub/repos/apt/ bionic-pgdg main"
 wget --quiet -O - https://postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -
 apt-get -y update
-apt-get -y install postgresql-9.5 postgresql-client-9.5
-cp pg_hba.conf /etc/postgresql/9.5/main/
-cp postgresql.conf /etc/postgresql/9.5/main/
+apt-get -y install postgresql-11 postgresql-client-11
+cp pg_hba.conf /etc/postgresql/11/main/
+cp postgresql.conf /etc/postgresql/11/main/
 /etc/init.d/postgresql start
 sudo -u postgres createuser -s digdag_test
 sudo -u postgres createdb -O digdag_test digdag_test

--- a/docker/bootstrap/postgresql.conf
+++ b/docker/bootstrap/postgresql.conf
@@ -38,15 +38,15 @@
 # The default values of these variables are driven from the -D command-line
 # option or PGDATA environment variable, represented here as ConfigDir.
 
-data_directory = '/var/lib/postgresql/9.5/main'		# use data in another directory
+data_directory = '/var/lib/postgresql/11/main'		# use data in another directory
 					# (change requires restart)
-hba_file = '/etc/postgresql/9.5/main/pg_hba.conf'	# host-based authentication file
+hba_file = '/etc/postgresql/11/main/pg_hba.conf'	# host-based authentication file
 					# (change requires restart)
-ident_file = '/etc/postgresql/9.5/main/pg_ident.conf'	# ident configuration file
+ident_file = '/etc/postgresql/11/main/pg_ident.conf'	# ident configuration file
 					# (change requires restart)
 
 # If external_pid_file is not explicitly set, no extra PID file is written.
-external_pid_file = '/var/run/postgresql/9.5-main.pid'			# write an extra PID file
+external_pid_file = '/var/run/postgresql/11-main.pid'			# write an extra PID file
 					# (change requires restart)
 
 
@@ -443,7 +443,7 @@ log_timezone = 'UTC'
 
 # - Process Title -
 
-cluster_name = '9.5/main'			# added to process titles if nonempty
+cluster_name = '11/main'			# added to process titles if nonempty
 					# (change requires restart)
 #update_process_title = on
 
@@ -459,7 +459,7 @@ cluster_name = '9.5/main'			# added to process titles if nonempty
 #track_io_timing = off
 #track_functions = none			# none, pl, all
 #track_activity_query_size = 1024	# (change requires restart)
-stats_temp_directory = '/var/run/postgresql/9.5-main.pg_stat_tmp'
+stats_temp_directory = '/var/run/postgresql/11-main.pg_stat_tmp'
 
 
 # - Statistics Monitoring -

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,9 +8,17 @@ if [ ! -z "$DIGDAG_TEST_REDIS" ]; then
     redis-server &
 fi
 
-export TEST_S3_ACCESS_KEY_ID=$(cat /dev/urandom | LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
-export TEST_S3_SECRET_ACCESS_KEY=$(cat /dev/urandom | LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
-export TEST_S3_ENDPOINT=http://127.0.0.1:9000
+if [ -z "$TEST_S3_ACCESS_KEY_ID" ]; then
+    export TEST_S3_ACCESS_KEY_ID=$(cat /dev/urandom | LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
+fi
+
+if [ -z "$TEST_S3_SECRET_ACCESS_KEY" ]; then
+    export TEST_S3_SECRET_ACCESS_KEY=$(cat /dev/urandom | LC_CTYPE=C tr -dc 'a-zA-Z0-9' | fold -w 16 | head -n 1)
+fi
+
+if [ -z "$TEST_S3_ENDPOINT" ]; then
+    export TEST_S3_ENDPOINT=http://127.0.0.1:9000
+fi
 
 export MINIO_ACCESS_KEY=${TEST_S3_ACCESS_KEY_ID}
 export MINIO_SECRET_KEY=${TEST_S3_SECRET_ACCESS_KEY}
@@ -18,4 +26,9 @@ export MINIO_SECRET_KEY=${TEST_S3_SECRET_ACCESS_KEY}
 mkdir -p /tmp/minio
 minio server /tmp/minio/ &
 
+cat <<EOF > /tmp/minio_credential.txt
+export TEST_S3_ENDPOINT=${TEST_S3_ENDPOINT}
+export TEST_S3_ACCESS_KEY_ID=${TEST_S3_ACCESS_KEY_ID}
+export TEST_S3_SECRET_ACCESS_KEY=${TEST_S3_SECRET_ACCESS_KEY}
+EOF
 exec "$@"


### PR DESCRIPTION
This PR is back port from Treasure Workflow

- Stop using `circleci/postgres:9.5-alpine` docker image which will be deprecated
   https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034
- All integration tests will run in CircleCI for simplicity
- Fix an issue that some integration tests are skipped unexpectedly.
- Update docker image
- Upgrade PostgreSQL from 9.5 to 11

Note: This PR will disable `DockerIT` test because it does not work in CircleCI.
We may need to use `machine` executor instead of `docker`.
https://circleci.com/docs/2.0/executor-types/#using-machine