### PR TITLE
Backport API enhancement

### DIFF
--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
@@ -580,6 +580,7 @@ public class DatabaseProjectStoreManager
         ") a on a.id = rev.id" +
         " where proj.site_id = :siteId" +
         " and proj.name is not null" +
+        " and proj.name like :namePattern" +
         " and <acFilter>" +
         " and proj.id > :lastId" +
         " order by proj.id asc" +
@@ -646,6 +647,7 @@ public class DatabaseProjectStoreManager
             " join revisions rev on proj.id = rev.project_id" +
             " where proj.site_id = :siteId" +
             " and proj.name is not null" +
+            " and proj.name like :namePattern" +
             " and <acFilter>" +
             " and proj.id > :lastId" +
         ") as projects_with_revision" +

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
@@ -125,11 +125,6 @@ public class DatabaseProjectStoreManager
             this.siteId = siteId;
         }
 
-        //public List<StoredProject> getAllProjects()
-        //{
-        //    return dao.getProjects(siteId, Integer.MAX_VALUE, 0);
-        //}
-
         @DigdagTimed(value = "dpst_", category = "db", appendMethodName = true)
         @Override
         public List<StoredProjectWithRevision> getProjectsWithLatestRevision(int pageSize, Optional<Integer> lastId, AccessController.ListFilter acFilter)
@@ -139,9 +134,9 @@ public class DatabaseProjectStoreManager
 
         @DigdagTimed(value = "dpst_", category = "db", appendMethodName = true)
         @Override
-        public List<StoredProject> getProjects(int pageSize, Optional<Integer> lastId, AccessController.ListFilter acFilter)
+        public List<StoredProject> getProjects(int pageSize, Optional<Integer> lastId, Optional<String> namePattern, AccessController.ListFilter acFilter)
         {
-            return autoCommit((handle, dao) -> dao.getProjects(siteId, pageSize, lastId.or(0), acFilter.getSql()));
+            return autoCommit((handle, dao) -> dao.getProjects(siteId, pageSize, lastId.or(0), generatePartialMatchPattern(namePattern), acFilter.getSql()));
         }
 
         @DigdagTimed(value = "dpst_", category = "db", appendMethodName = true)
@@ -710,6 +705,7 @@ public class DatabaseProjectStoreManager
                 " where proj.site_id = :siteId" +
                 " and proj.name is not null" +
                 " and proj.id \\> :lastId" +
+                " and proj.name like :namePattern" +
                 " and <acFilter>" +
                 " order by proj.id asc" +
                 " limit :limit")
@@ -717,6 +713,7 @@ public class DatabaseProjectStoreManager
                 @Bind("siteId") int siteId,
                 @Bind("limit") int limit,
                 @Bind("lastId") int lastId,
+                @Bind("namePattern") String namePattern,
                 @Define("acFilter") String acFilter);
 
         List<StoredProjectWithRevision> getProjectsWithLatestRevision(@Bind("siteId") int siteId, @Bind("limit") int limit, @Bind("lastId") int lastId, @Define("acFilter") String acFilter);

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseProjectStoreManager.java
@@ -127,9 +127,9 @@ public class DatabaseProjectStoreManager
 
         @DigdagTimed(value = "dpst_", category = "db", appendMethodName = true)
         @Override
-        public List<StoredProjectWithRevision> getProjectsWithLatestRevision(int pageSize, Optional<Integer> lastId, AccessController.ListFilter acFilter)
+        public List<StoredProjectWithRevision> getProjectsWithLatestRevision(int pageSize, Optional<Integer> lastId, Optional<String> namePattern, AccessController.ListFilter acFilter)
         {
-            return autoCommit((handle, dao) -> dao.getProjectsWithLatestRevision(siteId, pageSize, lastId.or(0), acFilter.getSql()));
+            return autoCommit((handle, dao) -> dao.getProjectsWithLatestRevision(siteId, pageSize, lastId.or(0), generatePartialMatchPattern(namePattern), acFilter.getSql()));
         }
 
         @DigdagTimed(value = "dpst_", category = "db", appendMethodName = true)
@@ -584,7 +584,12 @@ public class DatabaseProjectStoreManager
         " and proj.id > :lastId" +
         " order by proj.id asc" +
         " limit :limit")
