### PR TITLE
Add multiple options to make a connection with ECS Cluster.

### DIFF
--- a/digdag-docs/src/command_executor.md
+++ b/digdag-docs/src/command_executor.md
@@ -39,8 +39,8 @@ Each sub keys of `agent.command_executor` are as follows:
 | key                                |  description                                     |
 | :--------------------------------- | :----------------------------------------------- |
 | ecs.name                           | ECS Cluster name. The value &lt;name&gt; is used as the key of following configuration |
-| ecs.&lt;name&gt;.access_key_id     | AWS access key for ECS. The key needs permissions for ECS and CloudWatch  |
-| ecs.&lt;name&gt;.secret_access_key | AWS secret key                                   |
+| ecs.&lt;name&gt;.access_key_id     | (Optional)AWS access key for ECS. The key needs permissions for ECS and CloudWatch. If it is not specified, other credentials are used for authorization.  |
+| ecs.&lt;name&gt;.secret_access_key | (Optional)AWS secret key                                   |
 | ecs.&lt;name&gt;.launch_type       | The launch type of container. `FARGATE` or `EC2` |
 | ecs.&lt;name&gt;.region            | AWS region                                       |
 | ecs.&lt;name&gt;.subnets           | AWS subnet                                       |
@@ -55,6 +55,10 @@ Following keys are for configuration of temporal storage with AWS S3.
 | ecs.temporal_storage.s3.endpoint                      | The end point URL for S3         |
 | ecs.temporal_storage.s3.credentials.access-key-id     | AWS access key for the bucket    |
 | ecs.temporal_storage.s3.credentials.secret-access-key | AWS secret key                   |
+
+#### The ways of authorizing to ECS cluster and tasks.
+[DefaultAWSCredentialsProviderChain](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html) besides AWS access key and secret can be used as a credential for connecting with ECS on version 0.10.5 or above . As a result of that, if `ecs.<name>.access_key_id` is not specified, digdag server looks for one of the credentials described in the document.
+
 
 ### How to use from workflow
 

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/DefaultEcsClientFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/DefaultEcsClientFactory.java
@@ -2,8 +2,10 @@ package io.digdag.standards.command.ecs;
 
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.Protocol;
+import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.services.ecs.AmazonECSClient;
 import com.amazonaws.services.logs.AWSLogs;
 import com.amazonaws.services.logs.AWSLogsClient;
@@ -16,9 +18,19 @@ public class DefaultEcsClientFactory
     public EcsClient createClient(final EcsClientConfig ecsClientConfig)
             throws ConfigException
     {
-        // TODO improve to enable several types of credentials providers
-        final AWSStaticCredentialsProvider credentials = new AWSStaticCredentialsProvider(
-                new BasicAWSCredentials(ecsClientConfig.getAccessKeyId(), ecsClientConfig.getSecretAccessKey()));
+        final AWSCredentialsProvider credentials;
+        if (ecsClientConfig.getAccessKeyId().isPresent()) {
+                credentials = new AWSStaticCredentialsProvider(
+                        new BasicAWSCredentials(
+                                ecsClientConfig.getAccessKeyId().get(),
+                                ecsClientConfig.getSecretAccessKey().get()
+                                )
+                        );
+                }
+        else {
+                credentials = new DefaultAWSCredentialsProviderChain();
+        }
+
         // TODO improve to enable more options
         final ClientConfiguration clientConfig = new ClientConfiguration()
                 .withProtocol(Protocol.HTTPS)

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
@@ -112,8 +112,8 @@ public class EcsClientConfig
         return EcsClientConfig.builder()
                 .withClusterName(clusterName)
                 .withLaunchType(ecsConfig.getOptional("launch_type", String.class))
-                .withAccessKeyId(ecsConfig.get("access_key_id", String.class))
-                .withSecretAccessKey(ecsConfig.get("secret_access_key", String.class))
+                .withAccessKeyId(ecsConfig.getOptional("access_key_id", String.class))
+                .withSecretAccessKey(ecsConfig.getOptional("secret_access_key", String.class))
                 .withRegion(ecsConfig.get("region", String.class))
                 .withSubnets(ecsConfig.getOptional("subnets", String.class))
                 .withMaxRetries(ecsConfig.get("max_retries", int.class, DEFAULT_MAX_RETRIES))
@@ -133,8 +133,8 @@ public class EcsClientConfig
     }
 
     private final String clusterName;
