### PR TITLE
Support start_date and end_date for schedule

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/client/ShowSchedule.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/ShowSchedule.java
@@ -50,6 +50,8 @@ public class ShowSchedule
             ln("  project: %s", sched.getProject().getName());
             ln("  workflow: %s", sched.getWorkflow().getName());
             ln("  disabled at: " + sched.getDisabledAt().transform(ts -> formatTimeWithDiff(now, ts)).or(""));
+            ln("  start date : " + sched.getStartDate().transform(ts -> formatTimeWithDiff(now, ts)).or(""));
+            ln("  end date: " + sched.getEndDate().transform(ts -> formatTimeWithDiff(now, ts)).or(""));
             ln("  next session time: %s", formatTime(sched.getNextScheduleTime()));
             ln("  next scheduled to run at: %s", formatTimeWithDiff(now, sched.getNextRunTime()));
             ln("");

--- a/digdag-client/src/main/java/io/digdag/client/api/RestSchedule.java
+++ b/digdag-client/src/main/java/io/digdag/client/api/RestSchedule.java
@@ -23,6 +23,10 @@ public interface RestSchedule
 
     Optional<Instant> getDisabledAt();
 
+    Optional<Instant> getStartDate();
+
+    Optional<Instant> getEndDate();
+
     static ImmutableRestSchedule.Builder builder()
     {
         return ImmutableRestSchedule.builder();

--- a/digdag-client/src/main/java/io/digdag/client/api/RestScheduleSummary.java
+++ b/digdag-client/src/main/java/io/digdag/client/api/RestScheduleSummary.java
@@ -26,6 +26,10 @@ public interface RestScheduleSummary
 
     Optional<Instant> getDisabledAt();
 
+    Optional<Instant> getStartDate();
+
+    Optional<Instant> getEndDate();
+
     static ImmutableRestScheduleSummary.Builder builder()
     {
         return ImmutableRestScheduleSummary.builder();

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseMigrator.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseMigrator.java
@@ -42,6 +42,7 @@ public class DatabaseMigrator
         new Migration_20191105105927_AddIndexToSessions(),
         new Migration_20200716114008_AddLastAttemptIdIndexToSessions(),
         new Migration_20200803184355_ReplacePartialIndexOnSessionAttempts(),
+        new Migration_20220223095752_AddStartDateAndEndDateColumnsToSchedules(),
     })
     .sorted(Comparator.comparing(m -> m.getVersion()))
     .collect(Collectors.toList());

--- a/digdag-core/src/main/java/io/digdag/core/database/DatabaseScheduleStoreManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/DatabaseScheduleStoreManager.java
@@ -256,6 +256,7 @@ public class DatabaseScheduleStoreManager
         @SqlQuery("select s.*, wd.name as name from schedules s" +
                 " join workflow_definitions wd on wd.id = s.workflow_definition_id" +
                 " where s.next_run_time \\<= :currentTime" +
+                " and :currentTime between coalesce(s.start_date, 0) and coalesce(s.end_date, 253402300799)" +
                 " and s.disabled_at is null" +
                 " limit :limit" +
                 " for update of s skip locked")
@@ -330,6 +331,7 @@ public class DatabaseScheduleStoreManager
 
         @SqlQuery("select id from schedules" +
                 " where next_run_time \\<= :currentTime" +
+                " and :currentTime between coalesce(start_date, 0) and coalesce(end_date, 253402300799)" +
                 " and disabled_at is null" +
                 " limit :limit" +
                 " for update")
@@ -386,6 +388,8 @@ public class DatabaseScheduleStoreManager
                 .updatedAt(getTimestampInstant(r, "updated_at"))
                 .disabledAt(getOptionalTimestampInstant(r, "disabled_at"))
                 .lastSessionTime(getOptionalLong(r, "last_session_time").transform(Instant::ofEpochSecond))
+                .startDate(getOptionalLong(r, "start_date").transform(Instant::ofEpochSecond))
+                .endDate(getOptionalLong(r, "end_date").transform(Instant::ofEpochSecond))
                 .build();
         }
     }

--- a/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20220223095752_AddStartDateAndEndDateColumnsToSchedules.java
+++ b/digdag-core/src/main/java/io/digdag/core/database/migrate/Migration_20220223095752_AddStartDateAndEndDateColumnsToSchedules.java
@@ -1,0 +1,21 @@
+package io.digdag.core.database.migrate;
+
+import org.skife.jdbi.v2.Handle;
+
+public class Migration_20220223095752_AddStartDateAndEndDateColumnsToSchedules
+        implements Migration
+{
+    @Override
+    public void migrate(Handle handle, MigrationContext context)
+    {
+        handle.update("alter table schedules" +
+                " add column start_date bigint");
+        handle.update("alter table schedules" +
+                " add column end_date bigint");
+
+        if (context.isPostgres()) {
+            handle.update("drop index schedules_on_next_run_time");
+            handle.update("create index schedules_on_next_run_time on schedules (next_run_time, start_date, end_date) where disabled_at is null");
+        }
+    }
+}

