### PR TITLE
Update js-untar

### DIFF
--- a/digdag-ui/package-lock.json
+++ b/digdag-ui/package-lock.json
@@ -13942,9 +13942,9 @@
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-untar": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/js-untar/-/js-untar-0.1.4.tgz",
-      "integrity": "sha1-BBi/T9jboZ4QRaVHix7ZA2rldl0="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/js-untar/-/js-untar-2.0.0.tgz",
+      "integrity": "sha512-7CsDLrYQMbLxDt2zl9uKaPZSdmJMvGGQ7wo9hoB3J+z/VcO2w63bXFgHVnjF1+S9wD3zAu8FBVj7EYWjTQ3Z7g=="
     },
     "js-yaml": {
       "version": "3.13.1",

--- a/digdag-ui/package.json
+++ b/digdag-ui/package.json
@@ -27,7 +27,7 @@
     "cryptiles": "4.1.2",
     "duration": "^0.2.0",
     "jquery": "3.5.1",
-    "js-untar": "0.1.4",
+    "js-untar": "^2.0.0",
     "js-yaml": "3.13.1",
     "lodash": "^4.17.21",
     "lru-cache": "4.0.2",


### PR DESCRIPTION
fix https://github.com/treasure-data/digdag/issues/1652

I updated js-untar to v2.0.0.
js-untar v0.1.4 doesn't terminate Web Worker after completing untar.

see: https://github.com/InvokIT/js-untar/pull/17