### PR TITLE
[WIP] Upgrade Jdbi2 to 3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,7 @@ subprojects {
         jacksonDatabindVersion = "2.9.10"
         awsJavaSdkVersion = "1.11.686"
         guavaVersion = "30.1.1-jre"
+        jdbi3Version = "3.26.0"
     }
 
     tasks.withType(JavaCompile) {

--- a/digdag-cli/src/main/java/io/digdag/cli/Migrate.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Migrate.java
@@ -8,6 +8,7 @@ import io.digdag.core.config.PropertyUtils;
 import io.digdag.core.database.DataSourceProvider;
 import io.digdag.core.database.DatabaseConfig;
 import io.digdag.core.database.DatabaseMigrator;
+import io.digdag.core.database.JdbiHelper;
 import io.digdag.core.database.migrate.Migration;
 import org.jdbi.v3.core.Jdbi;
 
@@ -33,7 +34,7 @@ public class Migrate
         checkArgs();
         DatabaseConfig dbConfig = DatabaseConfig.convertFrom(buildConfig());
         try (DataSourceProvider dsp = new DataSourceProvider(dbConfig)) {
-            Jdbi dbi = Jdbi.create(dsp.get());
+            Jdbi dbi = JdbiHelper.createJdbi(dsp.get());
             DatabaseMigrator migrator = new DatabaseMigrator(dbi, dbConfig);
             switch (subCommand) {
                 case RUN:

--- a/digdag-cli/src/main/java/io/digdag/cli/Migrate.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Migrate.java
@@ -8,7 +8,7 @@ import io.digdag.core.config.PropertyUtils;
 import io.digdag.core.database.DataSourceProvider;
 import io.digdag.core.database.DatabaseConfig;
 import io.digdag.core.database.DatabaseMigrator;
-import io.digdag.core.database.JdbiHelper;
+import io.digdag.core.database.DatabaseHelper;
 import io.digdag.core.database.migrate.Migration;
 import org.jdbi.v3.core.Jdbi;
 
@@ -34,7 +34,7 @@ public class Migrate
         checkArgs();
         DatabaseConfig dbConfig = DatabaseConfig.convertFrom(buildConfig());
         try (DataSourceProvider dsp = new DataSourceProvider(dbConfig)) {
-            Jdbi dbi = JdbiHelper.createJdbi(dsp.get());
+            Jdbi dbi = DatabaseHelper.createJdbi(dsp.get());
             DatabaseMigrator migrator = new DatabaseMigrator(dbi, dbConfig);
             switch (subCommand) {
                 case RUN:

--- a/digdag-cli/src/main/java/io/digdag/cli/Migrate.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/Migrate.java
@@ -9,7 +9,7 @@ import io.digdag.core.database.DataSourceProvider;
 import io.digdag.core.database.DatabaseConfig;
 import io.digdag.core.database.DatabaseMigrator;
 import io.digdag.core.database.migrate.Migration;
-import org.skife.jdbi.v2.DBI;
+import org.jdbi.v3.core.Jdbi;
 
 import java.nio.file.Paths;
 import java.util.List;
@@ -33,7 +33,7 @@ public class Migrate
         checkArgs();
         DatabaseConfig dbConfig = DatabaseConfig.convertFrom(buildConfig());
         try (DataSourceProvider dsp = new DataSourceProvider(dbConfig)) {
-            DBI dbi = new DBI(dsp.get());
+            Jdbi dbi = Jdbi.create(dsp.get());
             DatabaseMigrator migrator = new DatabaseMigrator(dbi, dbConfig);
             switch (subCommand) {
                 case RUN:

--- a/digdag-core/build.gradle
+++ b/digdag-core/build.gradle
@@ -14,7 +14,9 @@ dependencies {
         exclude group: 'com.google.inject', module: 'guice'
     }
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${project.ext.jacksonVersion}"
-    compile 'org.jdbi:jdbi:2.75'
+    compile 'org.jdbi:jdbi3-core:3.26.0'
+    compile 'org.jdbi:jdbi3-sqlobject:3.26.0'
+    compile 'org.jdbi:jdbi3-stringtemplate4:3.26.0'
     runtime 'org.antlr:stringtemplate:3.2.1' // Used by jdbi2's string template v3 at runtime
     compile 'com.zaxxer:HikariCP:2.4.7'
     compile 'com.h2database:h2:1.4.192'

--- a/digdag-core/build.gradle
+++ b/digdag-core/build.gradle
@@ -14,10 +14,20 @@ dependencies {
         exclude group: 'com.google.inject', module: 'guice'
     }
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${project.ext.jacksonVersion}"
-    compile "org.jdbi:jdbi3-core:${project.ext.jdbi3Version}"
+    // Downgrade caffeine which jdbi3-core depends on to 2.x to support Java8
+    // If Digdag drop support of Java8, remove it.
+    compile ('com.github.ben-manes.caffeine:caffeine:2.9.3') {
+        version {
+            strictly '2.9.3'
+        }
+    }
+    compile ("org.jdbi:jdbi3-core:${project.ext.jdbi3Version}") {
+        exclude group: 'com.github.ben-manes.caffeine', module: 'caffeine'
+    }
     compile "org.jdbi:jdbi3-postgres:${project.ext.jdbi3Version}"
     compile "org.jdbi:jdbi3-sqlobject:${project.ext.jdbi3Version}"
     compile "org.jdbi:jdbi3-stringtemplate4:${project.ext.jdbi3Version}"
+
     runtime 'org.antlr:stringtemplate:3.2.1' // Used by jdbi2's string template v3 at runtime
     compile 'com.zaxxer:HikariCP:2.4.7'
     compile 'com.h2database:h2:1.4.192'

--- a/digdag-core/build.gradle
+++ b/digdag-core/build.gradle
@@ -14,13 +14,15 @@ dependencies {
         exclude group: 'com.google.inject', module: 'guice'
     }
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${project.ext.jacksonVersion}"
-    compile 'org.jdbi:jdbi3-core:3.26.0'
-    compile 'org.jdbi:jdbi3-sqlobject:3.26.0'
-    compile 'org.jdbi:jdbi3-stringtemplate4:3.26.0'
+    compile "org.jdbi:jdbi3-core:${project.ext.jdbi3Version}"
+    compile "org.jdbi:jdbi3-postgres:${project.ext.jdbi3Version}"
+    compile "org.jdbi:jdbi3-sqlobject:${project.ext.jdbi3Version}"
+    compile "org.jdbi:jdbi3-stringtemplate4:${project.ext.jdbi3Version}"
     runtime 'org.antlr:stringtemplate:3.2.1' // Used by jdbi2's string template v3 at runtime
     compile 'com.zaxxer:HikariCP:2.4.7'
     compile 'com.h2database:h2:1.4.192'
-    compile 'org.postgresql:postgresql:9.4.1211'
+    compile 'org.postgresql:postgresql:42.3.1'
+    //compile 'org.postgresql:postgresql:9.4.1211'
     compile 'org.yaml:snakeyaml:1.23'
     compile 'com.google.code.findbugs:annotations:3.0.1'
     compile 'org.weakref:jmxutils:1.19'

--- a/digdag-core/src/main/java/io/digdag/core/database/BasicDatabaseStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/BasicDatabaseStoreManager.java
@@ -12,9 +12,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import io.digdag.commons.ThrowablesUtil;
-import org.skife.jdbi.v2.Handle;
-import org.skife.jdbi.v2.exceptions.UnableToExecuteStatementException;
-import org.skife.jdbi.v2.exceptions.TransactionFailedException;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
+import org.jdbi.v3.core.transaction.TransactionException;
 import com.google.common.base.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -194,7 +194,7 @@ public abstract class BasicDatabaseStoreManager <D>
             ThrowablesUtil.propagateIfInstanceOf(ex, exClass2);
             ThrowablesUtil.propagateIfInstanceOf(ex, exClass3);
             ThrowablesUtil.propagateIfPossible(ex);
-            throw new TransactionFailedException(
+            throw new TransactionException(
                     "Transaction failed due to exception being thrown " +
                             "from within the callback. See cause " +
                             "for the original exception.", ex);

--- a/digdag-core/src/main/java/io/digdag/core/database/ConfigMapper.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/ConfigMapper.java
@@ -12,9 +12,10 @@ import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.inject.Inject;
 import io.digdag.commons.ThrowablesUtil;
-import org.skife.jdbi.v2.StatementContext;
-import org.skife.jdbi.v2.tweak.Argument;
-import org.skife.jdbi.v2.tweak.ArgumentFactory;
+import org.jdbi.v3.core.argument.AbstractArgumentFactory;
+import org.jdbi.v3.core.argument.Argument;
+import org.jdbi.v3.core.config.ConfigRegistry;
+import org.jdbi.v3.core.statement.StatementContext;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigFactory;
 
@@ -97,17 +98,15 @@ class ConfigMapper
         }
     }
 
-    public class ConfigArgumentFactory
-            implements ArgumentFactory<Config>
+    public class ConfigArgumentFactory extends AbstractArgumentFactory<Config>
     {
-        @Override
-        public boolean accepts(Class<?> expectedType, Object value, StatementContext ctx)
+        public ConfigArgumentFactory()
         {
-            return value instanceof Config;
+            super(Types.CLOB);
         }
 
         @Override
-        public Argument build(Class<?> expectedType, Config value, StatementContext ctx)
+        protected Argument build(Config value, ConfigRegistry config)
         {
             return new ConfigArgument(value);
         }

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseHelper.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseHelper.java
@@ -7,14 +7,18 @@ import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 
 import javax.sql.DataSource;
 
-public class JdbiHelper
+public class DatabaseHelper
 {
     public static Jdbi createJdbi(DataSource ds)
     {
         Jdbi jdbi = Jdbi.create(ds);
         jdbi.installPlugin(new SqlObjectPlugin());
-        jdbi.installPlugin(new PostgresPlugin());
-        jdbi.installPlugin(new H2DatabasePlugin());
+        if (ds.getClass().getCanonicalName().startsWith("org.h2")) {
+            jdbi.installPlugin(new H2DatabasePlugin());
+        }
+        else {
+            jdbi.installPlugin(new PostgresPlugin());
+        }
         return jdbi;
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseModule.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseModule.java
@@ -11,7 +11,7 @@ import io.digdag.core.queue.QueueSettingStoreManager;
 import io.digdag.core.repository.ProjectStoreManager;
 import io.digdag.core.schedule.ScheduleStoreManager;
 import io.digdag.core.session.SessionStoreManager;
-import org.skife.jdbi.v2.DBI;
+import org.jdbi.v3.core.Jdbi;
 
 public class DatabaseModule
         implements Module
@@ -29,7 +29,7 @@ public class DatabaseModule
         binder.bind(DatabaseConfig.class).toProvider(DatabaseConfigProvider.class).in(Scopes.SINGLETON);
         binder.bind(DataSource.class).toProvider(DataSourceProvider.class).in(Scopes.SINGLETON);
         binder.bind(AutoMigrator.class);
-        binder.bind(DBI.class).toProvider(DbiProvider.class);  // don't make this singleton because DBI.registerMapper is called for each StoreManager
+        binder.bind(Jdbi.class).toProvider(DbiProvider.class);  // don't make this singleton because Jdbi.registerMapper is called for each StoreManager
         binder.bind(TransactionManager.class).to(ThreadLocalTransactionManager.class).in(Scopes.SINGLETON);
         binder.bind(ConfigMapper.class).in(Scopes.SINGLETON);
         binder.bind(DatabaseMigrator.class).in(Scopes.SINGLETON);
@@ -51,7 +51,7 @@ public class DatabaseModule
         public AutoMigrator(DataSource ds, DatabaseConfig config)
         {
             if (config.getAutoMigrate()) {
-                this.migrator = new DatabaseMigrator(new DBI(ds), config);
+                this.migrator = new DatabaseMigrator(Jdbi.create(ds), config);
             }
         }
 
@@ -66,7 +66,7 @@ public class DatabaseModule
     }
 
     public static class DbiProvider
-            implements Provider<DBI>
+            implements Provider<Jdbi>
     {
         private final DataSource ds;
 
@@ -78,9 +78,9 @@ public class DatabaseModule
         }
 
         @Override
-        public DBI get()
+        public Jdbi get()
         {
-            return new DBI(ds);
+            return Jdbi.create(ds);
         }
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseModule.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseModule.java
@@ -51,7 +51,7 @@ public class DatabaseModule
         public AutoMigrator(DataSource ds, DatabaseConfig config)
         {
             if (config.getAutoMigrate()) {
-                this.migrator = new DatabaseMigrator(Jdbi.create(ds), config);
+                this.migrator = new DatabaseMigrator(JdbiHelper.createJdbi(ds), config);
             }
         }
 
@@ -80,7 +80,7 @@ public class DatabaseModule
         @Override
         public Jdbi get()
         {
-            return Jdbi.create(ds);
+            return JdbiHelper.createJdbi(ds);
         }
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseModule.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseModule.java
@@ -51,7 +51,7 @@ public class DatabaseModule
         public AutoMigrator(DataSource ds, DatabaseConfig config)
         {
             if (config.getAutoMigrate()) {
-                this.migrator = new DatabaseMigrator(JdbiHelper.createJdbi(ds), config);
+                this.migrator = new DatabaseMigrator(DatabaseHelper.createJdbi(ds), config);
             }
         }
 
@@ -80,7 +80,7 @@ public class DatabaseModule
         @Override
         public Jdbi get()
         {
-            return JdbiHelper.createJdbi(ds);
+            return DatabaseHelper.createJdbi(ds);
         }
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
@@ -410,7 +410,7 @@ public class DatabaseProjectStoreManager
         {
             this.handle = handle;
             this.siteId = siteId;
-            this.dao = handle.attach(Dao.class);
+            this.dao = handle.attach(dao(databaseType));
         }
 
         /**

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
@@ -31,15 +31,15 @@ import io.digdag.metrics.DigdagTimed;
 import io.digdag.spi.ScheduleTime;
 import io.digdag.spi.ac.AccessController;
 import org.immutables.value.Value;
-import org.skife.jdbi.v2.Handle;
-import org.skife.jdbi.v2.StatementContext;
-import org.skife.jdbi.v2.sqlobject.Bind;
-import org.skife.jdbi.v2.sqlobject.GetGeneratedKeys;
-import org.skife.jdbi.v2.sqlobject.SqlQuery;
-import org.skife.jdbi.v2.sqlobject.SqlUpdate;
-import org.skife.jdbi.v2.sqlobject.customizers.Define;
-import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
-import org.skife.jdbi.v2.tweak.ResultSetMapper;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import org.jdbi.v3.sqlobject.customizer.Define;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.stringtemplate4.UseStringTemplateEngine;
 
 import javax.activation.DataSource;
 
@@ -388,10 +388,10 @@ public class DatabaseProjectStoreManager
     }
 
     private static class IdTimeZoneMapper
-            implements ResultSetMapper<IdTimeZone>
+            implements RowMapper<IdTimeZone>
     {
         @Override
-        public IdTimeZone map(int index, ResultSet r, StatementContext ctx)
+        public IdTimeZone map(ResultSet r, StatementContext ctx)
                 throws SQLException
         {
             return new IdTimeZone(r.getLong("id"), ZoneId.of(r.getString("timezone")));
@@ -534,7 +534,7 @@ public class DatabaseProjectStoreManager
             // delete unused schedules
             if (!oldScheduleNames.isEmpty()) {
                 // those names don exist any more.
-                handle.createStatement(
+                handle.createUpdate(
                         "delete from schedules" +
                         " where id " + inLargeIdListExpression(oldScheduleNames.values())
                     )
@@ -550,7 +550,7 @@ public class DatabaseProjectStoreManager
         }
     }
 
-    @UseStringTemplate3StatementLocator
+    @UseStringTemplateEngine
     public interface H2Dao
             extends Dao
     {
@@ -609,7 +609,7 @@ public class DatabaseProjectStoreManager
                 @Define("acFilter") String acFilter);
     }
 
-    @UseStringTemplate3StatementLocator
+    @UseStringTemplateEngine
     public interface PgDao
             extends Dao
     {
@@ -928,7 +928,7 @@ public class DatabaseProjectStoreManager
     }
 
     static class StoredProjectMapper
-            implements ResultSetMapper<StoredProject>
+            implements RowMapper<StoredProject>
     {
         private final ConfigMapper cfm;
 
@@ -938,7 +938,7 @@ public class DatabaseProjectStoreManager
         }
 
         @Override
-        public StoredProject map(int index, ResultSet r, StatementContext ctx)
+        public StoredProject map(ResultSet r, StatementContext ctx)
                 throws SQLException
         {
             String name = r.getString("name");
@@ -958,7 +958,7 @@ public class DatabaseProjectStoreManager
     }
 
     static class StoredProjectWithRevisionMapper
-            implements ResultSetMapper<StoredProjectWithRevision>
+            implements RowMapper<StoredProjectWithRevision>
     {
         private final ConfigMapper cfm;
 
@@ -968,7 +968,7 @@ public class DatabaseProjectStoreManager
         }
 
         @Override
-        public StoredProjectWithRevision map(int index, ResultSet r, StatementContext ctx)
+        public StoredProjectWithRevision map(ResultSet r, StatementContext ctx)
                 throws SQLException
         {
             String name = r.getString("name");
@@ -992,7 +992,7 @@ public class DatabaseProjectStoreManager
     }
 
     static class StoredRevisionMapper
-            implements ResultSetMapper<StoredRevision>
+            implements RowMapper<StoredRevision>
     {
         private final ConfigMapper cfm;
 
@@ -1002,7 +1002,7 @@ public class DatabaseProjectStoreManager
         }
 
         @Override
-        public StoredRevision map(int index, ResultSet r, StatementContext ctx)
+        public StoredRevision map(ResultSet r, StatementContext ctx)
                 throws SQLException
         {
             return ImmutableStoredRevision.builder()
@@ -1020,7 +1020,7 @@ public class DatabaseProjectStoreManager
     }
 
     static class StoredWorkflowDefinitionMapper
-            implements ResultSetMapper<StoredWorkflowDefinition>
+            implements RowMapper<StoredWorkflowDefinition>
     {
         private final ConfigMapper cfm;
 
@@ -1030,7 +1030,7 @@ public class DatabaseProjectStoreManager
         }
 
         @Override
-        public StoredWorkflowDefinition map(int index, ResultSet r, StatementContext ctx)
+        public StoredWorkflowDefinition map(ResultSet r, StatementContext ctx)
                 throws SQLException
         {
             return ImmutableStoredWorkflowDefinition.builder()
@@ -1044,7 +1044,7 @@ public class DatabaseProjectStoreManager
     }
 
     static class StoredWorkflowDefinitionWithProjectMapper
-            implements ResultSetMapper<StoredWorkflowDefinitionWithProject>
+            implements RowMapper<StoredWorkflowDefinitionWithProject>
     {
         private final ConfigMapper cfm;
 
@@ -1054,7 +1054,7 @@ public class DatabaseProjectStoreManager
         }
 
         @Override
-        public StoredWorkflowDefinitionWithProject map(int index, ResultSet r, StatementContext ctx)
+        public StoredWorkflowDefinitionWithProject map(ResultSet r, StatementContext ctx)
                 throws SQLException
         {
             String projName = r.getString("proj_name");
@@ -1084,10 +1084,10 @@ public class DatabaseProjectStoreManager
     }
 
     static class WorkflowConfigMapper
-            implements ResultSetMapper<WorkflowConfig>
+            implements RowMapper<WorkflowConfig>
     {
         @Override
-        public WorkflowConfig map(int index, ResultSet r, StatementContext ctx)
+        public WorkflowConfig map(ResultSet r, StatementContext ctx)
                 throws SQLException
         {
             return ImmutableWorkflowConfig.builder()
@@ -1099,10 +1099,10 @@ public class DatabaseProjectStoreManager
     }
 
     static class IdNameMapper
-            implements ResultSetMapper<IdName>
+            implements RowMapper<IdName>
     {
         @Override
-        public IdName map(int index, ResultSet r, StatementContext ctx)
+        public IdName map(ResultSet r, StatementContext ctx)
                 throws SQLException
         {
             return IdName.of(r.getInt("id"), r.getString("name"));
@@ -1119,10 +1119,10 @@ public class DatabaseProjectStoreManager
     }
 
     static class ScheduleStatusMapper
-            implements ResultSetMapper<ScheduleStatus>
+            implements RowMapper<ScheduleStatus>
     {
         @Override
-        public ScheduleStatus map(int index, ResultSet r, StatementContext ctx)
+        public ScheduleStatus map(ResultSet r, StatementContext ctx)
                 throws SQLException
         {
             return ScheduleStatus.of(

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
@@ -33,6 +33,7 @@ import io.digdag.spi.ac.AccessController;
 import org.immutables.value.Value;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.statement.StatementContext;
+import org.jdbi.v3.sqlobject.SingleValue;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
@@ -754,6 +755,7 @@ public class DatabaseProjectStoreManager
                 " limit :limit")
         List<StoredRevision> getRevisions(@Bind("siteId") int siteId, @Bind("projId") int projId, @Bind("limit") int limit, @Bind("lastId") int lastId);
 
+        @SingleValue
         @SqlQuery("select archive_data from revision_archives" +
                 " where id = :revId")
         byte[] selectRevisionArchiveData(@Bind("revId") int revId);

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseQueueSettingStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseQueueSettingStoreManager.java
@@ -4,24 +4,17 @@ import java.util.List;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import com.google.common.base.*;
-import com.google.common.collect.*;
 import com.google.inject.Inject;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import io.digdag.core.queue.QueueSettingStore;
 import io.digdag.core.queue.QueueSettingStoreManager;
 import io.digdag.core.queue.StoredQueueSetting;
 import io.digdag.core.queue.ImmutableStoredQueueSetting;
-import org.skife.jdbi.v2.DBI;
-import org.skife.jdbi.v2.Handle;
-import org.skife.jdbi.v2.sqlobject.SqlQuery;
-import org.skife.jdbi.v2.sqlobject.SqlUpdate;
-import org.skife.jdbi.v2.sqlobject.Bind;
-import org.skife.jdbi.v2.sqlobject.GetGeneratedKeys;
-import org.skife.jdbi.v2.StatementContext;
-import org.skife.jdbi.v2.sqlobject.customizers.Mapper;
-import org.skife.jdbi.v2.tweak.ResultSetMapper;
-import io.digdag.client.config.Config;
-import io.digdag.core.repository.ResourceConflictException;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.GetGeneratedKeys;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.jdbi.v3.core.mapper.RowMapper;
 import io.digdag.core.repository.ResourceNotFoundException;
 
 public class DatabaseQueueSettingStoreManager
@@ -129,7 +122,7 @@ public class DatabaseQueueSettingStoreManager
     }
 
     static class StoredQueueSettingMapper
-            implements ResultSetMapper<StoredQueueSetting>
+            implements RowMapper<StoredQueueSetting>
     {
         private final ConfigMapper cfm;
 
@@ -139,7 +132,7 @@ public class DatabaseQueueSettingStoreManager
         }
 
         @Override
-        public StoredQueueSetting map(int index, ResultSet r, StatementContext ctx)
+        public StoredQueueSetting map(ResultSet r, StatementContext ctx)
                 throws SQLException
         {
             return ImmutableStoredQueueSetting.builder()

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseScheduleStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseScheduleStoreManager.java
@@ -12,24 +12,20 @@ import io.digdag.core.schedule.ScheduleStoreManager;
 import io.digdag.core.schedule.StoredSchedule;
 import io.digdag.spi.ScheduleTime;
 import io.digdag.spi.ac.AccessController;
-import org.skife.jdbi.v2.DBI;
-import org.skife.jdbi.v2.Handle;
-import org.skife.jdbi.v2.StatementContext;
-import org.skife.jdbi.v2.sqlobject.Bind;
-import org.skife.jdbi.v2.sqlobject.SqlQuery;
-import org.skife.jdbi.v2.sqlobject.SqlUpdate;
-import org.skife.jdbi.v2.sqlobject.customizers.Define;
-import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
-import org.skife.jdbi.v2.tweak.ResultSetMapper;
-
-import javax.sql.DataSource;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import org.jdbi.v3.sqlobject.customizer.Define;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.jdbi.v3.stringtemplate4.UseStringTemplateEngine;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class DatabaseScheduleStoreManager
@@ -243,13 +239,13 @@ public class DatabaseScheduleStoreManager
         }
     }
 
-    @UseStringTemplate3StatementLocator
+    @UseStringTemplateEngine
     public interface H2Dao
             extends Dao
     {
     }
 
-    @UseStringTemplate3StatementLocator
+    @UseStringTemplateEngine
     public interface PgDao
             extends Dao
     {
@@ -362,7 +358,7 @@ public class DatabaseScheduleStoreManager
     }
 
     static class StoredScheduleMapper
-            implements ResultSetMapper<StoredSchedule>
+            implements RowMapper<StoredSchedule>
     {
         private final ConfigMapper cfm;
 
@@ -372,7 +368,7 @@ public class DatabaseScheduleStoreManager
         }
 
         @Override
-        public StoredSchedule map(int index, ResultSet r, StatementContext ctx)
+        public StoredSchedule map(ResultSet r, StatementContext ctx)
                 throws SQLException
         {
             return ImmutableStoredSchedule.builder()

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSecretControlStore.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSecretControlStore.java
@@ -4,11 +4,11 @@ import com.google.common.base.Optional;
 import io.digdag.core.crypto.SecretCrypto;
 import io.digdag.core.database.DatabaseSecretStore.EncryptedSecret;
 import io.digdag.spi.SecretControlStore;
-import org.skife.jdbi.v2.DBI;
-import org.skife.jdbi.v2.Handle;
-import org.skife.jdbi.v2.sqlobject.Bind;
-import org.skife.jdbi.v2.sqlobject.SqlQuery;
-import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
 import java.util.List;
 import static java.util.Locale.ENGLISH;

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSecretControlStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSecretControlStoreManager.java
@@ -5,7 +5,7 @@ import io.digdag.client.config.Config;
 import io.digdag.core.crypto.SecretCrypto;
 import io.digdag.spi.SecretControlStore;
 import io.digdag.spi.SecretControlStoreManager;
-import org.skife.jdbi.v2.DBI;
+import org.jdbi.v3.core.Jdbi;
 
 public class DatabaseSecretControlStoreManager
         implements SecretControlStoreManager

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSecretStore.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSecretStore.java
@@ -3,11 +3,11 @@ package io.digdag.core.database;
 import com.google.common.base.Optional;
 import io.digdag.core.crypto.SecretCrypto;
 import io.digdag.spi.SecretStore;
-import org.skife.jdbi.v2.DBI;
-import org.skife.jdbi.v2.StatementContext;
-import org.skife.jdbi.v2.sqlobject.Bind;
-import org.skife.jdbi.v2.sqlobject.SqlQuery;
-import org.skife.jdbi.v2.tweak.ResultSetMapper;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.statement.StatementContext;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.core.mapper.RowMapper;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -71,10 +71,10 @@ class DatabaseSecretStore
     }
 
     static class ScopedSecretMapper
-            implements ResultSetMapper<EncryptedSecret>
+            implements RowMapper<EncryptedSecret>
     {
         @Override
-        public EncryptedSecret map(int index, ResultSet r, StatementContext ctx)
+        public EncryptedSecret map(ResultSet r, StatementContext ctx)
                 throws SQLException
         {
             return new EncryptedSecret(r.getString("engine"), r.getString("value"));

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseSecretStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseSecretStoreManager.java
@@ -4,7 +4,7 @@ import com.google.inject.Inject;
 import io.digdag.core.crypto.SecretCrypto;
 import io.digdag.spi.SecretStore;
 import io.digdag.spi.SecretStoreManager;
-import org.skife.jdbi.v2.DBI;
+import org.jdbi.v3.core.Jdbi;
 
 public class DatabaseSecretStoreManager
         implements SecretStoreManager

--- a/digdag-core/src/main/java/io/digdag/core/database/JdbiHelper.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/JdbiHelper.java
@@ -1,0 +1,20 @@
+package io.digdag.core.database;
+
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.h2.H2DatabasePlugin;
+import org.jdbi.v3.postgres.PostgresPlugin;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+
+import javax.sql.DataSource;
+
+public class JdbiHelper
+{
+    public static Jdbi createJdbi(DataSource ds)
+    {
+        Jdbi jdbi = Jdbi.create(ds);
+        jdbi.installPlugin(new SqlObjectPlugin());
+        jdbi.installPlugin(new PostgresPlugin());
+        jdbi.installPlugin(new H2DatabasePlugin());
+        return jdbi;
+    }
+}

--- a/digdag-core/src/main/java/io/digdag/core/database/ThreadLocalTransactionManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/ThreadLocalTransactionManager.java
@@ -2,6 +2,7 @@ package io.digdag.core.database;
 
 import com.google.inject.Inject;
 import io.digdag.commons.ThrowablesUtil;
+import org.jdbi.v3.core.Handles;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.Handle;
 import org.jdbi.v3.core.transaction.TransactionException;
@@ -62,7 +63,7 @@ public class ThreadLocalTransactionManager
             }
 
             if (handle == null) {
-                Jdbi dbi = Jdbi.create(ds);
+                Jdbi dbi = JdbiHelper.createJdbi(ds);
                 ConfigKeyListMapper cklm = new ConfigKeyListMapper();
                 dbi.registerRowMapper(new DatabaseProjectStoreManager.StoredProjectMapper(configMapper));
                 dbi.registerRowMapper(new DatabaseProjectStoreManager.StoredProjectWithRevisionMapper(configMapper));
@@ -94,6 +95,7 @@ public class ThreadLocalTransactionManager
                 handle = dbi.open();
 
                 try {
+                    handle.getConfig(Handles.class).setForceEndTransactions(false);
                     handle.getConnection().setAutoCommit(autoAutoCommit);
                 }
                 catch (SQLException ex) {

--- a/digdag-core/src/main/java/io/digdag/core/database/ThreadLocalTransactionManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/ThreadLocalTransactionManager.java
@@ -63,7 +63,7 @@ public class ThreadLocalTransactionManager
             }
 
             if (handle == null) {
-                Jdbi dbi = JdbiHelper.createJdbi(ds);
+                Jdbi dbi = DatabaseHelper.createJdbi(ds);
                 ConfigKeyListMapper cklm = new ConfigKeyListMapper();
                 dbi.registerRowMapper(new DatabaseProjectStoreManager.StoredProjectMapper(configMapper));
                 dbi.registerRowMapper(new DatabaseProjectStoreManager.StoredProjectWithRevisionMapper(configMapper));

--- a/digdag-core/src/main/java/io/digdag/core/database/ThreadLocalTransactionManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/ThreadLocalTransactionManager.java
@@ -2,9 +2,9 @@ package io.digdag.core.database;
 
 import com.google.inject.Inject;
 import io.digdag.commons.ThrowablesUtil;
-import org.skife.jdbi.v2.DBI;
-import org.skife.jdbi.v2.Handle;
-import org.skife.jdbi.v2.exceptions.TransactionFailedException;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.Handle;
+import org.jdbi.v3.core.transaction.TransactionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,43 +62,42 @@ public class ThreadLocalTransactionManager
             }
 
             if (handle == null) {
-                DBI dbi = new DBI(ds);
+                Jdbi dbi = Jdbi.create(ds);
                 ConfigKeyListMapper cklm = new ConfigKeyListMapper();
-                dbi.registerMapper(new DatabaseProjectStoreManager.StoredProjectMapper(configMapper));
-                dbi.registerMapper(new DatabaseProjectStoreManager.StoredProjectWithRevisionMapper(configMapper));
-                dbi.registerMapper(new DatabaseProjectStoreManager.StoredRevisionMapper(configMapper));
-                dbi.registerMapper(new DatabaseProjectStoreManager.StoredWorkflowDefinitionMapper(configMapper));
-                dbi.registerMapper(new DatabaseProjectStoreManager.StoredWorkflowDefinitionWithProjectMapper(configMapper));
-                dbi.registerMapper(new DatabaseProjectStoreManager.WorkflowConfigMapper());
-                dbi.registerMapper(new DatabaseProjectStoreManager.IdNameMapper());
-                dbi.registerMapper(new DatabaseProjectStoreManager.ScheduleStatusMapper());
-                dbi.registerMapper(new DatabaseQueueSettingStoreManager.StoredQueueSettingMapper(configMapper));
-                dbi.registerMapper(new DatabaseScheduleStoreManager.StoredScheduleMapper(configMapper));
-                dbi.registerMapper(new DatabaseSessionStoreManager.StoredTaskMapper(configMapper));
-                dbi.registerMapper(new DatabaseSessionStoreManager.ArchivedTaskMapper(cklm, configMapper));
-                dbi.registerMapper(new DatabaseSessionStoreManager.ResumingTaskMapper(cklm, configMapper));
-                dbi.registerMapper(new DatabaseSessionStoreManager.StoredSessionMapper(configMapper));
-                dbi.registerMapper(new DatabaseSessionStoreManager.StoredSessionWithLastAttemptMapper(configMapper));
-                dbi.registerMapper(new DatabaseSessionStoreManager.StoredSessionAttemptMapper(configMapper));
-                dbi.registerMapper(new DatabaseSessionStoreManager.StoredSessionAttemptWithSessionMapper(configMapper));
-                dbi.registerMapper(new DatabaseSessionStoreManager.TaskStateSummaryMapper());
-                dbi.registerMapper(new DatabaseSessionStoreManager.TaskAttemptSummaryMapper());
-                dbi.registerMapper(new DatabaseSessionStoreManager.SessionAttemptSummaryMapper());
-                dbi.registerMapper(new DatabaseSessionStoreManager.StoredSessionMonitorMapper(configMapper));
-                dbi.registerMapper(new DatabaseSessionStoreManager.StoredDelayedSessionAttemptMapper());
-                dbi.registerMapper(new DatabaseSessionStoreManager.TaskRelationMapper());
-                dbi.registerMapper(new DatabaseSessionStoreManager.InstantMapper());
-                dbi.registerMapper(new DatabaseSecretStore.ScopedSecretMapper());
-                dbi.registerMapper(new DatabaseTaskQueueServer.ImmutableTaskQueueLockMapper());
-
-                dbi.registerArgumentFactory(configMapper.getArgumentFactory());
+                dbi.registerRowMapper(new DatabaseProjectStoreManager.StoredProjectMapper(configMapper));
+                dbi.registerRowMapper(new DatabaseProjectStoreManager.StoredProjectWithRevisionMapper(configMapper));
+                dbi.registerRowMapper(new DatabaseProjectStoreManager.StoredRevisionMapper(configMapper));
+                dbi.registerRowMapper(new DatabaseProjectStoreManager.StoredWorkflowDefinitionMapper(configMapper));
+                dbi.registerRowMapper(new DatabaseProjectStoreManager.StoredWorkflowDefinitionWithProjectMapper(configMapper));
+                dbi.registerRowMapper(new DatabaseProjectStoreManager.WorkflowConfigMapper());
+                dbi.registerRowMapper(new DatabaseProjectStoreManager.IdNameMapper());
+                dbi.registerRowMapper(new DatabaseProjectStoreManager.ScheduleStatusMapper());
+                dbi.registerRowMapper(new DatabaseQueueSettingStoreManager.StoredQueueSettingMapper(configMapper));
+                dbi.registerRowMapper(new DatabaseScheduleStoreManager.StoredScheduleMapper(configMapper));
+                dbi.registerRowMapper(new DatabaseSessionStoreManager.StoredTaskMapper(configMapper));
+                dbi.registerRowMapper(new DatabaseSessionStoreManager.ArchivedTaskMapper(cklm, configMapper));
+                dbi.registerRowMapper(new DatabaseSessionStoreManager.ResumingTaskMapper(cklm, configMapper));
+                dbi.registerRowMapper(new DatabaseSessionStoreManager.StoredSessionMapper(configMapper));
+                dbi.registerRowMapper(new DatabaseSessionStoreManager.StoredSessionWithLastAttemptMapper(configMapper));
+                dbi.registerRowMapper(new DatabaseSessionStoreManager.StoredSessionAttemptMapper(configMapper));
+                dbi.registerRowMapper(new DatabaseSessionStoreManager.StoredSessionAttemptWithSessionMapper(configMapper));
+                dbi.registerRowMapper(new DatabaseSessionStoreManager.TaskStateSummaryMapper());
+                dbi.registerRowMapper(new DatabaseSessionStoreManager.TaskAttemptSummaryMapper());
+                dbi.registerRowMapper(new DatabaseSessionStoreManager.SessionAttemptSummaryMapper());
+                dbi.registerRowMapper(new DatabaseSessionStoreManager.StoredSessionMonitorMapper(configMapper));
+                dbi.registerRowMapper(new DatabaseSessionStoreManager.StoredDelayedSessionAttemptMapper());
+                dbi.registerRowMapper(new DatabaseSessionStoreManager.TaskRelationMapper());
+                dbi.registerRowMapper(new DatabaseSessionStoreManager.InstantMapper());
+                dbi.registerRowMapper(new DatabaseSecretStore.ScopedSecretMapper());
+                dbi.registerRowMapper(new DatabaseTaskQueueServer.ImmutableTaskQueueLockMapper());
+                dbi.registerArgument(configMapper.getArgumentFactory());
                 handle = dbi.open();
 
                 try {
                     handle.getConnection().setAutoCommit(autoAutoCommit);
                 }
                 catch (SQLException ex) {
-                    throw new TransactionFailedException("Failed to set auto commit: " + autoAutoCommit, ex);
+                    throw new TransactionException("Failed to set auto commit: " + autoAutoCommit, ex);
                 }
                 if (!autoAutoCommit) {
                     handle.begin();
@@ -129,11 +128,11 @@ public class ThreadLocalTransactionManager
                 isValid = handle.getConnection().isValid(30);
             }
             catch (SQLException ex) {
-                throw new TransactionFailedException(
+                throw new TransactionException(
                         "Can't validate a transaction before commit", ex);
             }
             if (!isValid) {
-                throw new TransactionFailedException(
+                throw new TransactionException(
                         "Trying to commit a transaction that is already aborted. " +
                                 "Because current transaction is aborted, commands including " +
                                 "commit are ignored until end of transaction block.");

--- a/digdag-core/src/main/java/io/digdag/core/database/Transaction.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/Transaction.java
@@ -1,6 +1,6 @@
 package io.digdag.core.database;
 
-import org.skife.jdbi.v2.Handle;
+import org.jdbi.v3.core.Handle;
 
 public interface Transaction
 {

--- a/digdag-core/src/main/java/io/digdag/core/database/TransactionManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/TransactionManager.java
@@ -1,6 +1,6 @@
 package io.digdag.core.database;
 
-import org.skife.jdbi.v2.Handle;
+import org.jdbi.v3.core.Handle;
 
 public interface TransactionManager
 {

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration.java
@@ -2,7 +2,7 @@ package io.digdag.core.database.migrate;
 
 import java.util.regex.Pattern;
 import java.util.regex.Matcher;
-import org.skife.jdbi.v2.Handle;
+import org.jdbi.v3.core.Handle;
 
 public interface Migration
 {

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20160602123456_SessionsOnProjectIdIndexToDesc.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20160602123456_SessionsOnProjectIdIndexToDesc.java
@@ -1,6 +1,6 @@
 package io.digdag.core.database.migrate;
 
-import org.skife.jdbi.v2.Handle;
+import org.jdbi.v3.core.Handle;
 
 public class Migration_20160602123456_SessionsOnProjectIdIndexToDesc
         implements Migration
@@ -8,7 +8,7 @@ public class Migration_20160602123456_SessionsOnProjectIdIndexToDesc
     @Override
     public void migrate(Handle handle, MigrationContext context)
     {
-        handle.update("create index sessions_on_project_id_desc on sessions (project_id, id desc)");
-        handle.update("drop index sessions_on_project_id");
+        handle.execute("create index sessions_on_project_id_desc on sessions (project_id, id desc)");
+        handle.execute("drop index sessions_on_project_id");
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20160602184025_CreateResumingTasks.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20160602184025_CreateResumingTasks.java
@@ -1,6 +1,6 @@
 package io.digdag.core.database.migrate;
 
-import org.skife.jdbi.v2.Handle;
+import org.jdbi.v3.core.Handle;
 
 public class Migration_20160602184025_CreateResumingTasks
         implements Migration
@@ -9,7 +9,7 @@ public class Migration_20160602184025_CreateResumingTasks
     public void migrate(Handle handle, MigrationContext context)
     {
         // resuming_tasks
-        handle.update(
+        handle.execute(
                 context.newCreateTableBuilder("resuming_tasks")
                 .addLongId("id")
                 .addLong("attempt_id", "not null references session_attempts (id)")
@@ -25,15 +25,15 @@ public class Migration_20160602184025_CreateResumingTasks
                 .addMediumText("error", "")
                 .build());
         if (context.isPostgres()) {
-            handle.update("create index resuming_tasks_on_attempt_id_and_full_name on resuming_tasks (attempt_id, full_name)");
+            handle.execute("create index resuming_tasks_on_attempt_id_and_full_name on resuming_tasks (attempt_id, full_name)");
         }
         else {
             // h2 doesn't support index on text
-            handle.update("create index resuming_tasks_on_attempt_id on resuming_tasks (attempt_id)");
+            handle.execute("create index resuming_tasks_on_attempt_id on resuming_tasks (attempt_id)");
         }
 
         // task_details.resuming_task_id
-        handle.update("alter table task_details" +
+        handle.execute("alter table task_details" +
                 " add column resuming_task_id bigint");
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20160610154832_MakeProjectsDeletable.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20160610154832_MakeProjectsDeletable.java
@@ -1,6 +1,6 @@
 package io.digdag.core.database.migrate;
 
-import org.skife.jdbi.v2.Handle;
+import org.jdbi.v3.core.Handle;
 
 public class Migration_20160610154832_MakeProjectsDeletable
         implements Migration
@@ -9,19 +9,19 @@ public class Migration_20160610154832_MakeProjectsDeletable
     public void migrate(Handle handle, MigrationContext context)
     {
         if (context.isPostgres()) {
-            handle.update("alter table projects" +
+            handle.execute("alter table projects" +
                     " add column deleted_at timestamp with time zone");
-            handle.update("alter table projects" +
+            handle.execute("alter table projects" +
                     " add column deleted_name text");
-            handle.update("alter table projects" +
+            handle.execute("alter table projects" +
                     " alter column name drop not null");
         }
         else {
-            handle.update("alter table projects" +
+            handle.execute("alter table projects" +
                     " add column deleted_at timestamp");
-            handle.update("alter table projects" +
+            handle.execute("alter table projects" +
                     " add column deleted_name varchar(255)");
-            handle.update("alter table projects" +
+            handle.execute("alter table projects" +
                     " alter column name drop not null");
         }
     }

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20160623123456_AddUserInfoColumnToRevisions.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20160623123456_AddUserInfoColumnToRevisions.java
@@ -1,6 +1,6 @@
 package io.digdag.core.database.migrate;
 
-import org.skife.jdbi.v2.Handle;
+import org.jdbi.v3.core.Handle;
 
 public class Migration_20160623123456_AddUserInfoColumnToRevisions
         implements Migration
@@ -8,7 +8,7 @@ public class Migration_20160623123456_AddUserInfoColumnToRevisions
     @Override
     public void migrate(Handle handle, MigrationContext context)
     {
-        handle.update("alter table revisions" +
+        handle.execute("alter table revisions" +
                 " add column user_info text");
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20160719172538_QueueRearchitecture.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20160719172538_QueueRearchitecture.java
@@ -1,6 +1,6 @@
 package io.digdag.core.database.migrate;
 
-import org.skife.jdbi.v2.Handle;
+import org.jdbi.v3.core.Handle;
 
 public class Migration_20160719172538_QueueRearchitecture
         implements Migration
@@ -9,10 +9,10 @@ public class Migration_20160719172538_QueueRearchitecture
     public void migrate(Handle handle, MigrationContext context)
     {
         // queued_task_locks
-        handle.update("drop table queued_task_locks");
-        handle.update("drop table queued_shared_task_locks");
+        handle.execute("drop table queued_task_locks");
+        handle.execute("drop table queued_shared_task_locks");
 
-        handle.update(
+        handle.execute(
                 context.newCreateTableBuilder("queued_task_locks")
                 .addLongId("id")  // references queued_tasks.id
                 .addInt("site_id", "")
@@ -23,33 +23,33 @@ public class Migration_20160719172538_QueueRearchitecture
                 .addString("lock_agent_id", "")
                 .build());
 
-        handle.update("insert into queued_task_locks" +
+        handle.execute("insert into queued_task_locks" +
                 " (id, site_id, queue_id, priority)" +
                 " select id, site_id, NULL, priority" +
                 " from queued_tasks");
 
         // queues
-        handle.update("alter table queues" +
+        handle.execute("alter table queues" +
                 " add column shared_site_id int");
 
         // resource_types
-        handle.update("drop table resource_types");
+        handle.execute("drop table resource_types");
 
         // queued_tasks
-        handle.update("alter table queued_tasks" +
+        handle.execute("alter table queued_tasks" +
                 " alter column task_id drop not null");
-        handle.update("alter table queued_tasks" +
+        handle.execute("alter table queued_tasks" +
                 " alter column queue_id drop not null");
-        handle.update("alter table queued_tasks" +
+        handle.execute("alter table queued_tasks" +
                 " alter column data drop not null");
-        handle.update("alter table queued_tasks" +
+        handle.execute("alter table queued_tasks" +
                 " drop column priority");
-        handle.update("alter table queued_tasks" +
+        handle.execute("alter table queued_tasks" +
                 " drop column resource_type_id");
-        handle.update("create unique index queued_tasks_on_site_id_task_id on queued_tasks (site_id, task_id)");
+        handle.execute("create unique index queued_tasks_on_site_id_task_id on queued_tasks (site_id, task_id)");
 
         if (context.isPostgres()) {
-            handle.update(
+            handle.execute(
                 "CREATE FUNCTION lock_shared_tasks(target_site_id int, target_site_max_concurrency bigint, limit_count int, lock_expire_seconds int, agent_id text) returns setof bigint as $$\n" +
                 "BEGIN\n" +
                 "  IF pg_try_advisory_xact_lock(23300, target_site_id) THEN\n" +
@@ -94,13 +94,13 @@ public class Migration_20160719172538_QueueRearchitecture
                 "$$ LANGUAGE plpgsql VOLATILE\n" +
             "");
 
-            handle.update("create index queued_tasks_shared_grouping on queued_task_locks (site_id, queue_id) where site_id is not null and lock_expire_time is not null");
-            handle.update("create index queued_tasks_ordering on queued_task_locks (site_id, queue_id, priority desc, id) where lock_expire_time is null");
-            handle.update("create index queued_tasks_expiration on queued_task_locks (lock_expire_time) where lock_expire_time is not null");
+            handle.execute("create index queued_tasks_shared_grouping on queued_task_locks (site_id, queue_id) where site_id is not null and lock_expire_time is not null");
+            handle.execute("create index queued_tasks_ordering on queued_task_locks (site_id, queue_id, priority desc, id) where lock_expire_time is null");
+            handle.execute("create index queued_tasks_expiration on queued_task_locks (lock_expire_time) where lock_expire_time is not null");
         }
         else {
-            handle.update("create index queued_tasks_shared_grouping on queued_task_locks (lock_expire_time, site_id, queue_id)");
-            handle.update("create index queued_tasks_ordering on queued_task_locks (site_id, queue_id, lock_expire_time, priority desc, id)");
+            handle.execute("create index queued_tasks_shared_grouping on queued_task_locks (lock_expire_time, site_id, queue_id)");
+            handle.execute("create index queued_tasks_ordering on queued_task_locks (site_id, queue_id, lock_expire_time, priority desc, id)");
         }
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20160817123456_AddSecretsTable.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20160817123456_AddSecretsTable.java
@@ -1,6 +1,6 @@
 package io.digdag.core.database.migrate;
 
-import org.skife.jdbi.v2.Handle;
+import org.jdbi.v3.core.Handle;
 
 public class Migration_20160817123456_AddSecretsTable
         implements Migration
@@ -8,7 +8,7 @@ public class Migration_20160817123456_AddSecretsTable
     @Override
     public void migrate(Handle handle, MigrationContext context)
     {
-        handle.update(
+        handle.execute(
                 context.newCreateTableBuilder("secrets")
                         .addLongId("id")
                         .addLong("site_id", "not null")
@@ -20,6 +20,6 @@ public class Migration_20160817123456_AddSecretsTable
                         .addTimestamp("updated_at", "not null")
                         .build());
 
-        handle.update("create index secrets_on_site_id_and_project_id_and_scope_and_key on secrets (site_id, project_id, scope, key)");
+        handle.execute("create index secrets_on_site_id_and_project_id_and_scope_and_key on secrets (site_id, project_id, scope, key)");
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20160818043815_AddFinishedAtToSessionAttempts.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20160818043815_AddFinishedAtToSessionAttempts.java
@@ -1,6 +1,6 @@
 package io.digdag.core.database.migrate;
 
-import org.skife.jdbi.v2.Handle;
+import org.jdbi.v3.core.Handle;
 
 public class Migration_20160818043815_AddFinishedAtToSessionAttempts
         implements Migration
@@ -9,11 +9,11 @@ public class Migration_20160818043815_AddFinishedAtToSessionAttempts
     public void migrate(Handle handle, MigrationContext context)
     {
         if (context.isPostgres()) {
-            handle.update("alter table session_attempts" +
+            handle.execute("alter table session_attempts" +
                     " add column finished_at timestamp with time zone");
         }
         else {
-            handle.update("alter table session_attempts" +
+            handle.execute("alter table session_attempts" +
                     " add column finished_at timestamp");
         }
     }

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20160818220026_QueueUniqueName.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20160818220026_QueueUniqueName.java
@@ -1,6 +1,6 @@
 package io.digdag.core.database.migrate;
 
-import org.skife.jdbi.v2.Handle;
+import org.jdbi.v3.core.Handle;
 
 public class Migration_20160818220026_QueueUniqueName
         implements Migration
@@ -8,35 +8,35 @@ public class Migration_20160818220026_QueueUniqueName
     @Override
     public void migrate(Handle handle, MigrationContext context)
     {
-        handle.update("drop index queued_tasks_on_queue_id_task_id");
-        handle.update("drop index queued_tasks_on_site_id_task_id");
+        handle.execute("drop index queued_tasks_on_queue_id_task_id");
+        handle.execute("drop index queued_tasks_on_site_id_task_id");
 
         // alter "task_id bigint" to "unique_name text"
         if (context.isPostgres()) {
-            handle.update("alter table queued_tasks" +
+            handle.execute("alter table queued_tasks" +
                     " alter column task_id type text");
-            handle.update("alter table queued_tasks" +
+            handle.execute("alter table queued_tasks" +
                         " rename column task_id to unique_name");
         }
         else {
-            handle.update("alter table queued_tasks" +
+            handle.execute("alter table queued_tasks" +
                     " alter column task_id varchar(255)");
-            handle.update("alter table queued_tasks" +
+            handle.execute("alter table queued_tasks" +
                         " alter column task_id rename to unique_name");
         }
 
-        handle.update("alter table queued_tasks" +
+        handle.execute("alter table queued_tasks" +
                     " alter unique_name set not null");
 
-        handle.update("create unique index queued_tasks_on_site_id_unique_name on queued_tasks (site_id, unique_name)");
+        handle.execute("create unique index queued_tasks_on_site_id_unique_name on queued_tasks (site_id, unique_name)");
         if (context.isPostgres()) {
-            handle.update("create unique index queued_tasks_on_queue_id_unique_name on queued_tasks (queue_id, unique_name) where queue_id is not null");
+            handle.execute("create unique index queued_tasks_on_queue_id_unique_name on queued_tasks (queue_id, unique_name) where queue_id is not null");
         }
         else {
-            handle.update("create unique index queued_tasks_on_queue_id_unique_name on queued_tasks (queue_id, unique_name)");
+            handle.execute("create unique index queued_tasks_on_queue_id_unique_name on queued_tasks (queue_id, unique_name)");
         }
 
-        handle.update("alter table tasks" +
+        handle.execute("alter table tasks" +
                 " add column retry_count int default 0");
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20160908175551_KeepSecretsUnique.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20160908175551_KeepSecretsUnique.java
@@ -1,6 +1,6 @@
 package io.digdag.core.database.migrate;
 
-import org.skife.jdbi.v2.Handle;
+import org.jdbi.v3.core.Handle;
 
 public class Migration_20160908175551_KeepSecretsUnique
         implements Migration
@@ -10,12 +10,12 @@ public class Migration_20160908175551_KeepSecretsUnique
     {
         if (context.isPostgres()) {
             // make sure records are unique
-            handle.update("delete from secrets where id = any(select id from (select row_number() over (partition by site_id, project_id, scope, key order by id) as i, id from secrets) win where i > 1)");
+            handle.execute("delete from secrets where id = any(select id from (select row_number() over (partition by site_id, project_id, scope, key order by id) as i, id from secrets) win where i > 1)");
         }
         else {
             // h2 doesn't support window function...
         }
-        handle.update("create unique index secrets_unique_on_site_id_and_project_id_and_scope_and_key on secrets (site_id, project_id, scope, key)");
-        handle.update("drop index secrets_on_site_id_and_project_id_and_scope_and_key");
+        handle.execute("create unique index secrets_unique_on_site_id_and_project_id_and_scope_and_key on secrets (site_id, project_id, scope, key)");
+        handle.execute("drop index secrets_on_site_id_and_project_id_and_scope_and_key");
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20160926123456_AddDisabledAtColumnToSchedules.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20160926123456_AddDisabledAtColumnToSchedules.java
@@ -1,6 +1,6 @@
 package io.digdag.core.database.migrate;
 
-import org.skife.jdbi.v2.Handle;
+import org.jdbi.v3.core.Handle;
 
 public class Migration_20160926123456_AddDisabledAtColumnToSchedules
         implements Migration
@@ -9,17 +9,17 @@ public class Migration_20160926123456_AddDisabledAtColumnToSchedules
     public void migrate(Handle handle, MigrationContext context)
     {
         if (context.isPostgres()) {
-            handle.update("alter table schedules" +
+            handle.execute("alter table schedules" +
                     " add column disabled_at timestamp with time zone");
         }
         else {
-            handle.update("alter table schedules" +
+            handle.execute("alter table schedules" +
                     " add column disabled_at timestamp");
         }
 
         if (context.isPostgres()) {
-            handle.update("drop index schedules_on_next_run_time");
-            handle.update("create index schedules_on_next_run_time on schedules (next_run_time) where disabled_at is null");
+            handle.execute("drop index schedules_on_next_run_time");
+            handle.execute("create index schedules_on_next_run_time on schedules (next_run_time) where disabled_at is null");
         }
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20160928203753_AddWorkflowOrderIndex.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20160928203753_AddWorkflowOrderIndex.java
@@ -1,6 +1,6 @@
 package io.digdag.core.database.migrate;
 
-import org.skife.jdbi.v2.Handle;
+import org.jdbi.v3.core.Handle;
 
 public class Migration_20160928203753_AddWorkflowOrderIndex
         implements Migration
@@ -9,12 +9,12 @@ public class Migration_20160928203753_AddWorkflowOrderIndex
     public void migrate(Handle handle, MigrationContext context)
     {
         // DatabaseProjectStoreManager.PgDao.getLatestActiveWorkflowDefinitions uses these indexes.
-        handle.update("create index workflow_definitions_on_revision_id_and_id on workflow_definitions (revision_id, id)");
+        handle.execute("create index workflow_definitions_on_revision_id_and_id on workflow_definitions (revision_id, id)");
         if (context.isPostgres()) {
-            handle.update("create index projects_on_site_id_and_id on projects (site_id, id) where deleted_at is null");
+            handle.execute("create index projects_on_site_id_and_id on projects (site_id, id) where deleted_at is null");
         }
         else {
-            handle.update("create index projects_on_site_id_and_id on projects (site_id, id)");
+            handle.execute("create index projects_on_site_id_and_id on projects (site_id, id)");
         }
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20161005225356_AddResetParamsToTaskState.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20161005225356_AddResetParamsToTaskState.java
@@ -1,6 +1,6 @@
 package io.digdag.core.database.migrate;
 
-import org.skife.jdbi.v2.Handle;
+import org.jdbi.v3.core.Handle;
 
 public class Migration_20161005225356_AddResetParamsToTaskState
         implements Migration
@@ -8,9 +8,9 @@ public class Migration_20161005225356_AddResetParamsToTaskState
     @Override
     public void migrate(Handle handle, MigrationContext context)
     {
-        handle.update("alter table task_state_details" +
+        handle.execute("alter table task_state_details" +
                 " add column reset_store_params text");
-        handle.update("alter table resuming_tasks" +
+        handle.execute("alter table resuming_tasks" +
                 " add column reset_store_params text");
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20161028112233_AddStateFlagsAndCreatedAtIndexToSessionAttempts.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20161028112233_AddStateFlagsAndCreatedAtIndexToSessionAttempts.java
@@ -1,6 +1,6 @@
 package io.digdag.core.database.migrate;
 
-import org.skife.jdbi.v2.Handle;
+import org.jdbi.v3.core.Handle;
 
 public class Migration_20161028112233_AddStateFlagsAndCreatedAtIndexToSessionAttempts
         implements Migration
@@ -10,9 +10,9 @@ public class Migration_20161028112233_AddStateFlagsAndCreatedAtIndexToSessionAtt
     {
         // for DatabaseSessionStoreManager.findActiveAttemptsCreatedBefore. This includes all running attempts excepting CANCEL_REQUESTED (flag=0x01)
         if (context.isPostgres()) {
-            handle.update("create index session_attempts_on_state_flags_and_created_at on session_attempts (created_at, id) where state_flags = 0");
+            handle.execute("create index session_attempts_on_state_flags_and_created_at on session_attempts (created_at, id) where state_flags = 0");
         } else {
-            handle.update("create index session_attempts_on_state_flags_and_created_at on session_attempts (state_flags, created_at, id)");
+            handle.execute("create index session_attempts_on_state_flags_and_created_at on session_attempts (state_flags, created_at, id)");
         }
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20161110112233_AddStartedAtColumnAndIndexToTasks.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20161110112233_AddStartedAtColumnAndIndexToTasks.java
@@ -1,6 +1,6 @@
 package io.digdag.core.database.migrate;
 
-import org.skife.jdbi.v2.Handle;
+import org.jdbi.v3.core.Handle;
 
 public class Migration_20161110112233_AddStartedAtColumnAndIndexToTasks
         implements Migration
@@ -9,18 +9,18 @@ public class Migration_20161110112233_AddStartedAtColumnAndIndexToTasks
     public void migrate(Handle handle, MigrationContext context)
     {
         if (context.isPostgres()) {
-            handle.update("alter table tasks" +
+            handle.execute("alter table tasks" +
                     " add column started_at timestamp with time zone");
         }
         else {
-            handle.update("alter table tasks" +
+            handle.execute("alter table tasks" +
                     " add column started_at timestamp");
         }
 
         if (context.isPostgres()) {
-            handle.update("create index tasks_on_state_and_started_at on tasks (state, started_at, id asc) where started_at is not null");
+            handle.execute("create index tasks_on_state_and_started_at on tasks (state, started_at, id asc) where started_at is not null");
         } else {
-            handle.update("create index tasks_on_state_and_started_at on tasks (state, started_at, id asc)");
+            handle.execute("create index tasks_on_state_and_started_at on tasks (state, started_at, id asc)");
         }
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20161209001857_CreateDelayedSessionAttempts.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20161209001857_CreateDelayedSessionAttempts.java
@@ -1,6 +1,6 @@
 package io.digdag.core.database.migrate;
 
-import org.skife.jdbi.v2.Handle;
+import org.jdbi.v3.core.Handle;
 
 public class Migration_20161209001857_CreateDelayedSessionAttempts
         implements Migration
@@ -8,13 +8,13 @@ public class Migration_20161209001857_CreateDelayedSessionAttempts
     @Override
     public void migrate(Handle handle, MigrationContext context)
     {
-        handle.update(
+        handle.execute(
                 context.newCreateTableBuilder("delayed_session_attempts")
                 .addLongIdNoAutoIncrement("id", "references session_attempts (id)")
                 .addLong("dependent_session_id", "")
                 .addLong("next_run_time", "not null")
                 .addTimestamp("updated_at", "not null")
                 .build());
-        handle.update("create index delayed_session_attempts_on_next_run_time on delayed_session_attempts (next_run_time)");
+        handle.execute("create index delayed_session_attempts_on_next_run_time on delayed_session_attempts (next_run_time)");
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20170116082921_AddAttemptIndexColumn1.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20170116082921_AddAttemptIndexColumn1.java
@@ -1,7 +1,7 @@
 package io.digdag.core.database.migrate;
 
 import java.util.List;
-import org.skife.jdbi.v2.Handle;
+import org.jdbi.v3.core.Handle;
 
 public class Migration_20170116082921_AddAttemptIndexColumn1
         implements Migration
@@ -9,7 +9,7 @@ public class Migration_20170116082921_AddAttemptIndexColumn1
     @Override
     public void migrate(Handle handle, MigrationContext context)
     {
-        handle.update("alter table session_attempts" +
+        handle.execute("alter table session_attempts" +
                 " add column index int");
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20170116090744_AddAttemptIndexColumn2.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20170116090744_AddAttemptIndexColumn2.java
@@ -1,7 +1,7 @@
 package io.digdag.core.database.migrate;
 
 import java.util.List;
-import org.skife.jdbi.v2.Handle;
+import org.jdbi.v3.core.Handle;
 
 public class Migration_20170116090744_AddAttemptIndexColumn2
         implements Migration
@@ -10,7 +10,7 @@ public class Migration_20170116090744_AddAttemptIndexColumn2
     public void migrate(Handle handle, MigrationContext context)
     {
         if (context.isPostgres()) {
-            handle.update(
+            handle.execute(
                     "update session_attempts set index = seq.index " +
                     "from (" +
                         "select id, rank() over (partition by session_id order by id) as index from session_attempts" +
@@ -20,7 +20,7 @@ public class Migration_20170116090744_AddAttemptIndexColumn2
         else {
             List<IdAndSessionId> list =
                 handle.createQuery("select id, session_id from session_attempts order by session_id, id")
-                .map((index, r, ctx) -> new IdAndSessionId(r.getLong("id"), r.getLong("session_id")))
+                .map((r, ctx) -> new IdAndSessionId(r.getLong("id"), r.getLong("session_id")))
                 .list();
             long lastSessionId = 0L;
             long lastIndex = 0;
@@ -30,17 +30,17 @@ public class Migration_20170116090744_AddAttemptIndexColumn2
                     lastIndex = 0;
                 }
                 lastIndex++;
-                handle.createStatement("update session_attempts set index = :index where id = :id")
+                handle.createUpdate("update session_attempts set index = :index where id = :id")
                     .bind("id", s.id)
                     .bind("index", lastIndex)
                     .execute();
             }
         }
 
-        handle.update("alter table session_attempts" +
+        handle.execute("alter table session_attempts" +
                 " alter column index set not null");
 
-        handle.update("create unique index session_attempts_on_session_id_and_index on session_attempts (session_id, index desc)");
+        handle.execute("create unique index session_attempts_on_session_id_and_index on session_attempts (session_id, index desc)");
     }
 
     private static class IdAndSessionId

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20170223220127_AddLastSessionTimeAndFlagsToSessions.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20170223220127_AddLastSessionTimeAndFlagsToSessions.java
@@ -1,6 +1,6 @@
 package io.digdag.core.database.migrate;
 
-import org.skife.jdbi.v2.Handle;
+import org.jdbi.v3.core.Handle;
 
 public class Migration_20170223220127_AddLastSessionTimeAndFlagsToSessions
         implements Migration
@@ -9,24 +9,24 @@ public class Migration_20170223220127_AddLastSessionTimeAndFlagsToSessions
     public void migrate(Handle handle, MigrationContext context)
     {
         if (context.isPostgres()) {
-            handle.update("alter table sessions" +
+            handle.execute("alter table sessions" +
                     " add column last_attempt_created_at timestamp with time zone");
-            handle.update(
+            handle.execute(
                     "update sessions" +
                     " set last_attempt_created_at = session_attempts.created_at" +
                     " from session_attempts" +
                     " where session_attempts.id = sessions.last_attempt_id");
         }
         else {
-            handle.update("alter table sessions" +
+            handle.execute("alter table sessions" +
                     " add column last_attempt_created_at timestamp");
-            handle.update("update sessions" +
+            handle.execute("update sessions" +
                     " set last_attempt_created_at = (" +
                         " select created_at from session_attempts" +
                         " where session_attempts.id = sessions.last_attempt_id" +
                     ")");
         }
 
-        handle.update("create index sessions_on_project_id_and_workflow_name_and_last_attempt_created_at on sessions (project_id, workflow_name, last_attempt_created_at desc)");
+        handle.execute("create index sessions_on_project_id_and_workflow_name_and_last_attempt_created_at on sessions (project_id, workflow_name, last_attempt_created_at desc)");
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20190318175338_AddIndexToSessionAttempts.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20190318175338_AddIndexToSessionAttempts.java
@@ -1,6 +1,6 @@
 package io.digdag.core.database.migrate;
 
-import org.skife.jdbi.v2.Handle;
+import org.jdbi.v3.core.Handle;
 
 public class Migration_20190318175338_AddIndexToSessionAttempts
         implements Migration
@@ -10,7 +10,7 @@ public class Migration_20190318175338_AddIndexToSessionAttempts
     {
         // DatabaseSessionStoreManager.getActiveAttemptCount uses this index.
         if (context.isPostgres()) {
-            handle.update("create index concurrently session_attempts_on_site_id_and_state_flags_partial_2 on session_attempts"
+            handle.execute("create index concurrently session_attempts_on_site_id_and_state_flags_partial_2 on session_attempts"
                     + " using btree(site_id) where state_flags & 2 = 0");
         }
         else {

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20191105105927_AddIndexToSessions.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20191105105927_AddIndexToSessions.java
@@ -1,6 +1,6 @@
 package io.digdag.core.database.migrate;
 
-import org.skife.jdbi.v2.Handle;
+import org.jdbi.v3.core.Handle;
 
 public class Migration_20191105105927_AddIndexToSessions
         implements Migration
@@ -9,9 +9,9 @@ public class Migration_20191105105927_AddIndexToSessions
     public void migrate(Handle handle, MigrationContext context)
     {
         if (context.isPostgres()) {
-            handle.update("create index concurrently sessions_on_project_id_and_workflow_name_desc on sessions (project_id, workflow_name, id DESC)");
+            handle.execute("create index concurrently sessions_on_project_id_and_workflow_name_desc on sessions (project_id, workflow_name, id DESC)");
         } else {
-            handle.update("create index sessions_on_project_id_and_workflow_name_desc on sessions (project_id, workflow_name, id DESC)");
+            handle.execute("create index sessions_on_project_id_and_workflow_name_desc on sessions (project_id, workflow_name, id DESC)");
         }
     }
 

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20200716114008_AddLastAttemptIdIndexToSessions.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20200716114008_AddLastAttemptIdIndexToSessions.java
@@ -1,6 +1,6 @@
 package io.digdag.core.database.migrate;
 
-import org.skife.jdbi.v2.Handle;
+import org.jdbi.v3.core.Handle;
 
 public class Migration_20200716114008_AddLastAttemptIdIndexToSessions
     implements Migration
@@ -9,9 +9,9 @@ public class Migration_20200716114008_AddLastAttemptIdIndexToSessions
     public void migrate(Handle handle, MigrationContext context)
     {
         if (context.isPostgres()) {
-            handle.update("create index concurrently sessions_on_last_attempt_id on sessions (last_attempt_id)");
+            handle.execute("create index concurrently sessions_on_last_attempt_id on sessions (last_attempt_id)");
         } else {
-            handle.update("create index sessions_on_last_attempt_id on sessions (last_attempt_id)");
+            handle.execute("create index sessions_on_last_attempt_id on sessions (last_attempt_id)");
         }
     }
 

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20200803184355_ReplacePartialIndexOnSessionAttempts.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20200803184355_ReplacePartialIndexOnSessionAttempts.java
@@ -1,6 +1,6 @@
 package io.digdag.core.database.migrate;
 
-import org.skife.jdbi.v2.Handle;
+import org.jdbi.v3.core.Handle;
 
 public class Migration_20200803184355_ReplacePartialIndexOnSessionAttempts
         implements Migration
@@ -10,8 +10,8 @@ public class Migration_20200803184355_ReplacePartialIndexOnSessionAttempts
     {
         if (context.isPostgres()) {
             // Don't use "create index concurrently" here since the following "drop index" should be issued after the completion of the index creation
-            handle.update("create index session_attempts_on_state_flags_and_created_at_partial on session_attempts (id, created_at) where state_flags = 0");
-            handle.update("drop index session_attempts_on_state_flags_and_created_at");
+            handle.execute("create index session_attempts_on_state_flags_and_created_at_partial on session_attempts (id, created_at) where state_flags = 0");
+            handle.execute("drop index session_attempts_on_state_flags_and_created_at");
         }
         else {
             // H2 does not support partial index

--- a/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java
+++ b/digdag-core/src/main/java/io/digdag/core/workflow/WorkflowExecutor.java
@@ -575,6 +575,7 @@ public class WorkflowExecutor
             return func.get();
         }
         catch (Exception e) {
+            e.printStackTrace();
             catchingNotify(e);
             metrics.increment(Category.EXECUTOR, "errorInRunWhile");
             logger.warn(errorMessage);

--- a/digdag-core/src/test/java/io/digdag/core/database/DatabaseProjectStoreManagerTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/database/DatabaseProjectStoreManagerTest.java
@@ -3,7 +3,6 @@ package io.digdag.core.database;
 import java.util.*;
 import java.time.Instant;
 import java.util.concurrent.atomic.AtomicReference;
-import org.skife.jdbi.v2.IDBI;
 import org.junit.*;
 import com.google.common.base.Optional;
 import com.google.common.collect.*;

--- a/digdag-core/src/test/java/io/digdag/core/database/DatabaseTestingUtils.java
+++ b/digdag-core/src/test/java/io/digdag/core/database/DatabaseTestingUtils.java
@@ -73,7 +73,7 @@ public class DatabaseTestingUtils
         DatabaseConfig config = getEnvironmentDatabaseConfig();
         DataSourceProvider dsp = new DataSourceProvider(config);
 
-        Jdbi dbi = Jdbi.create(dsp.get());
+        Jdbi dbi = JdbiHelper.createJdbi(dsp.get());
         TransactionManager tm = new ThreadLocalTransactionManager(dsp.get(), autoAutoCommit);
         // FIXME
         new DatabaseMigrator(dbi, config).migrate();

--- a/digdag-core/src/test/java/io/digdag/core/database/DatabaseTestingUtils.java
+++ b/digdag-core/src/test/java/io/digdag/core/database/DatabaseTestingUtils.java
@@ -73,7 +73,7 @@ public class DatabaseTestingUtils
         DatabaseConfig config = getEnvironmentDatabaseConfig();
         DataSourceProvider dsp = new DataSourceProvider(config);
 
-        Jdbi dbi = JdbiHelper.createJdbi(dsp.get());
+        Jdbi dbi = DatabaseHelper.createJdbi(dsp.get());
         TransactionManager tm = new ThreadLocalTransactionManager(dsp.get(), autoAutoCommit);
         // FIXME
         new DatabaseMigrator(dbi, config).migrate();

--- a/digdag-core/src/test/java/io/digdag/core/database/DatabaseTestingUtils.java
+++ b/digdag-core/src/test/java/io/digdag/core/database/DatabaseTestingUtils.java
@@ -10,9 +10,8 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.base.Optional;
 import io.digdag.commons.ThrowablesUtil;
-import org.skife.jdbi.v2.DBI;
-import org.skife.jdbi.v2.IDBI;
-import org.skife.jdbi.v2.Handle;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.Handle;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigFactory;
 import io.digdag.core.DigdagEmbed;
@@ -74,7 +73,7 @@ public class DatabaseTestingUtils
         DatabaseConfig config = getEnvironmentDatabaseConfig();
         DataSourceProvider dsp = new DataSourceProvider(config);
 
-        DBI dbi = new DBI(dsp.get());
+        Jdbi dbi = Jdbi.create(dsp.get());
         TransactionManager tm = new ThreadLocalTransactionManager(dsp.get(), autoAutoCommit);
         // FIXME
         new DatabaseMigrator(dbi, config).migrate();
@@ -106,25 +105,25 @@ public class DatabaseTestingUtils
     {
         cleanDatabase(
                 embed.getInjector().getInstance(DatabaseConfig.class).getType(),
-                embed.getInjector().getInstance(DBI.class));
+                embed.getInjector().getInstance(Jdbi.class));
     }
 
-    public static void cleanDatabase(String databaseType, IDBI dbi)
+    public static void cleanDatabase(String databaseType, Jdbi dbi)
     {
         try (Handle handle = dbi.open()) {
             switch (databaseType) {
             case "h2":
                 // h2 database can't truncate tables with references if REFERENTIAL_INTEGRITY is true (default)
-                handle.createStatement("SET REFERENTIAL_INTEGRITY FALSE").execute();
+                handle.createUpdate("SET REFERENTIAL_INTEGRITY FALSE").execute();
                 for (String name : Lists.reverse(Arrays.asList(ALL_TABLES))) {
-                    handle.createStatement("TRUNCATE TABLE " + name).execute();
+                    handle.createUpdate("TRUNCATE TABLE " + name).execute();
                 }
-                handle.createStatement("SET REFERENTIAL_INTEGRITY TRUE").execute();
+                handle.createUpdate("SET REFERENTIAL_INTEGRITY TRUE").execute();
                 break;
             default:
                 // postgresql needs "CASCADE" option to TRUNCATE
                 for (String name : Lists.reverse(Arrays.asList(ALL_TABLES))) {
-                    handle.createStatement("TRUNCATE " + name + " CASCADE").execute();
+                    handle.createUpdate("TRUNCATE " + name + " CASCADE").execute();
                 }
                 break;
             }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/param/PostgresqlParamServerClient.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/param/PostgresqlParamServerClient.java
@@ -8,7 +8,7 @@ import io.digdag.spi.ParamServerClient;
 import io.digdag.spi.ParamServerClientConnection;
 import io.digdag.spi.Record;
 import io.digdag.spi.ValueType;
-import org.skife.jdbi.v2.Handle;
+import org.jdbi.v3.core.Handle;
 
 import java.util.HashMap;
 import java.util.function.Consumer;
@@ -69,7 +69,7 @@ public class PostgresqlParamServerClient
             throw ThrowablesUtil.propagate(e);
         }
 
-        handle.insert(
+        handle.execute(
                 "insert into params (key, value, value_type, site_id, created_at, updated_at) values (?, ?, ?, ?, now(), now()) " +
                         "on conflict on constraint params_site_id_key_uniq do update set value = ?, updated_at = now()",
                 key, jsonValue, ValueType.STRING.ordinal(), siteId, jsonValue); // value_type is fixed to ValueType.STRING for now

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/param/PostgresqlServerClientConnection.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/param/PostgresqlServerClientConnection.java
@@ -1,7 +1,7 @@
 package io.digdag.standards.operator.param;
 
 import io.digdag.spi.ParamServerClientConnection;
-import org.skife.jdbi.v2.Handle;
+import org.jdbi.v3.core.Handle;
 
 public class PostgresqlServerClientConnection implements ParamServerClientConnection<Handle>
 {

--- a/digdag-tests/src/test/java/acceptance/MigrationIT.java
+++ b/digdag-tests/src/test/java/acceptance/MigrationIT.java
@@ -7,8 +7,8 @@ import io.digdag.core.database.migrate.Migration_20151204221156_CreateTables;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.skife.jdbi.v2.DBI;
-import org.skife.jdbi.v2.Handle;
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.core.Handle;
 import utils.TemporaryDigdagServer;
 
 import javax.sql.DataSource;
@@ -49,7 +49,7 @@ public class MigrationIT
         try {
             server.setupDatabase();
             DataSource ds = server.getTestDBDataSource();
-            DBI dbi = new DBI(ds);
+            Jdbi dbi = Jdbi.create(ds);
             DatabaseMigrator migrator = new DatabaseMigrator(dbi, server.getRemoteTestDatabaseConfig());
             MigrationContext context = new MigrationContext(migrator.getDatabaseType());
 

--- a/digdag-tests/src/test/java/acceptance/MigrationIT.java
+++ b/digdag-tests/src/test/java/acceptance/MigrationIT.java
@@ -1,7 +1,7 @@
 package acceptance;
 
 import io.digdag.core.database.DatabaseMigrator;
-import io.digdag.core.database.JdbiHelper;
+import io.digdag.core.database.DatabaseHelper;
 import io.digdag.core.database.migrate.Migration;
 import io.digdag.core.database.migrate.MigrationContext;
 import io.digdag.core.database.migrate.Migration_20151204221156_CreateTables;
@@ -50,7 +50,7 @@ public class MigrationIT
         try {
             server.setupDatabase();
             DataSource ds = server.getTestDBDataSource();
-            Jdbi dbi = JdbiHelper.createJdbi(ds);
+            Jdbi dbi = DatabaseHelper.createJdbi(ds);
             DatabaseMigrator migrator = new DatabaseMigrator(dbi, server.getRemoteTestDatabaseConfig());
             MigrationContext context = new MigrationContext(migrator.getDatabaseType());
 

--- a/digdag-tests/src/test/java/acceptance/MigrationIT.java
+++ b/digdag-tests/src/test/java/acceptance/MigrationIT.java
@@ -1,6 +1,7 @@
 package acceptance;
 
 import io.digdag.core.database.DatabaseMigrator;
+import io.digdag.core.database.JdbiHelper;
 import io.digdag.core.database.migrate.Migration;
 import io.digdag.core.database.migrate.MigrationContext;
 import io.digdag.core.database.migrate.Migration_20151204221156_CreateTables;
@@ -49,7 +50,7 @@ public class MigrationIT
         try {
             server.setupDatabase();
             DataSource ds = server.getTestDBDataSource();
-            Jdbi dbi = Jdbi.create(ds);
+            Jdbi dbi = JdbiHelper.createJdbi(ds);
             DatabaseMigrator migrator = new DatabaseMigrator(dbi, server.getRemoteTestDatabaseConfig());
             MigrationContext context = new MigrationContext(migrator.getDatabaseType());
 


### PR DESCRIPTION
The last release of Jdbi2 is on 2017. It is 5 years ago.
We should migrate to Jdbi3.
This PR try to migrate to Jdbi3 experimentally.
Unfortunately Jdbi3 is not fully compatible with Jdbi2 and need to fix many codes.
In addition Jdbi3 uses caffeine ver 3.x but it does not support Java8.
So force caffeine version to 2.x.