### PR TITLE
update Github actions packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,11 +22,12 @@ jobs:
       matrix:
         ci_node_index: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v4
       with:
-        java-version: 1.8
+        distribution: zulu
+        java-version: 8
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Run tests in Docker

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,17 +15,17 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         ref: ${{ matrix.ref }}
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v3
       with:
         languages: java
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v3
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v3


### PR DESCRIPTION
# Overview
I have updated packages in Github Actions. Because There is following message in Actions result page.

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v2, actions/setup-java@v1. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```

The setup-java requires v2 or higher to specify java distribution. So I choose "zulu". because it is [default distribution of setup-java@v1](https://github.com/actions/setup-java/pkgs/container/setup-java#v2-vs-v1).

# Links
https://github.blog/changelog/2024-01-12-code-scanning-deprecation-of-codeql-action-v2/
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/