### PR TITLE
 Workaround for error TS2769

### DIFF
--- a/digdag-ui/console.tsx
+++ b/digdag-ui/console.tsx
@@ -2034,13 +2034,13 @@ class LogFileView extends React.Component<LogFileViewProps> {
           <div className='card bg-light my-2'>
             <div className='card-body p-2'>
               <button
-                className="btn btn-sm btn-outline-secondary copy-btn"
-                title="Copy to clipboard"
-                onClick={() =>
-                  navigator.clipboard.writeText(
-                    pako.inflate(this.state.data, { to: "string" })
-                  )
-                }
+                className='btn btn-sm btn-outline-secondary copy-btn'
+                title='Copy to clipboard'
+                onClick={async () =>
+                  await navigator.clipboard.writeText(
+                    // @ts-expect-error ts-migrate(2769) FIXME: No overload matches this call.
+                    pako.inflate(this.state.data, { to: 'string' })
+                  )}
               >
                 <FontAwesomeIcon icon={faCopy} />
               </button>

--- a/digdag-ui/testlib/jest.setup.js
+++ b/digdag-ui/testlib/jest.setup.js
@@ -1,1 +1,1 @@
-import "@babel/polyfill";
+import '@babel/polyfill'

--- a/digdag-ui/webpack.make.js
+++ b/digdag-ui/webpack.make.js
@@ -39,7 +39,7 @@ module.exports = function buildWebpackConfig ({ build = false }) {
         test: /\.css$/,
         use: [MiniCssExtractPlugin.loader, 'css-loader'],
         include: [path.join(__dirname, 'node_modules'), path.join(__dirname, 'public')]
-      }, {  
+      }, {
         test: /\.(scss)$/,
         use: [
           MiniCssExtractPlugin.loader,
@@ -52,7 +52,7 @@ module.exports = function buildWebpackConfig ({ build = false }) {
                   return [
                     require('precss'),
                     require('autoprefixer')
-                  ];
+                  ]
                 }
               }
             }
@@ -60,7 +60,7 @@ module.exports = function buildWebpackConfig ({ build = false }) {
             loader: 'sass-loader'
           }
         ]
-      },{
+      }, {
         test: /\.eot(\?v=\d+\.\d+\.\d+)?$/,
         loader: 'file-loader'
       }, {


### PR DESCRIPTION
Follow-up #1760.

`digdag-ui:checkUi` failed due to TS2769.
I added ts-expect-error to disable error as a workaround.

```
..snip..
console.tsx(2041,34): error TS2769: No overload matches this call.
  Overload 1 of 2, '(data: Data, options: InflateFunctionOptions & { to: "string"; }): string', gave the following error.
    Argument of type 'Data | null' is not assignable to parameter of type 'Data'.
      Type 'null' is not assignable to type 'Data'.
  Overload 2 of 2, '(data: Data, options?: InflateFunctionOptions | undefined): Uint8Array', gave the following error.
    Argument of type 'Data | null' is not assignable to parameter of type 'Data'.
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! digdag-ui@1.0.0 type: `tsc --noEmit`
npm ERR! Exit status 2
..snip..
```