-        List<StoredProjectWithRevision> getProjectsWithLatestRevision(@Bind("siteId") int siteId, @Bind("limit") int limit, @Bind("lastId") int lastId, @Define("acFilter") String acFilter);
+        List<StoredProjectWithRevision> getProjectsWithLatestRevision(
+                @Bind("siteId") int siteId,
+                @Bind("limit") int limit,
+                @Bind("lastId") int lastId,
+                @Bind("namePattern") String namePattern,
+                @Define("acFilter") String acFilter);
 
         // h2's MERGE doesn't return generated id when conflicting row already exists
         @SqlUpdate("merge into projects" +
@@ -647,7 +652,12 @@ public class DatabaseProjectStoreManager
         " where projects_with_revision.revision_id = projects_with_revision.max_revision_id" +
         " order by id asc" +
         " limit :limit")
-        List<StoredProjectWithRevision> getProjectsWithLatestRevision(@Bind("siteId") int siteId, @Bind("limit") int limit, @Bind("lastId") int lastId, @Define("acFilter") String acFilter);
+        List<StoredProjectWithRevision> getProjectsWithLatestRevision(
+                @Bind("siteId") int siteId,
+                @Bind("limit") int limit,
+                @Bind("lastId") int lastId,
+                @Bind("namePattern") String namePattern,
+                @Define("acFilter") String acFilter);
 
         @SqlQuery("insert into projects" +
                 " (site_id, name, created_at)" +
@@ -716,7 +726,12 @@ public class DatabaseProjectStoreManager
                 @Bind("namePattern") String namePattern,
                 @Define("acFilter") String acFilter);
 