--- a/digdag-core/src/main/java/io/digdag/core/repository/ProjectControl.java
+++ b/digdag-core/src/main/java/io/digdag/core/repository/ProjectControl.java
@@ -98,7 +98,7 @@ public class ProjectControl
             Optional<Scheduler> sr = srm.tryGetScheduler(revision, def, true);
             if (sr.isPresent()) {
                 ScheduleTime firstTime = sr.get().getFirstScheduleTime(currentTime);
-                Schedule schedule = Schedule.of(def.getName(), def.getId(), firstTime.getRunTime(), firstTime.getTime());
+                Schedule schedule = Schedule.of(def.getName(), def.getId(), firstTime.getRunTime(), firstTime.getTime(), firstTime.getStartDate(), firstTime.getEndDate());
                 schedules.add(new ScheduleWithScheduler(schedule, sr.get()));
             }
         }
@@ -114,7 +114,7 @@ public class ProjectControl
                 .transform(it -> newSched.getScheduler().nextScheduleTime(it))
                 // otherwise, if this schedule hasn't run before, simply use the first execution
                 // time of the new schedule setting.
-                .or(() -> ScheduleTime.of(newSched.getNextScheduleTime(), newSched.getNextRunTime()));
+                .or(() -> ScheduleTime.of(newSched.getNextScheduleTime(), newSched.getNextRunTime(), newSched.getStartDate(), newSched.getEndDate()));
         });
     }
 
@@ -157,6 +157,18 @@ public class ProjectControl
         public Instant getNextScheduleTime()
         {
             return schedule.getNextScheduleTime();
+        }
+
+        @Override
+        public Optional<Instant> getStartDate()
+        {
+            return schedule.getStartDate();
+        }
+
+        @Override
+        public Optional<Instant> getEndDate()
+        {
+            return schedule.getEndDate();
         }
 
         public Scheduler getScheduler()

--- a/digdag-core/src/main/java/io/digdag/core/schedule/Schedule.java
+++ b/digdag-core/src/main/java/io/digdag/core/schedule/Schedule.java
@@ -18,13 +18,19 @@ public abstract class Schedule
 
     public abstract Instant getNextScheduleTime();
 
-    public static Schedule of(String workflowName, long workflowDefinitionId, Instant nextRunTime, Instant nextScheduleTime)
+    public abstract Optional<Instant> getStartDate();
+
+    public abstract Optional<Instant> getEndDate();
+
+    public static Schedule of(String workflowName, long workflowDefinitionId, Instant nextRunTime, Instant nextScheduleTime, Optional<Instant> startDate, Optional<Instant> endDate)
     {
         return ImmutableSchedule.builder()
             .workflowName(workflowName)
             .workflowDefinitionId(workflowDefinitionId)
             .nextRunTime(nextRunTime)
             .nextScheduleTime(nextScheduleTime)
+            .startDate(startDate)
+            .endDate(endDate)
             .build();
     }
 }

--- a/digdag-core/src/main/java/io/digdag/core/schedule/SchedulerManager.java
+++ b/digdag-core/src/main/java/io/digdag/core/schedule/SchedulerManager.java
@@ -1,5 +1,6 @@
 package io.digdag.core.schedule;
 
+import java.time.Instant;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -11,6 +12,7 @@ import java.util.function.Consumer;
 import com.google.inject.Inject;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
+import io.digdag.client.api.LocalTimeOrInstant;
 import io.digdag.core.agent.CheckedConfig;
 import io.digdag.core.agent.EditDistance;
 import io.digdag.spi.Scheduler;
@@ -114,6 +116,9 @@ public class SchedulerManager
             c.set("_command", command);
         }
 
+        Optional<Instant> startDate = c.getOptional("start_date", String.class).transform(it -> LocalTimeOrInstant.fromString(it).toInstant(workflowTimeZone));
+        Optional<Instant> endDate = c.getOptional("end_date", String.class).transform(it -> LocalTimeOrInstant.fromString(it).toInstant(workflowTimeZone));
+
         for(String param : BUILT_IN_SCHEDULE_PARAMS){
             usedKeys.add(param);
         }
@@ -138,7 +143,7 @@ public class SchedulerManager
             }
         }
 
-        return factory.newScheduler(c, workflowTimeZone);
+        return factory.newScheduler(c, workflowTimeZone, startDate, endDate);
     }
 
     private String getWarnUnusedKey(String shouldBeUsedButNotUsedKey, Collection<String> candidateKeys)

--- a/digdag-core/src/main/java/io/digdag/core/schedule/StoredSchedule.java
+++ b/digdag-core/src/main/java/io/digdag/core/schedule/StoredSchedule.java
@@ -25,4 +25,8 @@ public abstract class StoredSchedule
     public abstract Optional<Instant> getDisabledAt();
 
     public abstract Optional<Instant> getLastSessionTime();
