### PR TITLE
Add CLI options

### DIFF
--- a/digdag-cli/src/main/java/io/digdag/cli/client/ShowProjects.java
+++ b/digdag-cli/src/main/java/io/digdag/cli/client/ShowProjects.java
@@ -1,18 +1,31 @@
 package io.digdag.cli.client;
 
+import com.beust.jcommander.Parameter;
+import com.google.common.base.Optional;
 import io.digdag.cli.SystemExitException;
 import io.digdag.cli.TimeUtil;
 import io.digdag.client.DigdagClient;
+import io.digdag.client.api.Id;
 import io.digdag.client.api.RestProject;
 import io.digdag.client.api.RestProjectCollection;
 
 import javax.ws.rs.NotFoundException;
+
 
 import static io.digdag.cli.SystemExitException.systemExit;
 
 public class ShowProjects
         extends ClientCommand
 {
+    @Parameter(names = {"--last-id"})
+    Id lastId = null;
+
+    @Parameter(names = {"--count"})
+    int count = 100;
+
+    @Parameter(names = {"--name"})
+    String namePattern = null;
+
     @Override
     public void mainWithClientException()
             throws Exception
@@ -34,7 +47,7 @@ public class ShowProjects
     {
         DigdagClient client = buildClient();
 
-        RestProjectCollection projects = client.getProjects();
+        RestProjectCollection projects = client.getProjects(Optional.fromNullable(lastId), count, Optional.fromNullable(namePattern));
         ln("Projects");
         for (RestProject project : projects.getProjects()) {
             showProjectDetail(project);
@@ -71,6 +84,10 @@ public class ShowProjects
     public SystemExitException usage(String error)
     {
         err.println("Usage: " + programName + " projects [name]");
+        err.println("  Options:");
+        err.println("    --count number   number of workflows");
+        err.println("    --last-id id     last id of workflow");
+        err.println("    --name name      search by part of project name. work only without `name` argument");
         showCommonOptions();
         return systemExit(error);
     }

--- a/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
+++ b/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
@@ -343,12 +343,16 @@ public class DigdagClient implements AutoCloseable
                 .queryParam("last_id", lastId.orNull()));
     }
 
-    public RestWorkflowDefinitionCollection getWorkflowDefinitions(Optional<Id> lastId, int count)
+    public RestWorkflowDefinitionCollection getWorkflowDefinitions(Optional<Id> lastId, int count, String order,
+                                                                   Optional<String> namePattern)
     {
         return doGet(RestWorkflowDefinitionCollection.class,
                 target("/api/workflows")
                 .queryParam("last_id", lastId.orNull())
-                .queryParam("count", count));
+                .queryParam("count", count)
+                .queryParam("order", order)
+                .queryParam("name_pattern", namePattern.orNull())
+        );
     }
     
     public RestWorkflowDefinitionCollection getWorkflowDefinitions(Id projId)

--- a/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
+++ b/digdag-client/src/main/java/io/digdag/client/DigdagClient.java
@@ -309,6 +309,16 @@ public class DigdagClient implements AutoCloseable
                 target("/api/projects"));
     }
 
+    public RestProjectCollection getProjects(Optional<Id> lastId, int count, Optional<String> namePattern)
+    {
+        return doGet(RestProjectCollection.class,
+                target("/api/projects")
+                .queryParam("last_id", lastId.orNull())
+                .queryParam("count", count)
+                .queryParam("name_pattern", namePattern.orNull())
+        );
+    }
+
     public RestProject getProject(Id projId)
     {
         return doGet(RestProject.class,


### PR DESCRIPTION
As follow-up of #1697 and fix the request #1742, this PR introduces the following options in CLI

- `workflows` command
  - `--order`  change sort order (`asc` or `desc`)
  - `--name`  filter by partial name of workflows
- `projects` command
  - `--last-id` pagination based on id
  - `--count`  number of projects 
  - `--name`  filter by partial name of projects


