### PR TITLE
[Backport] Add parameters to clear schedules in "PUT /api/projects" 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ allprojects {
 
     apply plugin: 'idea'
     apply plugin: 'java'
+    apply plugin: 'java-test-fixtures'
     apply plugin: 'jacoco'
     apply plugin: 'net.ltgt.apt-idea'
     // 'maven' plugin is deprecated and replaced by 'maven-publish'.
@@ -79,6 +80,7 @@ subprojects {
         testCompile 'pl.pragmatists:JUnitParams:1.0.5'
         testImplementation 'org.powermock:powermock-api-mockito:1.6.6'
         testImplementation 'org.powermock:powermock-module-junit4:1.6.6'
+        testFixturesImplementation 'junit:junit:4.13.2'
     }
 
     ext {

--- a/digdag-commons/src/testFixtures/java/io/digdag/commons/AssertUtil.java
+++ b/digdag-commons/src/testFixtures/java/io/digdag/commons/AssertUtil.java
@@ -1,0 +1,21 @@
+package io.digdag.commons;
+
+import static org.junit.Assert.fail;
+
+public class AssertUtil {
+    public static <E> void assertException(Runnable func1, Class<E> expected, String failMessage)
+    {
+        try {
+            func1.run();
+            fail(failMessage);
+        }
+        catch (Exception e){
+            if (e.getClass().equals(expected)) {
+                //OK
+            }
+            else {
+                fail("Unexpected exception:" + e);
+            }
+        }
+    }
+}

--- a/digdag-core/src/main/java/io/digdag/core/repository/ProjectControlStore.java
+++ b/digdag-core/src/main/java/io/digdag/core/repository/ProjectControlStore.java
@@ -19,9 +19,39 @@ public interface ProjectControlStore
     StoredWorkflowDefinition insertWorkflowDefinition(int projId, int revId, WorkflowDefinition workflow, ZoneId workflowTimeZone)
         throws ResourceConflictException;
 
+    public class ScheduleTimeWithInfo
+    {
+        final ScheduleTime scheduleTime;
+        final boolean clearSchedule;
+
+        ScheduleTimeWithInfo(ScheduleTime scheduleTime, boolean clearSchedule)
+        {
+            this.scheduleTime = scheduleTime;
+            this.clearSchedule = clearSchedule;
+        }
+
+        public ScheduleTime getScheduleTime() {
+            return scheduleTime;
+        }
+
+        public boolean isClearSchedule() {
+            return clearSchedule;
+        }
+
+        public static ScheduleTimeWithInfo of(ScheduleTime scheduleTime)
+        {
+            return new ScheduleTimeWithInfo(scheduleTime, false);
+        }
+
+        public static ScheduleTimeWithInfo of(ScheduleTime scheduleTime, boolean clearSchedule)
+        {
+            return new ScheduleTimeWithInfo(scheduleTime, clearSchedule);
+        }
+    }
+
     interface ScheduleUpdateAction <T extends Schedule>
     {
-        ScheduleTime apply(ScheduleStatus oldStatus, T newSchedule);
+        ScheduleTimeWithInfo apply(ScheduleStatus oldStatus, T newSchedule);
     }
 
     <T extends Schedule> void updateSchedules(int projId, List<T> schedules, ScheduleUpdateAction<T> func)

--- a/digdag-core/src/test/java/io/digdag/core/database/DatabaseScheduleStoreManagerTest.java
+++ b/digdag-core/src/test/java/io/digdag/core/database/DatabaseScheduleStoreManagerTest.java
@@ -1,32 +1,65 @@
 package io.digdag.core.database;
 
-import java.time.Duration;
-import java.util.*;
-import java.time.Instant;
-import java.util.concurrent.atomic.AtomicReference;
-
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import io.digdag.client.config.Config;
 import io.digdag.core.acroute.DefaultAccountRoutingFactory;
+import io.digdag.core.repository.Project;
+import io.digdag.core.repository.ProjectControl;
+import io.digdag.core.repository.ProjectControlStore.ScheduleTimeWithInfo;
+import io.digdag.core.repository.ProjectStore;
+import io.digdag.core.repository.ProjectStoreManager;
+import io.digdag.core.repository.ResourceConflictException;
+import io.digdag.core.repository.ResourceNotFoundException;
+import io.digdag.core.repository.Revision;
+import io.digdag.core.repository.StoredProject;
+import io.digdag.core.repository.StoredRevision;
+import io.digdag.core.repository.StoredWorkflowDefinition;
+import io.digdag.core.repository.WorkflowDefinition;
+import io.digdag.core.schedule.Schedule;
+import io.digdag.core.schedule.ScheduleStore;
+import io.digdag.core.schedule.ScheduleStoreManager;
+import io.digdag.core.schedule.SchedulerManager;
+import io.digdag.core.schedule.StoredSchedule;
 import io.digdag.spi.AccountRouting;
-import org.junit.*;
-import com.google.common.base.Optional;
-import com.google.common.collect.*;
-import io.digdag.core.repository.*;
-import io.digdag.core.schedule.*;
 import io.digdag.spi.ScheduleTime;
+import io.digdag.spi.Scheduler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.skife.jdbi.v2.Handle;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static io.digdag.client.config.ConfigUtils.newConfig;
-import static io.digdag.core.database.DatabaseTestingUtils.*;
+import static io.digdag.core.database.DatabaseTestingUtils.assertNotFound;
+import static io.digdag.core.database.DatabaseTestingUtils.createRevision;
+import static io.digdag.core.database.DatabaseTestingUtils.createWorkflow;
+import static io.digdag.core.database.DatabaseTestingUtils.setupDatabase;
 import static java.time.temporal.ChronoUnit.SECONDS;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 
+@RunWith(MockitoJUnitRunner.class)
 public class DatabaseScheduleStoreManagerTest
 {
     private DatabaseFactory factory;
@@ -117,9 +150,7 @@ public class DatabaseScheduleStoreManagerTest
                                                 runTime1,
                                                 schedTime1)
                                 ),
-                                (oldStatus, newSched) -> {
-                                    return oldStatus.getNextScheduleTime();
-                                });
+                                (oldStatus, newSched) -> ScheduleTimeWithInfo.of(oldStatus.getNextScheduleTime()));
                         return lock.get();
                     });
             StoredWorkflowDefinition wf1Rev1 = wfRefA.get();