+
+    public abstract Optional<Instant> getStartDate();
+
+    public abstract Optional<Instant> getEndDate();
 }

--- a/digdag-core/src/test/java/io/digdag/core/schedule/ScheduleExecutorTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/schedule/ScheduleExecutorTest.java
@@ -111,6 +111,8 @@ public class ScheduleExecutorTest
         when(schedule.getWorkflowDefinitionId()).thenReturn(WORKFLOW_DEFINITION_ID);
         when(schedule.getNextScheduleTime()).thenReturn(now);
         when(schedule.getNextRunTime()).thenReturn(now);
+        when(schedule.getStartDate()).thenReturn(Optional.absent());
+        when(schedule.getEndDate()).thenReturn(Optional.absent());
 
         when(sessionStoreManager.getSessionStore(SITE_ID)).thenReturn(sessionStore);
         when(projectStoreManager.getWorkflowDetailsById(WORKFLOW_DEFINITION_ID)).thenReturn(workflowDefinition);

--- a/digdag-server/src/main/java/io/digdag/server/rs/RestModels.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/RestModels.java
@@ -192,6 +192,8 @@ public final class RestModels
             .nextRunTime(sched.getNextRunTime())
             .nextScheduleTime(OffsetDateTime.ofInstant(sched.getNextScheduleTime(), timeZone))
             .disabledAt(sched.getDisabledAt())
+            .startDate(sched.getStartDate())
+            .endDate(sched.getEndDate())
             .build();
     }
 
@@ -244,6 +246,8 @@ public final class RestModels
             .createdAt(sched.getCreatedAt())
             .updatedAt(sched.getCreatedAt())
             .disabledAt(sched.getDisabledAt())
+            .startDate(sched.getStartDate())
+            .endDate(sched.getEndDate())
             .build();
     }
 

--- a/digdag-spi/src/main/java/io/digdag/spi/ScheduleTime.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/ScheduleTime.java
@@ -4,6 +4,7 @@ import java.time.Instant;
 import org.immutables.value.Value;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.common.base.Optional;
 
 @Value.Immutable
 @JsonSerialize(as = ImmutableScheduleTime.class)
@@ -27,11 +28,17 @@ public interface ScheduleTime
      */
     Instant getTime();
 
-    static ScheduleTime of(Instant time, Instant runTime)
+    Optional<Instant> getStartDate();
+
+    Optional<Instant> getEndDate();
+
+    static ScheduleTime of(Instant time, Instant runTime, Optional<Instant> startDate, Optional<Instant> endDate)
     {
         return ImmutableScheduleTime.builder()
             .time(time)
             .runTime(runTime)
+            .startDate(startDate)
+            .endDate(endDate)
             .build();
     }
 

--- a/digdag-spi/src/main/java/io/digdag/spi/Scheduler.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/Scheduler.java
@@ -1,11 +1,17 @@
 package io.digdag.spi;
 
+import com.google.common.base.Optional;
+
 import java.time.Instant;
 import java.time.ZoneId;
 
 public interface Scheduler
 {
     ZoneId getTimeZone();
+
+    Optional<Instant> getStartDate();
+
+    Optional<Instant> getEndDate();
 
     // align given time with the last time of this schedule.
     // getRunTime of returned ScheduleTime is same or after currentTime.

--- a/digdag-spi/src/main/java/io/digdag/spi/SchedulerFactory.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/SchedulerFactory.java
@@ -1,11 +1,14 @@
 package io.digdag.spi;
 
+import java.time.Instant;
 import java.time.ZoneId;
+
+import com.google.common.base.Optional;
 import io.digdag.client.config.Config;
 
 public interface SchedulerFactory
 {
     String getType();
 
-    Scheduler newScheduler(Config config, ZoneId timeZone);
+    Scheduler newScheduler(Config config, ZoneId timeZone, Optional<Instant> startDate, Optional<Instant> endDate);
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/scheduler/CronScheduler.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/scheduler/CronScheduler.java
@@ -4,6 +4,8 @@ import java.util.Date;
 import java.util.TimeZone;
 import java.time.Instant;
 import java.time.ZoneId;
+
+import com.google.common.base.Optional;
 import io.digdag.spi.ScheduleTime;
 import io.digdag.spi.Scheduler;
 import it.sauronsoftware.cron4j.SchedulingPattern;
@@ -15,8 +17,10 @@ public class CronScheduler
     private final SchedulingPattern pattern;
     private final ZoneId timeZone;
     private final long delaySeconds;
+    private final Optional<Instant> startDate;
+    private final Optional<Instant> endDate;
 
-    CronScheduler(String cronPattern, ZoneId timeZone, long delaySeconds)
+    CronScheduler(String cronPattern, ZoneId timeZone, long delaySeconds, Optional<Instant> startDate, Optional<Instant> endDate)
     {
         this.pattern = new SchedulingPattern(cronPattern) {
             // workaround for a bug of cron4j:
@@ -29,12 +33,26 @@ public class CronScheduler
         };
         this.timeZone = timeZone;
         this.delaySeconds = delaySeconds;
+        this.startDate = startDate;
+        this.endDate = endDate;
     }
 
     @Override
     public ZoneId getTimeZone()
     {
         return timeZone;
+    }
+
+    @Override
+    public Optional<Instant> getStartDate()
+    {
+        return startDate;
+    }
+
+    @Override
+    public Optional<Instant> getEndDate()
+    {
+        return endDate;
     }
 
     @Override
@@ -58,7 +76,7 @@ public class CronScheduler
     public ScheduleTime nextScheduleTime(Instant lastScheduleTime)
     {
         Instant next = next(lastScheduleTime);
-        return ScheduleTime.of(next, next.plusSeconds(delaySeconds));
+        return ScheduleTime.of(next, next.plusSeconds(delaySeconds), startDate, endDate);
     }
 
     @Override
@@ -83,7 +101,7 @@ public class CronScheduler
         }
 
         // nextOfBefore is same with currentScheduleTime or after currentScheduleTime. nextOfBefore is next of before. done.
-        return ScheduleTime.of(before, before.plusSeconds(delaySeconds));
+        return ScheduleTime.of(before, before.plusSeconds(delaySeconds), startDate, endDate);
     }
 
     private Instant next(Instant time)

