### PR TITLE
[digdag-ui] display detailed time when mouse-over on relative time.

### DIFF
--- a/digdag-ui/console.jsx
+++ b/digdag-ui/console.jsx
@@ -1377,7 +1377,7 @@ class Timestamp extends React.Component {
     const m = moment(t)
     return (
       <span>
-        <span>{m.fromNow()}</span>
+        <span title={m.format()}>{m.fromNow()}</span>
         <ReactInterval timeout={1000} enabled={Boolean(true)} callback={() => this.forceUpdate()} />
       </span>
     )


### PR DESCRIPTION
# Overview
I have added a display of detailed time when mouse-over on relative time.
The time displayed is local time(format is "yyyy-MM-dd HH:mm:ss Z").

# Why?
#997 

# Resuls
## Demo(movie)
When mouseover on Last Attempt in Sessions
![mouseover-demo](https://user-images.githubusercontent.com/13377817/156917854-732e13f0-3f40-4fdd-9cc1-b86c3ed35db5.gif)

## Images
When mouseover on Last Attempt in Sessions
<img width="1326" alt="スクリーンショット 2022-03-06 18 41 28" src="https://user-images.githubusercontent.com/13377817/156917702-87bbec93-0cb4-4e7d-a380-384ba095896c.png">

When mouseover on Updated in Projects
<img width="1323" alt="スクリーンショット 2022-03-06 18 42 07" src="https://user-images.githubusercontent.com/13377817/156917725-329432d5-5d40-4c1d-a6d4-36d9a90d01bc.png">


When mouseover on Created in Attempts
<img width="1323" alt="スクリーンショット 2022-03-06 18 42 36" src="https://user-images.githubusercontent.com/13377817/156917745-b5c24cca-7eb2-4f01-a460-98f52ade6365.png">

