### PR TITLE
Use context for github credentials

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,8 @@ workflows:
           context:
             - aws-rd
       - docs_deployment: # master branch only
+          context:
+            - github
           filters:
             branches:
               only:


### PR DESCRIPTION
This PR address the security issue of circleCI.

- Move the credential handling to circleCI context