@@ -172,9 +203,9 @@ public class DatabaseScheduleStoreManagerTest
                                 ),
                                 (oldStatus, newSched) -> {
                                     // when conflicted (wf1), rollback 60 seconds schedule time and 120 seconds run time here
-                                    return ScheduleTime.of(
+                                    return ScheduleTimeWithInfo.of(ScheduleTime.of(
                                             oldStatus.getNextScheduleTime().getTime().minusSeconds(60),
-                                            oldStatus.getNextScheduleTime().getRunTime().minusSeconds(120));
+                                            oldStatus.getNextScheduleTime().getRunTime().minusSeconds(120)));
                                 });
                         return lock.get();
                     });
@@ -334,9 +365,7 @@ public class DatabaseScheduleStoreManagerTest
                                                 yesterday,
                                                 yesterday)
                                 ),
-                                (oldStatus, newSched) -> {
-                                    return oldStatus.getNextScheduleTime();
-                                });
+                                (oldStatus, newSched) -> ScheduleTimeWithInfo.of(oldStatus.getNextScheduleTime()));
                         return lock.get();
                     });
 
@@ -447,9 +476,7 @@ public class DatabaseScheduleStoreManagerTest
                                                 yesterday,
                                                 yesterday)
                                 ),
-                                (oldStatus, newSched) -> {
-                                    return oldStatus.getNextScheduleTime();
-                                });
+                                (oldStatus, newSched) -> ScheduleTimeWithInfo.of(oldStatus.getNextScheduleTime()));
                         return lock.get();
                     });
 
@@ -472,5 +499,128 @@ public class DatabaseScheduleStoreManagerTest
                 assertThat(ready.size(), is(0));
             }
         });
