### PR TITLE
Fixed to remove k8s pod on finished

### DIFF
--- a/digdag-standards/src/main/java/io/digdag/standards/command/KubernetesCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/KubernetesCommandExecutor.java
@@ -275,6 +275,7 @@ public class KubernetesCommandExecutor
             // Download output config archive
             final InputStream in = outConfigStorage.getContentInputStream(outputArchiveKey);
             ProjectArchives.extractTarArchive(context.getLocalProjectPath(), in); // runtime exception
+            client.deletePod(pod.getName());
         }
         else if (defaultPodTTL.isPresent() && isRunningLongerThanTTL(previousStatusJson)) {
             TaskRequest request = context.getTaskRequest();


### PR DESCRIPTION
When I executed KubernetesCommandExecutor, there was a case where the pod remained.
So I modified it to explicitly delete the pod after the archive file acquisition was complete.