--- a/digdag-standards/src/main/java/io/digdag/standards/scheduler/CronSchedulerFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/scheduler/CronSchedulerFactory.java
@@ -1,6 +1,9 @@
 package io.digdag.standards.scheduler;
 
+import java.time.Instant;
 import java.time.ZoneId;
+
+import com.google.common.base.Optional;
 import io.digdag.client.config.Config;
 import io.digdag.spi.Scheduler;
 import io.digdag.spi.SchedulerFactory;
@@ -15,11 +18,13 @@ public class CronSchedulerFactory
     }
 
     @Override
-    public Scheduler newScheduler(Config config, ZoneId timeZone)
+    public Scheduler newScheduler(Config config, ZoneId timeZone, Optional<Instant> startDate, Optional<Instant> endDate)
     {
         return new CronScheduler(
                 config.get("_command", String.class),
                 timeZone,
-                config.get("delay", long.class, 0L));
+                config.get("delay", long.class, 0L),
+                startDate,
+                endDate);
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/scheduler/DailySchedulerFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/scheduler/DailySchedulerFactory.java
@@ -1,6 +1,9 @@
 package io.digdag.standards.scheduler;
 
+import java.time.Instant;
 import java.time.ZoneId;
+
+import com.google.common.base.Optional;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigException;
 import io.digdag.spi.Scheduler;
@@ -16,10 +19,10 @@ public class DailySchedulerFactory
     }
 
     @Override
-    public Scheduler newScheduler(Config config, ZoneId timeZone)
+    public Scheduler newScheduler(Config config, ZoneId timeZone, Optional<Instant> startDate, Optional<Instant> endDate)
     {
         String at = config.getOptional("_command", String.class).or(() -> config.get("at", String.class));
-        return new CronScheduler("0 0 * * *", timeZone, parseAt("daily>", at));
+        return new CronScheduler("0 0 * * *", timeZone, parseAt("daily>", at), startDate, endDate);
     }
 
     static long parseAt(String kind, String at)

--- a/digdag-standards/src/main/java/io/digdag/standards/scheduler/HourlySchedulerFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/scheduler/HourlySchedulerFactory.java
@@ -1,6 +1,9 @@
 package io.digdag.standards.scheduler;
 
+import java.time.Instant;
 import java.time.ZoneId;
+
+import com.google.common.base.Optional;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigException;
 import io.digdag.spi.Scheduler;
@@ -16,10 +19,10 @@ public class HourlySchedulerFactory
     }
 
     @Override
-    public Scheduler newScheduler(Config config, ZoneId timeZone)
+    public Scheduler newScheduler(Config config, ZoneId timeZone, Optional<Instant> startDate, Optional<Instant> endDate)
     {
         String at = config.getOptional("_command", String.class).or(() -> config.get("at", String.class));
-        return new CronScheduler("0 * * * *", timeZone, parseAt(at));
+        return new CronScheduler("0 * * * *", timeZone, parseAt(at), startDate, endDate);
     }
 
     private long parseAt(String at)

--- a/digdag-standards/src/main/java/io/digdag/standards/scheduler/MinutesIntervalSchedulerFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/scheduler/MinutesIntervalSchedulerFactory.java
@@ -1,6 +1,9 @@
 package io.digdag.standards.scheduler;
 
+import java.time.Instant;
 import java.time.ZoneId;
+
+import com.google.common.base.Optional;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigException;
 import io.digdag.spi.Scheduler;
@@ -16,10 +19,10 @@ public class MinutesIntervalSchedulerFactory
     }
 
     @Override