-        List<StoredProjectWithRevision> getProjectsWithLatestRevision(@Bind("siteId") int siteId, @Bind("limit") int limit, @Bind("lastId") int lastId, @Define("acFilter") String acFilter);
+        List<StoredProjectWithRevision> getProjectsWithLatestRevision(
+                @Bind("siteId") int siteId,
+                @Bind("limit") int limit,
+                @Bind("lastId") int lastId,
+                @Bind("namePattern") String namePattern,
+                @Define("acFilter") String acFilter);
 
         @SqlUpdate("update projects" +
                 " set deleted_name = name, deleted_at = now(), name = NULL" +

--- a/digdag-core/src/main/java/io/digdag/core/repository/ProjectStore.java
+++ b/digdag-core/src/main/java/io/digdag/core/repository/ProjectStore.java
@@ -9,7 +9,7 @@ public interface ProjectStore
 {
     List<StoredProject> getProjects(int pageSize, Optional<Integer> lastId, Optional<String> namePattern, AccessController.ListFilter acFilter);
 
-    List<StoredProjectWithRevision> getProjectsWithLatestRevision(int pageSize, Optional<Integer> lastId, AccessController.ListFilter acFilter);
+    List<StoredProjectWithRevision> getProjectsWithLatestRevision(int pageSize, Optional<Integer> lastId, Optional<String> namePattern, AccessController.ListFilter acFilter);
 
     ProjectMap getProjectsByIdList(List<Integer> projIdList);
 

--- a/digdag-core/src/main/java/io/digdag/core/repository/ProjectStore.java
+++ b/digdag-core/src/main/java/io/digdag/core/repository/ProjectStore.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 public interface ProjectStore
 {
-    List<StoredProject> getProjects(int pageSize, Optional<Integer> lastId, AccessController.ListFilter acFilter);
+    List<StoredProject> getProjects(int pageSize, Optional<Integer> lastId, Optional<String> namePattern, AccessController.ListFilter acFilter);
 
     List<StoredProjectWithRevision> getProjectsWithLatestRevision(int pageSize, Optional<Integer> lastId, AccessController.ListFilter acFilter);
 

--- a/digdag-core/src/main/java/io/digdag/core/repository/ProjectStore.java
+++ b/digdag-core/src/main/java/io/digdag/core/repository/ProjectStore.java
@@ -1,11 +1,9 @@
 package io.digdag.core.repository;
 
-import java.util.List;
-import java.util.Map;
-import java.time.ZoneId;
-
 import com.google.common.base.Optional;
 import io.digdag.spi.ac.AccessController;
+
+import java.util.List;
 
 public interface ProjectStore
 {
@@ -58,16 +56,16 @@ public interface ProjectStore
     List<StoredWorkflowDefinition> getWorkflowDefinitions(int revId, int pageSize, Optional<Long> lastId, AccessController.ListFilter acFilter);
 
     StoredWorkflowDefinition getWorkflowDefinitionByName(int revId, String name)
-        throws ResourceNotFoundException;
+            throws ResourceNotFoundException;
 
     StoredWorkflowDefinitionWithProject getWorkflowDefinitionById(long wfId)
-        throws ResourceNotFoundException;
+            throws ResourceNotFoundException;
 
     StoredWorkflowDefinitionWithProject getLatestWorkflowDefinitionByName(int projId, String name)
-        throws ResourceNotFoundException;
+            throws ResourceNotFoundException;
 
-    List<StoredWorkflowDefinitionWithProject> getLatestActiveWorkflowDefinitions(int pageSize, Optional<Long> lastId, AccessController.ListFilter acFilter)
-        throws ResourceNotFoundException;
+    List<StoredWorkflowDefinitionWithProject> getLatestActiveWorkflowDefinitions(int pageSize, Optional<Long> lastId, Optional<String> namePattern, AccessController.ListFilter acFilter)
+            throws ResourceNotFoundException;
 
     TimeZoneMap getWorkflowTimeZonesByIdList(List<Long> defIdList);
 }

--- a/digdag-core/src/test/java/io/digdag/core/database/DatabaseProjectStoreManagerTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/database/DatabaseProjectStoreManagerTest.java
@@ -233,10 +233,10 @@ public class DatabaseProjectStoreManagerTest
             assertEquals(ImmutableList.of(proj2), store.getProjects(100, Optional.of(proj1.getId()), Optional.absent(), () -> "true"));
             assertEmpty(anotherSite.getProjects(100, Optional.absent(), Optional.absent(), () -> "true"));
 
-            assertEquals(ImmutableList.of(proj1Rev1, proj2Rev3), store.getProjectsWithLatestRevision(100, Optional.absent(), () -> "true"));
-            assertEquals(ImmutableList.of(proj1Rev1), store.getProjectsWithLatestRevision(1, Optional.absent(), () -> "true"));
-            assertEquals(ImmutableList.of(proj2Rev3), store.getProjectsWithLatestRevision(100, Optional.of(proj1.getId()), () -> "true"));
-            assertEmpty(anotherSite.getProjectsWithLatestRevision(100, Optional.absent(), () -> "true"));
+            assertEquals(ImmutableList.of(proj1Rev1, proj2Rev3), store.getProjectsWithLatestRevision(100, Optional.absent(), Optional.absent(), () -> "true"));
+            assertEquals(ImmutableList.of(proj1Rev1), store.getProjectsWithLatestRevision(1, Optional.absent(), Optional.absent(), () -> "true"));
+            assertEquals(ImmutableList.of(proj2Rev3), store.getProjectsWithLatestRevision(100, Optional.of(proj1.getId()), Optional.absent(), () -> "true"));
+            assertEmpty(anotherSite.getProjectsWithLatestRevision(100, Optional.absent(), Optional.absent(), () -> "true"));
 
             assertEquals(ImmutableList.of(rev3, rev2), store.getRevisions(proj2.getId(), 100, Optional.absent()));  // revision is returned in reverse order
             assertEquals(ImmutableList.of(rev3), store.getRevisions(proj2.getId(), 1, Optional.absent()));
@@ -432,7 +432,7 @@ public class DatabaseProjectStoreManagerTest
 
             // listing doesn't include deleted projects
             assertEquals(ImmutableList.of(), store.getProjects(100, Optional.absent(), Optional.absent(), () -> "true"));
-            assertEquals(ImmutableList.of(), store.getProjectsWithLatestRevision(100, Optional.absent(), () -> "true"));
+            assertEquals(ImmutableList.of(), store.getProjectsWithLatestRevision(100, Optional.absent(), Optional.absent(), () -> "true"));
             assertEquals(ImmutableList.of(), store.getLatestActiveWorkflowDefinitions(100, Optional.absent(), Optional.absent(), () -> "true"));
 
             // lookup by project/revision id succeeds and deletedAt is set

--- a/digdag-core/src/test/java/io/digdag/core/database/DatabaseProjectStoreManagerTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/database/DatabaseProjectStoreManagerTest.java
@@ -1,17 +1,45 @@
 package io.digdag.core.database;
 
-import java.util.*;
-import java.time.Instant;
-import java.util.concurrent.atomic.AtomicReference;
-import org.skife.jdbi.v2.IDBI;
-import org.junit.*;
 import com.google.common.base.Optional;
-import com.google.common.collect.*;
-import io.digdag.core.repository.*;
-import io.digdag.core.schedule.*;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import io.digdag.core.repository.ImmutableProject;
+import io.digdag.core.repository.ImmutableRevision;
+import io.digdag.core.repository.ImmutableWorkflowDefinition;
+import io.digdag.core.repository.Project;
+import io.digdag.core.repository.ProjectControl;
+import io.digdag.core.repository.ProjectMap;
+import io.digdag.core.repository.ProjectStore;
+import io.digdag.core.repository.ProjectStoreManager;
+import io.digdag.core.repository.Revision;
+import io.digdag.core.repository.StoredProject;
+import io.digdag.core.repository.StoredRevision;
+import io.digdag.core.repository.StoredWorkflowDefinition;
+import io.digdag.core.repository.StoredWorkflowDefinitionWithProject;
+import io.digdag.core.repository.TimeZoneMap;
+import io.digdag.core.repository.WorkflowDefinition;
+import io.digdag.core.schedule.SchedulerManager;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static io.digdag.core.database.DatabaseTestingUtils.assertConflict;
+import static io.digdag.core.database.DatabaseTestingUtils.assertEmpty;
+import static io.digdag.core.database.DatabaseTestingUtils.assertNotConflict;
+import static io.digdag.core.database.DatabaseTestingUtils.assertNotFound;
+import static io.digdag.core.database.DatabaseTestingUtils.createRevision;
+import static io.digdag.core.database.DatabaseTestingUtils.createWorkflow;
+import static io.digdag.core.database.DatabaseTestingUtils.setupDatabase;
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static io.digdag.core.database.DatabaseTestingUtils.*;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 public class DatabaseProjectStoreManagerTest
 {
@@ -217,10 +245,10 @@ public class DatabaseProjectStoreManagerTest
             assertEquals(ImmutableList.of(wf4), store.getWorkflowDefinitions(rev3.getId(), 100, Optional.of(wf3.getId()), () -> "true"));
             assertEmpty(anotherSite.getWorkflowDefinitions(rev3.getId(), 100, Optional.absent(), () -> "true"));
 
-            assertEquals(ImmutableList.of(wfDetails1, wfDetails3, wfDetails4), store.getLatestActiveWorkflowDefinitions(100, Optional.absent(), () -> "true"));
-            assertEquals(ImmutableList.of(wfDetails1), store.getLatestActiveWorkflowDefinitions(1, Optional.absent(), () -> "true"));
-            assertEquals(ImmutableList.of(wfDetails4), store.getLatestActiveWorkflowDefinitions(100, Optional.of(wfDetails3.getId()), () -> "true"));
-            assertEmpty(anotherSite.getLatestActiveWorkflowDefinitions(100, Optional.absent(), () -> "true"));
+            assertEquals(ImmutableList.of(wfDetails1, wfDetails3, wfDetails4), store.getLatestActiveWorkflowDefinitions(100, Optional.absent(), Optional.absent(), () -> "true"));
+            assertEquals(ImmutableList.of(wfDetails1), store.getLatestActiveWorkflowDefinitions(1, Optional.absent(), Optional.absent(), () -> "true"));
+            assertEquals(ImmutableList.of(wfDetails4), store.getLatestActiveWorkflowDefinitions(100, Optional.of(wfDetails3.getId()), Optional.absent(), () -> "true"));
+            assertEmpty(anotherSite.getLatestActiveWorkflowDefinitions(100, Optional.absent(), Optional.absent(), () -> "true"));
 
             ////
             // public simple getters
@@ -283,6 +311,71 @@ public class DatabaseProjectStoreManagerTest
     }
 
     @Test
+    public void testGetActiveWorkflows()
+            throws Exception
+    {
+        factory.begin(() -> {
+            Project srcProj1 = Project.of("proj1");
+            Revision srcRev1 = createRevision("rev1");
+            WorkflowDefinition srcWf1 = createWorkflow("wf1");
+            WorkflowDefinition srcWf2 = createWorkflow("test_wf2");
+            WorkflowDefinition srcWf3 = createWorkflow("test_wf3");
+            WorkflowDefinition srcWf4 = createWorkflow("wf%4");
+            WorkflowDefinition srcWf5 = createWorkflow("wf_5");
+            WorkflowDefinition srcWf6 = createWorkflow("wf%_6");
+            final AtomicReference<StoredRevision> revRef = new AtomicReference<>();
+            final AtomicReference<StoredWorkflowDefinition> wfRef1 = new AtomicReference<>();
+            final AtomicReference<StoredWorkflowDefinition> wfRef2 = new AtomicReference<>();
+            final AtomicReference<StoredWorkflowDefinition> wfRef3 = new AtomicReference<>();
+            final AtomicReference<StoredWorkflowDefinition> wfRef4 = new AtomicReference<>();
+            final AtomicReference<StoredWorkflowDefinition> wfRef5 = new AtomicReference<>();
+            final AtomicReference<StoredWorkflowDefinition> wfRef6 = new AtomicReference<>();
+            StoredProject proj1 = store.putAndLockProject(
+                    srcProj1,
+                    (store, stored) -> {
+                        ProjectControl lock = new ProjectControl(store, stored);
+                        assertNotConflict(() -> {
+                            revRef.set(lock.insertRevision(srcRev1));
+                            wfRef1.set(lock.insertWorkflowDefinitions(revRef.get(), ImmutableList.of(srcWf1), sm, Instant.now()).get(0));
+                            wfRef2.set(lock.insertWorkflowDefinitions(revRef.get(), ImmutableList.of(srcWf2), sm, Instant.now()).get(0));
+                            wfRef3.set(lock.insertWorkflowDefinitions(revRef.get(), ImmutableList.of(srcWf3), sm, Instant.now()).get(0));
+                            wfRef4.set(lock.insertWorkflowDefinitions(revRef.get(), ImmutableList.of(srcWf4), sm, Instant.now()).get(0));
+                            wfRef5.set(lock.insertWorkflowDefinitions(revRef.get(), ImmutableList.of(srcWf5), sm, Instant.now()).get(0));
+                            wfRef6.set(lock.insertWorkflowDefinitions(revRef.get(), ImmutableList.of(srcWf6), sm, Instant.now()).get(0));
+                        });
+                        return lock.get();
+                    });
+            StoredWorkflowDefinition wf1 = wfRef1.get();
+            StoredWorkflowDefinition wf2 = wfRef2.get();
+            StoredWorkflowDefinition wf3 = wfRef3.get();
+            StoredWorkflowDefinition wf4 = wfRef4.get();
+            StoredWorkflowDefinition wf5 = wfRef5.get();
+            StoredWorkflowDefinition wf6 = wfRef6.get();
+            StoredWorkflowDefinitionWithProject wfDetails1 = StoredWorkflowDefinitionWithProject.of(wf1, proj1, srcRev1);
+            StoredWorkflowDefinitionWithProject wfDetails2 = StoredWorkflowDefinitionWithProject.of(wf2, proj1, srcRev1);
+            StoredWorkflowDefinitionWithProject wfDetails3 = StoredWorkflowDefinitionWithProject.of(wf3, proj1, srcRev1);
+            StoredWorkflowDefinitionWithProject wfDetails4 = StoredWorkflowDefinitionWithProject.of(wf4, proj1, srcRev1);
+            StoredWorkflowDefinitionWithProject wfDetails5 = StoredWorkflowDefinitionWithProject.of(wf5, proj1, srcRev1);
+            StoredWorkflowDefinitionWithProject wfDetails6 = StoredWorkflowDefinitionWithProject.of(wf6, proj1, srcRev1);
+
+            assertEquals(ImmutableList.of(wfDetails1, wfDetails2, wfDetails3, wfDetails4, wfDetails5, wfDetails6),
+                    store.getLatestActiveWorkflowDefinitions(100, Optional.absent(), Optional.absent(), () -> "true"));
+            assertEquals(ImmutableList.of(wfDetails1, wfDetails2, wfDetails3, wfDetails4, wfDetails5, wfDetails6),
+                    store.getLatestActiveWorkflowDefinitions(100, Optional.absent(), Optional.fromNullable(""), () -> "true"));
+            assertEquals(ImmutableList.of(wfDetails2, wfDetails3),
+                    store.getLatestActiveWorkflowDefinitions(100, Optional.absent(), Optional.fromNullable("test"), () -> "true"));
+            assertEquals(ImmutableList.of(wfDetails4, wfDetails6),
+                    store.getLatestActiveWorkflowDefinitions(100, Optional.absent(), Optional.fromNullable("%"), () -> "true"));
+            assertEquals(ImmutableList.of(wfDetails2, wfDetails3, wfDetails5, wfDetails6),
+                    store.getLatestActiveWorkflowDefinitions(100, Optional.absent(), Optional.fromNullable("_"), () -> "true"));
+            assertEquals(ImmutableList.of(wfDetails6),
+                    store.getLatestActiveWorkflowDefinitions(100, Optional.absent(), Optional.fromNullable("%_"), () -> "true"));
+            assertEquals(ImmutableList.of(),
+                    store.getLatestActiveWorkflowDefinitions(100, Optional.absent(), Optional.fromNullable("*"), () -> "true"));
+        });
+    }
+
+    @Test
     public void testRevisionArchiveData()
         throws Exception
     {
@@ -337,7 +430,7 @@ public class DatabaseProjectStoreManagerTest
             // listing doesn't include deleted projects
             assertEquals(ImmutableList.of(), store.getProjects(100, Optional.absent(), () -> "true"));
             assertEquals(ImmutableList.of(), store.getProjectsWithLatestRevision(100, Optional.absent(), () -> "true"));
-            assertEquals(ImmutableList.of(), store.getLatestActiveWorkflowDefinitions(100, Optional.absent(), () -> "true"));
+            assertEquals(ImmutableList.of(), store.getLatestActiveWorkflowDefinitions(100, Optional.absent(), Optional.absent(), () -> "true"));
 
             // lookup by project/revision id succeeds and deletedAt is set
             StoredProject deletedProj = store.getProjectById(deletingProject.getId());

--- a/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
@@ -280,7 +280,10 @@ public class ProjectResource
                             siteTarget,
                             getAuthenticatedUser());
 
-                    collection = ps.getProjectsWithLatestRevision(100, Optional.absent(),
+                    collection = ps.getProjectsWithLatestRevision(
+                                Optional.fromNullable(count).or(100),
+                                Optional.fromNullable(lastId),
+                                Optional.fromNullable(namePattern),
                                 ac.getListProjectsFilterOfSite(siteTarget, getAuthenticatedUser()))
                             .stream()
                             .map(projWithRev -> {

--- a/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/ProjectResource.java
@@ -243,7 +243,13 @@ public class ProjectResource
     @ApiOperation("List projects with filters")
     public RestProjectCollection getProjects(
             @ApiParam(value="exact matching filter on project name", required=false)
-            @QueryParam("name") String name)
+            @QueryParam("name") String name,
+            @ApiParam(value="list projects whose id is grater than this id for pagination", required=false)
+            @QueryParam("last_id") Integer lastId,
+            @ApiParam(value="number of projects to return", required=false)
+            @QueryParam("count") Integer count,
+            @ApiParam(value="name pattern to be partially matched", required=false)
+            @QueryParam("name_pattern") String namePattern)
     {
         return tm.begin(() -> {
             ProjectStore ps = rm.getProjectStore(getSiteId());

--- a/digdag-server/src/main/java/io/digdag/server/rs/WorkflowResource.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/WorkflowResource.java
@@ -113,7 +113,10 @@ public class WorkflowResource
             @ApiParam(value="list workflows whose id is grater than this id for pagination", required=false)
             @QueryParam("last_id") Long lastId,
             @ApiParam(value="number of workflows to return", required=false)
-            @QueryParam("count") Integer count)
+            @QueryParam("count") Integer count,
+            @ApiParam(value="name pattern to be partially matched", required=false)
+            @QueryParam("name_pattern") String namePattern
+    )
             throws ResourceNotFoundException, AccessControlException
     {
         final SiteTarget siteTarget = SiteTarget.of(getSiteId());
@@ -123,6 +126,7 @@ public class WorkflowResource
             List<StoredWorkflowDefinitionWithProject> defs =
                     rm.getProjectStore(getSiteId())
                             .getLatestActiveWorkflowDefinitions(Optional.fromNullable(count).or(100), Optional.fromNullable(lastId), // check NotFound first
+                                    Optional.fromNullable(namePattern),
                                     ac.getListWorkflowsFilterOfSite(
                                             SiteTarget.of(getSiteId()),
                                             getAuthenticatedUser()));


### PR DESCRIPTION
Backporting API enhancement in TD. Add following parameters.

- `GET /api/workflows` supports `name_pattern` parameter to search by workflow name. (partial match).
- `GET /api/projects` supports `name_pattern` parameter to search by project name. (partial match).
- `GET /api/projects` supports `count` and `last_id` to change number of return and pagination like `/api/workflows`.
- Due to difference in ProjectResource.getProjects() implementation, re-implement the modification for `GET /api/projects`.

These changes do not affect default behavior of APIs.