### PR TITLE
add: ruby_examples_for_generating_subtasks

### DIFF
--- a/examples/python_generate_subtasks.dig
+++ b/examples/python_generate_subtasks.dig
@@ -5,4 +5,3 @@ timezone: UTC
 
 +parallel_process:
   py>: tasks.generate_subtasks.ParallelProcess.run
-

--- a/examples/ruby_generate_subtasks.dig
+++ b/examples/ruby_generate_subtasks.dig
@@ -1,0 +1,23 @@
+timezone: UTC
+
+_export:
+  rb:
+    require: tasks/generate_subtasks
+
++just_params:
+  +split:
+    rb>: JustParams::ParallelProcess.split
+  +parallel_process:
+    rb>: JustParams::ParallelProcess.run
+
++with_singleton_method:
+  +split:
+    rb>: WithSingletonMethod::ParallelProcess.split
+  +parallel_process:
+    rb>: WithSingletonMethod::ParallelProcess.run
+
++with_instance_method:
+  +split:
+    rb>: WithInstanceMethod::ParallelProcess.split
+  +parallel_process:
+    rb>: WithInstanceMethod::ParallelProcess.run

--- a/examples/tasks/generate_subtasks.rb
+++ b/examples/tasks/generate_subtasks.rb
@@ -1,0 +1,63 @@
+# add_subtask(params)
+module JustParams
+  class ParallelProcess
+    def split
+      Digdag.env.store(task_count: 3)
+    end
+
+    def run(task_count)
+      tasks = task_count.times.each_with_object({}) do |i, memo|
+        memo["+task#{i}"] = {
+          'rb>': 'JustParams::ParallelProcess.subtask',
+          index: i
+        }
+      end
+      tasks['_parallel'] = true
+      Digdag.env.add_subtask(tasks)
+    end
+  end
+
+  def subtask(index)
+    puts("Processing" + index.to_s)
+  end
+end
+
+# add_subtask(singleton_method_name, params={})
+module WithSingletonMethod
+  class ParallelProcess
+    def split
+      Digdag.env.store(task_count: 3)
+    end
+
+    def run(task_count)
+      task_count.times do |i|
+        Digdag.env.add_subtask(:subtask, index: i)
+      end
+      Digdag.env.subtask_config['_parallel'] = true
+    end
+  end
+end
+
+def subtask(index)
+  puts("Processing" + index.to_s)
+end
+
+# add_subtask(klass, instance_method_name, params={})
+module WithInstanceMethod
+  class ParallelProcess
+    def split
+      Digdag.env.store(task_count: 3)
+    end
+
+    def run(task_count)
+      task_count.times do |i|
+        Digdag.env.add_subtask(ParallelProcess, :subtask, index: i)
+      end
+      Digdag.env.subtask_config['_parallel'] = true
+    end
+
+    def subtask(index)
+      puts("Processing" + index.to_s)
+    end
+  end
+end


### PR DESCRIPTION
I added examples for `generating subtasks` with Ruby language API.

- a usecase with [add_subtask(params)()](https://github.com/treasure-data/digdag/blob/42ea7cb71270957ea6424c2df88dd7c65d248789/digdag-standards/src/main/resources/digdag/standards/rb/runner.rb#L58)
- a usecase with [add_subtask(singleton_method_name, params={})](https://github.com/treasure-data/digdag/blob/42ea7cb71270957ea6424c2df88dd7c65d248789/digdag-standards/src/main/resources/digdag/standards/rb/runner.rb#L62)
- a usecase with [add_subtask(klass, instance_method_name, params={})](https://github.com/treasure-data/digdag/blob/42ea7cb71270957ea6424c2df88dd7c65d248789/digdag-standards/src/main/resources/digdag/standards/rb/runner.rb#L80)