### PR TITLE
Use EnvironmentFile instead of Environment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,7 @@ subprojects {
     ext {
         jacksonVersion = "2.9.10"
         jacksonDatabindVersion = "2.9.10"
-        awsJavaSdkVersion = "1.11.686"
+        awsJavaSdkVersion = "1.12.270"
         guavaVersion = "30.1.1-jre"
         guiceVersion = "5.0.1"
     }

--- a/digdag-docs/src/command_executor.md
+++ b/digdag-docs/src/command_executor.md
@@ -45,6 +45,7 @@ Each sub keys of `agent.command_executor` are as follows:
 | ecs.&lt;name&gt;.region            | AWS region                                       |
 | ecs.&lt;name&gt;.subnets           | AWS subnet                                       |
 | ecs.&lt;name&gt;.max_retries       | Number of retry for AWS client                   |
+| ecs.&lt;name&gt;.use_environment_file       | (Optional) whether use environmentFiles or environment when setting variables to ECS. Default value is false and set variables individually.                   |
 
 Following keys are for configuration of temporal storage with AWS S3.
 
@@ -84,17 +85,6 @@ You need to set a tag `digdag.docker.image` in the task definition.
 ECS Command Executor try to search the tagged task definition.
 
 (This way lists and check all task definitions until found and take long time to run the task. See issue [#1488](https://github.com/treasure-data/digdag/issues/1488))
-
-If you need to use environment file, not passing environment variables to a container one by one, set `ecs.use_env_file: true` (default value is false).
-```
-_export:
-  ecs:
-    task_definition_arn: "arn:aws:ecs:us-east-1:..."
-    use_env_file: true
-
-+task1:
-  py>: ...
-```
 
 ## Docker
 ### Setup

--- a/digdag-docs/src/command_executor.md
+++ b/digdag-docs/src/command_executor.md
@@ -85,6 +85,17 @@ ECS Command Executor try to search the tagged task definition.
 
 (This way lists and check all task definitions until found and take long time to run the task. See issue [#1488](https://github.com/treasure-data/digdag/issues/1488))
 
+If you need to use environment file, not passing environment variables to a container one by one, set `ecs.use_env_file: true` (default value is false).
+```
+_export:
+  ecs:
+    task_definition_arn: "arn:aws:ecs:us-east-1:..."
+    use_env_file: true
+
++task1:
+  py>: ...
+```
+
 ## Docker
 ### Setup
 No configuration is required to use Docker Command Executor.

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -690,8 +690,8 @@ public class EcsCommandExecutor
             logger.error(LogMarkers.UNEXPECTED_SERVER_ERROR, message, e);
             throw new RuntimeException(message, e);
         }
-        // Create .env file and attach it to ECS Cluster because the max size of environment on ECS Task is 8KB.
-        // It's possible to set variables more than 8KB by using environment file instead of environment.
+        // Create .env file and attach it to ECS Cluster to save the count of characters because the maximum size of characters of ECS container overrides is 8KB.
+        // It's possible to set larger size of variables by using environment file instead of passing values to a container one by one.
         final Path envFilePath;
         try {
             envFilePath = Files.createTempFile(projectPath.resolve(".digdag/tmp"), "variables-", ".env");

--- a/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/EcsCommandExecutor.java
@@ -826,7 +826,7 @@ public class EcsCommandExecutor
         final TemporalProjectArchiveStorage temporalStorage = createTemporalProjectArchiveStorage(taskConfig); // config exception
         try {
             temporalStorage.uploadFile(envFileKey, envFilePath); // IOException
-            String temporalBucket = temporalStorage.getBucketName(systemConfig);
+            String temporalBucket = temporalStorage.getS3BucketName(systemConfig);
             final String temporalStorageS3ARN = createS3BucketARN(temporalBucket, envFileKey);
             environmentFile.setValue(temporalStorageS3ARN);
             environmentFile.setType("s3");
@@ -887,12 +887,12 @@ public class EcsCommandExecutor
                 .toString();
     }
 
-    private static String createS3BucketARN(final String Bucket, final String fileKey)
+    private static String createS3BucketARN(final String bucket, final String fileKey)
     {
-        // S3 File ARN: "arn:aws:s3::{torage_bucket}/{env_file}"
+        // S3 File ARN: "arn:aws:s3::{storage_bucket}/{env_file}"
         return new StringBuilder()
                 .append("arn:aws:s3:::")
-                .append(Bucket)
+                .append(bucket)
                 .append("/")
                 .append(fileKey)
                 .toString();

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfig.java
@@ -37,6 +37,7 @@ public class EcsClientConfig
         this.placementStrategyField = builder.getPlacementStrategyField();
         this.taskCpu = builder.getTaskCpu();
         this.taskMemory = builder.getTaskMemory();
+        this.useEnvironmentFile = builder.isUseEnvironmentFile();
 
         // All PlacementStrategyFields must be used with a PlacementStrategyType.
         // But some PlacementStrategyTypes can be used without any PlacementStrategyFields.
@@ -64,6 +65,7 @@ public class EcsClientConfig
         // - started_by (optional/String)
         // - task_cpu (optional/String) e.g. `1 vcpu` or `1024` (CPU unit)
         // - task_memory (optional/String) e.g. `1 GB` or `1024` (MiB)
+        // - use_environment_file (boolean)
         // For more detail of the value format of `task_cpu` and `task_memory`, please see
         // https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_definition_parameters.html#task_size
         final Config ecsConfig = taskConfig.getNested(TASK_CONFIG_ECS_KEY).deepCopy();
@@ -129,6 +131,7 @@ public class EcsClientConfig
                 .withPlacementStrategyField(ecsConfig.getOptional("placement_strategy_field", String.class))
                 .withTaskCpu(ecsConfig.getOptional("task_cpu", String.class))
                 .withTaskMemory(ecsConfig.getOptional("task_memory", String.class))
+                .withUseEnvironmentFile(ecsConfig.get("use_environment_file", boolean.class, false))
                 .build();
     }
 
@@ -145,6 +148,7 @@ public class EcsClientConfig
     private final Optional<Integer> containerMemory;
     private final Optional<String> taskCpu;
     private final Optional<String> taskMemory;
+    private final boolean useEnvironmentFile;
     private final Optional<String> startedBy;
     // In aws-sdk 1.11.686, only `random`, `spread`, and `binpack` are supported.
     // https://github.com/aws/aws-sdk-java/blob/1.11.686/aws-java-sdk-ecs/src/main/java/com/amazonaws/services/ecs/model/PlacementStrategyType.java#L23-L25
@@ -226,5 +230,10 @@ public class EcsClientConfig
     public Optional<String> getTaskMemory()
     {
         return taskMemory;
+    }
+
+    public boolean isUseEnvironmentFile()
+    {
+        return useEnvironmentFile;
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/EcsClientConfigBuilder.java
@@ -20,6 +20,7 @@ public class EcsClientConfigBuilder
     private Optional<Integer> containerMemory;
     private Optional<String> taskCpu;
     private Optional<String> taskMemory;
+    private boolean useEnvironmentFile;
     private Optional<String> startedBy;
     private Optional<String> placementStrategyType;
     private Optional<String> placementStrategyField;
@@ -130,6 +131,12 @@ public class EcsClientConfigBuilder
         return this;
     }
 
+    public EcsClientConfigBuilder withUseEnvironmentFile(boolean useEnvironmentFile)
+    {
+        this.useEnvironmentFile = useEnvironmentFile;
+        return this;
+    }
+
     public String getClusterName()
     {
         return clusterName;
@@ -208,5 +215,10 @@ public class EcsClientConfigBuilder
     public Optional<String> getTaskMemory()
     {
         return taskMemory;
+    }
+
+    public boolean isUseEnvironmentFile()
+    {
+        return useEnvironmentFile;
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/TemporalProjectArchiveStorage.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/TemporalProjectArchiveStorage.java
@@ -56,10 +56,9 @@ public class TemporalProjectArchiveStorage
         }
     }
 
-    public String getBucketName(final Config systemConfig)
+    public String getS3BucketName(final Config systemConfig)
     {
-        String type = systemConfig.get(PARAMS_PREFIX + "type", String.class);
-        String bucket = systemConfig.get(PARAMS_PREFIX + type + ".bucket", String.class);
+        String bucket = systemConfig.get(PARAMS_PREFIX + "s3.bucket", String.class);
         return bucket;
     }
 }

--- a/digdag-standards/src/main/java/io/digdag/standards/command/ecs/TemporalProjectArchiveStorage.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/command/ecs/TemporalProjectArchiveStorage.java
@@ -55,4 +55,11 @@ public class TemporalProjectArchiveStorage
             throw ThrowablesUtil.propagate(e);
         }
     }
+
+    public String getBucketName(final Config systemConfig)
+    {
+        String type = systemConfig.get(PARAMS_PREFIX + "type", String.class);
+        String bucket = systemConfig.get(PARAMS_PREFIX + type + ".bucket", String.class);
+        return bucket;
+    }
 }


### PR DESCRIPTION
## Overview
fix https://github.com/treasure-data/digdag/issues/1749

I made a change that [environment file](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerOverride.html#:~:text=Required%3A%20No-,environmentFiles,-A%20list%20of) is used when passing the values of environment to the container instead of [environment](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ContainerOverride.html#:~:text=environment,or%20the%20task%20definition.%20You%20must%20also%20specify%20a%20container%20name.), that is the way to add them to the container one by one. 
This change will be effective to avoid failing an execution of ECS Run Task because [a maximum size of characters of ECS container overrides is 8192](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html#:~:text=A%20list%20of,Type%3A%20TaskOverride%20object) and this limit includes environments defined by the current implementation.
it will be helpful especially when executing `sh>:` operator. In addition to variables defined in `_env`, variables defined in `_export` are also passed to the container unlike `py>:` and `rb>:` so the size of environment tends to be larger as the development progresses.

## The change points
- to upgrade awsJavaSdkVersion
    - it needs to use [EnvironmentFiles](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/ecs/model/EnvironmentFile.html)
- to use [withEnvironmentFiles](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/ecs/model/ContainerOverride.html#withEnvironmentFiles-com.amazonaws.services.ecs.model.EnvironmentFile...-:~:text=the%20container%20definition.-,withEnvironmentFiles,-public%C2%A0ContainerOverride) instead of [withEnvironment](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/ecs/model/ContainerOverride.html#withEnvironmentFiles-com.amazonaws.services.ecs.model.EnvironmentFile...-:~:text=a%20container%20name.-,withEnvironment,-public%C2%A0ContainerOverride)