-    private final String accessKeyId;
-    private final String secretAccessKey;
+    private final Optional<String> accessKeyId;
+    private final Optional<String> secretAccessKey;
     private final String region;
     private final int maxRetries;
     private boolean assignPublicIp;
@@ -164,12 +164,12 @@ public class EcsClientConfig
         return launchType;
     }
 
-    public String getAccessKeyId()
+    public Optional<String> getAccessKeyId()
     {
         return accessKeyId;
     }
 
-    public String getSecretAccessKey()
+    public Optional<String> getSecretAccessKey()
     {
         return secretAccessKey;
     }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
@@ -8,8 +8,8 @@ import java.util.List;
 public class EcsClientConfigBuilder
 {
     private String clusterName;
-    private String accessKeyId;
-    private String secretAccessKey;
+    private Optional<String> accessKeyId;
+    private Optional<String> secretAccessKey;
     private String region;
     private int maxRetries;
     private boolean assignPublicIp;
@@ -41,13 +41,13 @@ public class EcsClientConfigBuilder
         return this;
     }
 
-    public EcsClientConfigBuilder withAccessKeyId(String accessKeyId)
+    public EcsClientConfigBuilder withAccessKeyId(Optional<String> accessKeyId)
     {
         this.accessKeyId = accessKeyId;
         return this;
     }
 
-    public EcsClientConfigBuilder withSecretAccessKey(String secretAccessKey)
+    public EcsClientConfigBuilder withSecretAccessKey(Optional<String> secretAccessKey)
     {
         this.secretAccessKey = secretAccessKey;
         return this;
@@ -140,12 +140,12 @@ public class EcsClientConfigBuilder
         return launchType;
     }
 
-    public String getAccessKeyId()
+    public Optional<String> getAccessKeyId()
     {
         return accessKeyId;
     }
 
-    public String getSecretAccessKey()
+    public Optional<String> getSecretAccessKey()
     {
         return secretAccessKey;
     }

--- a/digdag-standards/src/test/java/io/digdag/standards/command/ecs/EcsClientConfigTest.java
+++ b/digdag-standards/src/test/java/io/digdag/standards/command/ecs/EcsClientConfigTest.java
@@ -40,8 +40,8 @@ public class EcsClientConfigTest
                                 .set("placement_strategy_type", "random"));
 
         final EcsClientConfig ecsConfig = EcsClientConfig.createFromTaskConfig(Optional.absent(), taskConfig, systemConfig);
-        assertEquals("cluster_specific_access_key", ecsConfig.getAccessKeyId());
-        assertEquals("cluster_specific_secret_access_key", ecsConfig.getSecretAccessKey());
+        assertEquals("cluster_specific_access_key", ecsConfig.getAccessKeyId().get());
+        assertEquals("cluster_specific_secret_access_key", ecsConfig.getSecretAccessKey().get());
     }
 
     @Test
@@ -55,8 +55,8 @@ public class EcsClientConfigTest
                                 .set("placement_strategy_type", "random"));
 
         final EcsClientConfig ecsConfig = EcsClientConfig.createFromTaskConfig(Optional.absent(), taskConfig, systemConfig);
-        assertEquals("default_custom_access_key", ecsConfig.getAccessKeyId());
-        assertEquals("default_custom_secret_access_key", ecsConfig.getSecretAccessKey());
+        assertEquals("default_custom_access_key", ecsConfig.getAccessKeyId().get());
+        assertEquals("default_custom_secret_access_key", ecsConfig.getSecretAccessKey().get());
     }
 
     @Test


### PR DESCRIPTION
## What I did
I added more options to access to ECS Cluster.
There is currently only one option to make a connection with ECS Cluster which is the way to connect with AWS AccessKeyId and SecretAccessKey.
I made a change that [DefaultAWSCredentialsProviderChain](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html) is called if agent.command_executor.ecs.\<name\>.access_key_id is not defined, and then the other types of credentials such as environment variables or Instance Profile are used.
I referred to [the process of authorizing S3 Bucket](https://github.com/treasure-data/digdag/blob/master/digdag-storage-s3/src/main/java/io/digdag/storage/s3/S3StorageFactory.java#L52-L79) and made the implementation closer to it as possible.

## What I confirmed
I confirmed the items below.
- `./gradlew check` is succeeded
- I can use access_key_id and secret_access_key if both are defined on properties.
- If access_key_id and secret_access_key are not written, the other credential is used and task is succeeded.

This is the first PR I create on this repository so I'm sorry in advance if there is any inconvenience.