### PR TITLE
Fix the s3_wait empty check example

### DIFF
--- a/digdag-docs/src/operators/s3_wait.md
+++ b/digdag-docs/src/operators/s3_wait.md
@@ -102,7 +102,7 @@ For more information about SSE-C, See the [AWS S3 Documentation](http://docs.aws
     timeout: 60s
     continue_on_timeout: true
   +task2:
-    if>: ${s3.last_object}
+    if>: ${!!s3.last_object}
     _do:
       echo>: "No timeout"
   ```


### PR DESCRIPTION
`s3_wait` operator shows an example for `continue_on_timeout`. However, it doesn't work when `${s3.last_object}` is found.

```
+task1:
  s3_wait>: bucket/object
  timeout: 60s
  continue_on_timeout: true
+task2:
  if>: ${s3.last_object}
  _do:
    echo>: "No timeout"
 ```
 
 So, update the example in order to pass the `task2` even if the operator isn't timed out.