### PR TITLE
add td_result_export.md to index

### DIFF
--- a/digdag-docs/src/operators/treasure_data.rst
+++ b/digdag-docs/src/operators/treasure_data.rst
@@ -13,4 +13,5 @@ Treasure Data operators
     td_wait_table.md
     td_partial_delete.md
     td_table_export.md
+    td_result_export.md
 


### PR DESCRIPTION
## Purpose
To make td_result_export more visible by adding it to the index of the Treasure Data operator.


https://docs.digdag.io/operators/treasure_data.html

This is the current page index. td_result_export is not listed here, so it is hard to find the operator if they don't know the operator.

<img width="1271" alt="Screen Shot 2022-09-20 at 15 27 53" src="https://user-images.githubusercontent.com/29527495/191183373-c238a42e-c07a-44ab-a392-0dcbd7126f33.png">
