### PR TITLE
Fix an integration test failure due to 1765

### DIFF
--- a/digdag-tests/src/test/java/acceptance/PyIT.java
+++ b/digdag-tests/src/test/java/acceptance/PyIT.java
@@ -183,7 +183,7 @@ public class PyIT
         final String logs = getAttemptLogs(client, attempt.getId());
         assertTrue(logs != null);
         assertThat(attempt.getSuccess(), is(false));
-        final String regex = "\\[ERROR\\] [^\\n]*Task failed with unexpected error: Python command failed with code 1.*Error messages from python:[^\\n]*duplicae module name with standard library";
+        final String regex = "\\[ERROR\\] [^\\n]*Task failed with unexpected error: Python command failed with code 1.*Error messages from python:[^\\n]*duplicate module name with standard library";
         assertTrue(Pattern.compile(regex, Pattern.DOTALL).matcher(logs).find());
     }
 


### PR DESCRIPTION
#1765 fixed the typo, but it caused the failure in an integration test because it checks log output.
This PR fix it.
