### PR TITLE
Fix CircleCI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Digdag
 
-[![Circle CI](https://circleci.com/gh/treasure-data/digdag.svg?style=svg&circle-token=8ccc5c665022ce4d1ee05cf7b829c84877387a6c)](https://circleci.com/gh/treasure-data/digdag)
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/treasure-data/digdag/tree/master.svg?style=svg&circle-token=5a93079551888e4dc43ad75fe6e2bd312153995c)](https://dl.circleci.com/status-badge/redirect/gh/treasure-data/digdag/tree/master)
 
 [![CI](https://github.com/treasure-data/digdag/workflows/CI/badge.svg)](https://github.com/treasure-data/digdag/actions)
 


### PR DESCRIPTION
Fixes the broken CircleCI status badge
> ![image](https://user-images.githubusercontent.com/127635/221480747-c40f7b7e-de73-438a-aafb-b20dfafc3ad6.png)

Generated with https://app.circleci.com/settings/project/github/treasure-data/digdag/status-badges