-    public Scheduler newScheduler(Config config, ZoneId timeZone)
+    public Scheduler newScheduler(Config config, ZoneId timeZone, Optional<Instant> startDate, Optional<Instant> endDate)
     {
         int interval = config.get("_command", int.class);
         long delay = config.get("delay", long.class, 0L);
-        return new CronScheduler("*/" + interval + " * * * *", timeZone, delay);
+        return new CronScheduler("*/" + interval + " * * * *", timeZone, delay, startDate, endDate);
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/scheduler/MonthlySchedulerFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/scheduler/MonthlySchedulerFactory.java
@@ -1,6 +1,9 @@
 package io.digdag.standards.scheduler;
 
+import java.time.Instant;
 import java.time.ZoneId;
+
+import com.google.common.base.Optional;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigException;
 import io.digdag.spi.Scheduler;
@@ -18,7 +21,7 @@ public class MonthlySchedulerFactory
     }
 
     @Override
-    public Scheduler newScheduler(Config config, ZoneId timeZone)
+    public Scheduler newScheduler(Config config, ZoneId timeZone, Optional<Instant> startDate, Optional<Instant> endDate)
     {
         String desc = config.getOptional("_command", String.class).or(() -> config.get("at", String.class));
 
@@ -37,6 +40,6 @@ public class MonthlySchedulerFactory
 
         long dailyDelay = parseAt("monthly>", fragments[1]);
 
-        return new CronScheduler("0 0 " + day + " * *", timeZone, dailyDelay);
+        return new CronScheduler("0 0 " + day + " * *", timeZone, dailyDelay, startDate, endDate);
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/scheduler/SecondsIntervalSchedulerFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/scheduler/SecondsIntervalSchedulerFactory.java
@@ -1,5 +1,6 @@
 package io.digdag.standards.scheduler;
 
+import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import io.digdag.client.config.Config;
 import io.digdag.spi.ScheduleTime;
@@ -21,11 +22,11 @@ public class SecondsIntervalSchedulerFactory
     }
 
     @Override
-    public Scheduler newScheduler(Config config, ZoneId timeZone)
+    public Scheduler newScheduler(Config config, ZoneId timeZone, Optional<Instant> startDate, Optional<Instant> endDate)
     {
         int interval = config.get("_command", int.class);
         long delay = config.get("delay", long.class, 0L);
-        return new SecondsIntervalScheduler(timeZone, interval, delay);
+        return new SecondsIntervalScheduler(timeZone, interval, delay, startDate, endDate);
     }
 
     static class SecondsIntervalScheduler
@@ -34,12 +35,16 @@ public class SecondsIntervalSchedulerFactory
         private final ZoneId timeZone;
         private final int interval;
         private final long delay;
+        private final Optional<Instant> startDate;
+        private final Optional<Instant> endDate;
 
-        SecondsIntervalScheduler(ZoneId timeZone, int interval, long delay)
+        SecondsIntervalScheduler(ZoneId timeZone, int interval, long delay, Optional<Instant> startDate, Optional<Instant> endDate)
         {
             this.timeZone = timeZone;
             this.interval = interval;
             this.delay = delay;
+            this.startDate = startDate;
+            this.endDate = endDate;
         }
 
         @Override
@@ -47,6 +52,19 @@ public class SecondsIntervalSchedulerFactory
         {
             return timeZone;
         }
+
+        @Override
+        public Optional<Instant> getStartDate()
+        {
+            return startDate;
+        }
+
+        @Override
+        public Optional<Instant> getEndDate()
+        {
+            return endDate;
+        }
+
 
         @Override
         public ScheduleTime getFirstScheduleTime(Instant currentTime)
@@ -62,7 +80,7 @@ public class SecondsIntervalSchedulerFactory
             long truncatedEpoch = lastScheduleTime.getEpochSecond() - (lastScheduleTime.getEpochSecond() % interval);
             long nextEpoch = truncatedEpoch + interval;
             Instant next = Instant.ofEpochSecond(nextEpoch);
-            return ScheduleTime.of(next, next.plusSeconds(delay));
+            return ScheduleTime.of(next, next.plusSeconds(delay), startDate, endDate);
         }
 
         @Override
@@ -72,7 +90,7 @@ public class SecondsIntervalSchedulerFactory
             currentScheduleTime = currentScheduleTime.minusNanos(1);
             long lastEpoch = currentScheduleTime.getEpochSecond() - (currentScheduleTime.getEpochSecond() % interval);
             Instant last = Instant.ofEpochSecond(lastEpoch);
-            return ScheduleTime.of(last, last.plusSeconds(delay));
+            return ScheduleTime.of(last, last.plusSeconds(delay), startDate, endDate);
         }
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/scheduler/WeeklySchedulerFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/scheduler/WeeklySchedulerFactory.java
@@ -1,11 +1,13 @@
 package io.digdag.standards.scheduler;
 
+import com.google.common.base.Optional;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigException;
 import io.digdag.spi.Scheduler;
 import io.digdag.spi.SchedulerFactory;
 import it.sauronsoftware.cron4j.SchedulingPattern;
 
