### PR TITLE
Fix for windows

### DIFF
--- a/digdag-docs/src/operators/sh.md
+++ b/digdag-docs/src/operators/sh.md
@@ -33,7 +33,23 @@ The shell defaults to `/bin/sh`. If an alternate shell such as `zsh` is desired,
     +step1:
       sh>: tasks/step2.sh
 
-On Windows, you can set PowerShell.exe to the `shell` option:
+On Windows, you can set PowerShell.exe to the `shell` option.
+Since ver.0.10.6, it is correct to specify ["powershell.exe"], 
+but digdag works with ["powershell.exe", "-"] in ver.0.9.46
+or earlier.
+
+>= 0.10.6
+    _export:
+      sh:
+        shell: ["powershell.exe"]
+
+    +step1:
+      sh>: step1.exe
+
+    +step2:
+      sh>: step2.ps1
+
+<= 0.9.46
 
     _export:
       sh:

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/ShOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/ShOperatorFactory.java
@@ -242,10 +242,8 @@ public class ShOperatorFactory
         {
             final String os = System.getProperty("os.name").toLowerCase();
             if ( os.startsWith("windows")) {
-                System.out.println("windows!!");
                 return true;
             }
-            System.out.println("not windows");
             return false;
         }
     }

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/ShOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/ShOperatorFactory.java
@@ -158,12 +158,9 @@ public class ShOperatorFactory
             final List<String> shell = getShell(params, winOS);
 
             final ImmutableList.Builder<String> cmdline = ImmutableList.builder();
-            if (params.has("shell")) {
-                cmdline.addAll(shell);
-            }
-            else {
-                cmdline.addAll(shell);
-            }
+
+            cmdline.addAll(shell);
+
             cmdline.add(workingDirectory.relativize(runnerPath).toString()); // relative
 
             final String shScript = UserSecretTemplate.of(params.get("_command", String.class))

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/ShOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/ShOperatorFactory.java
@@ -128,7 +128,7 @@ public class ShOperatorFactory
             }
         }
 
-        private List<String> getShell(Config params, Boolean winOS){
+        private List<String> getShell(final Config params, final Boolean winOS){
             // Until digdag ver. 0.9, it was necessary to write ["powershell.exe","-"] to specify shell, 
             // but since ver. 0.10, jobs are not executed unless ["powershell.exe"] is written.
             // To resolve this incompatibility, change the shell specification ["powershell.exe","-"]

--- a/digdag-standards/src/main/java/io/digdag/standards/operator/ShOperatorFactory.java
+++ b/digdag-standards/src/main/java/io/digdag/standards/operator/ShOperatorFactory.java
@@ -137,8 +137,10 @@ public class ShOperatorFactory
             if (params.has("shell")) {
                 temp_shell = params.getListOrEmpty("shell", String.class);
                 if (temp_shell.get(0).toLowerCase().contains("powershell") && temp_shell.size() == 2){
-                    temp_shell.remove(1);
-                    logger.info("removed \"-\" from shell specification --- from [\"powershell.exe\",\"-\"] to [\"powershell.exe\"] .");
+                    if (temp_shell.get(1).contains("-")){
+                        temp_shell.remove(1);
+                        logger.info("removed \"-\" from shell specification --- from [\"powershell.exe\",\"-\"] to [\"powershell.exe\"] .");
+                    }
                 }
             }
             else {


### PR DESCRIPTION
# sh> operator of v0.10.0 on Windows platform and compatibility

When specifying "powershell" for shell in a .dig file, the "powershell.exe" was 
specified as ["powershell.exe","-"] until digdag ver. 0.9.x. 
Since ver. 0.10 the "-" is no longer necessary. 

However, for compatibility, the specification ["powershell.exe","-"] 
should be read as ["powershell.exe"].

[[WIP] Fix sh> operator issue on Windows #1654](https://github.com/treasure-data/digdag/issues/1560) is also included.