+    }
+
+    @Test
+    public void testUpdateSchedulesWithClearSchedules()
+            throws Exception {
+        final Instant firstTime = Instant.parse("2022-05-15T13:00:00.00Z");
+        final Instant nextTime = Instant.parse("2022-05-30T13:00:00.00Z");
+
+        SchedulerManager sm = mock(SchedulerManager.class);
+        setUpScheduler(firstTime, nextTime, sm); // mock SchedulerManager to return dummy Scheduler
+
+        final ConfigMapper cfm = ((DatabaseProjectStoreManager) manager).configMapper;
+
+        factory.get().begin(() -> {
+            Handle handle = factory.get().getHandle(cfm);
+
+            Project srcProj1 = Project.of("proj1");
+            Revision srcRev1 = createRevision("rev1");
+            WorkflowDefinition srcWf1Rev1 = createWorkflow("wfA");
+            WorkflowDefinition srcWf2 = createWorkflow("wfB");
+
+            final AtomicReference<StoredRevision> revRef = new AtomicReference<>();
+            final AtomicReference<StoredWorkflowDefinition> wfRefA = new AtomicReference<>();
+            final AtomicReference<StoredWorkflowDefinition> wfRefB = new AtomicReference<>();
+
+            Instant now = Instant.now();
+            try {
+                StoredProject proj1 = store.putAndLockProject(
+                        srcProj1,
+                        (store, stored) -> {
+                            // prepare for workflow
+                            ProjectControl lock = new ProjectControl(store, stored);
+                            revRef.set(lock.insertRevision(srcRev1));
+                            wfRefA.set(lock.insertWorkflowDefinitionsWithoutSchedules(revRef.get(), ImmutableList.of(srcWf1Rev1)).get(0));
+                            wfRefB.set(lock.insertWorkflowDefinitionsWithoutSchedules(revRef.get(), ImmutableList.of(srcWf2)).get(0));
+                            StoredWorkflowDefinition wfA = wfRefA.get();
+                            StoredWorkflowDefinition wfB = wfRefB.get();
+                            List<StoredWorkflowDefinition> wfAll = Arrays.asList(wfA, wfB);
+                            // update schedules table initially.
+                            lock.updateSchedules(revRef.get(), wfAll, Collections.emptyMap(), sm, Instant.now());
+
+                            // get schedule
+                            StoredSchedule schdA = getScheduleByWorkflow(handle, wfA.getId());
+                            StoredSchedule schdB = getScheduleByWorkflow(handle, wfB.getId());
+
+                            // check schedule. This is first one. So calculate from getFirstScheduleTime
+                            assertThat(schdA.getNextScheduleTime(), is(firstTime));
+                            assertThat(schdB.getNextScheduleTime(), is(firstTime));
+
+                            // set last_session_time of the schedules
+                            updateLastSessionTime(handle, schdA.getId(), now);
+                            updateLastSessionTime(handle, schdB.getId(), now);
+                            // update schedules table again.
+                            lock.updateSchedules(revRef.get(), wfAll, Collections.emptyMap(), sm, Instant.now());
+                            schdA = getScheduleByWorkflow(handle, wfA.getId());
+                            schdB = getScheduleByWorkflow(handle, wfB.getId());
+                            // check schedule. calculated based on last_session_time
+                            assertThat(schdA.getNextScheduleTime(), is(nextTime));
+                            assertThat(schdB.getNextScheduleTime(), is(nextTime));
+
+                            // update schedule table with clearSchedules("wfA" -> true).
+                            lock.updateSchedules(revRef.get(), wfAll, Collections.singletonMap("wfA", true), sm, Instant.now());
+                            schdA = getScheduleByWorkflow(handle, wfA.getId());
+                            schdB = getScheduleByWorkflow(handle, wfB.getId());
+                            // check schedule.
+                            // wfA: last_session_time is cleared. So calculated from getFirstScheduleTime
+                            // wfB: last_session_time is not cleared. So calculated based on last_session_time
+                            assertThat(schdA.getNextScheduleTime(), is(firstTime));
+                            assertThat(schdB.getNextScheduleTime(), is(nextTime));
+
+                            return lock.get();
+                        });
+            }
+            catch (ResourceConflictException rce) {
+                rce.printStackTrace();
+                fail(rce.toString());
+            }
+            return 0;
+        });
+    }
+
+    private static void setUpScheduler(Instant firstTime, Instant nextTime, SchedulerManager sm)
+            throws Exception {
+        doReturn(Optional.of(new Scheduler() {
+
+            @Override
+            public ZoneId getTimeZone() {
+                return ZoneId.of("utc");
+            }
+
+            @Override
+            public ScheduleTime getFirstScheduleTime(Instant currentTime) {
+                return ScheduleTime.of(firstTime, firstTime);
+            }
+
+            @Override
+            public ScheduleTime nextScheduleTime(Instant lastScheduleTime) {
+                return ScheduleTime.of(nextTime, nextTime);
+            }
+
+            @Override
+            public ScheduleTime lastScheduleTime(Instant currentScheduleTime) {
+                return ScheduleTime.of(currentScheduleTime, currentScheduleTime);
+            }
+        }))
+                .when(sm).tryGetScheduler(any(Revision.class), any(WorkflowDefinition.class), any(Boolean.class));
+    }
+
+    private static int updateLastSessionTime(Handle handle, int scheduleId, Instant lastSessionTime)
+    {
+        return handle.createStatement("update schedules set last_session_time = :lastSessionTime, updated_at = now() where id = :id")
+                .bind("lastSessionTime", lastSessionTime.getEpochSecond())
+                .bind("id", scheduleId)
+                .execute();
+    }
+
+    private static StoredSchedule getScheduleByWorkflow(Handle handle, long id)
+    {
+        List<StoredSchedule> schdLists = handle.createQuery("select *, wd.name as name from schedules s join workflow_definitions wd on wd.id = s.workflow_definition_id where workflow_definition_id = :wfid")
+                .bind("wfid", id)
+                .mapTo(StoredSchedule.class).list();
+        assertThat(schdLists, hasSize(1));
+        return schdLists.get(0);
     }
 }

--- a/digdag-core/src/test/java/io/digdag/core/workflow/DummyAccessController.java
+++ b/digdag-core/src/test/java/io/digdag/core/workflow/DummyAccessController.java
@@ -4,6 +4,7 @@ import io.digdag.spi.AuthenticatedUser;
 import io.digdag.spi.ac.AccessControlException;
 import io.digdag.spi.ac.AccessController;
 import io.digdag.spi.ac.AttemptTarget;
+import io.digdag.spi.ac.ProjectContentTarget;
 import io.digdag.spi.ac.ProjectTarget;
 import io.digdag.spi.ac.ScheduleTarget;
 import io.digdag.spi.ac.SecretTarget;