+import java.time.Instant;
 import java.time.ZoneId;
 
 import static io.digdag.standards.scheduler.DailySchedulerFactory.parseAt;
@@ -20,7 +22,7 @@ public class WeeklySchedulerFactory
     }
 
     @Override
-    public Scheduler newScheduler(Config config, ZoneId timeZone)
+    public Scheduler newScheduler(Config config, ZoneId timeZone, Optional<Instant> startDate, Optional<Instant> endDate)
     {
         String desc = config.getOptional("_command", String.class).or(() -> config.get("at", String.class));
 
@@ -50,6 +52,6 @@ public class WeeklySchedulerFactory
             throw new ConfigException("weekly>: scheduler requires day,hh:mm:ss format: " + desc);
         }
 
-        return new CronScheduler(cronPattern, timeZone, dailyDelay);
+        return new CronScheduler(cronPattern, timeZone, dailyDelay, startDate, endDate);
     }
 }

--- a/digdag-standards/src/test/java/io/digdag/standards/scheduler/DailySchedulerTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/scheduler/DailySchedulerTest.java
@@ -3,6 +3,8 @@ package io.digdag.standards.scheduler;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+
+import com.google.common.base.Optional;
 import io.digdag.client.config.Config;
 import io.digdag.client.config.ConfigFactory;
 import io.digdag.spi.Scheduler;
@@ -22,7 +24,7 @@ public class DailySchedulerTest
 
     static Scheduler newScheduler(String pattern, String timeZone)
     {
-        return new DailySchedulerFactory().newScheduler(newConfig().set("_command", pattern), ZoneId.of(timeZone));
+        return new DailySchedulerFactory().newScheduler(newConfig().set("_command", pattern), ZoneId.of(timeZone), Optional.absent(), Optional.absent());
     }
 
     private static DateTimeFormatter TIME_FORMAT =
@@ -44,7 +46,9 @@ public class DailySchedulerTest
                 newScheduler("10:00:00", "UTC").getFirstScheduleTime(currentTime1),
                 is(ScheduleTime.of(
                         instant("2016-02-03 00:00:00 +0000"),
-                        instant("2016-02-03 10:00:00 +0000"))));
+                        instant("2016-02-03 10:00:00 +0000"),
+                        Optional.absent(),
+                        Optional.absent())));
 
         // current time is 16:00:00
         // schedule is 10:00:00 every day
@@ -54,7 +58,9 @@ public class DailySchedulerTest
                 newScheduler("10:00:00", "UTC").getFirstScheduleTime(currentTime2),
                 is(ScheduleTime.of(
                         instant("2016-02-04 00:00:00 +0000"),
-                        instant("2016-02-04 10:00:00 +0000"))));
+                        instant("2016-02-04 10:00:00 +0000"),
+                        Optional.absent(),
+                        Optional.absent())));
     }
 
     @Test
@@ -67,14 +73,18 @@ public class DailySchedulerTest
                 newScheduler("10:00:00", "Asia/Tokyo").getFirstScheduleTime(currentTime1),
                 is(ScheduleTime.of(
                         instant("2016-02-03 00:00:00 +0900"),
-                        instant("2016-02-03 10:00:00 +0900"))));
+                        instant("2016-02-03 10:00:00 +0900"),
+                        Optional.absent(),
+                        Optional.absent())));
 
         Instant currentTime2 = instant("2016-02-03 16:00:00 +0900");
         assertThat(
                 newScheduler("10:00:00", "Asia/Tokyo").getFirstScheduleTime(currentTime2),
                 is(ScheduleTime.of(
                         instant("2016-02-04 00:00:00 +0900"),
-                        instant("2016-02-04 10:00:00 +0900"))));
+                        instant("2016-02-04 10:00:00 +0900"),
+                        Optional.absent(),
+                        Optional.absent())));
     }
 
     @Test
@@ -91,14 +101,18 @@ public class DailySchedulerTest
                 newScheduler("10:00:00", "America/Los_Angeles").getFirstScheduleTime(currentTime1),
                 is(ScheduleTime.of(
                         instant("2016-03-13 00:00:00 -0800"),
-                        instant("2016-03-13 11:00:00 -0700"))));  // schedule runs at 10:00:00 although definition is "daily> 10:00:00"
+                        instant("2016-03-13 11:00:00 -0700"), // schedule runs at 10:00:00 although definition is "daily> 10:00:00"
+                        Optional.absent(),
+                        Optional.absent())));
 
         Instant currentTime2 = instant("2016-03-13 16:00:00 -0700");
         assertThat(
                 newScheduler("10:00:00", "America/Los_Angeles").getFirstScheduleTime(currentTime2),
                 is(ScheduleTime.of(
                         instant("2016-03-14 00:00:00 -0700"),
-                        instant("2016-03-14 10:00:00 -0700"))));
+                        instant("2016-03-14 10:00:00 -0700"),
+                        Optional.absent(),
+                        Optional.absent())));
     }
 
     @Test
