### PR TITLE
Bump HikariCP deps and keepaliveTime configurable

### DIFF
--- a/digdag-core/build.gradle
+++ b/digdag-core/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     compile "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${project.ext.jacksonVersion}"
     compile 'org.jdbi:jdbi:2.75'
     runtime 'org.antlr:stringtemplate:3.2.1' // Used by jdbi2's string template v3 at runtime
-    compile 'com.zaxxer:HikariCP:2.4.7'
+    compile 'com.zaxxer:HikariCP:4.0.3'
     compile 'com.h2database:h2:1.4.192'
     compile 'org.postgresql:postgresql:42.3.1'
     compile 'org.yaml:snakeyaml:1.23'

--- a/digdag-core/src/main/java/io/digdag/core/database/DataSourceProvider.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DataSourceProvider.java
@@ -81,6 +81,7 @@ public class DataSourceProvider
 
         hikari.setConnectionTimeout(config.getConnectionTimeout() * 1000);
         hikari.setIdleTimeout(config.getIdleTimeout() * 1000);
+        hikari.setKeepaliveTime(config.getKeepaliveTime() * 1000);
         hikari.setValidationTimeout(config.getValidationTimeout() * 1000);
         hikari.setMaximumPoolSize(config.getMaximumPoolSize());
         hikari.setMinimumIdle(config.getMinimumPoolSize());

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseConfig.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseConfig.java
@@ -39,6 +39,8 @@ public interface DatabaseConfig
 
     int getIdleTimeout();  // seconds
 
+    int getKeepaliveTime(); // seconds
+
     int getMaximumPoolSize();
 
     int getMinimumPoolSize();
@@ -98,6 +100,8 @@ public interface DatabaseConfig
                 config.get(keyPrefix + "." + "connectionTimeout", int.class, 30));  // HikariCP default: 30
         builder.idleTimeout(
                 config.get(keyPrefix + "." + "idleTimeout", int.class, 600));  // HikariCP default: 600
+        builder.keepaliveTime(
+                config.get(keyPrefix + "." + "keepaliveTime", int.class, 0)); // HikariCP default: 0 (disabled)
         builder.validationTimeout(
                 config.get(keyPrefix + "." + "validationTimeout", int.class, 5));  // HikariCP default: 5
 
@@ -175,6 +179,7 @@ public interface DatabaseConfig
         }
 
         config.set(keyPrefix + "." + "connectionTimeout", databaseConfig.getConnectionTimeout());
+        config.set(keyPrefix + "." + "keepaliveTime", databaseConfig.getKeepaliveTime());
         config.set(keyPrefix + "." + "idleTimeout", databaseConfig.getIdleTimeout());
         config.set(keyPrefix + "." + "validationTimeout", databaseConfig.getValidationTimeout());
         config.set(keyPrefix + "." + "maximumPoolSize", databaseConfig.getMaximumPoolSize());

--- a/digdag-core/src/test/java/io/digdag/core/database/DatabaseTestingUtils.java
+++ b/digdag-core/src/test/java/io/digdag/core/database/DatabaseTestingUtils.java
@@ -55,6 +55,7 @@ public class DatabaseTestingUtils
                 .autoMigrate(true)
                 .connectionTimeout(30)
                 .idleTimeout(600)
+                .keepaliveTime(0)
                 .validationTimeout(5)
                 .minimumPoolSize(0)
                 .maximumPoolSize(10)

--- a/digdag-docs/src/command_reference.rst
+++ b/digdag-docs/src/command_reference.rst
@@ -363,6 +363,7 @@ In the config file, following parameters are available
 * database.ssl (boolean, default: false)
 * database.connectionTimeout (seconds in integer, default: 30)
 * database.idleTimeout (seconds in integer, default: 600)
+* database.keepaliveTime (seconds in integer, default: 0)
 * database.validationTimeout (seconds in integer, default: 5)
 * database.maximumPoolSize (integer, default: available CPU cores * 32)
 * database.minimumPoolSize (integer, default: same as database.maximumPoolSize)


### PR DESCRIPTION
1. Bump HikariCP to 4.0.3 (Current [Java 8 maven artifact](https://github.com/brettwooldridge/HikariCP#artifacts))
1. Make keepaliveTime configurable (the config was [introduced](https://github.com/brettwooldridge/HikariCP/blob/dev/CHANGES) in 4.0.0)

According to [README](https://github.com/brettwooldridge/HikariCP#gear-configuration-knobs-baby), `keepaliveTime` is useful in the following cases 👍 
> This property controls how frequently HikariCP will attempt to keep a connection alive, in order to prevent it from being timed out by the database or network infrastructure. 