@@ -15,6 +16,11 @@ public class DummyAccessController
 {
     @Override
     public void checkPutProject(ProjectTarget target, AuthenticatedUser user)
+            throws AccessControlException
+    { }
+
+    @Override
+    public void checkPutProjectContent(ProjectContentTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 

--- a/digdag-server/build.gradle
+++ b/digdag-server/build.gradle
@@ -1,5 +1,6 @@
 
 dependencies {
+    testImplementation(testFixtures(project(':digdag-commons')))
     compile project(':digdag-core')
     compile project(':digdag-client')
     compile project(':digdag-guice-rs-server-undertow')

--- a/digdag-server/src/main/java/io/digdag/server/ServerModule.java
+++ b/digdag-server/src/main/java/io/digdag/server/ServerModule.java
@@ -30,6 +30,7 @@ import io.digdag.server.rs.SessionResource;
 import io.digdag.server.rs.UiResource;
 import io.digdag.server.rs.VersionResource;
 import io.digdag.server.rs.WorkflowResource;
+import io.digdag.server.rs.project.PutProjectsValidator;
 import io.digdag.spi.AuthenticatedUser;
 import io.digdag.spi.Authenticator;
 import io.digdag.spi.AuthenticatorFactory;
@@ -86,7 +87,6 @@ public class ServerModule
         bindExceptionhandlers(builder);
         bindSecrets();
         bindUiApplication();
-
         if (serverConfig.getEnableSwagger()) {
             enableSwagger(builder);
         }

--- a/digdag-server/src/main/java/io/digdag/server/ac/DefaultAccessController.java
+++ b/digdag-server/src/main/java/io/digdag/server/ac/DefaultAccessController.java
@@ -4,6 +4,7 @@ import io.digdag.spi.AuthenticatedUser;
 import io.digdag.spi.ac.AccessControlException;
 import io.digdag.spi.ac.AccessController;
 import io.digdag.spi.ac.AttemptTarget;
+import io.digdag.spi.ac.ProjectContentTarget;
 import io.digdag.spi.ac.ProjectTarget;
 import io.digdag.spi.ac.ScheduleTarget;
 import io.digdag.spi.ac.SecretTarget;
@@ -15,6 +16,11 @@ public class DefaultAccessController
 {
     @Override
     public void checkPutProject(ProjectTarget target, AuthenticatedUser user)
+            throws AccessControlException
+    { }
+
+    @Override
+    public void checkPutProjectContent(ProjectContentTarget target, AuthenticatedUser user)
             throws AccessControlException
     { }
 

--- a/digdag-server/src/main/java/io/digdag/server/rs/project/ProjectClearScheduleParam.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/project/ProjectClearScheduleParam.java
@@ -1,0 +1,39 @@
+package io.digdag.server.rs.project;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class ProjectClearScheduleParam {
+    final Set<String> workflowNames;
+    final boolean allWorkflows;
+
+    public ProjectClearScheduleParam(List<String> workflowNames, boolean allWorkflows) {
+        this.workflowNames = workflowNames.stream().collect(Collectors.toSet());
+        this.allWorkflows = allWorkflows;
+    }
+
+    public boolean checkClear(String workflow) {
+        return allWorkflows || workflowNames.contains(workflow);
+    }
+
+    /**
+     * Check the list of workflows should be cleared
+     * @param targetWorkflowNames
+     * @return Map of workflows with value (true:cleared false:no need).
+     */
+    public Map<String, Boolean> checkClearList(List<String> targetWorkflowNames)
+    {
+        return targetWorkflowNames.stream().collect(Collectors.toMap(String::toString, (s)-> checkClear(s)));
+    }
+
+    public void validateWorkflowNames(List<String> workflows) {
+        Set<String> allWorkflowNames = workflows.stream().collect(Collectors.toSet());
+        for (String wf : this.workflowNames) {
+            if (!allWorkflowNames.contains(wf)) {
+                throw new IllegalArgumentException(String.format("%s does not exist", wf));
+            }
+        }
+    }
+}

--- a/digdag-server/src/main/java/io/digdag/server/rs/project/PutProjectsValidator.java
+++ b/digdag-server/src/main/java/io/digdag/server/rs/project/PutProjectsValidator.java
@@ -1,0 +1,45 @@
+package io.digdag.server.rs.project;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+
+import static java.util.Locale.ENGLISH;
+
+public class PutProjectsValidator {
+    public Instant validateAndGetScheduleFrom(String scheduleFromString)
+    {
+        if (scheduleFromString == null || scheduleFromString.isEmpty()) {
+            return Instant.now();
+        }
+        else {
+            try {
+                return Instant.parse(scheduleFromString);
+            }
+            catch (DateTimeParseException ex) {
+                throw new IllegalArgumentException("Invalid schedule_from= parameter format. Expected yyyy-MM-dd'T'HH:mm:ss'Z' format", ex);
+            }
+        }
+    }
+
+    public int validateAndGetContentLength(long contentLengthParam, int maxArchiveTotalSize)
+    {
+        if (contentLengthParam > maxArchiveTotalSize) {
+            throw new IllegalArgumentException(String.format(ENGLISH,
+                    "Size of the uploaded archive file exceeds limit (%d bytes)", maxArchiveTotalSize));
+        }
+        return (int) contentLengthParam;
+    }
+
+    public void validateTarEntry(TarArchiveEntry entry, int maxArchiveFileSize)
+    {
+        if (entry.getSize() > maxArchiveFileSize) {
+            throw new IllegalArgumentException(String.format(ENGLISH,
+                    "Size of a file in the archive exceeds limit (%d > %d bytes): %s",
+                    entry.getSize(), maxArchiveFileSize, entry.getName()));
+        }
+    }
+
+}

--- a/digdag-server/src/test/java/io/digdag/server/rs/project/ProjectClearScheduleParamTest.java
+++ b/digdag-server/src/test/java/io/digdag/server/rs/project/ProjectClearScheduleParamTest.java
@@ -1,0 +1,88 @@
+package io.digdag.server.rs.project;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static io.digdag.commons.AssertUtil.assertException;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProjectClearScheduleParamTest {
+    private final ProjectClearScheduleParam paramData1 = new ProjectClearScheduleParam(Arrays.asList("wf1", "wf2", "wf3"), false);
+    private final ProjectClearScheduleParam paramData2 = new ProjectClearScheduleParam(Arrays.asList("wf1", "wf2"), true);
+
+    @Test
+    public void testCheckClear()
+    {
+        {
+            assertThat(paramData1.checkClear("wf1"), is(true));
+        }
+        {
+            assertThat(paramData1.checkClear("wf0"), is(false));
+        }
+        {
+            assertThat(paramData2.checkClear("wf1"), is(true));
+        }
+        {
+            assertThat(paramData2.checkClear("wf0"), is(true));
+        }
+    }
+
+    @Test
+    public void testCheckClearList()
+    {
+        {
+            List<String> l1 = Arrays.asList("wf1", "wf2", "wf3", "wf4");
+            Map<String, Boolean> result = paramData1.checkClearList(l1);
+            assertThat(result, hasEntry("wf1", true));
+            assertThat(result, hasEntry("wf2", true));
+            assertThat(result, hasEntry("wf3", true));
+            assertThat(result, hasEntry("wf4", false));
+        }
+        {
+            List<String> l1 = Arrays.asList("wf1", "wf2", "wf3", "wf4");
+            Map<String, Boolean> result = paramData2.checkClearList(l1);
+            assertThat(result, hasEntry("wf1", true));
+            assertThat(result, hasEntry("wf2", true));
+            assertThat(result, hasEntry("wf3", true));
+            assertThat(result, hasEntry("wf4", true));
+        }
+    }
+
+    @Test
+    public void testValidateWorkflowNames()
+    {
+        {
+            List<String> allWorkflowNames = Arrays.asList("wf1", "wf2", "wf3", "wf4");
+            paramData1.validateWorkflowNames(allWorkflowNames);
+        }
+        {
+            List<String> allWorkflowNames = Arrays.asList("wf1", "wf2", "wf3");
+            paramData1.validateWorkflowNames(allWorkflowNames);
+        }
+        {
+            List<String> allWorkflowNames = Arrays.asList("wf1", "wf2", "wf4", "wf5");
+            assertException(()->paramData1.validateWorkflowNames(allWorkflowNames), IllegalArgumentException.class, "Including non existent workflow wf3 must fail");
+        }
+        {
+            List<String> allWorkflowNames = Arrays.asList();
+            assertException(()->paramData1.validateWorkflowNames(allWorkflowNames), IllegalArgumentException.class, "Including non existent workflow must fail");
+        }
+        {
+            List<String> allWorkflowNames = Arrays.asList("wf1", "wf3", "wf4", "wf5");
+            assertException(()->paramData2.validateWorkflowNames(allWorkflowNames), IllegalArgumentException.class, "Including non existent workflow wf2 must fail");
+        }
+        {
+            List<String> allWorkflowNames = Arrays.asList();
+            assertException(()->paramData2.validateWorkflowNames(allWorkflowNames), IllegalArgumentException.class, "Including non existent workflow must fail");
+        }
+    }
+}

--- a/digdag-server/src/test/java/io/digdag/server/rs/project/PutProjectsValidatorTest.java
+++ b/digdag-server/src/test/java/io/digdag/server/rs/project/PutProjectsValidatorTest.java
@@ -1,0 +1,87 @@
+package io.digdag.server.rs.project;
+
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.time.Instant;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.mockito.Mockito.when;
+import static io.digdag.commons.AssertUtil.assertException;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PutProjectsValidatorTest {
+    private PutProjectsValidator validator;
+
+    @Mock TarArchiveEntry archiveEntry;
+
+    @Before
+    public void setUp()
+    {
+        validator = new PutProjectsValidator();
+    }
+
+    @Test
+    public void testValidateAndGetScheduleFrom()
+    {
+        Instant now = Instant.now();
+        {
+            Instant ret = validator.validateAndGetScheduleFrom(null);
+            assertThat(ret, notNullValue());
+            assertThat(ret.toEpochMilli(), greaterThanOrEqualTo(now.toEpochMilli()));
+        }
+        {
+            Instant ret = validator.validateAndGetScheduleFrom("");
+            assertThat(ret, notNullValue());
+            assertThat(ret.toEpochMilli(), greaterThanOrEqualTo(now.toEpochMilli()));
+        }
+        {
+            Instant ret = validator.validateAndGetScheduleFrom("2022-04-26T01:23:45Z");
+            assertThat(ret, notNullValue());
+            assertThat(ret.toEpochMilli(), greaterThanOrEqualTo(Instant.parse("2022-04-26T01:23:45Z").toEpochMilli()));
+        }
+        {
+            assertException(() -> validator.validateAndGetScheduleFrom("2022-04-26"), IllegalArgumentException.class, "Invalid format must fail");
+        }
+    }
+
+    @Test
+    public void testValidateAndGetContentLength()
+    {
+        final int MAX_CONTENT_LENGTH = 65534;
+        {
+            assertThat(validator.validateAndGetContentLength(0, MAX_CONTENT_LENGTH), is(0));
+        }
+        {
+            assertThat(validator.validateAndGetContentLength(MAX_CONTENT_LENGTH, MAX_CONTENT_LENGTH), is(MAX_CONTENT_LENGTH));
+        }
+        {
+            assertException(() -> validator.validateAndGetContentLength(MAX_CONTENT_LENGTH + 1, MAX_CONTENT_LENGTH), IllegalArgumentException.class, "Exceeded size must fail");
+        }
+    }
+
+    @Test
+    public void testValidateTarEntry()
+    {
+        final int MAX_ARCHIVE_FILE_SIZE = 10*1024*1024;
+        {
+            when(archiveEntry.getSize()).thenReturn(0L);
+            validator.validateTarEntry(archiveEntry, MAX_ARCHIVE_FILE_SIZE);
+        }
+        {
+            when(archiveEntry.getSize()).thenReturn(MAX_ARCHIVE_FILE_SIZE + 0L);
+            validator.validateTarEntry(archiveEntry, MAX_ARCHIVE_FILE_SIZE);
+        }
+        {
+            when(archiveEntry.getSize()).thenReturn(MAX_ARCHIVE_FILE_SIZE + 1L);
+            assertException(() -> validator.validateTarEntry(archiveEntry, MAX_ARCHIVE_FILE_SIZE), IllegalArgumentException.class, "Exceeded size must fail");
+        }
+    }
+}

--- a/digdag-spi/src/main/java/io/digdag/spi/ac/AccessController.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/ac/AccessController.java
@@ -26,6 +26,16 @@ public interface AccessController
             throws AccessControlException;
 
     /**
+     * Check if the user has permissions to put a project in considering of the content.
+     *
+     * @param target
+     * @param user
+     * @throws AccessControlException
+     */
+    void checkPutProjectContent(ProjectContentTarget target, AuthenticatedUser user)
+            throws AccessControlException;
+
+    /**
      * Check if the user has permissions to delete the project.
      *
      * @param target

--- a/digdag-spi/src/main/java/io/digdag/spi/ac/ProjectContentTarget.java
+++ b/digdag-spi/src/main/java/io/digdag/spi/ac/ProjectContentTarget.java
@@ -1,0 +1,22 @@
+package io.digdag.spi.ac;
+
+import io.digdag.client.config.Config;
+import org.immutables.value.Value;
+
+import java.util.List;
+
+@Value.Immutable
+public interface ProjectContentTarget
+{
+    ProjectTarget getProjectTarget();
+
+    List<Config> taskConfigs();
+
+    static ProjectContentTarget of(ProjectTarget projectTarget, List<Config> taskConfigs)
+    {
+        return ImmutableProjectContentTarget.builder()
+                .projectTarget(projectTarget)
+                .taskConfigs(taskConfigs)
+                .build();
+    }
+}

--- a/digdag-tests/src/test/java/acceptance/AccessControllerIT.java
+++ b/digdag-tests/src/test/java/acceptance/AccessControllerIT.java
@@ -39,6 +39,7 @@ import io.digdag.spi.AuthenticatedUser;
 import io.digdag.spi.ac.AccessControlException;
 import io.digdag.spi.ac.AccessController;
 import io.digdag.spi.ac.AttemptTarget;
+import io.digdag.spi.ac.ProjectContentTarget;
 import io.digdag.spi.ac.ProjectTarget;
 import io.digdag.spi.ac.SiteTarget;
 import io.digdag.spi.ac.WorkflowTarget;
@@ -255,6 +256,23 @@ public class AccessControllerIT
             switch (target.getName()) {
                 case "put_project_403":
                     throw new AccessControlException("not allow"); // 403
+                default:
+                    return; // ok
+            }
+        }
+
+        @Override
+        public void checkPutProjectContent(ProjectContentTarget target, AuthenticatedUser user)
+                throws AccessControlException
+        {
+            switch (target.getProjectTarget().getName()) {
+                case "put_project_content_check_0":
+                case "put_project_content_check_1":
+                    if (target.taskConfigs().stream().anyMatch(taskConfig ->
+                            taskConfig.getKeys().contains("sh>")
+                    )) {
+                        throw new AccessControlException("not allow"); // 403
+                    }
                 default:
                     return; // ok
             }
@@ -856,7 +874,6 @@ public class AccessControllerIT
     {
         { // ok
             final String projectName = "put_project_ok";
-            final String wfName = projectName;
             final Path projectDir = folder.getRoot().toPath().resolve(projectName);
 
             // Create new project
@@ -876,13 +893,54 @@ public class AccessControllerIT
         }
 
         { // 403
-            final String projectName = "put_project_ok";
-            final String wfName = projectName;
+            final String projectName = "put_project_403";
             final Path projectDir = folder.getRoot().toPath().resolve(projectName);
 
             // Create new project
             CommandStatus initStatus = main("init",
                     "-c", config.toString(),
+                    projectDir.toString());
+            assertThat(initStatus.code(), is(0));
+
+            // Push the project
+            CommandStatus pushStatus = main("push",
+                    "--project", projectDir.toString(),
+                    projectName,
+                    "-c", config.toString(),
+                    "-e", server.endpoint(),
+                    "-r", "4711");
+            assertThat(pushStatus.errUtf8(), pushStatus.code(), is(1));
+        }
+
+
+        { // ok (`sh` operator isn't contained)
+            final String projectName = "put_project_content_check_0";
+            final Path projectDir = folder.getRoot().toPath().resolve(projectName);
+
+            // Create new project
+            CommandStatus initStatus = main("init",
+                    "-c", config.toString(),
+                    projectDir.toString());
+            assertThat(initStatus.code(), is(0));
+
+            // Push the project
+            CommandStatus pushStatus = main("push",
+                    "--project", projectDir.toString(),
+                    projectName,
+                    "-c", config.toString(),
+                    "-e", server.endpoint(),
+                    "-r", "4711");
+            assertThat(pushStatus.errUtf8(), pushStatus.code(), is(0));
+        }
+
+        { // 403 (`sh` operator is contained)
+            final String projectName = "put_project_content_check_1";
+            final Path projectDir = folder.getRoot().toPath().resolve(projectName);
+
+            // Create new project
+            CommandStatus initStatus = main("init",
+                    "-c", config.toString(),
+                    "-t", "sh",
                     projectDir.toString());
             assertThat(initStatus.code(), is(0));
 

--- a/digdag-tests/src/test/java/acceptance/ApiProjectsIT.java
+++ b/digdag-tests/src/test/java/acceptance/ApiProjectsIT.java
@@ -1,0 +1,181 @@
+package acceptance;
+
+import com.google.common.base.Optional;
+import com.google.common.io.ByteStreams;
+import io.digdag.client.DigdagClient;
+import io.digdag.client.api.RestProject;
+import io.digdag.client.api.RestSchedule;
+import io.digdag.client.api.RestWorkflowDefinition;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.skife.jdbi.v2.DBI;
+import org.skife.jdbi.v2.Handle;
+import utils.TemporaryDigdagServer;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assume.assumeTrue;
+import static utils.TestUtils.copyResource;
+
+public class ApiProjectsIT
+{
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    public TemporaryDigdagServer server;
+
+    private Path projectDir;
+
+    private DigdagClient digdagClient;
+
+    private DBI dbi;
+
+    @Before()
+    public void setUp()
+            throws Exception
+    {
+        server =  TemporaryDigdagServer.of();
+        server.start();
+
+        digdagClient = DigdagClient.builder()
+                .host(server.host())
+                .port(server.port())
+                .build();
+        digdagClient.getVersion();
+
+        projectDir = folder.getRoot().toPath().resolve("foobar");
+        Files.createDirectory(projectDir);
+    }
+
+    @After
+    public void tearDown()
+    {
+        if (server != null) {
+            server.close();
+            server = null;
+        }
+    }
+
+    @Test
+    public void putProjectsWithClearSchedule()
+            throws Exception {
+        assumeTrue(server.isRemoteDatabase());
+
+        dbi = new DBI(server.getTestDBDataSource());
+
+        // Prepare project archive
+        copyResource("acceptance/api_projects/schedule1.dig", projectDir.resolve("wf1.dig"));
+        copyResource("acceptance/api_projects/schedule2.dig", projectDir.resolve("wf2.dig"));
+        Path archivePath = Files.createTempFile(folder.getRoot().toPath(), "archive-", ".tar.gz");
+        archivePath.toFile().deleteOnExit();
+        archiveProject(archivePath, projectDir);
+
+
+        // Push the project and get schedule of wf1
+        digdagClient.putProjectRevision("prj1", "rev1", archivePath.toFile(), Optional.absent());
+        RestProject prj1 = digdagClient.getProject("prj1");
+        RestWorkflowDefinition wf1 = digdagClient.getWorkflowDefinition(prj1.getId(), "wf1");
+        RestSchedule wf1sch1 = digdagClient.getSchedule(prj1.getId(), "wf1");
+
+        Instant tomorrowMidnightUTC = Instant.now().truncatedTo(ChronoUnit.DAYS).plus(1, ChronoUnit.DAYS);
+        Instant nextOfTomorrowMidnightUTC = tomorrowMidnightUTC.plus(1, ChronoUnit.DAYS);
+
+        // initial schedule is tomorrowMidnightUTC for "daily>: 00:00:00"
+        {
+            assertThat(wf1sch1.getNextRunTime(), is(tomorrowMidnightUTC));
+        }
+
+        // update last_session_time and next run time will be calculated from it.
+        {
+            updateLastSessionTime(wf1sch1.getId().asInt(), tomorrowMidnightUTC);
+            digdagClient.putProjectRevision("prj1", "rev2", archivePath.toFile(), Optional.absent());
+            RestSchedule wf1sch2 = digdagClient.getSchedule(prj1.getId(), "wf1");
+            assertThat(wf1sch2.getNextRunTime(), is(nextOfTomorrowMidnightUTC));
+        }
+
+        // clearSchedule option for "wf1". So next run time is calculated as initial schedule
+        {
+            updateLastSessionTime(wf1sch1.getId().asInt(), tomorrowMidnightUTC);
+            digdagClient.putProjectRevision("prj1", "rev3", archivePath.toFile(), Optional.absent(), Arrays.asList("wf1"), Optional.absent());
+            RestSchedule wf1sch2 = digdagClient.getSchedule(prj1.getId(), "wf1");
+            assertThat(wf1sch2.getNextRunTime(), is(tomorrowMidnightUTC));
+        }
+
+        // clearSchedule for "wf2", no impact to wf1
+        {
+            updateLastSessionTime(wf1sch1.getId().asInt(), tomorrowMidnightUTC);
+            digdagClient.putProjectRevision("prj1", "rev4", archivePath.toFile(), Optional.absent(), Arrays.asList("wf2"), Optional.absent());
+            RestSchedule wf1sch2 = digdagClient.getSchedule(prj1.getId(), "wf1");
+            assertThat(wf1sch2.getNextRunTime(), is(nextOfTomorrowMidnightUTC));
+        }
+
+        // set clearAllSchedule. next run time is calculated as initial schedule
+        {
+            updateLastSessionTime(wf1sch1.getId().asInt(), tomorrowMidnightUTC);
+            digdagClient.putProjectRevision("prj1", "rev5", archivePath.toFile(), Optional.absent(), Arrays.asList(), Optional.of(true));
+            RestSchedule wf1sch2 = digdagClient.getSchedule(prj1.getId(), "wf1");
+            assertThat(wf1sch2.getNextRunTime(), is(tomorrowMidnightUTC));
+        }
+    }
+
+    private void updateLastSessionTime(int id, Instant lastSessionTime)
+    {
+        try (Handle handle = dbi.open()) {
+            handle.createStatement("update schedules set last_session_time = :last_session_time, updated_at = now() where id = :id")
+                    .bind("id", id)
+                    .bind("last_session_time", lastSessionTime.getEpochSecond())
+                    .execute();
+        }
+    }
+
+    private List<Path> listFiles(Path dir)
+            throws IOException
+    {
+        try (Stream<Path> stream = Files.walk(dir, 10)) {
+            return stream
+                    .filter(file -> !Files.isDirectory(file))
+                    .collect(Collectors.toList());
+        }
+    }
+
+    private void archiveProject(Path archivePath, Path projectPath)
+            throws IOException
+    {
+        try (TarArchiveOutputStream tar = new TarArchiveOutputStream(new GzipCompressorOutputStream(Files.newOutputStream(archivePath)))) {
+            tar.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
+            listFiles(projectPath).stream().forEach((path) -> {
+                try {
+                    if (Files.isReadable(path.toAbsolutePath())) {
+                        TarArchiveEntry e  = new TarArchiveEntry(path.toFile(), path.toFile().getName());
+                        tar.putArchiveEntry(e);
+                        try (InputStream in = Files.newInputStream(path)) {
+                            ByteStreams.copy(in, tar);
+                        }
+                        tar.closeArchiveEntry();
+                    }
+                }
+                catch (IOException ioe) {
+                    ioe.printStackTrace();
+                    throw new RuntimeException(ioe);
+                }
+            });
+        }
+    }
+}

--- a/digdag-tests/src/test/resources/acceptance/api_projects/schedule1.dig
+++ b/digdag-tests/src/test/resources/acceptance/api_projects/schedule1.dig
@@ -1,0 +1,7 @@
+timezone: UTC
+
+schedule:
+  daily>: 00:00:00
+
++t1:
+  echo>: "schedule1 called"

--- a/digdag-tests/src/test/resources/acceptance/api_projects/schedule2.dig
+++ b/digdag-tests/src/test/resources/acceptance/api_projects/schedule2.dig
@@ -1,0 +1,7 @@
+timezone: UTC
+
+schedule:
+  daily>: 00:00:00
+
++t1:
+  echo>: "schedule2 called"


### PR DESCRIPTION
Backport from Treasure Workflows.

* Add an extension point to check pushed project content
* Add parameters in 'PUT /api/projects'
* Refactoring. Add unit tests.
* Support clear_schedule, clear_schedule_all in DigdagClient