@@ -109,21 +123,27 @@ public class DailySchedulerTest
                 newScheduler("10:00:00", "UTC").getFirstScheduleTime(currentTime1),
                 is(ScheduleTime.of(
                         instant("2016-03-13 00:00:00 +0000"),
-                        instant("2016-03-13 10:00:00 +0000"))));
+                        instant("2016-03-13 10:00:00 +0000"),
+                        Optional.absent(),
+                        Optional.absent())));
 
         Instant currentTime2 = instant("2016-03-13 10:00:00 +0000");
         assertThat(
                 newScheduler("10:00:00", "UTC").getFirstScheduleTime(currentTime2),
                 is(ScheduleTime.of(
                         instant("2016-03-13 00:00:00 +0000"),
-                        instant("2016-03-13 10:00:00 +0000"))));
+                        instant("2016-03-13 10:00:00 +0000"),
+                        Optional.absent(),
+                        Optional.absent())));
 
         Instant currentTime3 = instant("2016-03-13 00:00:00 +0000");
         assertThat(
                 newScheduler("00:00:00", "UTC").getFirstScheduleTime(currentTime3),
                 is(ScheduleTime.of(
                         instant("2016-03-13 00:00:00 +0000"),
-                        instant("2016-03-13 00:00:00 +0000"))));
+                        instant("2016-03-13 00:00:00 +0000"),
+                        Optional.absent(),
+                        Optional.absent())));
     }
 
     @Test
@@ -137,7 +157,9 @@ public class DailySchedulerTest
                 newScheduler("10:00:00", "UTC").nextScheduleTime(lastScheduleTime1),
                 is(ScheduleTime.of(
                         instant("2016-02-04 00:00:00 +0000"),
-                        instant("2016-02-04 10:00:00 +0000"))));
+                        instant("2016-02-04 10:00:00 +0000"),
+                        Optional.absent(),
+                        Optional.absent())));
     }
 
     @Test
@@ -150,7 +172,9 @@ public class DailySchedulerTest
                 newScheduler("10:00:00", "Asia/Tokyo").nextScheduleTime(lastScheduleTime1),
                 is(ScheduleTime.of(
                         instant("2016-02-04 00:00:00 +0900"),
-                        instant("2016-02-04 10:00:00 +0900"))));
+                        instant("2016-02-04 10:00:00 +0900"),
+                        Optional.absent(),
+                        Optional.absent())));
     }
 
     @Test
@@ -161,14 +185,18 @@ public class DailySchedulerTest
                 newScheduler("10:00:00", "America/Los_Angeles").nextScheduleTime(lastScheduleTime1),
                 is(ScheduleTime.of(
                         instant("2016-03-13 00:00:00 -0800"),
-                        instant("2016-03-13 10:00:00 -0800"))));
+                        instant("2016-03-13 10:00:00 -0800"),
+                        Optional.absent(),
+                        Optional.absent())));
 
         Instant lastScheduleTime2 = instant("2016-03-13 00:00:00 -0800");
         assertThat(
                 newScheduler("10:00:00", "America/Los_Angeles").nextScheduleTime(lastScheduleTime2),
                 is(ScheduleTime.of(
                         instant("2016-03-14 00:00:00 -0700"),
-                        instant("2016-03-14 10:00:00 -0700"))));
+                        instant("2016-03-14 10:00:00 -0700"),
+                        Optional.absent(),
+                        Optional.absent())));
     }
 
     @Test
@@ -182,7 +210,9 @@ public class DailySchedulerTest
                 newScheduler("10:00:00", "UTC").lastScheduleTime(currentScheduleTime1),
                 is(ScheduleTime.of(
                         instant("2016-02-02 00:00:00 +0000"),
-                        instant("2016-02-02 10:00:00 +0000"))));
+                        instant("2016-02-02 10:00:00 +0000"),
+                        Optional.absent(),
+                        Optional.absent())));
     }
 
     @Test
@@ -195,7 +225,9 @@ public class DailySchedulerTest
                 newScheduler("10:00:00", "Asia/Tokyo").lastScheduleTime(currentScheduleTime1),
                 is(ScheduleTime.of(
                         instant("2016-02-02 00:00:00 +0900"),
-                        instant("2016-02-02 10:00:00 +0900"))));
+                        instant("2016-02-02 10:00:00 +0900"),
+                        Optional.absent(),
+                        Optional.absent())));
     }
 
     @Test
@@ -206,13 +238,17 @@ public class DailySchedulerTest
                 newScheduler("10:00:00", "America/Los_Angeles").lastScheduleTime(currentScheduleTime1),
                 is(ScheduleTime.of(
                         instant("2016-03-12 00:00:00 -0800"),
-                        instant("2016-03-12 10:00:00 -0800"))));
+                        instant("2016-03-12 10:00:00 -0800"),
+                        Optional.absent(),
+                        Optional.absent())));
 
         Instant currentScheduleTime2 = instant("2016-03-14 00:00:00 -0700");
         assertThat(
                 newScheduler("10:00:00", "America/Los_Angeles").lastScheduleTime(currentScheduleTime2),
                 is(ScheduleTime.of(
                         instant("2016-03-13 00:00:00 -0800"),
-                        instant("2016-03-13 10:00:00 -0800"))));
+                        instant("2016-03-13 10:00:00 -0800"),
+                        Optional.absent(),
+                        Optional.absent())));
     }
 }

