### PR TITLE
[digdag-ui] added a button to copy logs to clipboard

### DIFF
--- a/digdag-ui/console.tsx
+++ b/digdag-ui/console.tsx
@@ -38,6 +38,7 @@ import {
   faAngleDown,
   faSignOutAlt,
   faCheckCircle,
+  faCopy,
   faExclamationCircle,
   faPlayCircle,
   faSyncAlt
@@ -2031,6 +2032,17 @@ class LogFileView extends React.Component<LogFileViewProps> {
 
           <div className='card bg-light my-2'>
             <div className='card-body p-2'>
+              <button
+                className="btn btn-sm btn-outline-secondary copy-btn"
+                title="Copy to clipboard"
+                onClick={() =>
+                  navigator.clipboard.writeText(
+                    pako.inflate(this.state.data, { to: "string" })
+                  )
+                }
+              >
+                <FontAwesomeIcon icon={faCopy} />
+              </button>
               <pre className='m-0 small'>
                 <code>
                   {pako.inflate(this.state.data, { to: 'string' })}

--- a/digdag-ui/style.less
+++ b/digdag-ui/style.less
@@ -74,3 +74,12 @@ pre {
   padding-top: 50px;
   margin-top: -50px;
 }
+
+.copy-btn {
+  display: flex;
+  margin-left: auto;
+  visibility: hidden;
+  :hover > & {
+    visibility: visible;
+  }
+}


### PR DESCRIPTION
# Overview
fix #1538

I added a button to copy logs to clipboard on the attempts and sessions page.

The button appears only when hovering over the log area.
I put a blank space at the top of the log area so that the buttons and logs do not overlap.



# Why?
#1538

# Demo
## Movie
https://user-images.githubusercontent.com/13377817/180629882-4737fe18-8f2f-407e-adcf-b8a4d266597b.mov

## Images
When mouseover on a log area
<img width="1440" alt="スクリーンショット 2022-07-24 11 43 22" src="https://user-images.githubusercontent.com/13377817/180629944-489dd20d-4973-43fb-a5a0-2701f825552b.png">

When mouseover on a copy button
<img width="1440" alt="スクリーンショット 2022-07-24 11 43 32" src="https://user-images.githubusercontent.com/13377817/180629954-72d983c1-95d8-449e-a2a0-bc1857506838.png">