--- a/digdag-standards/src/test/java/io/digdag/standards/scheduler/SecondsIntervalSchedulerTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/scheduler/SecondsIntervalSchedulerTest.java
@@ -1,5 +1,6 @@
 package io.digdag.standards.scheduler;
 
+import com.google.common.base.Optional;
 import io.digdag.spi.ScheduleTime;
 import io.digdag.standards.scheduler.SecondsIntervalSchedulerFactory.SecondsIntervalScheduler;
 import org.junit.Test;
@@ -16,38 +17,38 @@ public class SecondsIntervalSchedulerTest
     public void testGetFirstScheduleTime()
             throws Exception
     {
-        SecondsIntervalScheduler scheduler = new SecondsIntervalScheduler(UTC, 3, 2);
+        SecondsIntervalScheduler scheduler = new SecondsIntervalScheduler(UTC, 3, 2, Optional.absent(), Optional.absent());
 
         assertThat(scheduler.getFirstScheduleTime(Instant.ofEpochSecond(3)),
-                is(ScheduleTime.of(Instant.ofEpochSecond(3), Instant.ofEpochSecond(5))));
+                is(ScheduleTime.of(Instant.ofEpochSecond(3), Instant.ofEpochSecond(5), Optional.absent(), Optional.absent())));
 
         assertThat(scheduler.getFirstScheduleTime(Instant.ofEpochSecond(4)),
-                is(ScheduleTime.of(Instant.ofEpochSecond(6), Instant.ofEpochSecond(8))));
+                is(ScheduleTime.of(Instant.ofEpochSecond(6), Instant.ofEpochSecond(8), Optional.absent(), Optional.absent())));
     }
 
     @Test
     public void testNextScheduleTime()
             throws Exception
     {
-        SecondsIntervalScheduler scheduler = new SecondsIntervalScheduler(UTC, 3, 2);
+        SecondsIntervalScheduler scheduler = new SecondsIntervalScheduler(UTC, 3, 2, Optional.absent(), Optional.absent());
 
         assertThat(scheduler.nextScheduleTime(Instant.ofEpochSecond(3)),
-                is(ScheduleTime.of(Instant.ofEpochSecond(6), Instant.ofEpochSecond(8))));
+                is(ScheduleTime.of(Instant.ofEpochSecond(6), Instant.ofEpochSecond(8), Optional.absent(), Optional.absent())));
 
         assertThat(scheduler.nextScheduleTime(Instant.ofEpochSecond(4)),
-                is(ScheduleTime.of(Instant.ofEpochSecond(6), Instant.ofEpochSecond(8))));
+                is(ScheduleTime.of(Instant.ofEpochSecond(6), Instant.ofEpochSecond(8), Optional.absent(), Optional.absent())));
     }
 
     @Test
     public void testLastScheduleTime()
             throws Exception
     {
-        SecondsIntervalScheduler scheduler = new SecondsIntervalScheduler(UTC, 3, 2);
+        SecondsIntervalScheduler scheduler = new SecondsIntervalScheduler(UTC, 3, 2, Optional.absent(), Optional.absent());
 
         assertThat(scheduler.lastScheduleTime(Instant.ofEpochSecond(3)),
-                is(ScheduleTime.of(Instant.ofEpochSecond(0), Instant.ofEpochSecond(2))));
+                is(ScheduleTime.of(Instant.ofEpochSecond(0), Instant.ofEpochSecond(2), Optional.absent(), Optional.absent())));
 
         assertThat(scheduler.lastScheduleTime(Instant.ofEpochSecond(4)),
-                is(ScheduleTime.of(Instant.ofEpochSecond(3), Instant.ofEpochSecond(5))));
+                is(ScheduleTime.of(Instant.ofEpochSecond(3), Instant.ofEpochSecond(5), Optional.absent(), Optional.absent())));
     }
 }


### PR DESCRIPTION
I sometimes want to run workflows only limited period.
This PR includes:

* Add `start_date` and `end_date` columns into `schedules` table
* Both columns are nullable, so
  * When both of them are null, it behaves as is
  * When start_date is set, it runs once start_date comes
  * When end_date is set, it runs until end_date comes
  * When both of them are set, it runs only when `start_date < now() < end_date`
* `start_date` and `end_date` can be specified only on dig file like below, acceptable datetime format is arguable, but I think it's better to not allow to set timezone (timezone can be configurable only `timezone` confg)

```
timezone: Asia/Tokyo

schedule:
  minutes_interval>: 1
  start_date: 2022-02-23T14:01:00
  end_date: 2022-02-23T14:03:00

_export:

+say_hello:
  echo>: Hello world!
```